### PR TITLE
Fix/type stabiltiy exclusive periodic

### DIFF
--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -199,7 +199,7 @@ function _extend_exclusive(x::AbstractVector, y::AbstractVector, bc::PeriodicBC)
     x_ext = if x isa AbstractRange
         range(first(x), step = step(x), length = length(x) + 1)
     else
-        vcat(x, [x_end])
+        vcat(x, x_end)
     end
     y_ext = _extend_values(y)
     return x_ext, y_ext
@@ -221,14 +221,14 @@ function _extend_exclusive(x::AbstractVector, y_mat::AbstractMatrix, bc::Periodi
     x_ext = if x isa AbstractRange
         range(first(x), step = step(x), length = length(x) + 1)
     else
-        vcat(x, [x_end])
+        vcat(x, x_end)
     end
     y_ext = vcat(y_mat, y_mat[1:1, :])
     return x_ext, y_ext
 end
 
 # Value extension: append first element
-_extend_values(y::AbstractVector) = vcat(y, [first(y)])
+_extend_values(y::AbstractVector) = vcat(y, first(y))
 
 # ========================================
 # ND Exclusive Endpoint Extension
@@ -286,7 +286,7 @@ function _prepare_periodic_nd(
         grid_ext = if grid_d isa AbstractRange
             range(first(grid_d), step = step(grid_d), length = length(grid_d) + 1)
         else
-            vcat(grid_d, [x_end])
+            vcat(grid_d, x_end)
         end
         bc_ext = _with_resolved_period(bc_d, period)
         return (grid_ext, bc_ext)

--- a/test/test_periodic_exclusive.jl
+++ b/test/test_periodic_exclusive.jl
@@ -298,6 +298,31 @@ using FastInterpolations: _prepare_periodic, _prepare_periodic_nd,
         @test vals[2] ≈ cos(1.0) atol = 1.0e-4
     end
 
+    @testset "CubicSeriesInterpolant — Exclusive endpoint (Vector grid)" begin
+        # Build inclusive reference from non-uniform grid
+        x_incl = [0.0, 0.5, 1.5, 3.0, 5.0, 2π]
+        y1_incl = sin.(x_incl)
+        y2_incl = cos.(x_incl)
+        y1_incl[end] = y1_incl[1]
+        y2_incl[end] = y2_incl[1]
+
+        x_excl = x_incl[1:(end - 1)]
+        y1_excl = y1_incl[1:(end - 1)]
+        y2_excl = y2_incl[1:(end - 1)]
+
+        bc_excl = PeriodicBC(endpoint = :exclusive, period = 2π)
+
+        mitp_incl = cubic_interp(x_incl, Series(y1_incl, y2_incl); bc = PeriodicBC())
+        mitp_excl = cubic_interp(x_excl, Series(y1_excl, y2_excl); bc = bc_excl)
+
+        for xq in [0.1, 1.0, π, 5.5]
+            v_incl = mitp_incl(xq)
+            v_excl = mitp_excl(xq)
+            @test v_excl[1] ≈ v_incl[1] atol = 1.0e-14
+            @test v_excl[2] ≈ v_incl[2] atol = 1.0e-14
+        end
+    end
+
     # ========================================
     # Derivative Tests
     # ========================================


### PR DESCRIPTION
## Summary

- **Replace `_extend_grid` with inline `isa` branch** for type-stable grid extension in exclusive periodic BC paths (1D + ND). The old `_extend_grid` returned `Union{StepRangeLen, Vector}`, causing downstream boxing. The `isa AbstractRange` branch lets Julia eliminate the dead branch at compile time, yielding a concrete return type.

- **Fix mixed-precision `isapprox` bug in `_resolve_exclusive_period`**. The default `isapprox` for `Float32 x Float64` used Float32's generous `rtol ~ 3e-4`, silently accepting mismatched periods (e.g. `Float32(1.0002)` on a Float64 grid with inferred period `1.0`). Now promotes both operands to grid eltype and uses `rtol = sqrt(eps(Tg))` for strict validation.

- Delete unused `_extend_grid` (both `AbstractRange` and `AbstractVector` methods).

## Design note

On a Range grid, explicit `period` acts as a **sanity-check assertion**: if it matches the Range-inferred period (within grid-precision tolerance), it passes through; if not, it errors with a clear message. This guarantees the `isa AbstractRange` branch always produces a correct Range extension, preserving uniform-grid performance in the interpolant.