### PR TITLE
(feat): Hermite 1D — OnTheFly integrate + in-place cumulative_integrate!

### DIFF
--- a/src/FastInterpolations.jl
+++ b/src/FastInterpolations.jl
@@ -97,7 +97,7 @@ export AbstractSide, NearestSide, LeftSide, RightSide
 export Search, Extrap, Side
 
 # Integration
-export integrate, cumulative_integrate
+export integrate, cumulative_integrate, cumulative_integrate!
 
 # Polynomial coefficient extraction
 export CellPoly, coeffs

--- a/src/core/show.jl
+++ b/src/core/show.jl
@@ -1147,6 +1147,10 @@ _short_method_name(::LinearInterp) = "Linear"
 _short_method_name(::QuadraticInterp) = "Quadratic"
 _short_method_name(::ConstantInterp) = "Constant"
 _short_method_name(::NoInterp) = "NoInterp"
+_short_method_name(::PchipInterp) = "PCHIP"
+_short_method_name(::CardinalInterp) = "Cardinal"
+_short_method_name(::AkimaInterp) = "Akima"
+_short_method_name(::CubicHermiteInterp) = "CubicHermite"
 
 function Base.show(io::IO, itp::HeteroInterpolantND{Tg, Tv, N}) where {Tg, Tv, N}
     sizes = join([string(length(g)) for g in itp.grids], "×")

--- a/src/hermite/hermite_integrate.jl
+++ b/src/hermite/hermite_integrate.jl
@@ -74,7 +74,8 @@ end
     spacing = _spacing(itp)
 
     in_domain = @inline (a, b) -> _integrate_hermite_onthefly_inner(
-        sm, x, y, spacing, a, b, searcher, Tout)
+        sm, x, y, spacing, a, b, searcher, Tout
+    )
 
     return _dispatch_extrap_integrate_1d(itp.extrap, in_domain, x, y[1], y[end], x0, x1, Tout)
 end

--- a/src/hermite/hermite_integrate.jl
+++ b/src/hermite/hermite_integrate.jl
@@ -1,8 +1,10 @@
 # ========================================
 # Hermite Family 1D — Bounded Integration (shared)
 # ========================================
-# Single dispatch for all AbstractHermiteInterpolant1D subtypes.
-# All store (x, y, dy, spacing) and use _hermite_integral_kernel_1d.
+# Single top-level dispatch for all AbstractHermiteInterpolant1D subtypes.
+# Branches on `itp.dy` concrete type (AbstractVector = PreCompute,
+# AbstractSlopeMethod = OnTheFly) via trait-dispatch helper. Both strategies
+# use the same `_hermite_integral_kernel_1d`; only the slope source differs.
 
 @inline function integrate(
         itp::AbstractHermiteInterpolant1D{Tg, Tv},
@@ -10,29 +12,140 @@
         search::AbstractSearchPolicy = itp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing,
     ) where {Tg <: AbstractFloat, Tv}
-    itp.dy isa AbstractSlopeMethod && _throw_onthefly_unsupported("integrate")
+    return _integrate_hermite_1d(itp.dy, itp, x0, x1, search, hint)
+end
+
+# ── PreCompute path: dy is a precomputed slope vector (unchanged behavior) ──
+@inline function _integrate_hermite_1d(
+        dy::AbstractVector,
+        itp::AbstractHermiteInterpolant1D{Tg, Tv},
+        x0::Real, x1::Real,
+        search::AbstractSearchPolicy,
+        hint::Union{Nothing, Base.RefValue{Int}},
+    ) where {Tg <: AbstractFloat, Tv}
     x = itp.x
     y = itp.y
-    dy = itp.dy
+    spacing = _spacing(itp)
     Tout = promote_type(Tv, Tg, typeof(x0), typeof(x1))
     searcher = _resolve_search(x, x0, search, hint)
 
+    # `_get_inv_h(spacing, i)` reads a cached field (ScalarSpacing) or an
+    # indexed load (VectorSpacing) — always cheaper than `inv(h)` which emits
+    # a hardware division. The spacing is already in scope for the cellwise
+    # walker, so capturing it in the closure is free.
     partial = @inline (i, xL, h, a2, b2) -> begin
-        inv_h = inv(h)
+        inv_h = _get_inv_h(spacing, i)
         @inbounds _hermite_integral_kernel_1d(
             y[i], y[i + 1], dy[i], dy[i + 1],
             h, inv_h, a2 - xL, b2 - xL,
         )
     end
     full = @inline (i, h) -> begin
-        inv_h = inv(h)
+        inv_h = _get_inv_h(spacing, i)
         @inbounds _hermite_integral_kernel_1d(
             y[i], y[i + 1], dy[i], dy[i + 1],
             h, inv_h, zero(Tg), h,
         )
     end
 
-    in_domain = @inline (a, b) -> _integrate_1d_cellwise(x, _spacing(itp), a, b, searcher, partial, full, Tout)
+    in_domain = @inline (a, b) -> _integrate_1d_cellwise(x, spacing, a, b, searcher, partial, full, Tout)
 
     return _dispatch_extrap_integrate_1d(itp.extrap, in_domain, x, y[1], y[end], x0, x1, Tout)
+end
+
+# ── OnTheFly path: dy is a slope method sentinel, slopes computed per cell ──
+# Uses a dedicated sliding-window helper (`_integrate_hermite_onthefly_inner`)
+# as the `in_domain` callback. Each call from the extrap dispatcher gets a
+# fresh sliding-window pass, so WrapExtrap's multiple sub-interval calls work
+# automatically without any state leakage.
+# Memory overhead: 2 scalars (dy_L, dy_R) on the stack — zero heap, zero pool,
+# regardless of grid size. This preserves the OnTheFly "memory O(1)" contract.
+@inline function _integrate_hermite_1d(
+        sm::AbstractSlopeMethod,
+        itp::AbstractHermiteInterpolant1D{Tg, Tv},
+        x0::Real, x1::Real,
+        search::AbstractSearchPolicy,
+        hint::Union{Nothing, Base.RefValue{Int}},
+    ) where {Tg <: AbstractFloat, Tv}
+    x = itp.x
+    y = itp.y
+    Tout = promote_type(Tv, Tg, typeof(x0), typeof(x1))
+    searcher = _resolve_search(x, x0, search, hint)
+    spacing = _spacing(itp)
+
+    in_domain = @inline (a, b) -> _integrate_hermite_onthefly_inner(
+        sm, x, y, spacing, a, b, searcher, Tout)
+
+    return _dispatch_extrap_integrate_1d(itp.extrap, in_domain, x, y[1], y[end], x0, x1, Tout)
+end
+
+# ── Sliding-window inner helper for OnTheFly bounded integrate ──
+# Walks cells [i0..i1] in order, threading two slope scalars (dy_L, dy_R)
+# through the loop. Each cell reuses the previous cell's right slope as its
+# own left slope, so `_local_slope` is called exactly `(i1 - i0 + 2)` times
+# total — one for i0, one for each subsequent cell's right edge.
+#
+# This is the OnTheFly analogue of `_integrate_1d_cellwise` with the inline
+# closure pattern, but with state threaded through local variables instead
+# of captured state. The duplication is limited to the cell-location logic
+# (~10 lines); the numerical kernel is `_hermite_integral_kernel_1d`, shared
+# with the PreCompute path above.
+@inline function _integrate_hermite_onthefly_inner(
+        sm::AbstractSlopeMethod,
+        x::AbstractVector, y::AbstractVector, spacing::AbstractGridSpacing,
+        a::Real, b::Real, searcher::Searcher, ::Type{Tout},
+    ) where {Tout}
+    sign, lo, hi = _normalize_bounds_1d(a, b)
+    sign == 0 && return zero(Tout)
+    n = length(x)
+
+    i0, xL0, _ = search_interval(searcher, x, spacing, lo)
+    i1, xL1, _ = search_interval(searcher, x, spacing, hi)
+
+    dy_L = _local_slope(sm, x, y, i0, n)
+    dy_R = _local_slope(sm, x, y, i0 + 1, n)
+
+    # Single-cell fast path — both bounds fall in the same cell.
+    # `_get_inv_h(spacing, i)` reads a cached field (ScalarSpacing) or an
+    # indexed load (VectorSpacing), avoiding a hardware division per cell.
+    if i0 == i1
+        h = _get_h(spacing, i0)
+        inv_h = _get_inv_h(spacing, i0)
+        return sign * _hermite_integral_kernel_1d(
+            @inbounds(y[i0]), @inbounds(y[i0 + 1]), dy_L, dy_R,
+            h, inv_h, lo - xL0, hi - xL0,
+        )
+    end
+
+    # First partial cell [lo, xL0 + h0]
+    h0 = _get_h(spacing, i0)
+    inv_h0 = _get_inv_h(spacing, i0)
+    total = _hermite_integral_kernel_1d(
+        @inbounds(y[i0]), @inbounds(y[i0 + 1]), dy_L, dy_R,
+        h0, inv_h0, lo - xL0, h0,
+    )
+
+    # Interior full cells — sliding window
+    @inbounds for i in (i0 + 1):(i1 - 1)
+        dy_L = dy_R                                    # roll: old right becomes new left
+        dy_R = _local_slope(sm, x, y, i + 1, n)        # only right side is fresh
+        h = _get_h(spacing, i)
+        inv_h = _get_inv_h(spacing, i)
+        total += _hermite_integral_kernel_1d(
+            y[i], y[i + 1], dy_L, dy_R,
+            h, inv_h, zero(eltype(x)), h,
+        )
+    end
+
+    # Final partial cell [xL1, hi]
+    dy_L = dy_R
+    dy_R = _local_slope(sm, x, y, i1 + 1, n)
+    h1 = _get_h(spacing, i1)
+    inv_h1 = _get_inv_h(spacing, i1)
+    total += _hermite_integral_kernel_1d(
+        @inbounds(y[i1]), @inbounds(y[i1 + 1]), dy_L, dy_R,
+        h1, inv_h1, zero(eltype(x)), hi - xL1,
+    )
+
+    return sign * total
 end

--- a/src/hermite/hermite_slope_methods.jl
+++ b/src/hermite/hermite_slope_methods.jl
@@ -57,13 +57,3 @@ Each slope depends on at most 5 neighboring points (4 secants).
 Used as: `akima_interp(x, y; coeffs=OnTheFly())`
 """
 struct AkimaSlopes <: AbstractSlopeMethod end
-
-# Error helper for unsupported operations on OnTheFly interpolants
-@noinline function _throw_onthefly_unsupported(op::String)
-    throw(
-        ArgumentError(
-            "$op is not yet supported for OnTheFly interpolants. " *
-                "Use coeffs=PreCompute() to enable $op."
-        )
-    )
-end

--- a/src/hetero/hetero_adjoint.jl
+++ b/src/hetero/hetero_adjoint.jl
@@ -383,6 +383,33 @@ end
 end
 
 # ========================================
+# Graceful-error helper
+# ========================================
+
+@noinline function _throw_hetero_adjoint_hermite_unsupported(methods)
+    local_names = String[]
+    for m in methods
+        if m isa PchipInterp || m isa CardinalInterp || m isa AkimaInterp
+            push!(local_names, string(typeof(m)))
+        end
+    end
+    throw(
+        ArgumentError(
+            "hetero_adjoint / ND reverse-mode AD is not yet implemented for " *
+                "Hermite family methods (found $(join(unique(local_names), ", "))). " *
+                "This also affects `Zygote.gradient` / `ChainRulesCore.rrule` on " *
+                "`HeteroInterpolantND` built with PCHIP / Cardinal / Akima axes. " *
+                "Tracking: claudedocs/TODO/hermite_onthefly_integrate_and_nd_adjoint.md (Task 2). " *
+                "Workarounds: (1) switch Hermite axes to `CubicInterp` for AD support; " *
+                "(2) use `ForwardDiff.gradient` on a scalar-query closure, which works " *
+                "through the forward OnTheFly path without needing an adjoint; " *
+                "(3) for 1D, `pchip_adjoint(x, y, xq)` / `cardinal_adjoint(x, xq)` / " *
+                "`akima_adjoint(x, y, xq)` are fully supported."
+        )
+    )
+end
+
+# ========================================
 # Constructor
 # ========================================
 
@@ -487,6 +514,12 @@ function _build_hetero_nd_adjoint(
         methods::Tuple{Vararg{AbstractInterpMethod, N}},
         extraps::Tuple{Vararg{AbstractExtrap, N}}
     ) where {N, Tg <: AbstractFloat}
+    # Reject Hermite family methods upfront with a clear message. Without this
+    # guard, the scatter path below would fail deep in the per-axis weight
+    # computation with an obscure MethodError. Single point of entry for both
+    # direct `hetero_adjoint(...)` calls and the Zygote/ChainRules rrule
+    # (see `_adjoint_func_from_itp(::HeteroInterpolantND) = hetero_adjoint`).
+    _has_any_local_method(methods) && _throw_hetero_adjoint_hermite_unsupported(methods)
     # Validate grid size and cubic PolyFit BC support requirements
     @inbounds for d in 1:N
         len_d = length(grids[d])

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -164,6 +164,48 @@ end
 @inline _nd_sample_value(itp::CubicInterpolantND) = @inbounds itp.nodal_derivs.partials[1]
 @inline _nd_sample_value(itp::QuadraticInterpolantND) = @inbounds itp.nodal_derivs.partials[1]
 
+# HeteroInterpolantND: explicit not-implemented error. Beats the MethodError
+# the generic dispatch below would hit inside `_full_cell_integral_nd`, and
+# tells the user about the actual workaround (per-axis 1D integration, or
+# switching to a homogeneous specialized ND type).
+function integrate(
+        itp::HeteroInterpolantND;
+        search = nothing,
+        hint = nothing,
+    )
+    _throw_hetero_nd_integrate_unsupported(itp.methods)
+end
+
+# Bounded ND integrate never existed; add a HeteroInterpolantND-specific
+# overload too so `integrate(itp, a, b)` doesn't surface as a MethodError
+# asking the user about Real vs Tuple bound types. Must use `::Real, ::Real`
+# to win dispatch against the `(::AbstractInterpolant, ::Real, ::Real)`
+# fallback in integrate_api.jl (more specific first arg + equal specificity
+# on bounds).
+function integrate(
+        itp::HeteroInterpolantND, ::Real, ::Real;
+        search = nothing, hint = nothing,
+    )
+    _throw_hetero_nd_integrate_unsupported(itp.methods)
+end
+
+@noinline function _throw_hetero_nd_integrate_unsupported(methods)
+    throw(
+        ArgumentError(
+            "integrate is not yet implemented for HeteroInterpolantND " *
+                "(method tuple: $(methods)). ND tensor-product integration over " *
+                "mixed/Hermite axes is tracked in " *
+                "claudedocs/TODO/hermite_onthefly_integrate_and_nd_adjoint.md (Task 2) " *
+                "and the broader ND-integrate gap. Workarounds: " *
+                "(1) use a homogeneous specialized ND type " *
+                "(`cubic_interp`, `quadratic_interp`, `linear_interp`, `constant_interp`) " *
+                "which do support `integrate`; " *
+                "(2) integrate axis-by-axis via 1D `integrate` calls on per-fiber " *
+                "1D interpolants."
+        )
+    )
+end
+
 # Generic ND full-domain: catches all ND types
 @inline function integrate(
         itp::AbstractInterpolantND{Tg, Tv, N};

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -91,7 +91,10 @@ end
 # integrate(itp) — 1D full-domain fast path
 # ═══════════════════════════════════════════════════════════════
 
-# Generic 1D: catches Cubic, Linear, Quadratic (not Constant, not Hermite — see overrides below)
+# Generic 1D: catches any interpolant whose `_full_cell_fn(itp)` trait is the
+# single-arg form — Cubic, Linear, Quadratic, and the entire Hermite family
+# (PreCompute + OnTheFly via `_full_cell_fn`'s internal dispatch on `itp.dy`).
+# Constant has its own override below because its full-cell trait depends on `side`.
 @inline function integrate(
         itp::AbstractInterpolant{Tg, Tv};
         search = nothing, hint = nothing

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -26,11 +26,37 @@ end
     return @inline (i, h) -> @inbounds _quadratic_integral_kernel(_EvalIntegralCell(), a[i], d[i], y[i], h)
 end
 
-@inline function _full_cell_fn(itp::AbstractHermiteInterpolant1D)
-    y, dy = itp.y, itp.dy
+@inline _full_cell_fn(itp::AbstractHermiteInterpolant1D) =
+    _hermite_full_cell_fn(itp, itp.dy)
+
+# PreCompute branch: slopes live in `itp.dy::AbstractVector`, indexed directly.
+# `inv_h` is pulled from the spacing's precomputed cache via `_get_inv_h`
+# (cached field for ScalarSpacing, indexed load for VectorSpacing) — always
+# cheaper than computing `inv(h)` per cell.
+@inline function _hermite_full_cell_fn(itp::AbstractHermiteInterpolant1D, dy::AbstractVector)
+    y = itp.y
+    spacing = _spacing(itp)
     return @inline (i, h) -> begin
-        inv_h = inv(h)
+        inv_h = _get_inv_h(spacing, i)
         @inbounds _hermite_integral_kernel_1d(y[i], y[i + 1], dy[i], dy[i + 1], h, inv_h, zero(h), h)
+    end
+end
+
+# OnTheFly branch: slopes computed locally per call via `_local_slope`.
+# Each cell independently computes its two slopes — no sliding-window state,
+# so the closure stays immutable and heap-free. The PCHIP/Cardinal/Akima stencils
+# are O(1), so the extra recomputation (2(n-1) calls vs n for a sliding window)
+# adds only a constant factor to full-domain integration; the code simplification
+# removes three dedicated kernels.
+@inline function _hermite_full_cell_fn(itp::AbstractHermiteInterpolant1D, sm::AbstractSlopeMethod)
+    x, y = _grid_1d(itp), itp.y
+    spacing = _spacing(itp)
+    n = length(x)
+    return @inline (i, h) -> begin
+        dy_L = _local_slope(sm, x, y, i, n)
+        dy_R = _local_slope(sm, x, y, i + 1, n)
+        inv_h = _get_inv_h(spacing, i)
+        @inbounds _hermite_integral_kernel_1d(y[i], y[i + 1], dy_L, dy_R, h, inv_h, zero(h), h)
     end
 end
 
@@ -65,29 +91,29 @@ end
 # integrate(itp) — 1D full-domain fast path
 # ═══════════════════════════════════════════════════════════════
 
-# Generic 1D: catches Cubic, Linear, Quadratic (not Constant — see override below)
+# Generic 1D: catches Cubic, Linear, Quadratic (not Constant, not Hermite — see overrides below)
 @inline function integrate(
         itp::AbstractInterpolant{Tg, Tv};
         search = nothing, hint = nothing
     ) where {Tg <: AbstractFloat, Tv}
-    # Guard: OnTheFly Hermite interpolants don't support integrate yet
-    if itp isa AbstractHermiteInterpolant1D && itp.dy isa AbstractSlopeMethod
-        _throw_onthefly_unsupported("integrate")
-    end
     x = _grid_1d(itp)
     Tout = promote_type(Tv, Tg)
     return _integrate_1d_fulldomain(x, _spacing(itp), _full_cell_fn(itp), Tout)
 end
 
-# Constant override: side is parametric → compiler knows concrete type
+# Constant override: side is parametric → compiler knows concrete type,
+# so `_full_cell_fn(itp, side)` is a distinct method from the generic single-arg form.
 @inline function integrate(
         itp::ConstantInterpolant{Tg, Tv};
         search = nothing, hint = nothing
     ) where {Tg <: AbstractFloat, Tv}
-    x = itp.x
+    x = _grid_1d(itp)
     Tout = promote_type(Tv, Tg)
     return _integrate_1d_fulldomain(x, _spacing(itp), _full_cell_fn(itp, itp.side), Tout)
 end
+
+# Hermite family is handled by the generic path above — `_full_cell_fn`
+# internally dispatches on `itp.dy` (PreCompute vs OnTheFly).
 
 # ═══════════════════════════════════════════════════════════════
 # integrate(sitp) — 1D Series full-domain fast path
@@ -113,7 +139,7 @@ end
         sitp::ConstantSeriesInterpolant{Tg, Tv};
         search = nothing, hint = nothing
     ) where {Tg <: AbstractFloat, Tv}
-    x = sitp.x
+    x = _grid_1d(sitp)
     Tout = promote_type(Tv, Tg)
     n = n_series(sitp)
     results = Vector{Tout}(undef, n)
@@ -225,25 +251,53 @@ end
 end
 
 # ═══════════════════════════════════════════════════════════════
-# cumulative_integrate — 1D prefix-sum of per-cell integrals
+# cumulative_integrate / cumulative_integrate! — 1D prefix-sum
 # ═══════════════════════════════════════════════════════════════
+#
+# Architecture: the in-place `cumulative_integrate!(out, itp)` is the real
+# implementation; the allocating `cumulative_integrate(itp)` is a thin
+# wrapper that allocates `out` and forwards. Every interpolant type gets
+# *one* method on `cumulative_integrate!` — Hermite OnTheFly joins the
+# generic path via `_full_cell_fn(itp)`'s internal dispatch on `itp.dy`.
 
-# Generic 1D: catches Cubic, Linear, Quadratic
-function cumulative_integrate(
-        itp::AbstractInterpolant{Tg, Tv}
-    ) where {Tg <: AbstractFloat, Tv}
-    x = _grid_1d(itp)
-    Tout = promote_type(Tv, Tg)
-    return _cumulative_integrate_1d(x, _spacing(itp), _full_cell_fn(itp), Tout)
+@noinline function _throw_cumulative_length_mismatch(got::Int, expected::Int)
+    throw(
+        DimensionMismatch(
+            "cumulative_integrate! output buffer length $got does not match grid length $expected"
+        )
+    )
 end
 
-# Constant override: side is parametric → compiler knows concrete type
-function cumulative_integrate(
-        itp::ConstantInterpolant{Tg, Tv}
+@inline function _check_cumulative_out(out::AbstractVector, n::Int)
+    length(out) == n || _throw_cumulative_length_mismatch(length(out), n)
+    return nothing
+end
+
+# Generic 1D: catches Cubic, Linear, Quadratic, and the entire Hermite family
+# (PreCompute + OnTheFly via `_full_cell_fn`'s trait dispatch on `itp.dy`).
+function cumulative_integrate!(
+        out::AbstractVector, itp::AbstractInterpolant{Tg, Tv}
     ) where {Tg <: AbstractFloat, Tv}
-    x = itp.x
+    x = _grid_1d(itp)
+    _check_cumulative_out(out, length(x))
+    return _cumulative_integrate_1d!(out, x, _spacing(itp), _full_cell_fn(itp))
+end
+
+# Constant override: side is parametric → compiler knows concrete type,
+# so `_full_cell_fn(itp, side)` dispatches to a distinct specialized method.
+function cumulative_integrate!(
+        out::AbstractVector, itp::ConstantInterpolant{Tg, Tv}
+    ) where {Tg <: AbstractFloat, Tv}
+    x = _grid_1d(itp)
+    _check_cumulative_out(out, length(x))
+    return _cumulative_integrate_1d!(out, x, _spacing(itp), _full_cell_fn(itp, itp.side))
+end
+
+# Allocating wrappers: allocate output vector then forward to the in-place path.
+function cumulative_integrate(itp::AbstractInterpolant{Tg, Tv}) where {Tg <: AbstractFloat, Tv}
     Tout = promote_type(Tv, Tg)
-    return _cumulative_integrate_1d(x, _spacing(itp), _full_cell_fn(itp, itp.side), Tout)
+    out = Vector{Tout}(undef, length(_grid_1d(itp)))
+    return cumulative_integrate!(out, itp)
 end
 
 # Generic Series: catches Cubic, Linear, Quadratic series
@@ -265,7 +319,7 @@ end
 function cumulative_integrate(
         sitp::ConstantSeriesInterpolant{Tg, Tv}
     ) where {Tg <: AbstractFloat, Tv}
-    x = sitp.x
+    x = _grid_1d(sitp)
     Tout = promote_type(Tv, Tg)
     n_pts = length(x)
     n_ser = n_series(sitp)

--- a/src/nodal_partials.jl
+++ b/src/nodal_partials.jl
@@ -42,6 +42,8 @@ end
 @inline function _partials_array(itp::HeteroInterpolantND)
     if itp.data isa _HeteroPartials
         return itp.data.partials
+    elseif _has_any_local_method(itp.methods)
+        _throw_nodal_partials_hermite_nd(itp.methods)
     else
         throw(
             ArgumentError(
@@ -50,6 +52,32 @@ end
             )
         )
     end
+end
+
+# Dedicated error for the "local Hermite ND + nodal_partials" combo.
+# Following the user advice to "use PreCompute" would dead-end: PreCompute
+# is rejected upstream by `_validate_nd_coeffs` for Hermite family ND.
+# This message points users at the correct workaround (per-axis 1D access)
+# and the tracking TODO.
+@noinline function _throw_nodal_partials_hermite_nd(methods)
+    local_names = String[]
+    for m in methods
+        if m isa PchipInterp || m isa CardinalInterp || m isa AkimaInterp
+            push!(local_names, string(typeof(m)))
+        end
+    end
+    throw(
+        ArgumentError(
+            "nodal_partials is not yet implemented for Hermite family ND " *
+                "(found $(join(unique(local_names), ", "))). The Hermite ND PreCompute " *
+                "backend has not been written yet — tracked in " *
+                "claudedocs/TODO/hermite_nd_precompute.md. " *
+                "Workaround: compute per-axis 1D slopes via `pchip_interp` / " *
+                "`cardinal_interp` / `akima_interp` with `deriv=DerivOp(1)`, " *
+                "or switch the relevant axes to CubicInterp / QuadraticInterp " *
+                "which do support nodal_partials."
+        )
+    )
 end
 
 @noinline _partials_array(::LinearInterpolantND) = throw(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,6 +131,10 @@ else
     # Nodal partials API
     include("test_nodal_partials.jl")
 
+    # Hermite family ND — graceful not-implemented errors for the release
+    # contract (nodal_partials, integrate, hetero_adjoint / AD)
+    include("test_hermite_nd_graceful_errors.jl")
+
     # Integration API
     include("test_integral_api.jl")
     include("test_integral_cubic_1d.jl")

--- a/test/test_hermite_nd_graceful_errors.jl
+++ b/test/test_hermite_nd_graceful_errors.jl
@@ -1,0 +1,126 @@
+using Test
+using FastInterpolations
+
+# ============================================================================
+# Graceful error messages for Hermite family ND
+# ============================================================================
+#
+# PCHIP / Cardinal / Akima do not yet have a PreCompute backend, ND integrate,
+# or ND adjoint. Rather than letting users hit MethodError or a confusing
+# "use PreCompute" advice that dead-ends at another error, these entry points
+# throw explicit ArgumentError messages pointing at the tracking TODOs and
+# listing concrete workarounds.
+#
+# This test suite pins the error surface so the release contract is explicit.
+
+@testset "Hermite ND — graceful not-implemented errors" begin
+    x = collect(range(0.0, 1.0, 8))
+    y = collect(range(0.0, 1.0, 6))
+    data = [sin(xi) * cos(yj) for xi in x, yj in y]
+
+    @testset "nodal_partials — pure local Hermite ND" begin
+        # Pure Hermite tuple → OnTheFly is the only working coeffs strategy.
+        # nodal_partials must tell the user this is not yet implemented and
+        # point at the tracking TODO, NOT tell them to "use PreCompute" (which
+        # would be rejected upstream).
+        for m in (PchipInterp(), CardinalInterp(), AkimaInterp())
+            itp = interp((x, y), data; method = (m, m))
+            err = try
+                nodal_partials(itp, (0, 0))
+                nothing
+            catch e
+                e
+            end
+            @test err isa ArgumentError
+            @test occursin("not yet implemented for Hermite family ND", err.msg)
+            @test occursin("hermite_nd_precompute.md", err.msg)
+            # Must not give the misleading "use PreCompute" advice.
+            @test !occursin("coeffs=PreCompute()", err.msg)
+        end
+    end
+
+    @testset "nodal_partials — mixed Cubic × Hermite ND" begin
+        # Mixed tuple also can't produce nodal_partials: PreCompute is rejected,
+        # and OnTheFly has no partials array at all. Same error path.
+        itp = interp((x, y), data; method = (CubicInterp(), PchipInterp()))
+        err = try
+            nodal_partials(itp, (1, 0))
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("Hermite family ND", err.msg)
+        @test occursin("PchipInterp", err.msg)
+    end
+
+    @testset "nodal_partials — pure Cubic ND still works" begin
+        # Regression guard: graceful-error path must NOT affect legitimate
+        # Cubic ND callers.
+        itp = interp((x, y), data; method = (CubicInterp(), CubicInterp()))
+        @test size(nodal_partials(itp, (0, 0))) == size(data)
+        @test size(nodal_partials(itp, (1, 0))) == size(data)
+        @test size(nodal_partials(itp, (1, 1))) == size(data)
+    end
+
+    @testset "integrate(HeteroInterpolantND) — full-domain" begin
+        itp = interp((x, y), data; method = (PchipInterp(), CardinalInterp()))
+        err = try
+            integrate(itp)
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("not yet implemented for HeteroInterpolantND", err.msg)
+        @test occursin("hermite_onthefly_integrate_and_nd_adjoint.md", err.msg)
+        @test occursin("cubic_interp", err.msg)  # suggests homogeneous workaround
+    end
+
+    @testset "integrate(HeteroInterpolantND, a, b) — bounded" begin
+        itp = interp((x, y), data; method = (CubicInterp(), AkimaInterp()))
+        err = try
+            integrate(itp, 0.1, 0.9)
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("not yet implemented for HeteroInterpolantND", err.msg)
+    end
+
+    @testset "integrate(pure Cubic ND) — regression guard" begin
+        # The HeteroInterpolantND override must NOT shadow the existing
+        # CubicInterpolantND integrate path.
+        itp = interp((x, y), data; method = (CubicInterp(), CubicInterp()))
+        val = integrate(itp)
+        @test val isa Real
+        @test isfinite(val)
+    end
+
+    @testset "hetero_adjoint — rejects Hermite family" begin
+        xq = [0.3, 0.7]
+        yq = [0.4, 0.6]
+        for m in (PchipInterp(), CardinalInterp(), AkimaInterp())
+            err = try
+                hetero_adjoint((x, y), (xq, yq); methods = (CubicInterp(), m))
+                nothing
+            catch e
+                e
+            end
+            @test err isa ArgumentError
+            @test occursin("not yet implemented for", err.msg)
+            @test occursin("hermite_onthefly_integrate_and_nd_adjoint.md", err.msg)
+            @test occursin("ForwardDiff", err.msg)  # suggested workaround
+        end
+    end
+
+    @testset "hetero_adjoint — pure Cubic×Linear still works" begin
+        xq = [0.3, 0.7]
+        yq = [0.4, 0.6]
+        adj = hetero_adjoint((x, y), (xq, yq); methods = (CubicInterp(), LinearInterp()))
+        y_bar = [1.0, 1.0]
+        f_bar = adj(y_bar)
+        @test size(f_bar) == size(data)
+    end
+end

--- a/test/test_hermite_onthefly.jl
+++ b/test/test_hermite_onthefly.jl
@@ -1,4 +1,5 @@
 using Test
+using Random: MersenneTwister
 using FastInterpolations
 using FastInterpolations: _local_slope, PchipSlopes, CardinalSlopes, AkimaSlopes,
     _pchip_slopes!, _cardinal_slopes!, _akima_slopes!,
@@ -102,6 +103,72 @@ using FastInterpolations: _local_slope, PchipSlopes, CardinalSlopes, AkimaSlopes
 
         # Internal API also works
         @test _pchip_interp_onthefly(collect(Float64, x), sin.(x), Float64(xq), NoExtrap(), EvalValue(), AutoSearch(), nothing) ≈ pchip_interp(x, y, xq) atol = 1.0e-14
+    end
+
+    # ========================================
+    # 3b. Extended PreCompute vs OnTheFly regression sweep (item 7)
+    # ========================================
+    # Cross-strategy regression safety net: sweeps grid type, function shape,
+    # query location, method, and derivative order. Any future divergence
+    # between the PreCompute and OnTheFly kernels — even one rounded away on
+    # a single function — will trip this test before release.
+    #
+    # Tolerance: strict `1e-14` because both strategies use the same cubic
+    # Hermite kernel (`_hermite_integral_kernel_1d` / `_hermite_eval_kernel`),
+    # just fed from different slope sources. Their floating-point results
+    # should agree to the last few ULPs.
+    @testset "Sweep: OnTheFly ≈ PreCompute (values + 1st derivative)" begin
+        # Grid setups — uniform Range + non-uniform Vector
+        grids = (
+            ("uniform Range, n=30",      collect(range(0.0, 2π, 30))),
+            ("uniform Range, n=15",      collect(range(-1.0, 3.0, 15))),
+            ("non-uniform Vector, n=25", sort!(vcat(0.0, 2π, 0.02 .+ (2π - 0.04) .* sort!(rand(MersenneTwister(7), 23))))),
+        )
+        # Function shapes — different curvature profiles catch different bug classes
+        functions = (
+            ("sin",        x -> sin(3x)),
+            ("polynomial", x -> 0.3x^3 - 1.2x^2 + 0.5x - 0.7),
+            ("gaussian",   x -> exp(-(x - 1.5)^2)),
+        )
+        # Methods
+        makers = (
+            ("pchip",               (xx, yy; coeffs) -> pchip_interp(xx, yy; coeffs = coeffs)),
+            ("cardinal tension=0",  (xx, yy; coeffs) -> cardinal_interp(xx, yy; tension = 0.0, coeffs = coeffs)),
+            ("cardinal tension=0.3",(xx, yy; coeffs) -> cardinal_interp(xx, yy; tension = 0.3, coeffs = coeffs)),
+            ("cardinal tension=0.7",(xx, yy; coeffs) -> cardinal_interp(xx, yy; tension = 0.7, coeffs = coeffs)),
+            ("akima",               (xx, yy; coeffs) -> akima_interp(xx, yy; coeffs = coeffs)),
+        )
+
+        for (g_label, x) in grids, (f_label, f) in functions, (m_label, maker) in makers
+            y = f.(x)
+            itp_pre = maker(x, y; coeffs = PreCompute())
+            itp_otf = maker(x, y; coeffs = OnTheFly())
+
+            # 50 scattered queries strictly inside the domain
+            xlo, xhi = first(x), last(x)
+            rng = MersenneTwister(123)
+            scattered = xlo .+ (xhi - xlo) .* (0.01 .+ 0.98 .* rand(rng, 50))
+            # Edge queries: each cell's midpoint + each interior grid point + near-boundary
+            edges = vcat(
+                [0.5 * (x[i] + x[i + 1]) for i in 1:(length(x) - 1)],  # mid-cell
+                [x[i] + 1.0e-9 * (x[i + 1] - x[i]) for i in 1:(length(x) - 1)],  # just after left
+                [x[i + 1] - 1.0e-9 * (x[i + 1] - x[i]) for i in 1:(length(x) - 1)], # just before right
+                [x[2], x[end - 1]],  # near-boundary grid points
+            )
+            all_q = vcat(scattered, edges)
+
+            for q in all_q
+                # Value equivalence
+                v_pre = itp_pre(q)
+                v_otf = itp_otf(q)
+                @test v_otf ≈ v_pre atol = 1.0e-13 rtol = 1.0e-13
+
+                # 1st derivative equivalence — catches slope-source bugs that value tests miss
+                d_pre = itp_pre(q; deriv = DerivOp(1))
+                d_otf = itp_otf(q; deriv = DerivOp(1))
+                @test d_otf ≈ d_pre atol = 1.0e-12 rtol = 1.0e-12
+            end
+        end
     end
 
     # ========================================
@@ -585,6 +652,83 @@ using FastInterpolations: _local_slope, PchipSlopes, CardinalSlopes, AkimaSlopes
         # Scalar oneshot Float32
         v = pchip_interp(x32, y32, 1.0f0; coeffs = OnTheFly())
         @test v isa Float32
+    end
+
+    # ========================================
+    # 16b. Float32 ND smoke test (item 6) — release regression guard
+    # ========================================
+    # Pins three properties for the cell-local OnTheFly ND path on Float32:
+    #   1. Eval returns Float32 (no silent Float64 promotion through the pool buffers)
+    #   2. Numerical agreement with the Float64-upcast reference within Float32 ULP slack
+    #   3. Zero-alloc after warmup (no Float64 boxing slipping into closure captures)
+    # If any of these regress on a future kernel/pool change, this test will trip
+    # before reaching a release.
+    @testset "Float32 Hermite ND smoke (eval + zero-alloc)" begin
+        x32 = collect(range(0.0f0, Float32(2π), 16))
+        y32 = collect(range(-1.0f0, 1.0f0, 13))
+        z32 = collect(range(0.0f0, 1.0f0, 9))
+        d2_32 = Float32[sin(2 * xi) * cos(yj) for xi in x32, yj in y32]
+        d3_32 = Float32[sin(2 * xi) * cos(yj) * (1 + zk) for xi in x32, yj in y32, zk in z32]
+        # Float64 reference (build interpolant in Float64 to compare against)
+        x64, y64, z64 = Float64.(x32), Float64.(y32), Float64.(z32)
+        d2_64 = Float64.(d2_32)
+        d3_64 = Float64.(d3_32)
+        q2_32 = (1.7f0, 0.4f0)
+        q3_32 = (1.7f0, 0.4f0, 0.6f0)
+        q2_64 = (1.7, 0.4)
+        q3_64 = (1.7, 0.4, 0.6)
+
+        for (m_label, methods_2d, methods_3d) in (
+                ("PCHIP",    (PchipInterp(),    PchipInterp()),    (PchipInterp(),    PchipInterp(),    PchipInterp())),
+                ("Cardinal", (CardinalInterp(), CardinalInterp()), (CardinalInterp(), CardinalInterp(), CardinalInterp())),
+                ("Akima",    (AkimaInterp(),    AkimaInterp()),    (AkimaInterp(),    AkimaInterp(),    AkimaInterp())),
+            )
+            # 2D — Float32 eltype + Float64 reference comparison
+            itp32_2d = interp((x32, y32), d2_32; method = methods_2d, coeffs = OnTheFly())
+            itp64_2d = interp((x64, y64), d2_64; method = methods_2d, coeffs = OnTheFly())
+            v32 = itp32_2d(q2_32)
+            v64 = itp64_2d(q2_64)
+            @test v32 isa Float32
+            @test Float64(v32) ≈ v64 atol = 1.0f-5
+
+            # 3D — Float32 eltype + Float64 reference comparison
+            itp32_3d = interp((x32, y32, z32), d3_32; method = methods_3d, coeffs = OnTheFly())
+            itp64_3d = interp((x64, y64, z64), d3_64; method = methods_3d, coeffs = OnTheFly())
+            v3_32 = itp32_3d(q3_32)
+            v3_64 = itp64_3d(q3_64)
+            @test v3_32 isa Float32
+            @test Float64(v3_32) ≈ v3_64 atol = 1.0f-5
+        end
+
+        # Zero-alloc check (function-barrier pattern: setup + warmup + @allocated
+        # all inside one function — required because @testset wraps body in a
+        # try/catch that boxes locals. See test_cubic_nd.jl for the same pattern.)
+        function _alloc_f32_2d(methods)
+            x = collect(range(0.0f0, Float32(2π), 16))
+            y = collect(range(-1.0f0, 1.0f0, 13))
+            data = Float32[sin(2 * xi) * cos(yj) for xi in x, yj in y]
+            itp = interp((x, y), data; method = methods, coeffs = OnTheFly())
+            q = (1.7f0, 0.4f0)
+            itp(q); itp(q)  # warmup
+            return @allocated itp(q)
+        end
+        function _alloc_f32_3d(methods)
+            x = collect(range(0.0f0, Float32(2π), 16))
+            y = collect(range(-1.0f0, 1.0f0, 13))
+            z = collect(range(0.0f0, 1.0f0, 9))
+            data = Float32[sin(2 * xi) * cos(yj) * (1 + zk) for xi in x, yj in y, zk in z]
+            itp = interp((x, y, z), data; method = methods, coeffs = OnTheFly())
+            q = (1.7f0, 0.4f0, 0.6f0)
+            itp(q); itp(q)  # warmup
+            return @allocated itp(q)
+        end
+
+        @test _alloc_f32_2d((PchipInterp(),    PchipInterp()))    <= ALLOC_THRESHOLD
+        @test _alloc_f32_2d((CardinalInterp(), CardinalInterp())) <= ALLOC_THRESHOLD
+        @test _alloc_f32_2d((AkimaInterp(),    AkimaInterp()))    <= ALLOC_THRESHOLD
+        @test _alloc_f32_3d((PchipInterp(),    PchipInterp(),    PchipInterp()))    <= ALLOC_THRESHOLD
+        @test _alloc_f32_3d((CardinalInterp(), CardinalInterp(), CardinalInterp())) <= ALLOC_THRESHOLD
+        @test _alloc_f32_3d((AkimaInterp(),    AkimaInterp(),    AkimaInterp()))    <= ALLOC_THRESHOLD
     end
 
     # ========================================

--- a/test/test_hermite_onthefly.jl
+++ b/test/test_hermite_onthefly.jl
@@ -4,7 +4,7 @@ using FastInterpolations: _local_slope, PchipSlopes, CardinalSlopes, AkimaSlopes
     _pchip_slopes!, _cardinal_slopes!, _akima_slopes!,
     _resolve_coeffs, _deriv_size, _is_deriv_method,
     _pchip_interp_onthefly, _akima_interp_onthefly, _cardinal_interp_onthefly,
-    _adjoint_func, _throw_onthefly_unsupported
+    _adjoint_func
 
 @testset "Hermite OnTheFly" begin
 
@@ -682,17 +682,193 @@ using FastInterpolations: _local_slope, PchipSlopes, CardinalSlopes, AkimaSlopes
     end
 
     # ========================================
-    # 21. Coverage: _throw_onthefly_unsupported
+    # 21. OnTheFly integrate — equivalence with PreCompute
     # ========================================
-    @testset "Coverage: _throw_onthefly_unsupported" begin
-        # Direct call
-        @test_throws ArgumentError _throw_onthefly_unsupported("integrate")
+    # Sliding-window OnTheFly integrate (bounded, full-domain, cumulative)
+    # must produce numerically equivalent results to the PreCompute path on
+    # the same (x, y) data. Both paths share `_hermite_integral_kernel_1d`;
+    # the only difference is how slopes are materialized (bulk vector vs
+    # per-cell `_local_slope`), so differences should be at the ULP level.
+    @testset "OnTheFly integrate — equivalence with PreCompute" begin
+        x = collect(range(0.0, 2π, 25))
+        y = sin.(x)
 
-        # Via integrate on OnTheFly interpolant
-        x = range(0.0, 2π, 20)
-        y = sin.(collect(x))
-        itp_otf = pchip_interp(x, y; coeffs = OnTheFly())
-        @test_throws ArgumentError integrate(itp_otf, 0.0, 1.0)
+        @testset "$label — bounded / full-domain / cumulative" for (label, maker) in [
+                ("PCHIP", (xx, yy; coeffs) -> pchip_interp(xx, yy; coeffs = coeffs)),
+                ("Cardinal", (xx, yy; coeffs) -> cardinal_interp(xx, yy; coeffs = coeffs)),
+                ("Akima", (xx, yy; coeffs) -> akima_interp(xx, yy; coeffs = coeffs)),
+            ]
+            itp_pre = maker(x, y; coeffs = PreCompute())
+            itp_otf = maker(x, y; coeffs = OnTheFly())
+
+            # Bounded — interior, both-ends, single-cell, reversed
+            for (a, b) in [(0.5, 4.0), (x[1], x[end]), (1.3, 1.4), (4.0, 0.5)]
+                ref = integrate(itp_pre, a, b)
+                got = integrate(itp_otf, a, b)
+                @test got ≈ ref rtol = 1.0e-12 atol = 1.0e-14
+            end
+
+            # Full-domain integrate(itp)
+            @test integrate(itp_otf) ≈ integrate(itp_pre) rtol = 1.0e-12 atol = 1.0e-14
+
+            # Cumulative_integrate(itp)
+            cum_pre = cumulative_integrate(itp_pre)
+            cum_otf = cumulative_integrate(itp_otf)
+            @test cum_otf ≈ cum_pre rtol = 1.0e-12 atol = 1.0e-14
+            @test length(cum_otf) == length(x)
+            @test cum_otf[1] == 0
+        end
+
+        # hermite_interp with user slopes — PreCompute only (no OnTheFly for user slopes);
+        # include a smoke test to guard against accidental regression of the user-slope path
+        # when we added the Hermite-family override on integrate.
+        @testset "hermite_interp user slopes still works" begin
+            dy = cos.(x)
+            itp_usr = hermite_interp(x, y, dy)
+            @test integrate(itp_usr, 0.0, π) ≈ 2.0 atol = 1.0e-3   # ∫₀^π sin x dx = 2
+            @test integrate(itp_usr) isa Real
+            @test length(cumulative_integrate(itp_usr)) == length(x)
+        end
+    end
+
+    # ========================================
+    # 21b. OnTheFly integrate — extrap correctness
+    # ========================================
+    # All five extraps must match PreCompute. WrapExtrap is the most subtle
+    # because `_dispatch_extrap_integrate_1d` calls `in_domain_fn` multiple
+    # times for wrap-around cases; each call must start fresh sliding state.
+    @testset "OnTheFly integrate — extrap equivalence" begin
+        x = collect(range(0.0, 2π, 30))
+        y = sin.(x)
+
+        # In-domain queries — all extraps (NoExtrap included)
+        in_domain_bounds = [
+            (0.5, 4.0),
+            (x[1], x[end]),
+            (1.3, 1.4),
+            (4.0, 0.5),   # reversed
+        ]
+
+        # Out-of-domain queries — only for extraps that can handle them
+        out_of_domain_bounds = [
+            (-1.0, 3.0),          # left-extrapolated start
+            (5.0, 2π + 2.0),      # right-extrapolated end
+            (-1.0, 2π + 2.0),     # both ends extrapolated
+            (-5.0, 2π + 5.0),     # spans multiple periods (WrapExtrap)
+        ]
+
+        for (ename, extrap_obj, bounds_list) in [
+                ("NoExtrap", NoExtrap(), in_domain_bounds),
+                ("ClampExtrap", ClampExtrap(), vcat(in_domain_bounds, out_of_domain_bounds)),
+                ("FillExtrap", FillExtrap(0.5), vcat(in_domain_bounds, out_of_domain_bounds)),
+                ("ExtendExtrap", ExtendExtrap(), in_domain_bounds),
+                ("WrapExtrap", WrapExtrap(), vcat(in_domain_bounds, out_of_domain_bounds)),
+            ]
+            @testset "$ename × PCHIP" begin
+                itp_pre = pchip_interp(x, y; coeffs = PreCompute(), extrap = extrap_obj)
+                itp_otf = pchip_interp(x, y; coeffs = OnTheFly(), extrap = extrap_obj)
+
+                for (a, b) in bounds_list
+                    ref = integrate(itp_pre, a, b)
+                    got = integrate(itp_otf, a, b)
+                    @test got ≈ ref rtol = 1.0e-12 atol = 1.0e-14
+                end
+            end
+        end
+    end
+
+    # ========================================
+    # 21c. OnTheFly integrate — zero allocation after warmup
+    # ========================================
+    # Sliding-window path has no pool, no heap allocation — `dy_L`, `dy_R`
+    # are scalar locals. This test pins the "memory O(1)" contract.
+    #
+    # Uses `ALLOC_THRESHOLD` (defined in runtests.jl) to tolerate small LTS
+    # boxing overhead (Julia 1.10: ~240 B; Julia 1.12+: 0 B). See
+    # `test_cubic_nd.jl` for the same pattern on ND alloc tests.
+    @testset "OnTheFly integrate — zero alloc" begin
+        x = collect(range(0.0, 2π, 50))
+        y = sin.(x)
+
+        function _alloc_bounded(maker)
+            itp = maker(x, y; coeffs = OnTheFly())
+            integrate(itp, 0.5, 4.0)   # warmup
+            return @allocated integrate(itp, 0.5, 4.0)
+        end
+        function _alloc_fulldomain(maker)
+            itp = maker(x, y; coeffs = OnTheFly())
+            integrate(itp)             # warmup
+            return @allocated integrate(itp)
+        end
+
+        # Bounded integrate — sliding window, strictly no pool touches
+        @test _alloc_bounded((xx, yy; coeffs) -> pchip_interp(xx, yy; coeffs = coeffs)) <= ALLOC_THRESHOLD
+        @test _alloc_bounded((xx, yy; coeffs) -> cardinal_interp(xx, yy; coeffs = coeffs)) <= ALLOC_THRESHOLD
+        @test _alloc_bounded((xx, yy; coeffs) -> akima_interp(xx, yy; coeffs = coeffs)) <= ALLOC_THRESHOLD
+
+        # Full-domain integrate — same sliding window over all cells
+        @test _alloc_fulldomain((xx, yy; coeffs) -> pchip_interp(xx, yy; coeffs = coeffs)) <= ALLOC_THRESHOLD
+        @test _alloc_fulldomain((xx, yy; coeffs) -> cardinal_interp(xx, yy; coeffs = coeffs)) <= ALLOC_THRESHOLD
+        @test _alloc_fulldomain((xx, yy; coeffs) -> akima_interp(xx, yy; coeffs = coeffs)) <= ALLOC_THRESHOLD
+
+        # cumulative_integrate — allocates the length-n result vector (unavoidable),
+        # so we compare against `n * sizeof(Tout) + small overhead`.
+        # The important invariant is that NO extra pool/scratch beyond the return vector.
+        function _alloc_cumulative_bounded(maker)
+            itp = maker(x, y; coeffs = OnTheFly())
+            cumulative_integrate(itp)  # warmup
+            return @allocated cumulative_integrate(itp)
+        end
+        expected_result_bytes = length(x) * sizeof(Float64)   # result Vector{Float64}
+        # Result array data + Julia Array header (~80 B on x86_64) + LTS threshold slack
+        cumulative_slack = expected_result_bytes + 128 + ALLOC_THRESHOLD
+        @test _alloc_cumulative_bounded((xx, yy; coeffs) -> pchip_interp(xx, yy; coeffs = coeffs)) <= cumulative_slack
+        @test _alloc_cumulative_bounded((xx, yy; coeffs) -> cardinal_interp(xx, yy; coeffs = coeffs)) <= cumulative_slack
+        @test _alloc_cumulative_bounded((xx, yy; coeffs) -> akima_interp(xx, yy; coeffs = coeffs)) <= cumulative_slack
+
+        # ── cumulative_integrate! in-place — TRUE zero-alloc ──
+        # User-supplied buffer means no result vector allocation; sliding window
+        # keeps dy state on the stack. This is the opt-in path for users that
+        # want to drive repeated cumulative integrations with no GC pressure.
+        function _alloc_cumulative_inplace(maker)
+            itp = maker(x, y; coeffs = OnTheFly())
+            out = similar(x)
+            cumulative_integrate!(out, itp)  # warmup
+            return @allocated cumulative_integrate!(out, itp)
+        end
+        @test _alloc_cumulative_inplace((xx, yy; coeffs) -> pchip_interp(xx, yy; coeffs = coeffs)) <= ALLOC_THRESHOLD
+        @test _alloc_cumulative_inplace((xx, yy; coeffs) -> cardinal_interp(xx, yy; coeffs = coeffs)) <= ALLOC_THRESHOLD
+        @test _alloc_cumulative_inplace((xx, yy; coeffs) -> akima_interp(xx, yy; coeffs = coeffs)) <= ALLOC_THRESHOLD
+
+        # Correctness: in-place result must equal allocating variant (bit-equal for
+        # PCHIP/Cardinal, ≤ few ULPs for Akima — but same code path, so bit-equal here).
+        let itp = pchip_interp(x, y; coeffs = OnTheFly())
+            out = similar(x)
+            cumulative_integrate!(out, itp)
+            @test out == cumulative_integrate(itp)
+        end
+        let itp = cardinal_interp(x, y; coeffs = OnTheFly())
+            out = similar(x)
+            cumulative_integrate!(out, itp)
+            @test out == cumulative_integrate(itp)
+        end
+        let itp = akima_interp(x, y; coeffs = OnTheFly())
+            out = similar(x)
+            cumulative_integrate!(out, itp)
+            @test out == cumulative_integrate(itp)
+        end
+        # PreCompute path also accepts the ! variant via the shared entry point.
+        let itp = pchip_interp(x, y; coeffs = PreCompute())
+            out = similar(x)
+            cumulative_integrate!(out, itp)
+            @test out == cumulative_integrate(itp)
+        end
+
+        # Length-mismatch error path
+        let itp = pchip_interp(x, y; coeffs = OnTheFly())
+            bad = similar(x, length(x) - 1)
+            @test_throws DimensionMismatch cumulative_integrate!(bad, itp)
+        end
     end
 
     # ========================================

--- a/test/test_hermite_onthefly.jl
+++ b/test/test_hermite_onthefly.jl
@@ -113,15 +113,21 @@ using FastInterpolations: _local_slope, PchipSlopes, CardinalSlopes, AkimaSlopes
     # between the PreCompute and OnTheFly kernels — even one rounded away on
     # a single function — will trip this test before release.
     #
-    # Tolerance: strict `1e-14` because both strategies use the same cubic
-    # Hermite kernel (`_hermite_integral_kernel_1d` / `_hermite_eval_kernel`),
-    # just fed from different slope sources. Their floating-point results
-    # should agree to the last few ULPs.
+    # Tolerance: tight but not bit-equal. Both strategies use the same cubic
+    # Hermite kernels (`_hermite_integral_kernel_1d` / `_hermite_eval_kernel`),
+    # but the slope source differs (precomputed Vector lookup vs per-cell
+    # `_local_slope` recomputation), and the resulting SSA order can disagree
+    # by 1-2 ULPs after lowering. The atol=1e-13/1e-12 below leaves ~5 ULPs of
+    # headroom, strict enough to catch real divergence and loose enough to
+    # survive Julia/LLVM version drift.
     @testset "Sweep: OnTheFly ≈ PreCompute (values + 1st derivative)" begin
-        # Grid setups — uniform Range + non-uniform Vector
+        # Grid setups — keep uniform grids as `range(...)` (NOT collected!) so
+        # they exercise the AbstractRange / ScalarSpacing / direct-stride
+        # search path, distinct from the Vector / VectorSpacing / binary-search
+        # path that the non-uniform case covers.
         grids = (
-            ("uniform Range, n=30", collect(range(0.0, 2π, 30))),
-            ("uniform Range, n=15", collect(range(-1.0, 3.0, 15))),
+            ("uniform Range, n=30", range(0.0, 2π, 30)),
+            ("uniform Range, n=15", range(-1.0, 3.0, 15)),
             ("non-uniform Vector, n=25", sort!(vcat(0.0, 2π, 0.02 .+ (2π - 0.04) .* sort!(rand(MersenneTwister(7), 23))))),
         )
         # Function shapes — different curvature profiles catch different bug classes

--- a/test/test_hermite_onthefly.jl
+++ b/test/test_hermite_onthefly.jl
@@ -120,23 +120,23 @@ using FastInterpolations: _local_slope, PchipSlopes, CardinalSlopes, AkimaSlopes
     @testset "Sweep: OnTheFly ≈ PreCompute (values + 1st derivative)" begin
         # Grid setups — uniform Range + non-uniform Vector
         grids = (
-            ("uniform Range, n=30",      collect(range(0.0, 2π, 30))),
-            ("uniform Range, n=15",      collect(range(-1.0, 3.0, 15))),
+            ("uniform Range, n=30", collect(range(0.0, 2π, 30))),
+            ("uniform Range, n=15", collect(range(-1.0, 3.0, 15))),
             ("non-uniform Vector, n=25", sort!(vcat(0.0, 2π, 0.02 .+ (2π - 0.04) .* sort!(rand(MersenneTwister(7), 23))))),
         )
         # Function shapes — different curvature profiles catch different bug classes
         functions = (
-            ("sin",        x -> sin(3x)),
+            ("sin", x -> sin(3x)),
             ("polynomial", x -> 0.3x^3 - 1.2x^2 + 0.5x - 0.7),
-            ("gaussian",   x -> exp(-(x - 1.5)^2)),
+            ("gaussian", x -> exp(-(x - 1.5)^2)),
         )
         # Methods
         makers = (
-            ("pchip",               (xx, yy; coeffs) -> pchip_interp(xx, yy; coeffs = coeffs)),
-            ("cardinal tension=0",  (xx, yy; coeffs) -> cardinal_interp(xx, yy; tension = 0.0, coeffs = coeffs)),
-            ("cardinal tension=0.3",(xx, yy; coeffs) -> cardinal_interp(xx, yy; tension = 0.3, coeffs = coeffs)),
-            ("cardinal tension=0.7",(xx, yy; coeffs) -> cardinal_interp(xx, yy; tension = 0.7, coeffs = coeffs)),
-            ("akima",               (xx, yy; coeffs) -> akima_interp(xx, yy; coeffs = coeffs)),
+            ("pchip", (xx, yy; coeffs) -> pchip_interp(xx, yy; coeffs = coeffs)),
+            ("cardinal tension=0", (xx, yy; coeffs) -> cardinal_interp(xx, yy; tension = 0.0, coeffs = coeffs)),
+            ("cardinal tension=0.3", (xx, yy; coeffs) -> cardinal_interp(xx, yy; tension = 0.3, coeffs = coeffs)),
+            ("cardinal tension=0.7", (xx, yy; coeffs) -> cardinal_interp(xx, yy; tension = 0.7, coeffs = coeffs)),
+            ("akima", (xx, yy; coeffs) -> akima_interp(xx, yy; coeffs = coeffs)),
         )
 
         for (g_label, x) in grids, (f_label, f) in functions, (m_label, maker) in makers
@@ -679,9 +679,9 @@ using FastInterpolations: _local_slope, PchipSlopes, CardinalSlopes, AkimaSlopes
         q3_64 = (1.7, 0.4, 0.6)
 
         for (m_label, methods_2d, methods_3d) in (
-                ("PCHIP",    (PchipInterp(),    PchipInterp()),    (PchipInterp(),    PchipInterp(),    PchipInterp())),
+                ("PCHIP", (PchipInterp(), PchipInterp()), (PchipInterp(), PchipInterp(), PchipInterp())),
                 ("Cardinal", (CardinalInterp(), CardinalInterp()), (CardinalInterp(), CardinalInterp(), CardinalInterp())),
-                ("Akima",    (AkimaInterp(),    AkimaInterp()),    (AkimaInterp(),    AkimaInterp(),    AkimaInterp())),
+                ("Akima", (AkimaInterp(), AkimaInterp()), (AkimaInterp(), AkimaInterp(), AkimaInterp())),
             )
             # 2D — Float32 eltype + Float64 reference comparison
             itp32_2d = interp((x32, y32), d2_32; method = methods_2d, coeffs = OnTheFly())
@@ -723,12 +723,12 @@ using FastInterpolations: _local_slope, PchipSlopes, CardinalSlopes, AkimaSlopes
             return @allocated itp(q)
         end
 
-        @test _alloc_f32_2d((PchipInterp(),    PchipInterp()))    <= ALLOC_THRESHOLD
+        @test _alloc_f32_2d((PchipInterp(), PchipInterp())) <= ALLOC_THRESHOLD
         @test _alloc_f32_2d((CardinalInterp(), CardinalInterp())) <= ALLOC_THRESHOLD
-        @test _alloc_f32_2d((AkimaInterp(),    AkimaInterp()))    <= ALLOC_THRESHOLD
-        @test _alloc_f32_3d((PchipInterp(),    PchipInterp(),    PchipInterp()))    <= ALLOC_THRESHOLD
+        @test _alloc_f32_2d((AkimaInterp(), AkimaInterp())) <= ALLOC_THRESHOLD
+        @test _alloc_f32_3d((PchipInterp(), PchipInterp(), PchipInterp())) <= ALLOC_THRESHOLD
         @test _alloc_f32_3d((CardinalInterp(), CardinalInterp(), CardinalInterp())) <= ALLOC_THRESHOLD
-        @test _alloc_f32_3d((AkimaInterp(),    AkimaInterp(),    AkimaInterp()))    <= ALLOC_THRESHOLD
+        @test _alloc_f32_3d((AkimaInterp(), AkimaInterp(), AkimaInterp())) <= ALLOC_THRESHOLD
     end
 
     # ========================================

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -1244,9 +1244,9 @@
         data = [sin(xi) * cos(yj) for xi in x, yj in y]
 
         for (method_pair, expected) in (
-                ((PchipInterp(), PchipInterp()),       "PCHIP"),
+                ((PchipInterp(), PchipInterp()), "PCHIP"),
                 ((CardinalInterp(), CardinalInterp()), "Cardinal"),
-                ((AkimaInterp(), AkimaInterp()),       "Akima"),
+                ((AkimaInterp(), AkimaInterp()), "Akima"),
             )
             itp = interp((x, y), data; method = method_pair, coeffs = OnTheFly())
             s = sprint(show, MIME("text/plain"), itp)
@@ -1260,9 +1260,9 @@
     # yet wired through HeteroInterpolantND, so a direct call is the only way
     # to pin its display string today.
     @testset "Direct test of _short_method_name (Hermite family)" begin
-        @test FastInterpolations._short_method_name(PchipInterp())        == "PCHIP"
-        @test FastInterpolations._short_method_name(CardinalInterp())     == "Cardinal"
-        @test FastInterpolations._short_method_name(AkimaInterp())        == "Akima"
+        @test FastInterpolations._short_method_name(PchipInterp()) == "PCHIP"
+        @test FastInterpolations._short_method_name(CardinalInterp()) == "Cardinal"
+        @test FastInterpolations._short_method_name(AkimaInterp()) == "Akima"
         @test FastInterpolations._short_method_name(CubicHermiteInterp()) == "CubicHermite"
     end
 end

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -1233,4 +1233,36 @@
         @test occursin("3 points", verbose_str)
         @test occursin("BC:", verbose_str)
     end
+
+    # Covers the _short_method_name dispatch for each local Hermite method when
+    # rendered inside a HeteroInterpolantND. Keeps the show path exercised and
+    # pins the display strings so user-facing output is stable for the three
+    # method types currently wired through the HeteroInterpolantND pipeline.
+    @testset "HeteroInterpolantND show — local Hermite methods" begin
+        x = collect(range(0.0, 1.0, 8))
+        y = collect(range(0.0, 2.0, 9))
+        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+
+        for (method_pair, expected) in (
+                ((PchipInterp(), PchipInterp()),       "PCHIP"),
+                ((CardinalInterp(), CardinalInterp()), "Cardinal"),
+                ((AkimaInterp(), AkimaInterp()),       "Akima"),
+            )
+            itp = interp((x, y), data; method = method_pair, coeffs = OnTheFly())
+            s = sprint(show, MIME("text/plain"), itp)
+            @test occursin(expected, s)
+        end
+    end
+
+    # Direct unit tests of _short_method_name for every local Hermite method
+    # type, mirroring the existing "Direct test of _short_bc_name_nd" /
+    # "Direct test of _short_side_name_nd" patterns. CubicHermiteInterp isn't
+    # yet wired through HeteroInterpolantND, so a direct call is the only way
+    # to pin its display string today.
+    @testset "Direct test of _short_method_name (Hermite family)" begin
+        @test FastInterpolations._short_method_name(PchipInterp())        == "PCHIP"
+        @test FastInterpolations._short_method_name(CardinalInterp())     == "Cardinal"
+        @test FastInterpolations._short_method_name(AkimaInterp())        == "Akima"
+        @test FastInterpolations._short_method_name(CubicHermiteInterp()) == "CubicHermite"
+    end
 end


### PR DESCRIPTION
## Summary

Closes the last user-visible API gaps in the local Hermite 1D family (PCHIP / Cardinal / Akima) before the next release. `integrate` and `cumulative_integrate` now work uniformly across both coefficient strategies, a new `cumulative_integrate!` in-place variant gives users a true zero-alloc path, and unsupported Hermite ND operations now fail with actionable error messages instead of cryptic `MethodError`s.

## Key Changes

- **`integrate` / `cumulative_integrate` now support `coeffs=OnTheFly()`** for PCHIP/Cardinal/Akima. Previously threw `ArgumentError` because the integrate path was hard-wired to read `itp.dy::Vector`. The new sliding-window kernel keeps slope state on the stack (two scalars `dy_L`/`dy_R` rolled per cell), so OnTheFly integration is zero-alloc end-to-end.

- **New exported `cumulative_integrate!(out, itp)`** — in-place variant that overwrites a caller-supplied buffer. The allocating `cumulative_integrate(itp)` is now a thin allocate-and-forward wrapper, mirroring Julia's `sort` / `sort!` and `copy` / `copyto!` patterns. Throws `DimensionMismatch` if `length(out) != length(grid)`.

- **Unified Hermite OnTheFly into the generic `_full_cell_fn` trait pipeline.** `_full_cell_fn(itp::AbstractHermiteInterpolant1D)` now dispatches internally on `itp.dy` (`AbstractVector` → PreCompute, `AbstractSlopeMethod` → OnTheFly), so all three full-domain entry points (`integrate`, `cumulative_integrate`, `cumulative_integrate!`) join the generic pipeline. Removed ~100 lines of duplicated Hermite-specific kernels and brought `integrate_fulldomain.jl` from 81% to 100% file coverage. Bounded `integrate(itp, a, b)` keeps its dedicated sliding-window helper for now — unifying it would need a parallel `_partial_cell_fn` trait across all eight 1D types.

- **Friendly errors for unsupported Hermite ND ops.** `nodal_partials`, `integrate`, and Zygote/Enzyme adjoints on `HeteroInterpolantND` now throw `ArgumentError` with concrete workarounds (use a homogeneous specialized ND type, or integrate per-fiber) instead of cryptic `MethodError`s.

- **Perf cleanup**: replaced 8 `inv_h = inv(h)` hardware divisions with `_get_inv_h(spacing, i)` cached reads on the Hermite 1D integrate hot path — cached field for `ScalarSpacing`, indexed load for `VectorSpacing`. Mirrors what the ND Cubic/Quadratic paths already do, saves ~20 cycles per cell.

- **Grid accessor normalization** — Constant / Constant Series integrate paths now use `_grid_1d(itp)` like the rest of the codebase.
