### PR TITLE
Tweak benchmark readme

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -23,7 +23,7 @@ Note: The result plots below were generated with `DEFAULT_BENCH_SECONDS = 5.0` o
 ## Usage
 
 ```julia
-using Pkg; Pkg.activate("benchmark")
+using Pkg; Pkg.activate(".") # assuming `benchmark` is working directory
 include("simple_benchmarks.jl")
 include("plot_scaling.jl")
 
@@ -31,6 +31,7 @@ include("plot_scaling.jl")
 result = benchmark_scaling()
 
 # Generate plots
+plot_scaling_results(result) # combined plot
 plot_scaling_separate(result; save_dir="../docs/images", dpi=250)
 ```
 


### PR DESCRIPTION
The first code block in the readme has `cd benchmark` so the user should be already working in that directory.
This PR changes the path in the 2nd block accordingly.

It also adds `plot_scaling_results(result) # combined plot` because on first use a user is more likely to want to see the combined plot than to want to write results to files.