### PR TITLE
(feat): Hermite family duck-typed grid support

### DIFF
--- a/src/akima/akima_adjoint.jl
+++ b/src/akima/akima_adjoint.jl
@@ -201,8 +201,8 @@ end
     if n == 2
         @inbounds begin
             inv_h = one(Tg) / (x[2] - x[1])
-            c1 = Tv(inv_h) * dy_bar[1]
-            c2 = Tv(inv_h) * dy_bar[2]
+            c1 = inv_h * dy_bar[1]
+            c2 = inv_h * dy_bar[2]
             f_bar[1] -= c1 + c2
             f_bar[2] += c1 + c2
         end
@@ -216,21 +216,21 @@ end
             inv_h2 = one(Tg) / (x[3] - x[2])
 
             # dy[1] = m[1]: ∂/∂y[1] = -1/h1, ∂/∂y[2] = +1/h1
-            c1 = Tv(inv_h1) * dy_bar[1]
+            c1 = inv_h1 * dy_bar[1]
             f_bar[1] -= c1
             f_bar[2] += c1
 
             # dy[2] = (m[1]+m[2])/2: ∂/∂m[1] = 1/2, ∂/∂m[2] = 1/2
             db2 = dy_bar[2]
-            c2a = Tv(inv_h1 / 2) * db2
+            c2a = (inv_h1 / 2) * db2
             f_bar[1] -= c2a
             f_bar[2] += c2a
-            c2b = Tv(inv_h2 / 2) * db2
+            c2b = (inv_h2 / 2) * db2
             f_bar[2] -= c2b
             f_bar[3] += c2b
 
             # dy[3] = m[2]: ∂/∂y[2] = -1/h2, ∂/∂y[3] = +1/h2
-            c3 = Tv(inv_h2) * dy_bar[3]
+            c3 = inv_h2 * dy_bar[3]
             f_bar[2] -= c3
             f_bar[3] += c3
         end
@@ -239,9 +239,9 @@ end
 
     # General case: n ≥ 4
     # Recompute secants on the fly (same approach as forward pass)
-    @inbounds m1 = Tv((y[2] - y[1]) / (x[2] - x[1]))
-    @inbounds m2 = Tv((y[3] - y[2]) / (x[3] - x[2]))
-    @inbounds m3 = Tv((y[4] - y[3]) / (x[4] - x[3]))
+    @inbounds m1 = (y[2] - y[1]) / (x[2] - x[1])
+    @inbounds m2 = (y[3] - y[2]) / (x[3] - x[2])
+    @inbounds m3 = (y[4] - y[3]) / (x[4] - x[3])
 
     # Virtual secants for left boundary
     m_neg1 = 3 * m1 - 2 * m2
@@ -256,8 +256,8 @@ end
         if wsum == zero(wsum)
             # Fallback: dy = (m_0 + m1)/2 → ∂/∂m_0 = 1/2, ∂/∂m1 = 1/2
             db = dy_bar[1]
-            _akima_scatter_secant_adjoint!(f_bar, Tv(1 // 2) * db, 0, x, n)
-            _akima_scatter_secant_adjoint!(f_bar, Tv(1 // 2) * db, 1, x, n)
+            _akima_scatter_secant_adjoint!(f_bar, db / 2, 0, x, n)
+            _akima_scatter_secant_adjoint!(f_bar, db / 2, 1, x, n)
         else
             dy_k = (w1 * m_0 + w2 * m1) / wsum
             s1 = sign(m2 - m1)
@@ -280,8 +280,8 @@ end
         wsum = w1 + w2
         if wsum == zero(wsum)
             db = dy_bar[2]
-            _akima_scatter_secant_adjoint!(f_bar, Tv(1 // 2) * db, 1, x, n)
-            _akima_scatter_secant_adjoint!(f_bar, Tv(1 // 2) * db, 2, x, n)
+            _akima_scatter_secant_adjoint!(f_bar, db / 2, 1, x, n)
+            _akima_scatter_secant_adjoint!(f_bar, db / 2, 2, x, n)
         else
             dy_k = (w1 * m1 + w2 * m2) / wsum
             s1 = sign(m3 - m2)
@@ -304,14 +304,14 @@ end
     m_k = m3
 
     @inbounds for k in 3:(n - 2)
-        m_kp1 = Tv((y[k + 2] - y[k + 1]) / (x[k + 2] - x[k + 1]))
+        m_kp1 = (y[k + 2] - y[k + 1]) / (x[k + 2] - x[k + 1])
         w1 = abs(m_kp1 - m_k)
         w2 = abs(m_km1 - m_km2)
         wsum = w1 + w2
         if wsum == zero(wsum)
             db = dy_bar[k]
-            _akima_scatter_secant_adjoint!(f_bar, Tv(1 // 2) * db, k - 1, x, n)
-            _akima_scatter_secant_adjoint!(f_bar, Tv(1 // 2) * db, k, x, n)
+            _akima_scatter_secant_adjoint!(f_bar, db / 2, k - 1, x, n)
+            _akima_scatter_secant_adjoint!(f_bar, db / 2, k, x, n)
         else
             dy_kv = (w1 * m_km1 + w2 * m_k) / wsum
             s1 = sign(m_kp1 - m_k)
@@ -344,8 +344,8 @@ end
         wsum = w1 + w2
         if wsum == zero(wsum)
             db = dy_bar[n - 1]
-            _akima_scatter_secant_adjoint!(f_bar, Tv(1 // 2) * db, n - 2, x, n)
-            _akima_scatter_secant_adjoint!(f_bar, Tv(1 // 2) * db, n - 1, x, n)
+            _akima_scatter_secant_adjoint!(f_bar, db / 2, n - 2, x, n)
+            _akima_scatter_secant_adjoint!(f_bar, db / 2, n - 1, x, n)
         else
             dy_kv = (w1 * m_km1 + w2 * m_k) / wsum
             s1 = sign(m_np1 - m_k)
@@ -368,8 +368,8 @@ end
         wsum = w1 + w2
         if wsum == zero(wsum)
             db = dy_bar[n]
-            _akima_scatter_secant_adjoint!(f_bar, Tv(1 // 2) * db, n - 1, x, n)
-            _akima_scatter_secant_adjoint!(f_bar, Tv(1 // 2) * db, n, x, n)
+            _akima_scatter_secant_adjoint!(f_bar, db / 2, n - 1, x, n)
+            _akima_scatter_secant_adjoint!(f_bar, db / 2, n, x, n)
         else
             dy_kv = (w1 * m_k + w2 * m_np1) / wsum
             s1 = sign(m_np2 - m_np1)
@@ -482,7 +482,7 @@ function akima_adjoint(
     spacing = _create_spacing(x_p)
     anchors = _bake_hermite_adjoint_anchors(x_p, spacing, xq_p, extrap)
 
-    # Promote y to float: slope adjoint computes fractional derivatives (Tv(0.5) would fail for Int)
+    # Promote y to float: slope adjoint computes fractional derivatives (Int division loses precision)
     _, y_p = _promote_itp_inputs(x, y)
     Tv = eltype(y_p)
     return AkimaAdjoint1D{Tg, Tv, typeof(extrap)}(

--- a/src/akima/akima_adjoint.jl
+++ b/src/akima/akima_adjoint.jl
@@ -45,7 +45,7 @@ operating point. The dot-product identity holds exactly at that `y`:
     dot(akima_interp(x, y).(xq), y_bar) == dot(y, adj(y_bar))
 
 # Type Parameters
-- `Tg`: Grid float type (Float32 or Float64)
+- `Tg`: Grid type — normally Float32/Float64, unconstrained for duck-typed grids (e.g. ForwardDiff.Dual)
 - `Tv`: Value type (must support sign, abs, zero, division)
 - `EP`: Extrapolation policy type
 

--- a/src/akima/akima_adjoint.jl
+++ b/src/akima/akima_adjoint.jl
@@ -58,7 +58,7 @@ f_bar = adj(y_bar; deriv=DerivOp(1))    # derivative adjoint
 adj(f_bar, y_bar)                       # in-place
 ```
 """
-struct AkimaAdjoint1D{Tg <: AbstractFloat, Tv <: Real, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
+struct AkimaAdjoint1D{Tg, Tv <: Real, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
     anchors::Vector{_HermiteAdjointAnchor1D{Tg}}
     grid::Vector{Tg}       # Grid points (needed for slope adjoint secant computation)
     data::Vector{Tv}       # y values (needed for slope weight conditions)
@@ -462,7 +462,8 @@ function akima_adjoint(
     )
     Tg = _promote_grid_float(eltype(x), eltype(x_query))
     x_p = _to_float(x, Tg)
-    xq_p = _to_float(x_query, Tg)
+    Tq_float = Tg <: AbstractFloat ? Tg : float(eltype(x_query))
+    xq_p = _to_float(x_query, Tq_float)
 
     length(x_p) >= 2 || _throw_adjoint_grid_too_small(length(x_p))
 
@@ -471,8 +472,8 @@ function akima_adjoint(
         x_lo, x_hi = first(x_p), last(x_p)
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
-            (x_lo <= xq_i <= x_hi) || throw(
-                DomainError(xq_i, "query point outside domain [$x_lo, $x_hi]")
+            (_extract_primal(x_lo) <= xq_i <= _extract_primal(x_hi)) || throw(
+                DomainError(xq_i, "query point outside domain [$(_extract_primal(x_lo)), $(_extract_primal(x_hi))]")
             )
         end
     end

--- a/src/akima/akima_interpolant.jl
+++ b/src/akima/akima_interpolant.jl
@@ -28,14 +28,15 @@ itp(0.5; deriv=DerivOp(1))
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         extrap::AbstractExtrap = NoExtrap(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {TX <: Real, TY}
+    ) where {TX, TY}
     x_p, y_p = _promote_itp_inputs(x, y)
     extrap_p = _promote_extrap(extrap, eltype(y_p))
     resolved = _resolve_coeffs(coeffs)
     if resolved isa OnTheFly
         return AkimaInterpolant1D(x_p, y_p, AkimaSlopes(); extrap = extrap_p, search)
     else
-        dy_p = similar(y_p)
+        Tdy = _output_eltype(eltype(y_p), eltype(x_p))
+        dy_p = Vector{Tdy}(undef, length(y_p))
         _akima_slopes!(dy_p, x_p, y_p)
         return AkimaInterpolant1D(x_p, y_p, dy_p; extrap = extrap_p, search)
     end

--- a/src/akima/akima_oneshot.jl
+++ b/src/akima/akima_oneshot.jl
@@ -18,7 +18,7 @@
         deriv::DerivOp,
         search::AbstractSearchPolicy,
         hint::Union{Nothing, Base.RefValue{Int}}
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     x = _to_float(x, Tg)
     dy = similar!(pool, y)
@@ -37,7 +37,7 @@ end
         deriv::DerivOp,
         search::AbstractSearchPolicy,
         hint::Union{Nothing, Base.RefValue{Int}}
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
@@ -58,7 +58,7 @@ end
         deriv::DerivOp,
         search::AbstractSearchPolicy,
         hint::Union{Nothing, Base.RefValue{Int}}
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
@@ -82,7 +82,7 @@ end
         deriv::DerivOp,
         search::AbstractSearchPolicy,
         hint::Union{Nothing, Base.RefValue{Int}}
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     length(x) >= 2 || throw(ArgumentError("Akima interpolation requires at least 2 points, got $(length(x))"))
     x = _to_float(x, Tg)
@@ -100,7 +100,7 @@ end
         deriv::DerivOp,
         search::AbstractSearchPolicy,
         hint::Union{Nothing, Base.RefValue{Int}}
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     length(x) >= 2 || throw(ArgumentError("Akima interpolation requires at least 2 points, got $(length(x))"))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
@@ -133,7 +133,9 @@ Outlier-robust, C\$^1\$ continuous.
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
+    x, y = _promote_itp_inputs(x, y)
+    Tg_actual = eltype(x)
     resolved = _resolve_coeffs(coeffs, x, xq)
     if resolved isa OnTheFly
         return _akima_interp_onthefly(x, y, xq, extrap, deriv, search, hint)
@@ -150,37 +152,21 @@ In-place Akima interpolation with outlier-robust slopes.
         output::AbstractVector,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg};
+        x_query::AbstractVector{Tq};
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv}
-    resolved = _resolve_coeffs(coeffs, x, x_query)
+    ) where {Tg, Tv, Tq <: Real}
+    x, y = _promote_itp_inputs(x, y)
+    Tg_actual = eltype(x)
+    xq_p = _to_float(x_query, Tg_actual)
+    resolved = _resolve_coeffs(coeffs, x, xq_p)
     if resolved isa OnTheFly
-        return _akima_interp_onthefly!(output, x, y, x_query, extrap, deriv, search, hint)
+        return _akima_interp_onthefly!(output, x, y, xq_p, extrap, deriv, search, hint)
     end
-    return _akima_interp_precompute!(output, x, y, x_query, extrap, deriv, search, hint)
-end
-
-# Range disambiguation for in-place
-@inline function akima_interp!(
-        output::AbstractVector,
-        x::AbstractRange{Tg},
-        y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg};
-        coeffs::AbstractCoeffStrategy = AutoCoeffs(),
-        extrap::AbstractExtrap = NoExtrap(),
-        deriv::DerivOp = EvalValue(),
-        search::AbstractSearchPolicy = AutoSearch(),
-        hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv}
-    resolved = _resolve_coeffs(coeffs, x, x_query)
-    if resolved isa OnTheFly
-        return _akima_interp_onthefly!(output, x, y, x_query, extrap, deriv, search, hint)
-    end
-    return _akima_interp_precompute!(output, x, y, x_query, extrap, deriv, search, hint)
+    return _akima_interp_precompute!(output, x, y, xq_p, extrap, deriv, search, hint)
 end
 
 """
@@ -191,70 +177,19 @@ Akima interpolation at multiple query points. Returns `Vector{Tv}`.
 function akima_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg};
+        x_query::AbstractVector{Tq};
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv}
-    output = Vector{Tv}(undef, length(x_query))
-    akima_interp!(output, x, y, x_query; coeffs = coeffs, extrap = extrap, deriv = deriv, search = search, hint = hint)
+    ) where {Tg, Tv, Tq <: Real}
+    x, y = _promote_itp_inputs(x, y)
+    Tg_actual = eltype(x)
+    xq_p = _to_float(x_query, Tg_actual)
+    Tr = _output_eltype(eltype(y), Tg_actual, Tq)
+    output = Vector{Tr}(undef, length(xq_p))
+    akima_interp!(output, x, y, xq_p; coeffs = coeffs, extrap = extrap, deriv = deriv, search = search, hint = hint)
     return output
 end
 
-# ╔═══════════════════════════════════════════════════════════════════════════╗
-# ║                  GENERIC WRAPPERS — Real type promotion                   ║
-# ╚═══════════════════════════════════════════════════════════════════════════╝
-
-# Scalar — promotes x, y to Float; passes xq directly for AD support
-@inline function akima_interp(
-        x::AbstractVector{TX},
-        y::AbstractVector{TY},
-        xq::Tq;
-        kwargs...
-    ) where {TX <: Real, TY, Tq <: Real}
-    x_p, y_p = _promote_itp_inputs(x, y)
-    return akima_interp(x_p, y_p, xq; kwargs...)
-end
-
-# Vector — allocating
-function akima_interp(
-        x::AbstractVector{TX},
-        y::AbstractVector{TY},
-        x_query::AbstractVector{Tq};
-        kwargs...
-    ) where {TX <: Real, TY, Tq <: Real}
-    x_p, y_p, xq_p = _promote_itp_inputs(x, y, x_query)
-    Tv_float = eltype(y_p)
-    output = Vector{Tv_float}(undef, length(x_query))
-    akima_interp!(output, x_p, y_p, xq_p; kwargs...)
-    return output
-end
-
-# Vector — in-place
-function akima_interp!(
-        output::AbstractVector,
-        x::AbstractVector{TX},
-        y::AbstractVector{TY},
-        x_query::AbstractVector{Tq};
-        kwargs...
-    ) where {TX <: Real, TY, Tq <: Real}
-    @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
-    @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
-
-    x_p, y_p, xq_p = _promote_itp_inputs(x, y, x_query)
-    Tv_float = eltype(y_p)
-
-    Tout = eltype(output)
-    if promote_type(Tout, Tv_float) !== Tout
-        throw(
-            ArgumentError(
-                "output eltype $Tout cannot hold interpolation result type $Tv_float. " *
-                    "Use Vector{$Tv_float} or a wider type."
-            )
-        )
-    end
-
-    return akima_interp!(output, x_p, y_p, xq_p; kwargs...)
-end

--- a/src/akima/akima_oneshot.jl
+++ b/src/akima/akima_oneshot.jl
@@ -21,7 +21,8 @@
     ) where {Tg, Tv, Tq <: Real}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     x = _to_float(x, Tg)
-    dy = similar!(pool, y)
+    Tdy = _output_eltype(Tv, Tg)
+    dy = acquire!(pool, Tdy, length(y))
     _akima_slopes!(dy, x, y)
     searcher = _resolve_search(x, xq, search, hint)
     return _hermite_eval_at_point(x, y, dy, xq, extrap, deriv, searcher)
@@ -32,7 +33,7 @@ end
         output::AbstractVector,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg},
+        x_query::AbstractVector,
         extrap::AbstractExtrap,
         deriv::DerivOp,
         search::AbstractSearchPolicy,
@@ -42,7 +43,8 @@ end
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
     x_query = _to_float(x_query, Tg)
-    dy = similar!(pool, y)
+    Tdy = _output_eltype(Tv, Tg)
+    dy = acquire!(pool, Tdy, length(y))
     _akima_slopes!(dy, x, y)
     searcher = _resolve_search(x, x_query, search, hint)
     return _hermite_vector_loop!(output, x, y, dy, x_query, extrap, deriv, searcher)
@@ -53,7 +55,7 @@ end
         output::AbstractVector,
         x::AbstractRange{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg},
+        x_query::AbstractVector,
         extrap::AbstractExtrap,
         deriv::DerivOp,
         search::AbstractSearchPolicy,
@@ -63,7 +65,8 @@ end
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
     x_query = _to_float(x_query, Tg)
-    dy = similar!(pool, y)
+    Tdy = _output_eltype(Tv, Tg)
+    dy = acquire!(pool, Tdy, length(y))
     _akima_slopes!(dy, x, y)
     searcher = _resolve_search(x, x_query, search, hint)
     return _hermite_vector_loop!(output, x, y, dy, x_query, extrap, deriv, searcher)
@@ -95,7 +98,7 @@ end
         output::AbstractVector,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg},
+        x_query::AbstractVector,
         extrap::AbstractExtrap,
         deriv::DerivOp,
         search::AbstractSearchPolicy,
@@ -135,7 +138,6 @@ Outlier-robust, C\$^1\$ continuous.
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, Tq <: Real}
     x, y = _promote_itp_inputs(x, y)
-    Tg_actual = eltype(x)
     resolved = _resolve_coeffs(coeffs, x, xq)
     if resolved isa OnTheFly
         return _akima_interp_onthefly(x, y, xq, extrap, deriv, search, hint)
@@ -161,7 +163,8 @@ In-place Akima interpolation with outlier-robust slopes.
     ) where {Tg, Tv, Tq <: Real}
     x, y = _promote_itp_inputs(x, y)
     Tg_actual = eltype(x)
-    xq_p = _to_float(x_query, Tg_actual)
+    Tq_float = Tg_actual <: AbstractFloat ? Tg_actual : float(Tq)
+    xq_p = _to_float(x_query, Tq_float)
     resolved = _resolve_coeffs(coeffs, x, xq_p)
     if resolved isa OnTheFly
         return _akima_interp_onthefly!(output, x, y, xq_p, extrap, deriv, search, hint)
@@ -186,7 +189,8 @@ function akima_interp(
     ) where {Tg, Tv, Tq <: Real}
     x, y = _promote_itp_inputs(x, y)
     Tg_actual = eltype(x)
-    xq_p = _to_float(x_query, Tg_actual)
+    Tq_float = Tg_actual <: AbstractFloat ? Tg_actual : float(Tq)
+    xq_p = _to_float(x_query, Tq_float)
     Tr = _output_eltype(eltype(y), Tg_actual, Tq)
     output = Vector{Tr}(undef, length(xq_p))
     akima_interp!(output, x, y, xq_p; coeffs = coeffs, extrap = extrap, deriv = deriv, search = search, hint = hint)

--- a/src/akima/akima_oneshot.jl
+++ b/src/akima/akima_oneshot.jl
@@ -196,4 +196,3 @@ function akima_interp(
     akima_interp!(output, x, y, xq_p; coeffs = coeffs, extrap = extrap, deriv = deriv, search = search, hint = hint)
     return output
 end
-

--- a/src/akima/akima_oneshot.jl
+++ b/src/akima/akima_oneshot.jl
@@ -42,7 +42,7 @@ end
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
-    x_query = _to_float(x_query, Tg)
+
     Tdy = _output_eltype(Tv, Tg)
     dy = acquire!(pool, Tdy, length(y))
     _akima_slopes!(dy, x, y)
@@ -64,7 +64,7 @@ end
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
-    x_query = _to_float(x_query, Tg)
+
     Tdy = _output_eltype(Tv, Tg)
     dy = acquire!(pool, Tdy, length(y))
     _akima_slopes!(dy, x, y)
@@ -108,7 +108,7 @@ end
     length(x) >= 2 || throw(ArgumentError("Akima interpolation requires at least 2 points, got $(length(x))"))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
-    x_query = _to_float(x_query, Tg)
+
     searcher = _resolve_search(x, x_query, search, hint)
     return _hermite_vector_loop!(output, x, y, AkimaSlopes(), x_query, extrap, deriv, searcher)
 end
@@ -175,7 +175,7 @@ end
 """
     akima_interp(x, y, x_query; coeffs=PreCompute(), ...)
 
-Akima interpolation at multiple query points. Returns `Vector{Tv}`.
+Akima interpolation at multiple query points. Returns `Vector`.
 """
 function akima_interp(
         x::AbstractVector{Tg},

--- a/src/akima/akima_slopes.jl
+++ b/src/akima/akima_slopes.jl
@@ -41,10 +41,10 @@ secant sequence.
 O(n), single pass, zero allocation (writes into `dy`).
 """
 function _akima_slopes!(
-        dy::AbstractVector{Tv},
+        dy::AbstractVector,
         x::AbstractVector{Tg},
-        y::AbstractVector{Tv}
-    ) where {Tg <: AbstractFloat, Tv}
+        y::AbstractVector
+    ) where {Tg}
     n = length(x)
     @assert n >= 2 "Akima requires at least 2 points"
     @assert length(y) == n "y length must match x"

--- a/src/akima/akima_types.jl
+++ b/src/akima/akima_types.jl
@@ -27,7 +27,7 @@ itp(0.5; deriv=DerivOp(1))
 ```
 """
 struct AkimaInterpolant1D{
-        Tg <: AbstractFloat,
+        Tg,
         Tv,
         X <: AbstractVector{Tg},
         Y <: AbstractVector{Tv},
@@ -46,11 +46,11 @@ struct AkimaInterpolant1D{
 
     # PreCompute inner constructor
     function AkimaInterpolant1D{Tg, Tv, X, Y, DY, S, E, P, PreCompute}(
-            x::AbstractVector{Tg}, y::AbstractVector{Tv}, dy::AbstractVector{Tv},
+            x::AbstractVector{Tg}, y::AbstractVector{Tv}, dy::AbstractVector,
             spacing::S, extrap::E, search::P
         ) where {
-            Tg <: AbstractFloat, Tv,
-            X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractVector{Tv},
+            Tg, Tv,
+            X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractVector,
             S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy,
         }
         length(x) == length(y) || _throw_length_mismatch(length(x), length(y))
@@ -66,7 +66,7 @@ struct AkimaInterpolant1D{
             x::AbstractVector{Tg}, y::AbstractVector{Tv}, dy::AbstractSlopeMethod,
             spacing::S, extrap::E, search::P
         ) where {
-            Tg <: AbstractFloat, Tv,
+            Tg, Tv,
             X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractSlopeMethod,
             S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy,
         }
@@ -91,8 +91,8 @@ end
         extrap::AbstractExtrap = NoExtrap(),
         search::P = AutoSearch()
     ) where {
-        Tg <: AbstractFloat, Tv,
-        X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractVector{Tv},
+        Tg, Tv,
+        X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractVector,
         P <: AbstractSearchPolicy,
     }
     E = typeof(extrap)
@@ -111,7 +111,7 @@ end
         extrap::AbstractExtrap = NoExtrap(),
         search::P = AutoSearch()
     ) where {
-        Tg <: AbstractFloat, Tv,
+        Tg, Tv,
         X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractSlopeMethod,
         P <: AbstractSearchPolicy,
     }

--- a/src/cardinal/cardinal_adjoint.jl
+++ b/src/cardinal/cardinal_adjoint.jl
@@ -53,7 +53,7 @@ f_bar = adj(y_bar; deriv=DerivOp(1))    # derivative adjoint
 adj(f_bar, y_bar)                       # in-place
 ```
 """
-struct CardinalAdjoint1D{Tg <: AbstractFloat, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
+struct CardinalAdjoint1D{Tg, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
     anchors::Vector{_HermiteAdjointAnchor1D{Tg}}
     grid::Vector{Tg}       # Grid points (needed for slope adjoint stencil widths)
     grid_size::Int
@@ -178,7 +178,8 @@ function cardinal_adjoint(
     )
     Tg = _promote_grid_float(eltype(x), eltype(x_query))
     x_p = _to_float(x, Tg)
-    xq_p = _to_float(x_query, Tg)
+    Tq_float = Tg <: AbstractFloat ? Tg : float(eltype(x_query))
+    xq_p = _to_float(x_query, Tq_float)
 
     length(x_p) >= 2 || _throw_adjoint_grid_too_small(length(x_p))
 
@@ -187,8 +188,8 @@ function cardinal_adjoint(
         x_lo, x_hi = first(x_p), last(x_p)
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
-            (x_lo <= xq_i <= x_hi) || throw(
-                DomainError(xq_i, "query point outside domain [$x_lo, $x_hi]")
+            (_extract_primal(x_lo) <= xq_i <= _extract_primal(x_hi)) || throw(
+                DomainError(xq_i, "query point outside domain [$(_extract_primal(x_lo)), $(_extract_primal(x_hi))]")
             )
         end
     end

--- a/src/cardinal/cardinal_adjoint.jl
+++ b/src/cardinal/cardinal_adjoint.jl
@@ -41,7 +41,7 @@ and the dot-product identity holds exactly:
     dot(cardinal_interp(x, y; tension=t).(xq), y_bar) == dot(y, adj(y_bar))
 
 # Type Parameters
-- `Tg`: Grid float type (Float32 or Float64)
+- `Tg`: Grid type — normally Float32/Float64, unconstrained for duck-typed grids (e.g. ForwardDiff.Dual)
 - `EP`: Extrapolation policy type
 
 # Usage

--- a/src/cardinal/cardinal_interpolant.jl
+++ b/src/cardinal/cardinal_interpolant.jl
@@ -31,7 +31,7 @@ itp(0.5)
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         extrap::AbstractExtrap = NoExtrap(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {TX <: Real, TY}
+    ) where {TX, TY}
     x_p, y_p = _promote_itp_inputs(x, y)
     Tg = eltype(x_p)
     extrap_p = _promote_extrap(extrap, eltype(y_p))
@@ -39,7 +39,8 @@ itp(0.5)
     if resolved isa OnTheFly
         return CardinalInterpolant1D(x_p, y_p, CardinalSlopes(Tg(tension)); tension = Tg(tension), extrap = extrap_p, search)
     else
-        dy_p = similar(y_p)
+        Tdy = _output_eltype(eltype(y_p), Tg)
+        dy_p = Vector{Tdy}(undef, length(y_p))
         _cardinal_slopes!(dy_p, x_p, y_p, Tg(tension))
         return CardinalInterpolant1D(x_p, y_p, dy_p; tension = Tg(tension), extrap = extrap_p, search)
     end

--- a/src/cardinal/cardinal_oneshot.jl
+++ b/src/cardinal/cardinal_oneshot.jl
@@ -19,7 +19,7 @@
         deriv::DerivOp,
         search::AbstractSearchPolicy,
         hint::Union{Nothing, Base.RefValue{Int}}
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     x = _to_float(x, Tg)
     dy = similar!(pool, y)
@@ -39,7 +39,7 @@ end
         deriv::DerivOp,
         search::AbstractSearchPolicy,
         hint::Union{Nothing, Base.RefValue{Int}}
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
@@ -61,7 +61,7 @@ end
         deriv::DerivOp,
         search::AbstractSearchPolicy,
         hint::Union{Nothing, Base.RefValue{Int}}
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
@@ -86,7 +86,7 @@ end
         deriv::DerivOp,
         search::AbstractSearchPolicy,
         hint::Union{Nothing, Base.RefValue{Int}}
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     length(x) >= 2 || throw(ArgumentError("Cardinal interpolation requires at least 2 points, got $(length(x))"))
     x = _to_float(x, Tg)
@@ -105,7 +105,7 @@ end
         deriv::DerivOp,
         search::AbstractSearchPolicy,
         hint::Union{Nothing, Base.RefValue{Int}}
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     length(x) >= 2 || throw(ArgumentError("Cardinal interpolation requires at least 2 points, got $(length(x))"))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
@@ -116,7 +116,7 @@ end
 end
 
 # ╔═══════════════════════════════════════════════════════════════════════════╗
-# ║                    PUBLIC API — typed entry points                         ║
+# ║                    TYPED CORE — all grid types                            ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
 """
@@ -139,12 +139,14 @@ Default `tension=0` is Catmull-Rom. C\$^1\$ continuous.
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
+    x, y = _promote_itp_inputs(x, y)
+    Tg_actual = eltype(x)
     resolved = _resolve_coeffs(coeffs, x, xq)
     if resolved isa OnTheFly
-        return _cardinal_interp_onthefly(x, y, xq, Tg(tension), extrap, deriv, search, hint)
+        return _cardinal_interp_onthefly(x, y, xq, Tg_actual(tension), extrap, deriv, search, hint)
     end
-    return _cardinal_interp_precompute(x, y, xq, Tg(tension), extrap, deriv, search, hint)
+    return _cardinal_interp_precompute(x, y, xq, Tg_actual(tension), extrap, deriv, search, hint)
 end
 
 """
@@ -156,39 +158,22 @@ In-place cardinal spline interpolation.
         output::AbstractVector,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg};
+        x_query::AbstractVector{Tq};
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
-        tension::Real = zero(Tg),
+        tension::Real = 0.0,
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv}
-    resolved = _resolve_coeffs(coeffs, x, x_query)
+    ) where {Tg, Tv, Tq <: Real}
+    x, y = _promote_itp_inputs(x, y)
+    Tg_actual = eltype(x)
+    xq_p = _to_float(x_query, Tg_actual)
+    resolved = _resolve_coeffs(coeffs, x, xq_p)
     if resolved isa OnTheFly
-        return _cardinal_interp_onthefly!(output, x, y, x_query, Tg(tension), extrap, deriv, search, hint)
+        return _cardinal_interp_onthefly!(output, x, y, xq_p, Tg_actual(tension), extrap, deriv, search, hint)
     end
-    return _cardinal_interp_precompute!(output, x, y, x_query, Tg(tension), extrap, deriv, search, hint)
-end
-
-# Range disambiguation for in-place
-@inline function cardinal_interp!(
-        output::AbstractVector,
-        x::AbstractRange{Tg},
-        y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg};
-        coeffs::AbstractCoeffStrategy = AutoCoeffs(),
-        tension::Real = zero(Tg),
-        extrap::AbstractExtrap = NoExtrap(),
-        deriv::DerivOp = EvalValue(),
-        search::AbstractSearchPolicy = AutoSearch(),
-        hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv}
-    resolved = _resolve_coeffs(coeffs, x, x_query)
-    if resolved isa OnTheFly
-        return _cardinal_interp_onthefly!(output, x, y, x_query, Tg(tension), extrap, deriv, search, hint)
-    end
-    return _cardinal_interp_precompute!(output, x, y, x_query, Tg(tension), extrap, deriv, search, hint)
+    return _cardinal_interp_precompute!(output, x, y, xq_p, Tg_actual(tension), extrap, deriv, search, hint)
 end
 
 """
@@ -199,71 +184,19 @@ Cardinal spline interpolation at multiple query points. Returns `Vector{Tv}`.
 function cardinal_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg};
+        x_query::AbstractVector{Tq};
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
-        tension::Real = zero(Tg),
+        tension::Real = 0.0,
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv}
-    output = Vector{Tv}(undef, length(x_query))
-    cardinal_interp!(output, x, y, x_query; coeffs = coeffs, tension = tension, extrap = extrap, deriv = deriv, search = search, hint = hint)
+    ) where {Tg, Tv, Tq <: Real}
+    x, y = _promote_itp_inputs(x, y)
+    Tg_actual = eltype(x)
+    xq_p = _to_float(x_query, Tg_actual)
+    Tr = _output_eltype(eltype(y), Tg_actual, Tq)
+    output = Vector{Tr}(undef, length(xq_p))
+    cardinal_interp!(output, x, y, xq_p; coeffs = coeffs, tension = tension, extrap = extrap, deriv = deriv, search = search, hint = hint)
     return output
-end
-
-# ╔═══════════════════════════════════════════════════════════════════════════╗
-# ║                  GENERIC WRAPPERS — Real type promotion                   ║
-# ╚═══════════════════════════════════════════════════════════════════════════╝
-
-# Scalar — promotes x, y to Float; passes xq directly for AD support
-@inline function cardinal_interp(
-        x::AbstractVector{TX},
-        y::AbstractVector{TY},
-        xq::Tq;
-        kwargs...
-    ) where {TX <: Real, TY, Tq <: Real}
-    x_p, y_p = _promote_itp_inputs(x, y)
-    return cardinal_interp(x_p, y_p, xq; kwargs...)
-end
-
-# Vector — allocating
-function cardinal_interp(
-        x::AbstractVector{TX},
-        y::AbstractVector{TY},
-        x_query::AbstractVector{Tq};
-        kwargs...
-    ) where {TX <: Real, TY, Tq <: Real}
-    x_p, y_p, xq_p = _promote_itp_inputs(x, y, x_query)
-    Tv_float = eltype(y_p)
-    output = Vector{Tv_float}(undef, length(x_query))
-    cardinal_interp!(output, x_p, y_p, xq_p; kwargs...)
-    return output
-end
-
-# Vector — in-place
-function cardinal_interp!(
-        output::AbstractVector,
-        x::AbstractVector{TX},
-        y::AbstractVector{TY},
-        x_query::AbstractVector{Tq};
-        kwargs...
-    ) where {TX <: Real, TY, Tq <: Real}
-    @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
-    @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
-
-    x_p, y_p, xq_p = _promote_itp_inputs(x, y, x_query)
-    Tv_float = eltype(y_p)
-
-    Tout = eltype(output)
-    if promote_type(Tout, Tv_float) !== Tout
-        throw(
-            ArgumentError(
-                "output eltype $Tout cannot hold interpolation result type $Tv_float. " *
-                    "Use Vector{$Tv_float} or a wider type."
-            )
-        )
-    end
-
-    return cardinal_interp!(output, x_p, y_p, xq_p; kwargs...)
 end

--- a/src/cardinal/cardinal_oneshot.jl
+++ b/src/cardinal/cardinal_oneshot.jl
@@ -44,7 +44,7 @@ end
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
-    x_query = _to_float(x_query, Tg)
+
     Tdy = _output_eltype(Tv, Tg)
     dy = acquire!(pool, Tdy, length(y))
     _cardinal_slopes!(dy, x, y, tension)
@@ -67,7 +67,7 @@ end
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
-    x_query = _to_float(x_query, Tg)
+
     Tdy = _output_eltype(Tv, Tg)
     dy = acquire!(pool, Tdy, length(y))
     _cardinal_slopes!(dy, x, y, tension)
@@ -113,7 +113,7 @@ end
     length(x) >= 2 || throw(ArgumentError("Cardinal interpolation requires at least 2 points, got $(length(x))"))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
-    x_query = _to_float(x_query, Tg)
+
     searcher = _resolve_search(x, x_query, search, hint)
     return _hermite_vector_loop!(output, x, y, CardinalSlopes(tension), x_query, extrap, deriv, searcher)
 end
@@ -183,7 +183,7 @@ end
 """
     cardinal_interp(x, y, x_query; coeffs=AutoCoeffs(), tension=0.0, ...)
 
-Cardinal spline interpolation at multiple query points. Returns `Vector{Tv}`.
+Cardinal spline interpolation at multiple query points. Returns `Vector`.
 """
 function cardinal_interp(
         x::AbstractVector{Tg},

--- a/src/cardinal/cardinal_oneshot.jl
+++ b/src/cardinal/cardinal_oneshot.jl
@@ -22,7 +22,8 @@
     ) where {Tg, Tv, Tq <: Real}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     x = _to_float(x, Tg)
-    dy = similar!(pool, y)
+    Tdy = _output_eltype(Tv, Tg)
+    dy = acquire!(pool, Tdy, length(y))
     _cardinal_slopes!(dy, x, y, tension)
     searcher = _resolve_search(x, xq, search, hint)
     return _hermite_eval_at_point(x, y, dy, xq, extrap, deriv, searcher)
@@ -33,7 +34,7 @@ end
         output::AbstractVector,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg},
+        x_query::AbstractVector,
         tension::Tg,
         extrap::AbstractExtrap,
         deriv::DerivOp,
@@ -44,7 +45,8 @@ end
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
     x_query = _to_float(x_query, Tg)
-    dy = similar!(pool, y)
+    Tdy = _output_eltype(Tv, Tg)
+    dy = acquire!(pool, Tdy, length(y))
     _cardinal_slopes!(dy, x, y, tension)
     searcher = _resolve_search(x, x_query, search, hint)
     return _hermite_vector_loop!(output, x, y, dy, x_query, extrap, deriv, searcher)
@@ -55,7 +57,7 @@ end
         output::AbstractVector,
         x::AbstractRange{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg},
+        x_query::AbstractVector,
         tension::Tg,
         extrap::AbstractExtrap,
         deriv::DerivOp,
@@ -66,7 +68,8 @@ end
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
     x_query = _to_float(x_query, Tg)
-    dy = similar!(pool, y)
+    Tdy = _output_eltype(Tv, Tg)
+    dy = acquire!(pool, Tdy, length(y))
     _cardinal_slopes!(dy, x, y, tension)
     searcher = _resolve_search(x, x_query, search, hint)
     return _hermite_vector_loop!(output, x, y, dy, x_query, extrap, deriv, searcher)
@@ -99,7 +102,7 @@ end
         output::AbstractVector,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg},
+        x_query::AbstractVector,
         tension::Tg,
         extrap::AbstractExtrap,
         deriv::DerivOp,
@@ -134,7 +137,7 @@ Default `tension=0` is Catmull-Rom. C\$^1\$ continuous.
         y::AbstractVector{Tv},
         xq::Tq;
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
-        tension::Real = zero(Tg),
+        tension::Real = 0.0,
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
@@ -168,7 +171,8 @@ In-place cardinal spline interpolation.
     ) where {Tg, Tv, Tq <: Real}
     x, y = _promote_itp_inputs(x, y)
     Tg_actual = eltype(x)
-    xq_p = _to_float(x_query, Tg_actual)
+    Tq_float = Tg_actual <: AbstractFloat ? Tg_actual : float(Tq)
+    xq_p = _to_float(x_query, Tq_float)
     resolved = _resolve_coeffs(coeffs, x, xq_p)
     if resolved isa OnTheFly
         return _cardinal_interp_onthefly!(output, x, y, xq_p, Tg_actual(tension), extrap, deriv, search, hint)
@@ -194,7 +198,8 @@ function cardinal_interp(
     ) where {Tg, Tv, Tq <: Real}
     x, y = _promote_itp_inputs(x, y)
     Tg_actual = eltype(x)
-    xq_p = _to_float(x_query, Tg_actual)
+    Tq_float = Tg_actual <: AbstractFloat ? Tg_actual : float(Tq)
+    xq_p = _to_float(x_query, Tq_float)
     Tr = _output_eltype(eltype(y), Tg_actual, Tq)
     output = Vector{Tr}(undef, length(xq_p))
     cardinal_interp!(output, x, y, xq_p; coeffs = coeffs, tension = tension, extrap = extrap, deriv = deriv, search = search, hint = hint)

--- a/src/cardinal/cardinal_slopes.jl
+++ b/src/cardinal/cardinal_slopes.jl
@@ -25,11 +25,11 @@ Compute cardinal spline slopes in-place.
 O(n), single pass, zero allocation (writes into `dy`).
 """
 function _cardinal_slopes!(
-        dy::AbstractVector{Tv},
+        dy::AbstractVector,
         x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        tension::Tg
-    ) where {Tg <: AbstractFloat, Tv}
+        y::AbstractVector,
+        tension
+    ) where {Tg}
     n = length(x)
     @assert n >= 2 "Cardinal spline requires at least 2 points"
     @assert length(y) == n "y length must match x"

--- a/src/cardinal/cardinal_types.jl
+++ b/src/cardinal/cardinal_types.jl
@@ -31,7 +31,7 @@ itp(0.5; deriv=DerivOp(1))
 ```
 """
 struct CardinalInterpolant1D{
-        Tg <: AbstractFloat,
+        Tg,
         Tv,
         X <: AbstractVector{Tg},
         Y <: AbstractVector{Tv},
@@ -51,11 +51,11 @@ struct CardinalInterpolant1D{
 
     # PreCompute inner constructor
     function CardinalInterpolant1D{Tg, Tv, X, Y, DY, S, E, P, PreCompute}(
-            x::AbstractVector{Tg}, y::AbstractVector{Tv}, dy::AbstractVector{Tv},
+            x::AbstractVector{Tg}, y::AbstractVector{Tv}, dy::AbstractVector,
             spacing::S, extrap::E, search::P, tension::Tg
         ) where {
-            Tg <: AbstractFloat, Tv,
-            X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractVector{Tv},
+            Tg, Tv,
+            X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractVector,
             S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy,
         }
         length(x) == length(y) || _throw_length_mismatch(length(x), length(y))
@@ -71,7 +71,7 @@ struct CardinalInterpolant1D{
             x::AbstractVector{Tg}, y::AbstractVector{Tv}, dy::AbstractSlopeMethod,
             spacing::S, extrap::E, search::P, tension::Tg
         ) where {
-            Tg <: AbstractFloat, Tv,
+            Tg, Tv,
             X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractSlopeMethod,
             S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy,
         }
@@ -97,8 +97,8 @@ end
         extrap::AbstractExtrap = NoExtrap(),
         search::P = AutoSearch()
     ) where {
-        Tg <: AbstractFloat, Tv,
-        X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractVector{Tv},
+        Tg, Tv,
+        X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractVector,
         P <: AbstractSearchPolicy,
     }
     E = typeof(extrap)
@@ -118,7 +118,7 @@ end
         extrap::AbstractExtrap = NoExtrap(),
         search::P = AutoSearch()
     ) where {
-        Tg <: AbstractFloat, Tv,
+        Tg, Tv,
         X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractSlopeMethod,
         P <: AbstractSearchPolicy,
     }

--- a/src/core/abstract_types.jl
+++ b/src/core/abstract_types.jl
@@ -84,7 +84,7 @@ for `_itp_eval_scalar`, `_itp_vector_loop!`, and `integrate`.
 - `CardinalInterpolant1D`: Central finite difference (+ tension parameter)
 - `AkimaInterpolant1D`: Weighted-average outlier-robust slopes
 """
-abstract type AbstractHermiteInterpolant1D{Tg <: AbstractFloat, Tv} <: AbstractInterpolant1D{Tg, Tv} end
+abstract type AbstractHermiteInterpolant1D{Tg, Tv} <: AbstractInterpolant1D{Tg, Tv} end
 
 """
     AbstractSeriesInterpolant{Tg<:AbstractFloat, Tv}

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -388,14 +388,15 @@ _promote_for_anchor(dual, Float64)   # → dual (preserved Dual type)
 
 "Scalar domain check for NoExtrap: throws DomainError if out of domain."
 @inline function _check_domain(x::AbstractVector, xi::Real, ::NoExtrap)
-    x_min, x_max = first(x), last(x)
+    x_min, x_max = _extract_primal(first(x)), _extract_primal(last(x))
     (xi < x_min || xi > x_max) && _throw_domain_error(xi, x_min, x_max)
     return nothing
 end
 
 # _CachedRange: use domain_lo/domain_hi (wider bracket on x86_64 fast path).
 @inline function _check_domain(x::_CachedRange, xi::Real, ::NoExtrap)
-    (xi < x.domain_lo || xi > x.domain_hi) && _throw_domain_error(xi, x.lo, x.hi)
+    lo, hi = _extract_primal(x.domain_lo), _extract_primal(x.domain_hi)
+    (xi < lo || xi > hi) && _throw_domain_error(xi, _extract_primal(x.lo), _extract_primal(x.hi))
     return nothing
 end
 
@@ -419,7 +420,7 @@ end
 "Vector domain check for NoExtrap: validate batch, return InBounds()."
 @inline function _check_domain(x::AbstractVector, xi::AbstractVector{<:Real}, ::NoExtrap)
     @boundscheck begin
-        x_min, x_max = first(x), last(x)
+        x_min, x_max = _extract_primal(first(x)), _extract_primal(last(x))
         xq_min, xq_max = minimum(xi), maximum(xi)
         (xq_min < x_min || xq_max > x_max) &&
             _throw_domain_error(xq_min < x_min ? xq_min : xq_max, x_min, x_max)
@@ -430,9 +431,10 @@ end
 # _CachedRange: use domain_lo/domain_hi for vector domain checks.
 @inline function _check_domain(x::_CachedRange, xi::AbstractVector{<:Real}, ::NoExtrap)
     @boundscheck begin
+        lo, hi = _extract_primal(x.domain_lo), _extract_primal(x.domain_hi)
         xq_min, xq_max = minimum(xi), maximum(xi)
-        (xq_min < x.domain_lo || xq_max > x.domain_hi) &&
-            _throw_domain_error(xq_min < x.domain_lo ? xq_min : xq_max, x.lo, x.hi)
+        (xq_min < lo || xq_max > hi) &&
+            _throw_domain_error(xq_min < lo ? xq_min : xq_max, _extract_primal(x.lo), _extract_primal(x.hi))
     end
     return InBounds()
 end

--- a/src/cubic/nd/cubic_nd_math.jl
+++ b/src/cubic/nd/cubic_nd_math.jl
@@ -98,9 +98,9 @@ Returns interpolated function value.
 """
 @inline function _hermite_kernel_1d(
         ::EvalValue,
-        yL::Tv, yR::Tv, dyL::Tv, dyR::Tv,
+        yL, yR, dyL, dyR,
         h::Tg, inv_h::Tg, dL::Tq
-    ) where {Tv, Tg, Tq}
+    ) where {Tg, Tq}
     # Promote to output type for intermediate calculations
     t = dL * inv_h
 
@@ -122,9 +122,9 @@ Evaluate first derivative: dP/dx = (dP/dt) / h
 """
 @inline function _hermite_kernel_1d(
         ::EvalDeriv1,
-        yL::Tv, yR::Tv, dyL::Tv, dyR::Tv,
+        yL, yR, dyL, dyR,
         h::Tg, inv_h::Tg, dL::Tq
-    ) where {Tv, Tg, Tq}
+    ) where {Tg, Tq}
     # Let t remain in coordinate type - basis derivatives stay real
     t = dL * inv_h
     t_sq = t * t
@@ -150,9 +150,9 @@ Evaluate second derivative: d²P/dx² = (d²P/dt²) / h²
 """
 @inline function _hermite_kernel_1d(
         ::EvalDeriv2,
-        yL::Tv, yR::Tv, dyL::Tv, dyR::Tv,
+        yL, yR, dyL, dyR,
         h::Tg, inv_h::Tg, dL::Tq
-    ) where {Tv, Tg, Tq}
+    ) where {Tg, Tq}
     # Let t remain in coordinate type - basis derivatives stay real
     t = dL * inv_h
 
@@ -178,9 +178,9 @@ Evaluate third derivative: d³P/dx³ = (d³P/dt³) / h³ (constant within interv
 """
 @inline function _hermite_kernel_1d(
         ::EvalDeriv3,
-        yL::Tv, yR::Tv, dyL::Tv, dyR::Tv,
+        yL, yR, dyL, dyR,
         h::Tg, inv_h::Tg, dL::Tq
-    ) where {Tv, Tg, Tq}
+    ) where {Tg, Tq}
     # Third derivatives are constants: d³h00/dt³=12, d³h10/dt³=6, d³h01/dt³=-12, d³h11/dt³=6
     # Auto-promote naturally through arithmetic with value types
     value_contrib = 12 * (yL - yR)
@@ -198,9 +198,9 @@ Generic fallback: N-th derivative of cubic Hermite is zero for N ≥ 4.
 """
 @inline function _hermite_kernel_1d(
         ::DerivOp{N},
-        yL::Tv, ::Tv, ::Tv, ::Tv,
+        yL, ::Any, ::Any, ::Any,
         ::Tg, ::Tg, ::Tq
-    ) where {N, Tv, Tg, Tq}
+    ) where {N, Tg, Tq}
     return 0 * yL
 end
 

--- a/src/hermite/hermite_adjoint.jl
+++ b/src/hermite/hermite_adjoint.jl
@@ -28,7 +28,7 @@ to `f_bar[idx]`, `f_bar[idx+1]`, `dy_bar[idx]`, `dy_bar[idx+1]` respectively.
 
 Weight tuples for derivative orders 0–3 are pre-baked at construction time.
 """
-struct _HermiteAdjointAnchor1D{Tg <: AbstractFloat}
+struct _HermiteAdjointAnchor1D{Tg}
     idx::Int              # Interval index
     w0::NTuple{4, Tg}     # (w_yL, w_yR, w_dyL, w_dyR) for EvalValue
     w1::NTuple{4, Tg}     # for EvalDeriv1
@@ -98,9 +98,9 @@ OOB handling baked into weights at construction time (no runtime OOB checks).
 function _bake_hermite_adjoint_anchors(
         x::AbstractVector{Tg},
         spacing::AbstractGridSpacing{Tg},
-        xq::AbstractVector{Tg},
+        xq::AbstractVector,
         extrap::AbstractExtrap
-    ) where {Tg <: AbstractFloat}
+    ) where {Tg}
     x_lo, x_hi = first(x), last(x)
 
     need_clamp = extrap isa Union{ClampExtrap, FillExtrap}
@@ -351,7 +351,7 @@ adj(f_bar, y_bar; deriv=DerivOp(1))
 @assert dot(itp.(xq), y_bar) ≈ dot(y, adj(y_bar))
 ```
 """
-struct HermiteAdjoint1D{Tg <: AbstractFloat, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
+struct HermiteAdjoint1D{Tg, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
     anchors::Vector{_HermiteAdjointAnchor1D{Tg}}
     grid_size::Int
     extrap::EP
@@ -424,7 +424,9 @@ function hermite_adjoint(
     )
     Tg = _promote_grid_float(eltype(x), eltype(x_query))
     x_p = _to_float(x, Tg)
-    xq_p = _to_float(x_query, Tg)
+    # Query stays Float — adjoint queries don't carry grid-parameter partials
+    Tq_float = Tg <: AbstractFloat ? Tg : float(eltype(x_query))
+    xq_p = _to_float(x_query, Tq_float)
 
     length(x_p) >= 2 || _throw_adjoint_grid_too_small(length(x_p))
 
@@ -433,8 +435,8 @@ function hermite_adjoint(
         x_lo, x_hi = first(x_p), last(x_p)
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
-            (x_lo <= xq_i <= x_hi) || throw(
-                DomainError(xq_i, "query point outside domain [$x_lo, $x_hi]")
+            (_extract_primal(x_lo) <= xq_i <= _extract_primal(x_hi)) || throw(
+                DomainError(xq_i, "query point outside domain [$(_extract_primal(x_lo)), $(_extract_primal(x_hi))]")
             )
         end
     end

--- a/src/hermite/hermite_adjoint.jl
+++ b/src/hermite/hermite_adjoint.jl
@@ -331,7 +331,7 @@ considering only the `y`-dependence (slopes `dy` are treated as fixed).
 Constructed from a grid and query points (query-baked, data-free).
 
 # Type Parameters
-- `Tg`: Grid float type (Float32 or Float64)
+- `Tg`: Grid type — normally Float32/Float64, unconstrained for duck-typed grids (e.g. ForwardDiff.Dual)
 - `EP`: Extrapolation policy type (`NoExtrap`, `ExtendExtrap`, `ClampExtrap`, `FillExtrap`, `WrapExtrap`)
 
 # Usage

--- a/src/hermite/hermite_eval.jl
+++ b/src/hermite/hermite_eval.jl
@@ -16,12 +16,12 @@
 @inline function _hermite_eval_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        dy::AbstractVector{Tv},
+        dy::AbstractVector,
         xq::Tq,
         extrap::AbstractExtrap,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     @boundscheck _check_domain(x, xq, extrap)
     idx, xL, xR = search_interval(searcher, x, xq)
     dL = xq - xL
@@ -34,12 +34,12 @@ end
 @inline function _hermite_eval_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        dy::AbstractVector{Tv},
+        dy::AbstractVector,
         xq::Tq,
         extrap::_ClampOrFill,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_primal = _extract_primal(xq)
     if xq_primal < first(x)
         return _eval_extrapolation(op, first(y), extrap, xq)
@@ -57,12 +57,12 @@ end
 @inline function _hermite_eval_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        dy::AbstractVector{Tv},
+        dy::AbstractVector,
         xq::Tq,
         ::WrapExtrap,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_wrapped = _wrap_to_domain(xq, first(x), last(x))
     idx, xL, xR = search_interval(searcher, x, xq_wrapped)
     dL = xq_wrapped - xL
@@ -80,12 +80,12 @@ end
         x::AbstractVector{Tg},
         spacing::AbstractGridSpacing{Tg},
         y::AbstractVector{Tv},
-        dy::AbstractVector{Tv},
+        dy::AbstractVector,
         xq::Tq,
         extrap::AbstractExtrap,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     @boundscheck _check_domain(x, xq, extrap)
     idx, xL, _ = search_interval(searcher, x, spacing, xq)
     dL = xq - xL
@@ -99,12 +99,12 @@ end
         x::AbstractVector{Tg},
         spacing::AbstractGridSpacing{Tg},
         y::AbstractVector{Tv},
-        dy::AbstractVector{Tv},
+        dy::AbstractVector,
         xq::Tq,
         extrap::_ClampOrFill,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_primal = _extract_primal(xq)
     if xq_primal < first(x)
         return _eval_extrapolation(op, first(y), extrap, xq)
@@ -123,12 +123,12 @@ end
         x::AbstractVector{Tg},
         spacing::AbstractGridSpacing{Tg},
         y::AbstractVector{Tv},
-        dy::AbstractVector{Tv},
+        dy::AbstractVector,
         xq::Tq,
         ::WrapExtrap,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_wrapped = _wrap_to_domain(xq, first(x), last(x))
     idx, xL, _ = search_interval(searcher, x, spacing, xq_wrapped)
     dL = xq_wrapped - xL
@@ -146,12 +146,12 @@ end
         output::AbstractVector,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        dy::AbstractVector{Tv},
+        dy::AbstractVector,
         xq::AbstractVector{<:Real},
         extrap::E,
         deriv::O,
         searcher::P
-    ) where {Tg <: AbstractFloat, Tv, E <: AbstractExtrap, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg, Tv, E <: AbstractExtrap, O <: AbstractEvalOp, P <: Searcher}
     extrap = _check_domain(x, xq, extrap)
     @inbounds for i in eachindex(xq, output)
         output[i] = _hermite_eval_at_point(x, y, dy, xq[i], extrap, deriv, searcher)
@@ -164,12 +164,12 @@ end
         output::AbstractVector,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        dy::AbstractVector{Tv},
+        dy::AbstractVector,
         xq::AbstractVector{<:Real},
         ::WrapExtrap,
         deriv::O,
         searcher::P
-    ) where {Tg <: AbstractFloat, Tv, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg, Tv, O <: AbstractEvalOp, P <: Searcher}
     x_min, x_max = first(x), last(x)
     qmin, qmax = minimum(xq), maximum(xq)
 
@@ -192,12 +192,12 @@ end
         x::AbstractVector{Tg},
         spacing::AbstractGridSpacing{Tg},
         y::AbstractVector{Tv},
-        dy::AbstractVector{Tv},
+        dy::AbstractVector,
         xq::AbstractVector{<:Real},
         extrap::E,
         deriv::O,
         searcher::P
-    ) where {Tg <: AbstractFloat, Tv, E <: AbstractExtrap, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg, Tv, E <: AbstractExtrap, O <: AbstractEvalOp, P <: Searcher}
     extrap = _check_domain(x, xq, extrap)
     @inbounds for i in eachindex(xq, output)
         output[i] = _hermite_eval_at_point(x, spacing, y, dy, xq[i], extrap, deriv, searcher)
@@ -211,12 +211,12 @@ end
         x::AbstractVector{Tg},
         spacing::AbstractGridSpacing{Tg},
         y::AbstractVector{Tv},
-        dy::AbstractVector{Tv},
+        dy::AbstractVector,
         xq::AbstractVector{<:Real},
         ::WrapExtrap,
         deriv::O,
         searcher::P
-    ) where {Tg <: AbstractFloat, Tv, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg, Tv, O <: AbstractEvalOp, P <: Searcher}
     x_min, x_max = first(x), last(x)
     qmin, qmax = minimum(xq), maximum(xq)
 
@@ -249,7 +249,7 @@ end
         extrap::AbstractExtrap,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     @boundscheck _check_domain(x, xq, extrap)
     idx, xL, xR = search_interval(searcher, x, xq)
     n = length(x)
@@ -269,7 +269,7 @@ end
         extrap::_ClampOrFill,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_primal = _extract_primal(xq)
     if xq_primal < first(x)
         return _eval_extrapolation(op, first(y), extrap, xq)
@@ -294,7 +294,7 @@ end
         ::WrapExtrap,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_wrapped = _wrap_to_domain(xq, first(x), last(x))
     idx, xL, xR = search_interval(searcher, x, xq_wrapped)
     n = length(x)
@@ -317,7 +317,7 @@ end
         extrap::AbstractExtrap,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     @boundscheck _check_domain(x, xq, extrap)
     idx, xL, _ = search_interval(searcher, x, spacing, xq)
     n = length(x)
@@ -338,7 +338,7 @@ end
         extrap::_ClampOrFill,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_primal = _extract_primal(xq)
     if xq_primal < first(x)
         return _eval_extrapolation(op, first(y), extrap, xq)
@@ -364,7 +364,7 @@ end
         ::WrapExtrap,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_wrapped = _wrap_to_domain(xq, first(x), last(x))
     idx, xL, _ = search_interval(searcher, x, spacing, xq_wrapped)
     n = length(x)
@@ -388,7 +388,7 @@ end
         extrap::E,
         deriv::O,
         searcher::P
-    ) where {Tg <: AbstractFloat, Tv, E <: AbstractExtrap, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg, Tv, E <: AbstractExtrap, O <: AbstractEvalOp, P <: Searcher}
     extrap = _check_domain(x, xq, extrap)
     @inbounds for i in eachindex(xq, output)
         output[i] = _hermite_eval_at_point(x, y, sm, xq[i], extrap, deriv, searcher)
@@ -406,7 +406,7 @@ end
         ::WrapExtrap,
         deriv::O,
         searcher::P
-    ) where {Tg <: AbstractFloat, Tv, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg, Tv, O <: AbstractEvalOp, P <: Searcher}
     x_min, x_max = first(x), last(x)
     qmin, qmax = minimum(xq), maximum(xq)
 
@@ -434,7 +434,7 @@ end
         extrap::E,
         deriv::O,
         searcher::P
-    ) where {Tg <: AbstractFloat, Tv, E <: AbstractExtrap, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg, Tv, E <: AbstractExtrap, O <: AbstractEvalOp, P <: Searcher}
     extrap = _check_domain(x, xq, extrap)
     @inbounds for i in eachindex(xq, output)
         output[i] = _hermite_eval_at_point(x, spacing, y, sm, xq[i], extrap, deriv, searcher)
@@ -453,7 +453,7 @@ end
         ::WrapExtrap,
         deriv::O,
         searcher::P
-    ) where {Tg <: AbstractFloat, Tv, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg, Tv, O <: AbstractEvalOp, P <: Searcher}
     x_min, x_max = first(x), last(x)
     qmin, qmax = minimum(xq), maximum(xq)
 

--- a/src/hermite/hermite_eval.jl
+++ b/src/hermite/hermite_eval.jl
@@ -41,9 +41,9 @@ end
         searcher::S
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_primal = _extract_primal(xq)
-    if xq_primal < first(x)
+    if xq_primal < _extract_primal(first(x))
         return _eval_extrapolation(op, first(y), extrap, xq)
-    elseif xq_primal > last(x)
+    elseif xq_primal > _extract_primal(last(x))
         return _eval_extrapolation(op, last(y), extrap, xq)
     end
     idx, xL, xR = search_interval(searcher, x, xq)
@@ -106,9 +106,9 @@ end
         searcher::S
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_primal = _extract_primal(xq)
-    if xq_primal < first(x)
+    if xq_primal < _extract_primal(first(x))
         return _eval_extrapolation(op, first(y), extrap, xq)
-    elseif xq_primal > last(x)
+    elseif xq_primal > _extract_primal(last(x))
         return _eval_extrapolation(op, last(y), extrap, xq)
     end
     idx, xL, _ = search_interval(searcher, x, spacing, xq)
@@ -271,9 +271,9 @@ end
         searcher::S
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_primal = _extract_primal(xq)
-    if xq_primal < first(x)
+    if xq_primal < _extract_primal(first(x))
         return _eval_extrapolation(op, first(y), extrap, xq)
-    elseif xq_primal > last(x)
+    elseif xq_primal > _extract_primal(last(x))
         return _eval_extrapolation(op, last(y), extrap, xq)
     end
     idx, xL, xR = search_interval(searcher, x, xq)
@@ -340,9 +340,9 @@ end
         searcher::S
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_primal = _extract_primal(xq)
-    if xq_primal < first(x)
+    if xq_primal < _extract_primal(first(x))
         return _eval_extrapolation(op, first(y), extrap, xq)
-    elseif xq_primal > last(x)
+    elseif xq_primal > _extract_primal(last(x))
         return _eval_extrapolation(op, last(y), extrap, xq)
     end
     idx, xL, _ = search_interval(searcher, x, spacing, xq)

--- a/src/hermite/hermite_integrate.jl
+++ b/src/hermite/hermite_integrate.jl
@@ -11,7 +11,7 @@
         x0::Real, x1::Real;
         search::AbstractSearchPolicy = itp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing,
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     return _integrate_hermite_1d(itp.dy, itp, x0, x1, search, hint)
 end
 
@@ -22,7 +22,7 @@ end
         x0::Real, x1::Real,
         search::AbstractSearchPolicy,
         hint::Union{Nothing, Base.RefValue{Int}},
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     x = itp.x
     y = itp.y
     spacing = _spacing(itp)
@@ -66,7 +66,7 @@ end
         x0::Real, x1::Real,
         search::AbstractSearchPolicy,
         hint::Union{Nothing, Base.RefValue{Int}},
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     x = itp.x
     y = itp.y
     Tout = promote_type(Tv, Tg, typeof(x0), typeof(x1))

--- a/src/hermite/hermite_interpolant.jl
+++ b/src/hermite/hermite_interpolant.jl
@@ -31,8 +31,8 @@ end
         extrap::AbstractExtrap = NoExtrap(),
         search::P = AutoSearch()
     ) where {
-        Tg <: AbstractFloat, Tv,
-        X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractVector{Tv},
+        Tg, Tv,
+        X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractVector,
         P <: AbstractSearchPolicy,
     }
     E = typeof(extrap)
@@ -83,7 +83,7 @@ itp(1.0; deriv=DerivOp(1))       # ≈ cos(1.0)
         dy::AbstractVector;
         extrap::AbstractExtrap = NoExtrap(),
         search::AbstractSearchPolicy = AutoSearch(),
-    ) where {TX <: Real, TY}
+    ) where {TX, TY}
     x_p, y_p, dy_p = _promote_hermite_inputs(x, y, dy)
     extrap_p = _promote_extrap(extrap, eltype(y_p))
     return CubicHermiteInterpolant1D(x_p, y_p, dy_p; extrap = extrap_p, search)

--- a/src/hermite/hermite_oneshot.jl
+++ b/src/hermite/hermite_oneshot.jl
@@ -61,7 +61,8 @@ function hermite_interp!(
     ) where {Tg, Tv, Tq <: Real}
     x, y, dy = _promote_hermite_inputs(x, y, dy)
     Tg_actual = eltype(x)
-    xq_p = _to_float(x_query, Tg_actual)
+    Tq_float = Tg_actual <: AbstractFloat ? Tg_actual : float(Tq)
+    xq_p = _to_float(x_query, Tq_float)
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(dy) == length(x) || _throw_length_mismatch(length(x), length(dy), "x", "dy")
     @boundscheck length(output) == length(xq_p) || _throw_length_mismatch(length(xq_p), length(output), "x_query", "output")
@@ -92,7 +93,8 @@ function hermite_interp(
     ) where {Tg, Tv, Tq <: Real}
     x, y, dy = _promote_hermite_inputs(x, y, dy)
     Tg_actual = eltype(x)
-    xq_p = _to_float(x_query, Tg_actual)
+    Tq_float = Tg_actual <: AbstractFloat ? Tg_actual : float(Tq)
+    xq_p = _to_float(x_query, Tq_float)
     Tr = _output_eltype(eltype(y), Tg_actual, Tq)
     output = Vector{Tr}(undef, length(xq_p))
     searcher = _resolve_search(x, xq_p, search, hint)

--- a/src/hermite/hermite_oneshot.jl
+++ b/src/hermite/hermite_oneshot.jl
@@ -5,7 +5,7 @@
 # No cache, no solve, no wrapper.
 
 # ╔═══════════════════════════════════════════════════════════════════════════╗
-# ║                         HOT PATH — AbstractFloat grid                     ║
+# ║                         TYPED CORE — all grid types                       ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
 # ========================================
@@ -23,18 +23,18 @@ C\$^1\$ continuous — slopes are used directly, no global spline solve.
 @inline function hermite_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        dy::AbstractVector{Tv},
+        dy::AbstractVector,
         xq::Tq;
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing,
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
+    x, y, dy = _promote_hermite_inputs(x, y, dy)
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(dy) == length(x) || _throw_length_mismatch(length(x), length(dy), "x", "dy")
     @boundscheck length(x) >= 2 || throw(ArgumentError("Hermite interpolation requires at least 2 points, got $(length(x))"))
 
-    x = _to_float(x, Tg)
     searcher = _resolve_search(x, xq, search, hint)
     return _hermite_eval_at_point(x, y, dy, xq, extrap, deriv, searcher)
 end
@@ -52,43 +52,22 @@ function hermite_interp!(
         output::AbstractVector,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        dy::AbstractVector{Tv},
-        x_query::AbstractVector{Tg};
+        dy::AbstractVector,
+        x_query::AbstractVector{Tq};
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing,
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv, Tq <: Real}
+    x, y, dy = _promote_hermite_inputs(x, y, dy)
+    Tg_actual = eltype(x)
+    xq_p = _to_float(x_query, Tg_actual)
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(dy) == length(x) || _throw_length_mismatch(length(x), length(dy), "x", "dy")
-    @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
+    @boundscheck length(output) == length(xq_p) || _throw_length_mismatch(length(xq_p), length(output), "x_query", "output")
 
-    x = _to_float(x, Tg)
-    x_query = _to_float(x_query, Tg)
-    searcher = _resolve_search(x, x_query, search, hint)
-    return _hermite_vector_loop!(output, x, y, dy, x_query, extrap, deriv, searcher)
-end
-
-# Range disambiguation for in-place
-function hermite_interp!(
-        output::AbstractVector,
-        x::AbstractRange{Tg},
-        y::AbstractVector{Tv},
-        dy::AbstractVector{Tv},
-        x_query::AbstractVector{Tg};
-        extrap::AbstractExtrap = NoExtrap(),
-        deriv::DerivOp = EvalValue(),
-        search::AbstractSearchPolicy = AutoSearch(),
-        hint::Union{Nothing, Base.RefValue{Int}} = nothing,
-    ) where {Tg <: AbstractFloat, Tv}
-    @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
-    @boundscheck length(dy) == length(x) || _throw_length_mismatch(length(x), length(dy), "x", "dy")
-    @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
-
-    x = _to_float(x, Tg)
-    x_query = _to_float(x_query, Tg)
-    searcher = _resolve_search(x, x_query, search, hint)
-    return _hermite_vector_loop!(output, x, y, dy, x_query, extrap, deriv, searcher)
+    searcher = _resolve_search(x, xq_p, search, hint)
+    return _hermite_vector_loop!(output, x, y, dy, xq_p, extrap, deriv, searcher)
 end
 
 # ========================================
@@ -99,25 +78,30 @@ end
     hermite_interp(x, y, dy, x_query; extrap=NoExtrap(), deriv=EvalValue(), search=AutoSearch(), hint=nothing)
 
 Cubic Hermite interpolation at multiple query points using user-supplied slopes.
-Returns `Vector{Tv}` of interpolated values.
+Returns `Vector` of interpolated values.
 """
 function hermite_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        dy::AbstractVector{Tv},
-        x_query::AbstractVector{Tg};
+        dy::AbstractVector,
+        x_query::AbstractVector{Tq};
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing,
-    ) where {Tg <: AbstractFloat, Tv}
-    output = Vector{_value_type(Tv, Tg)}(undef, length(x_query))
-    hermite_interp!(output, x, y, dy, x_query; extrap, deriv, search, hint)
+    ) where {Tg, Tv, Tq <: Real}
+    x, y, dy = _promote_hermite_inputs(x, y, dy)
+    Tg_actual = eltype(x)
+    xq_p = _to_float(x_query, Tg_actual)
+    Tr = _output_eltype(eltype(y), Tg_actual, Tq)
+    output = Vector{Tr}(undef, length(xq_p))
+    searcher = _resolve_search(x, xq_p, search, hint)
+    _hermite_vector_loop!(output, x, y, dy, xq_p, extrap, deriv, searcher)
     return output
 end
 
 # ╔═══════════════════════════════════════════════════════════════════════════╗
-# ║                  GENERIC WRAPPERS — Real type promotion                   ║
+# ║                  INPUT PROMOTION HELPER                                   ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
 # Joint promotion of (x, y, dy) — grid type Tg considers all three inputs,
@@ -126,70 +110,21 @@ end
         x::AbstractVector{TX},
         y::AbstractVector{TY},
         dy::AbstractVector{TDY},
-    ) where {TX <: Real, TY, TDY}
+    ) where {TX, TY, TDY}
     Tg_y = _promote_grid_float(TX, TY)
     Tg = TDY <: _PromotableValue ? promote_type(Tg_y, float(_real_eltype(TDY))) : Tg_y
     x_p = _to_float(x, Tg)
-    y_p = TY <: _PromotableValue ? _promote_value_type(y, Tg)[2] : y
-    dy_p = TDY <: _PromotableValue ? _promote_value_type(dy, Tg)[2] : dy
-    return x_p, y_p, dy_p
-end
-
-# Scalar — promotes x, y, dy to Float; passes xq directly for AD support
-@inline function hermite_interp(
-        x::AbstractVector{TX},
-        y::AbstractVector{TY},
-        dy::AbstractVector,
-        xq::Tq;
-        kwargs...
-    ) where {TX <: Real, TY, Tq <: Real}
-    x_p, y_p, dy_p = _promote_hermite_inputs(x, y, dy)
-    return hermite_interp(x_p, y_p, dy_p, xq; kwargs...)
-end
-
-# Vector — allocating
-function hermite_interp(
-        x::AbstractVector{TX},
-        y::AbstractVector{TY},
-        dy::AbstractVector,
-        x_query::AbstractVector{Tq};
-        kwargs...
-    ) where {TX <: Real, TY, Tq <: Real}
-    x_p, y_p, dy_p = _promote_hermite_inputs(x, y, dy)
-    Tg = eltype(x_p)
-    xq_p = _to_float(x_query, Tg)
-    output = Vector{eltype(y_p)}(undef, length(x_query))
-    hermite_interp!(output, x_p, y_p, dy_p, xq_p; kwargs...)
-    return output
-end
-
-# Vector — in-place
-function hermite_interp!(
-        output::AbstractVector,
-        x::AbstractVector{TX},
-        y::AbstractVector{TY},
-        dy::AbstractVector,
-        x_query::AbstractVector{Tq};
-        kwargs...
-    ) where {TX <: Real, TY, Tq <: Real}
-    @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
-    @boundscheck length(dy) == length(x) || _throw_length_mismatch(length(x), length(dy), "x", "dy")
-    @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
-
-    x_p, y_p, dy_p = _promote_hermite_inputs(x, y, dy)
-    Tg = eltype(x_p)
-    xq_p = _to_float(x_query, Tg)
-
-    Tv_float = eltype(y_p)
-    Tout = eltype(output)
-    if promote_type(Tout, Tv_float) !== Tout
-        throw(
-            ArgumentError(
-                "output eltype $Tout cannot hold interpolation result type $Tv_float. " *
-                    "Use Vector{$Tv_float} or a wider type."
-            )
-        )
+    # Only promote values when Tg is a standard float type — duck-typed Tg (Dual etc.)
+    # leaves y/dy as-is; Julia arithmetic promotion handles the rest in kernels.
+    if TY <: _PromotableValue && Tg <: AbstractFloat
+        y_p = _promote_value_type(y, Tg)[2]
+    else
+        y_p = y
     end
-
-    return hermite_interp!(output, x_p, y_p, dy_p, xq_p; kwargs...)
+    if TDY <: _PromotableValue && Tg <: AbstractFloat
+        dy_p = _promote_value_type(dy, Tg)[2]
+    else
+        dy_p = dy
+    end
+    return x_p, y_p, dy_p
 end

--- a/src/hermite/hermite_types.jl
+++ b/src/hermite/hermite_types.jl
@@ -37,7 +37,7 @@ itp(0.5; search=BinarySearch())  # override search
 ```
 """
 struct CubicHermiteInterpolant1D{
-        Tg <: AbstractFloat,
+        Tg,
         Tv,
         X <: AbstractVector{Tg},
         Y <: AbstractVector{Tv},
@@ -56,11 +56,11 @@ struct CubicHermiteInterpolant1D{
 
     # PreCompute inner constructor: dy is a precomputed slope vector
     function CubicHermiteInterpolant1D{Tg, Tv, X, Y, DY, S, E, P, PreCompute}(
-            x::AbstractVector{Tg}, y::AbstractVector{Tv}, dy::AbstractVector{Tv},
+            x::AbstractVector{Tg}, y::AbstractVector{Tv}, dy::AbstractVector,
             spacing::S, extrap::E, search::P
         ) where {
-            Tg <: AbstractFloat, Tv,
-            X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractVector{Tv},
+            Tg, Tv,
+            X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractVector,
             S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy,
         }
         length(x) == length(y) || _throw_length_mismatch(length(x), length(y))

--- a/src/integral/integrate_kernels.jl
+++ b/src/integral/integrate_kernels.jl
@@ -147,7 +147,7 @@ end
         fL, fR, dfL, dfR,
         h::Tg, inv_h::Tg,
         u0::Real, u1::Real
-    ) where {Tg <: AbstractFloat}
+    ) where {Tg}
     t0 = u0 * inv_h
     t1 = u1 * inv_h
     dH00 = _IH00(t1) - _IH00(t0)

--- a/src/linear/linear_adjoint.jl
+++ b/src/linear/linear_adjoint.jl
@@ -171,16 +171,16 @@ gets `state=IN_DOMAIN` (inside). This restores the correct OOB state flag based 
 original query position, so scatter can skip OOB contributions.
 """
 function _fixup_linear_anchor_state!(
-        anchors::Vector{_LinearAnchoredQuery{Tg, Tg}},
-        xq_original::AbstractVector{Tg},
-        x_lo::Tg, x_hi::Tg
-    ) where {Tg}
+        anchors::Vector{<:_LinearAnchoredQuery},
+        xq_original::AbstractVector,
+        x_lo, x_hi
+    )
     @inbounds for i in eachindex(anchors)
         xq_i = xq_original[i]
         (x_lo <= xq_i <= x_hi) && continue
         state = xq_i < x_lo ? OOB_LEFT : OOB_RIGHT
         aq = anchors[i]
-        anchors[i] = _LinearAnchoredQuery{Tg, Tg}(
+        anchors[i] = typeof(aq)(
             aq.idx, aq.xq, state, aq.xL, aq.h, aq.inv_h, aq.alpha
         )
     end
@@ -246,9 +246,9 @@ function linear_adjoint(
 
     length(x_p) >= 2 || _throw_adjoint_grid_too_small(length(x_p))
 
-    # NoExtrap: validate all queries in-domain
+    # NoExtrap: validate all queries in-domain (use primal for Dual grid boundaries)
     if extrap isa NoExtrap
-        x_lo, x_hi = first(x_p), last(x_p)
+        x_lo, x_hi = _extract_primal(first(x_p)), _extract_primal(last(x_p))
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
             (x_lo <= xq_i <= x_hi) || throw(
@@ -262,10 +262,10 @@ function linear_adjoint(
     if extrap isa _ClampOrFill
         # Clamp OOB queries to boundary for correct anchor weights (alpha ∈ [0,1]).
         # Then restore side flags so scatter can skip OOB contributions.
-        x_lo, x_hi = first(x_p), last(x_p)
-        xq_clamped = clamp.(xq_p, x_lo, x_hi)
+        x_lo_p, x_hi_p = _extract_primal(first(x_p)), _extract_primal(last(x_p))
+        xq_clamped = clamp.(xq_p, x_lo_p, x_hi_p)
         anchors = _anchor_query(x_p, xq_clamped, Val(:linear), false)
-        _fixup_linear_anchor_state!(anchors, xq_p, x_lo, x_hi)
+        _fixup_linear_anchor_state!(anchors, xq_p, x_lo_p, x_hi_p)
     else
         # ExtendExtrap: OOB uses boundary interval with extrapolated alpha (correct)
         # WrapExtrap: wraps to domain (correct)

--- a/src/pchip/pchip_adjoint.jl
+++ b/src/pchip/pchip_adjoint.jl
@@ -96,8 +96,8 @@ end
     if n == 2
         @inbounds begin
             inv_h = one(Tg) / (x[2] - x[1])
-            c1 = Tv(inv_h) * dy_bar[1]
-            c2 = Tv(inv_h) * dy_bar[2]
+            c1 = inv_h * dy_bar[1]
+            c2 = inv_h * dy_bar[2]
             f_bar[1] -= c1 + c2
             f_bar[2] += c1 + c2
         end
@@ -128,7 +128,7 @@ end
             # Sat-clamped: dy[1] = 3*δ1
             # ∂dy[1]/∂δ1 = 3, ∂dy[1]/∂δ2 = 0
             # δ1 = (y[2]-y[1])/h1 → ∂δ1/∂y[1] = -1/h1, ∂δ1/∂y[2] = +1/h1
-            c = Tv(3 / h1) * dy_bar[1]
+            c = (3 / h1) * dy_bar[1]
             f_bar[1] -= c
             f_bar[2] += c
         else
@@ -139,11 +139,11 @@ end
             ddy_dδ2 = -h1 / (h1 + h2)
             db = dy_bar[1]
             # δ1: y[1] → -1/h1, y[2] → +1/h1
-            c1 = Tv(ddy_dδ1 / h1) * db
+            c1 = (ddy_dδ1 / h1) * db
             f_bar[1] -= c1
             f_bar[2] += c1
             # δ2: y[2] → -1/h2, y[3] → +1/h2
-            c2 = Tv(ddy_dδ2 / h2) * db
+            c2 = (ddy_dδ2 / h2) * db
             f_bar[2] -= c2
             f_bar[3] += c2
         end
@@ -175,12 +175,12 @@ end
 
             db = dy_bar[k]
             # δ_prev is secant of interval [k-1, k]: ∂/∂y[k-1] = -1/h_prev, ∂/∂y[k] = +1/h_prev
-            c_prev = Tv(ddy_dδ_prev / h_prev) * db
+            c_prev = (ddy_dδ_prev / h_prev) * db
             f_bar[k - 1] -= c_prev
             f_bar[k] += c_prev
 
             # δ_curr is secant of interval [k, k+1]: ∂/∂y[k] = -1/h_curr, ∂/∂y[k+1] = +1/h_curr
-            c_curr = Tv(ddy_dδ_curr / h_curr) * db
+            c_curr = (ddy_dδ_curr / h_curr) * db
             f_bar[k] -= c_curr
             f_bar[k + 1] += c_curr
         end
@@ -210,7 +210,7 @@ end
         elseif sign(δ1_r) != sign(δ2_r) && abs(d_right) > abs(3 * δ1_r)
             # Sat-clamped: dy[n] = 3*δ1_r = 3*δ[n-1]
             # δ[n-1] = (y[n]-y[n-1])/h[n-1] → ∂/∂y[n-1] = -1/h[n-1], ∂/∂y[n] = +1/h[n-1]
-            c = Tv(3 / h1_r) * dy_bar[n]
+            c = (3 / h1_r) * dy_bar[n]
             f_bar[n - 1] -= c
             f_bar[n] += c
         else
@@ -222,12 +222,12 @@ end
             db = dy_bar[n]
             # δ1_r = δ[n-1]: interval [n-1, n]
             # ∂/∂y[n-1] = -1/h[n-1], ∂/∂y[n] = +1/h[n-1]
-            c1 = Tv(ddy_dδ1 / h1_r) * db
+            c1 = (ddy_dδ1 / h1_r) * db
             f_bar[n - 1] -= c1
             f_bar[n] += c1
             # δ2_r = δ[n-2]: interval [n-2, n-1]
             # ∂/∂y[n-2] = -1/h[n-2], ∂/∂y[n-1] = +1/h[n-2]
-            c2 = Tv(ddy_dδ2 / h2_r) * db
+            c2 = (ddy_dδ2 / h2_r) * db
             f_bar[n - 2] -= c2
             f_bar[n - 1] += c2
         end
@@ -330,7 +330,7 @@ function pchip_adjoint(
     spacing = _create_spacing(x_p)
     anchors = _bake_hermite_adjoint_anchors(x_p, spacing, xq_p, extrap)
 
-    # Promote y to float: slope adjoint computes fractional derivatives (Tv(0.666...) would fail for Int)
+    # Promote y to float: slope adjoint computes fractional derivatives (Int division loses precision)
     _, y_p = _promote_itp_inputs(x, y)
     Tv = eltype(y_p)
     return PchipAdjoint1D{Tg, Tv, typeof(extrap)}(

--- a/src/pchip/pchip_adjoint.jl
+++ b/src/pchip/pchip_adjoint.jl
@@ -58,7 +58,7 @@ f_bar = adj(y_bar; deriv=DerivOp(1))    # derivative adjoint
 adj(f_bar, y_bar)                       # in-place
 ```
 """
-struct PchipAdjoint1D{Tg <: AbstractFloat, Tv <: Real, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
+struct PchipAdjoint1D{Tg, Tv <: Real, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
     anchors::Vector{_HermiteAdjointAnchor1D{Tg}}
     grid::Vector{Tg}       # Grid points (needed for slope adjoint stencil widths)
     data::Vector{Tv}       # y values (needed for slope clamp conditions)
@@ -310,7 +310,8 @@ function pchip_adjoint(
     )
     Tg = _promote_grid_float(eltype(x), eltype(x_query))
     x_p = _to_float(x, Tg)
-    xq_p = _to_float(x_query, Tg)
+    Tq_float = Tg <: AbstractFloat ? Tg : float(eltype(x_query))
+    xq_p = _to_float(x_query, Tq_float)
 
     length(x_p) >= 2 || _throw_adjoint_grid_too_small(length(x_p))
 
@@ -319,8 +320,8 @@ function pchip_adjoint(
         x_lo, x_hi = first(x_p), last(x_p)
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
-            (x_lo <= xq_i <= x_hi) || throw(
-                DomainError(xq_i, "query point outside domain [$x_lo, $x_hi]")
+            (_extract_primal(x_lo) <= xq_i <= _extract_primal(x_hi)) || throw(
+                DomainError(xq_i, "query point outside domain [$(_extract_primal(x_lo)), $(_extract_primal(x_hi))]")
             )
         end
     end

--- a/src/pchip/pchip_adjoint.jl
+++ b/src/pchip/pchip_adjoint.jl
@@ -45,7 +45,7 @@ operating point. The dot-product identity holds exactly at that `y`:
     dot(pchip_interp(x, y).(xq), y_bar) == dot(y, adj(y_bar))
 
 # Type Parameters
-- `Tg`: Grid float type (Float32 or Float64)
+- `Tg`: Grid type — normally Float32/Float64, unconstrained for duck-typed grids (e.g. ForwardDiff.Dual)
 - `Tv`: Value type (must support sign, abs, zero, division)
 - `EP`: Extrapolation policy type
 

--- a/src/pchip/pchip_interpolant.jl
+++ b/src/pchip/pchip_interpolant.jl
@@ -48,14 +48,15 @@ itp(1.5; deriv=DerivOp(1))       # first derivative
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         extrap::AbstractExtrap = NoExtrap(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {TX <: Real, TY}
+    ) where {TX, TY}
     x_p, y_p = _promote_itp_inputs(x, y)
     extrap_p = _promote_extrap(extrap, eltype(y_p))
     resolved = _resolve_coeffs(coeffs)
     if resolved isa OnTheFly
         return PchipInterpolant1D(x_p, y_p, PchipSlopes(); extrap = extrap_p, search)
     else
-        dy_p = similar(y_p)
+        Tdy = _output_eltype(eltype(y_p), eltype(x_p))
+        dy_p = Vector{Tdy}(undef, length(y_p))
         _pchip_slopes!(dy_p, x_p, y_p)
         return PchipInterpolant1D(x_p, y_p, dy_p; extrap = extrap_p, search)
     end

--- a/src/pchip/pchip_oneshot.jl
+++ b/src/pchip/pchip_oneshot.jl
@@ -21,7 +21,8 @@
     ) where {Tg, Tv, Tq <: Real}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     x = _to_float(x, Tg)
-    dy = similar!(pool, y)
+    Tdy = _output_eltype(Tv, Tg)
+    dy = acquire!(pool, Tdy, length(y))
     _pchip_slopes!(dy, x, y)
     searcher = _resolve_search(x, xq, search, hint)
     return _hermite_eval_at_point(x, y, dy, xq, extrap, deriv, searcher)
@@ -32,7 +33,7 @@ end
         output::AbstractVector,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg},
+        x_query::AbstractVector,
         extrap::AbstractExtrap,
         deriv::DerivOp,
         search::AbstractSearchPolicy,
@@ -42,7 +43,8 @@ end
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
     x_query = _to_float(x_query, Tg)
-    dy = similar!(pool, y)
+    Tdy = _output_eltype(Tv, Tg)
+    dy = acquire!(pool, Tdy, length(y))
     _pchip_slopes!(dy, x, y)
     searcher = _resolve_search(x, x_query, search, hint)
     return _hermite_vector_loop!(output, x, y, dy, x_query, extrap, deriv, searcher)
@@ -53,7 +55,7 @@ end
         output::AbstractVector,
         x::AbstractRange{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg},
+        x_query::AbstractVector,
         extrap::AbstractExtrap,
         deriv::DerivOp,
         search::AbstractSearchPolicy,
@@ -63,7 +65,8 @@ end
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
     x_query = _to_float(x_query, Tg)
-    dy = similar!(pool, y)
+    Tdy = _output_eltype(Tv, Tg)
+    dy = acquire!(pool, Tdy, length(y))
     _pchip_slopes!(dy, x, y)
     searcher = _resolve_search(x, x_query, search, hint)
     return _hermite_vector_loop!(output, x, y, dy, x_query, extrap, deriv, searcher)
@@ -95,7 +98,7 @@ end
         output::AbstractVector,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg},
+        x_query::AbstractVector,
         extrap::AbstractExtrap,
         deriv::DerivOp,
         search::AbstractSearchPolicy,
@@ -135,7 +138,6 @@ C\$^1\$ continuous, monotonicity guaranteed for monotone input data.
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, Tq <: Real}
     x, y = _promote_itp_inputs(x, y)
-    Tg_actual = eltype(x)
     resolved = _resolve_coeffs(coeffs, x, xq)
     if resolved isa OnTheFly
         return _pchip_interp_onthefly(x, y, xq, extrap, deriv, search, hint)
@@ -161,7 +163,8 @@ In-place PCHIP interpolation with monotone-preserving slopes.
     ) where {Tg, Tv, Tq <: Real}
     x, y = _promote_itp_inputs(x, y)
     Tg_actual = eltype(x)
-    xq_p = _to_float(x_query, Tg_actual)
+    Tq_float = Tg_actual <: AbstractFloat ? Tg_actual : float(Tq)
+    xq_p = _to_float(x_query, Tq_float)
     resolved = _resolve_coeffs(coeffs, x, xq_p)
     if resolved isa OnTheFly
         return _pchip_interp_onthefly!(output, x, y, xq_p, extrap, deriv, search, hint)
@@ -186,7 +189,8 @@ function pchip_interp(
     ) where {Tg, Tv, Tq <: Real}
     x, y = _promote_itp_inputs(x, y)
     Tg_actual = eltype(x)
-    xq_p = _to_float(x_query, Tg_actual)
+    Tq_float = Tg_actual <: AbstractFloat ? Tg_actual : float(Tq)
+    xq_p = _to_float(x_query, Tq_float)
     Tr = _output_eltype(eltype(y), Tg_actual, Tq)
     output = Vector{Tr}(undef, length(xq_p))
     pchip_interp!(output, x, y, xq_p; coeffs = coeffs, extrap = extrap, deriv = deriv, search = search, hint = hint)

--- a/src/pchip/pchip_oneshot.jl
+++ b/src/pchip/pchip_oneshot.jl
@@ -18,7 +18,7 @@
         deriv::DerivOp,
         search::AbstractSearchPolicy,
         hint::Union{Nothing, Base.RefValue{Int}}
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     x = _to_float(x, Tg)
     dy = similar!(pool, y)
@@ -37,7 +37,7 @@ end
         deriv::DerivOp,
         search::AbstractSearchPolicy,
         hint::Union{Nothing, Base.RefValue{Int}}
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
@@ -58,7 +58,7 @@ end
         deriv::DerivOp,
         search::AbstractSearchPolicy,
         hint::Union{Nothing, Base.RefValue{Int}}
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
@@ -82,7 +82,7 @@ end
         deriv::DerivOp,
         search::AbstractSearchPolicy,
         hint::Union{Nothing, Base.RefValue{Int}}
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     length(x) >= 2 || throw(ArgumentError("PCHIP interpolation requires at least 2 points, got $(length(x))"))
     x = _to_float(x, Tg)
@@ -100,7 +100,7 @@ end
         deriv::DerivOp,
         search::AbstractSearchPolicy,
         hint::Union{Nothing, Base.RefValue{Int}}
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
@@ -110,7 +110,7 @@ end
 end
 
 # ╔═══════════════════════════════════════════════════════════════════════════╗
-# ║                    PUBLIC API — typed entry points                         ║
+# ║                    TYPED CORE — all grid types                             ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
 """
@@ -133,7 +133,9 @@ C\$^1\$ continuous, monotonicity guaranteed for monotone input data.
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
+    x, y = _promote_itp_inputs(x, y)
+    Tg_actual = eltype(x)
     resolved = _resolve_coeffs(coeffs, x, xq)
     if resolved isa OnTheFly
         return _pchip_interp_onthefly(x, y, xq, extrap, deriv, search, hint)
@@ -150,37 +152,21 @@ In-place PCHIP interpolation with monotone-preserving slopes.
         output::AbstractVector,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg};
+        x_query::AbstractVector{Tq};
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv}
-    resolved = _resolve_coeffs(coeffs, x, x_query)
+    ) where {Tg, Tv, Tq <: Real}
+    x, y = _promote_itp_inputs(x, y)
+    Tg_actual = eltype(x)
+    xq_p = _to_float(x_query, Tg_actual)
+    resolved = _resolve_coeffs(coeffs, x, xq_p)
     if resolved isa OnTheFly
-        return _pchip_interp_onthefly!(output, x, y, x_query, extrap, deriv, search, hint)
+        return _pchip_interp_onthefly!(output, x, y, xq_p, extrap, deriv, search, hint)
     end
-    return _pchip_interp_precompute!(output, x, y, x_query, extrap, deriv, search, hint)
-end
-
-# Range disambiguation for in-place
-@inline function pchip_interp!(
-        output::AbstractVector,
-        x::AbstractRange{Tg},
-        y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg};
-        coeffs::AbstractCoeffStrategy = AutoCoeffs(),
-        extrap::AbstractExtrap = NoExtrap(),
-        deriv::DerivOp = EvalValue(),
-        search::AbstractSearchPolicy = AutoSearch(),
-        hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv}
-    resolved = _resolve_coeffs(coeffs, x, x_query)
-    if resolved isa OnTheFly
-        return _pchip_interp_onthefly!(output, x, y, x_query, extrap, deriv, search, hint)
-    end
-    return _pchip_interp_precompute!(output, x, y, x_query, extrap, deriv, search, hint)
+    return _pchip_interp_precompute!(output, x, y, xq_p, extrap, deriv, search, hint)
 end
 
 """
@@ -191,70 +177,19 @@ PCHIP interpolation at multiple query points. Returns `Vector{Tv}`.
 function pchip_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg};
+        x_query::AbstractVector{Tq};
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv}
-    output = Vector{Tv}(undef, length(x_query))
-    pchip_interp!(output, x, y, x_query; coeffs = coeffs, extrap = extrap, deriv = deriv, search = search, hint = hint)
+    ) where {Tg, Tv, Tq <: Real}
+    x, y = _promote_itp_inputs(x, y)
+    Tg_actual = eltype(x)
+    xq_p = _to_float(x_query, Tg_actual)
+    Tr = _output_eltype(eltype(y), Tg_actual, Tq)
+    output = Vector{Tr}(undef, length(xq_p))
+    pchip_interp!(output, x, y, xq_p; coeffs = coeffs, extrap = extrap, deriv = deriv, search = search, hint = hint)
     return output
 end
 
-# ╔═══════════════════════════════════════════════════════════════════════════╗
-# ║                  GENERIC WRAPPERS — Real type promotion                   ║
-# ╚═══════════════════════════════════════════════════════════════════════════╝
-
-# Scalar — promotes x, y to Float; passes xq directly for AD support
-@inline function pchip_interp(
-        x::AbstractVector{TX},
-        y::AbstractVector{TY},
-        xq::Tq;
-        kwargs...
-    ) where {TX <: Real, TY, Tq <: Real}
-    x_p, y_p = _promote_itp_inputs(x, y)
-    return pchip_interp(x_p, y_p, xq; kwargs...)
-end
-
-# Vector — allocating
-function pchip_interp(
-        x::AbstractVector{TX},
-        y::AbstractVector{TY},
-        x_query::AbstractVector{Tq};
-        kwargs...
-    ) where {TX <: Real, TY, Tq <: Real}
-    x_p, y_p, xq_p = _promote_itp_inputs(x, y, x_query)
-    Tv_float = eltype(y_p)
-    output = Vector{Tv_float}(undef, length(x_query))
-    pchip_interp!(output, x_p, y_p, xq_p; kwargs...)
-    return output
-end
-
-# Vector — in-place
-function pchip_interp!(
-        output::AbstractVector,
-        x::AbstractVector{TX},
-        y::AbstractVector{TY},
-        x_query::AbstractVector{Tq};
-        kwargs...
-    ) where {TX <: Real, TY, Tq <: Real}
-    @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
-    @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
-
-    x_p, y_p, xq_p = _promote_itp_inputs(x, y, x_query)
-    Tv_float = eltype(y_p)
-
-    Tout = eltype(output)
-    if promote_type(Tout, Tv_float) !== Tout
-        throw(
-            ArgumentError(
-                "output eltype $Tout cannot hold interpolation result type $Tv_float. " *
-                    "Use Vector{$Tv_float} or a wider type."
-            )
-        )
-    end
-
-    return pchip_interp!(output, x_p, y_p, xq_p; kwargs...)
-end

--- a/src/pchip/pchip_oneshot.jl
+++ b/src/pchip/pchip_oneshot.jl
@@ -196,4 +196,3 @@ function pchip_interp(
     pchip_interp!(output, x, y, xq_p; coeffs = coeffs, extrap = extrap, deriv = deriv, search = search, hint = hint)
     return output
 end
-

--- a/src/pchip/pchip_oneshot.jl
+++ b/src/pchip/pchip_oneshot.jl
@@ -42,7 +42,7 @@ end
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
-    x_query = _to_float(x_query, Tg)
+
     Tdy = _output_eltype(Tv, Tg)
     dy = acquire!(pool, Tdy, length(y))
     _pchip_slopes!(dy, x, y)
@@ -64,7 +64,7 @@ end
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
-    x_query = _to_float(x_query, Tg)
+
     Tdy = _output_eltype(Tv, Tg)
     dy = acquire!(pool, Tdy, length(y))
     _pchip_slopes!(dy, x, y)
@@ -107,7 +107,7 @@ end
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
     x = _to_float(x, Tg)
-    x_query = _to_float(x_query, Tg)
+
     searcher = _resolve_search(x, x_query, search, hint)
     return _hermite_vector_loop!(output, x, y, PchipSlopes(), x_query, extrap, deriv, searcher)
 end
@@ -175,7 +175,7 @@ end
 """
     pchip_interp(x, y, x_query; coeffs=PreCompute(), ...)
 
-PCHIP interpolation at multiple query points. Returns `Vector{Tv}`.
+PCHIP interpolation at multiple query points. Returns `Vector`.
 """
 function pchip_interp(
         x::AbstractVector{Tg},

--- a/src/pchip/pchip_slopes.jl
+++ b/src/pchip/pchip_slopes.jl
@@ -59,10 +59,10 @@ Compute PCHIP (Fritsch-Carlson) monotone-preserving slopes in-place.
 O(n), single pass, zero allocation (writes into `dy`).
 """
 function _pchip_slopes!(
-        dy::AbstractVector{Tv},
+        dy::AbstractVector,
         x::AbstractVector{Tg},
-        y::AbstractVector{Tv}
-    ) where {Tg <: AbstractFloat, Tv}
+        y::AbstractVector
+    ) where {Tg}
     n = length(x)
     @assert n >= 2 "PCHIP requires at least 2 points"
     @assert length(y) == n "y length must match x"
@@ -92,7 +92,7 @@ function _pchip_slopes!(
     @inbounds for k in 2:(n - 1)
         if sign(δ_prev) != sign(δ_curr)
             # Local extremum: zero slope preserves monotonicity
-            dy[k] = zero(Tv)
+            dy[k] = zero(eltype(dy))
         else
             # Weighted harmonic mean (Fritsch-Carlson formula)
             w1 = 2 * h_curr + h_prev

--- a/src/pchip/pchip_types.jl
+++ b/src/pchip/pchip_types.jl
@@ -30,7 +30,7 @@ itp(0.5; deriv=DerivOp(1))       # first derivative
 ```
 """
 struct PchipInterpolant1D{
-        Tg <: AbstractFloat,
+        Tg,
         Tv,
         X <: AbstractVector{Tg},
         Y <: AbstractVector{Tv},
@@ -49,11 +49,11 @@ struct PchipInterpolant1D{
 
     # PreCompute inner constructor: dy is a precomputed slope vector
     function PchipInterpolant1D{Tg, Tv, X, Y, DY, S, E, P, PreCompute}(
-            x::AbstractVector{Tg}, y::AbstractVector{Tv}, dy::AbstractVector{Tv},
+            x::AbstractVector{Tg}, y::AbstractVector{Tv}, dy::AbstractVector,
             spacing::S, extrap::E, search::P
         ) where {
-            Tg <: AbstractFloat, Tv,
-            X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractVector{Tv},
+            Tg, Tv,
+            X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractVector,
             S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy,
         }
         length(x) == length(y) || _throw_length_mismatch(length(x), length(y))
@@ -69,7 +69,7 @@ struct PchipInterpolant1D{
             x::AbstractVector{Tg}, y::AbstractVector{Tv}, dy::AbstractSlopeMethod,
             spacing::S, extrap::E, search::P
         ) where {
-            Tg <: AbstractFloat, Tv,
+            Tg, Tv,
             X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractSlopeMethod,
             S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy,
         }
@@ -94,8 +94,8 @@ end
         extrap::AbstractExtrap = NoExtrap(),
         search::P = AutoSearch()
     ) where {
-        Tg <: AbstractFloat, Tv,
-        X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractVector{Tv},
+        Tg, Tv,
+        X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractVector,
         P <: AbstractSearchPolicy,
     }
     E = typeof(extrap)
@@ -114,7 +114,7 @@ end
         extrap::AbstractExtrap = NoExtrap(),
         search::P = AutoSearch()
     ) where {
-        Tg <: AbstractFloat, Tv,
+        Tg, Tv,
         X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, DY <: AbstractSlopeMethod,
         P <: AbstractSearchPolicy,
     }

--- a/test/ext/runtests.jl
+++ b/test/ext/runtests.jl
@@ -22,7 +22,8 @@ const ND_ALLOC_THRESHOLD = VERSION >= v"1.12" ? 0 : 240
 # ── Extension tests (order matters!) ──────────────────────────────────
 include("test_autodiff_Enzyme.jl")
 include("test_autodiff_ForwardDiff.jl")
-include("test_linear_dual_grid.jl")   # Linear 1D grid-side Dual (Phase 1)
+include("test_linear_dual_grid.jl")   # Linear 1D grid-side Dual
+include("test_hermite_dual_grid.jl")  # Hermite family grid-side Dual
 include("test_autodiff_Zygote.jl")
 include("test_autodiff_hetero.jl")
 include("test_hermite_rrule.jl")

--- a/test/ext/test_hermite_dual_grid.jl
+++ b/test/ext/test_hermite_dual_grid.jl
@@ -234,6 +234,52 @@ const FI = FastInterpolations
     end
 
     # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           Akima adjoint coverage: small grids + NoExtrap               ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "akima_adjoint — n=2 grid (Dual)" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        x2 = d .* [1.0, 2.0]
+        y2 = [3.0, 5.0]
+        adj = akima_adjoint(x2, y2, [1.5]; extrap = ExtendExtrap())
+        f_bar = adj(randn(1))
+        @test length(f_bar) == 2
+        @test eltype(f_bar) <: ForwardDiff.Dual
+    end
+
+    @testset "akima_adjoint — n=3 grid (Dual)" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        x3 = d .* [1.0, 2.0, 3.0]
+        y3 = [1.0, 4.0, 2.0]
+        adj = akima_adjoint(x3, y3, [1.5, 2.5]; extrap = ExtendExtrap())
+        f_bar = adj(randn(2))
+        @test length(f_bar) == 3
+        @test eltype(f_bar) <: ForwardDiff.Dual
+    end
+
+    @testset "akima_adjoint — wsum=0 branch (constant data, Dual grid)" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        # Constant y → all secants equal → wsum=0 in Akima weighted average
+        x_flat = d .* collect(1.0:1.0:6.0)
+        y_flat = fill(5.0, 6)
+        adj = akima_adjoint(x_flat, y_flat, [2.5, 3.5, 4.5]; extrap = ExtendExtrap())
+        f_bar = adj(randn(3))
+        @test length(f_bar) == 6
+        @test eltype(f_bar) <: ForwardDiff.Dual
+    end
+
+    @testset "akima_adjoint — NoExtrap domain check (Dual grid)" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        x_dual = d .* collect(1.0:1.0:5.0)
+        y_data = [1.0, 2.0, 1.5, 3.0, 2.0]
+        # In-domain queries — should not throw
+        adj = akima_adjoint(x_dual, y_data, [1.0, 3.0, 5.0]; extrap = NoExtrap())
+        @test adj isa FI.AkimaAdjoint1D
+        # Out-of-domain query — should throw
+        @test_throws DomainError akima_adjoint(x_dual, y_data, [0.5]; extrap = NoExtrap())
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
     # ║           Regression: Float path through same API                      ║
     # ╚═══════════════════════════════════════════════════════════════════════╝
 

--- a/test/ext/test_hermite_dual_grid.jl
+++ b/test/ext/test_hermite_dual_grid.jl
@@ -1,0 +1,252 @@
+# ╔═══════════════════════════════════════════════════════════════════════════╗
+# ║           Hermite Family — Dual Grid Tests (ForwardDiff)                  ║
+# ╚═══════════════════════════════════════════════════════════════════════════╝
+#
+# Tests that hermite_interp, pchip_interp, cardinal_interp, akima_interp
+# accept Vector{Dual} and Range{Dual} grids — enabling
+# ForwardDiff.derivative(t -> method_interp(t .* x, y, xq), 1.0).
+#
+# Follows the same pattern as test_linear_dual_grid.jl.
+
+using Test
+using FastInterpolations
+using ForwardDiff
+using LinearAlgebra
+
+const FI = FastInterpolations
+
+@testset "Hermite Family — Dual Grid" begin
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║                    Shared test data                                    ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    x_base = collect(range(0.0, 2π, 30))
+    y_base = sin.(x_base)
+    dy_base = cos.(x_base)  # exact slopes for hermite_interp
+    xq_scalar = 2.5
+    xq_vec = [1.0, 2.0, 3.0, 4.0, 5.0]
+    h_fd = 1e-7  # FD step
+
+    # Helper: finite-difference derivative of f(t) at t=1
+    fd_deriv(f) = (f(1.0 + h_fd) - f(1.0 - h_fd)) / (2h_fd)
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           hermite_interp (user-supplied slopes)                        ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "hermite_interp — scalar oneshot with Dual grid" begin
+        f = t -> hermite_interp(t .* x_base, y_base, dy_base, xq_scalar; extrap=ExtendExtrap())
+        v = f(ForwardDiff.Dual{:tag}(1.0, 1.0))
+        @test v isa ForwardDiff.Dual
+        @test ForwardDiff.value(v) ≈ hermite_interp(x_base, y_base, dy_base, xq_scalar; extrap=ExtendExtrap())
+        @test isapprox(ForwardDiff.partials(v)[1], fd_deriv(f); atol=1e-5)
+    end
+
+    @testset "hermite_interp — ForwardDiff.derivative MWE" begin
+        deriv = ForwardDiff.derivative(
+            t -> hermite_interp(t .* x_base, y_base, dy_base, xq_scalar; extrap=ExtendExtrap()), 1.0
+        )
+        fd = fd_deriv(t -> hermite_interp(t .* x_base, y_base, dy_base, xq_scalar; extrap=ExtendExtrap()))
+        @test isapprox(deriv, fd; atol=1e-5)
+    end
+
+    @testset "hermite_interp — interpolant with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        itp = hermite_interp(d .* x_base, y_base, dy_base; extrap=ExtendExtrap())
+        @test itp isa FI.CubicHermiteInterpolant1D
+        v = itp(xq_scalar)
+        @test v isa ForwardDiff.Dual
+        itp_f = hermite_interp(x_base, y_base, dy_base; extrap=ExtendExtrap())
+        @test ForwardDiff.value(v) ≈ itp_f(xq_scalar)
+    end
+
+    @testset "hermite_interp — vector oneshot with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        result = hermite_interp(d .* x_base, y_base, dy_base, xq_vec; extrap=ExtendExtrap())
+        @test eltype(result) <: ForwardDiff.Dual
+        ref = hermite_interp(x_base, y_base, dy_base, xq_vec; extrap=ExtendExtrap())
+        @test ForwardDiff.value.(result) ≈ ref
+    end
+
+    @testset "hermite_interp — adjoint with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        x_dual = d .* x_base
+        adj = hermite_adjoint(x_dual, xq_vec; extrap=ExtendExtrap())
+        @test adj isa FI.HermiteAdjoint1D
+        y_bar = randn(length(xq_vec))
+        f_bar = adj(y_bar)
+        @test eltype(f_bar) <: ForwardDiff.Dual
+    end
+
+    @testset "hermite_interp — integrate with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        itp = hermite_interp(d .* x_base, y_base, dy_base; extrap=ExtendExtrap())
+        I = integrate(itp, x_base[5], x_base[20])
+        @test I isa ForwardDiff.Dual
+        itp_f = hermite_interp(x_base, y_base, dy_base; extrap=ExtendExtrap())
+        @test ForwardDiff.value(I) ≈ integrate(itp_f, x_base[5], x_base[20])
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           pchip_interp                                                 ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "pchip_interp — scalar oneshot with Dual grid" begin
+        f = t -> pchip_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        v = f(ForwardDiff.Dual{:tag}(1.0, 1.0))
+        @test v isa ForwardDiff.Dual
+        @test ForwardDiff.value(v) ≈ pchip_interp(x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        @test isapprox(ForwardDiff.partials(v)[1], fd_deriv(f); atol=1e-5)
+    end
+
+    @testset "pchip_interp — ForwardDiff.derivative MWE" begin
+        deriv = ForwardDiff.derivative(
+            t -> pchip_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap()), 1.0
+        )
+        fd = fd_deriv(t -> pchip_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap()))
+        @test isapprox(deriv, fd; atol=1e-5)
+    end
+
+    @testset "pchip_interp — interpolant (PreCompute + OnTheFly)" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        itp_pre = pchip_interp(d .* x_base, y_base; coeffs=PreCompute(), extrap=ExtendExtrap())
+        itp_otf = pchip_interp(d .* x_base, y_base; coeffs=OnTheFly(), extrap=ExtendExtrap())
+        v_pre = itp_pre(xq_scalar)
+        v_otf = itp_otf(xq_scalar)
+        @test v_pre isa ForwardDiff.Dual
+        @test v_otf isa ForwardDiff.Dual
+        # Both strategies should give same primal
+        @test ForwardDiff.value(v_pre) ≈ ForwardDiff.value(v_otf)
+    end
+
+    @testset "pchip_interp — vector oneshot with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        result = pchip_interp(d .* x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        @test eltype(result) <: ForwardDiff.Dual
+        ref = pchip_interp(x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        @test ForwardDiff.value.(result) ≈ ref
+    end
+
+    @testset "pchip_interp — adjoint with Dual grid (construction)" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        adj = pchip_adjoint(d .* x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        @test adj isa FI.PchipAdjoint1D
+        # Note: adj(y_bar) involves slope adjoint with Tv(inv_h) casts that
+        # need deeper refactoring for duck-typed Tg. Construction works.
+    end
+
+    @testset "pchip_interp — Range{Dual} grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        x_range = d .* range(0.0, 2π, 30)
+        y_r = sin.(range(0.0, 2π, 30))
+        v = pchip_interp(x_range, y_r, xq_scalar; extrap=ExtendExtrap())
+        @test v isa ForwardDiff.Dual
+        @test ForwardDiff.value(v) ≈ pchip_interp(collect(range(0.0, 2π, 30)), y_r, xq_scalar; extrap=ExtendExtrap())
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           cardinal_interp                                              ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "cardinal_interp — scalar oneshot with Dual grid" begin
+        f = t -> cardinal_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        v = f(ForwardDiff.Dual{:tag}(1.0, 1.0))
+        @test v isa ForwardDiff.Dual
+        @test ForwardDiff.value(v) ≈ cardinal_interp(x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        @test isapprox(ForwardDiff.partials(v)[1], fd_deriv(f); atol=1e-5)
+    end
+
+    @testset "cardinal_interp — ForwardDiff.derivative MWE" begin
+        deriv = ForwardDiff.derivative(
+            t -> cardinal_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap()), 1.0
+        )
+        fd = fd_deriv(t -> cardinal_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap()))
+        @test isapprox(deriv, fd; atol=1e-5)
+    end
+
+    @testset "cardinal_interp — interpolant (PreCompute + OnTheFly)" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        itp_pre = cardinal_interp(d .* x_base, y_base; coeffs=PreCompute(), extrap=ExtendExtrap())
+        itp_otf = cardinal_interp(d .* x_base, y_base; coeffs=OnTheFly(), extrap=ExtendExtrap())
+        v_pre = itp_pre(xq_scalar)
+        v_otf = itp_otf(xq_scalar)
+        @test v_pre isa ForwardDiff.Dual
+        @test v_otf isa ForwardDiff.Dual
+        @test ForwardDiff.value(v_pre) ≈ ForwardDiff.value(v_otf)
+    end
+
+    @testset "cardinal_interp — with tension parameter" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        v = cardinal_interp(d .* x_base, y_base, xq_scalar; tension=0.5, extrap=ExtendExtrap())
+        @test v isa ForwardDiff.Dual
+        @test ForwardDiff.value(v) ≈ cardinal_interp(x_base, y_base, xq_scalar; tension=0.5, extrap=ExtendExtrap())
+    end
+
+    @testset "cardinal_interp — adjoint with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        adj = cardinal_adjoint(d .* x_base, xq_vec; tension=0.0, extrap=ExtendExtrap())
+        @test adj isa FI.CardinalAdjoint1D
+        y_bar = randn(length(xq_vec))
+        f_bar = adj(y_bar)
+        @test eltype(f_bar) <: ForwardDiff.Dual
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           akima_interp                                                 ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "akima_interp — scalar oneshot with Dual grid" begin
+        f = t -> akima_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        v = f(ForwardDiff.Dual{:tag}(1.0, 1.0))
+        @test v isa ForwardDiff.Dual
+        @test ForwardDiff.value(v) ≈ akima_interp(x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        @test isapprox(ForwardDiff.partials(v)[1], fd_deriv(f); atol=1e-5)
+    end
+
+    @testset "akima_interp — ForwardDiff.derivative MWE" begin
+        deriv = ForwardDiff.derivative(
+            t -> akima_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap()), 1.0
+        )
+        fd = fd_deriv(t -> akima_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap()))
+        @test isapprox(deriv, fd; atol=1e-5)
+    end
+
+    @testset "akima_interp — interpolant (PreCompute + OnTheFly)" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        itp_pre = akima_interp(d .* x_base, y_base; coeffs=PreCompute(), extrap=ExtendExtrap())
+        itp_otf = akima_interp(d .* x_base, y_base; coeffs=OnTheFly(), extrap=ExtendExtrap())
+        v_pre = itp_pre(xq_scalar)
+        v_otf = itp_otf(xq_scalar)
+        @test v_pre isa ForwardDiff.Dual
+        @test v_otf isa ForwardDiff.Dual
+        @test ForwardDiff.value(v_pre) ≈ ForwardDiff.value(v_otf)
+    end
+
+    @testset "akima_interp — adjoint with Dual grid (construction)" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        adj = akima_adjoint(d .* x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        @test adj isa FI.AkimaAdjoint1D
+        # Note: adj(y_bar) involves slope adjoint with Tv(inv_h) casts that
+        # need deeper refactoring for duck-typed Tg. Construction works.
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           Regression: Float path through same API                      ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "Regression: Float scalar path zero-alloc" begin
+        x = collect(range(0.0, 2π, 50))
+        y = sin.(x)
+
+        itp_p = pchip_interp(x, y)
+        itp_c = cardinal_interp(x, y)
+        itp_a = akima_interp(x, y)
+
+        # warmup
+        itp_p(2.5); itp_c(2.5); itp_a(2.5)
+        @test (@allocated itp_p(2.5)) <= ALLOC_THRESHOLD
+        @test (@allocated itp_c(2.5)) <= ALLOC_THRESHOLD
+        @test (@allocated itp_a(2.5)) <= ALLOC_THRESHOLD
+    end
+end

--- a/test/ext/test_hermite_dual_grid.jl
+++ b/test/ext/test_hermite_dual_grid.jl
@@ -128,12 +128,13 @@ const FI = FastInterpolations
         @test ForwardDiff.value.(result) ≈ ref
     end
 
-    @testset "pchip_interp — adjoint with Dual grid (construction)" begin
+    @testset "pchip_interp — adjoint with Dual grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
         adj = pchip_adjoint(d .* x_base, y_base, xq_vec; extrap=ExtendExtrap())
         @test adj isa FI.PchipAdjoint1D
-        # Note: adj(y_bar) involves slope adjoint with Tv(inv_h) casts that
-        # need deeper refactoring for duck-typed Tg. Construction works.
+        y_bar = randn(length(xq_vec))
+        f_bar = adj(y_bar)
+        @test eltype(f_bar) <: ForwardDiff.Dual
     end
 
     @testset "pchip_interp — Range{Dual} grid" begin
@@ -223,12 +224,13 @@ const FI = FastInterpolations
         @test ForwardDiff.value(v_pre) ≈ ForwardDiff.value(v_otf)
     end
 
-    @testset "akima_interp — adjoint with Dual grid (construction)" begin
+    @testset "akima_interp — adjoint with Dual grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
         adj = akima_adjoint(d .* x_base, y_base, xq_vec; extrap=ExtendExtrap())
         @test adj isa FI.AkimaAdjoint1D
-        # Note: adj(y_bar) involves slope adjoint with Tv(inv_h) casts that
-        # need deeper refactoring for duck-typed Tg. Construction works.
+        y_bar = randn(length(xq_vec))
+        f_bar = adj(y_bar)
+        @test eltype(f_bar) <: ForwardDiff.Dual
     end
 
     # ╔═══════════════════════════════════════════════════════════════════════╗

--- a/test/ext/test_hermite_dual_grid.jl
+++ b/test/ext/test_hermite_dual_grid.jl
@@ -26,7 +26,7 @@ const FI = FastInterpolations
     dy_base = cos.(x_base)  # exact slopes for hermite_interp
     xq_scalar = 2.5
     xq_vec = [1.0, 2.0, 3.0, 4.0, 5.0]
-    h_fd = 1e-7  # FD step
+    h_fd = 1.0e-7  # FD step
 
     # Helper: finite-difference derivative of f(t) at t=1
     fd_deriv(f) = (f(1.0 + h_fd) - f(1.0 - h_fd)) / (2h_fd)
@@ -36,43 +36,43 @@ const FI = FastInterpolations
     # ╚═══════════════════════════════════════════════════════════════════════╝
 
     @testset "hermite_interp — scalar oneshot with Dual grid" begin
-        f = t -> hermite_interp(t .* x_base, y_base, dy_base, xq_scalar; extrap=ExtendExtrap())
+        f = t -> hermite_interp(t .* x_base, y_base, dy_base, xq_scalar; extrap = ExtendExtrap())
         v = f(ForwardDiff.Dual{:tag}(1.0, 1.0))
         @test v isa ForwardDiff.Dual
-        @test ForwardDiff.value(v) ≈ hermite_interp(x_base, y_base, dy_base, xq_scalar; extrap=ExtendExtrap())
-        @test isapprox(ForwardDiff.partials(v)[1], fd_deriv(f); atol=1e-5)
+        @test ForwardDiff.value(v) ≈ hermite_interp(x_base, y_base, dy_base, xq_scalar; extrap = ExtendExtrap())
+        @test isapprox(ForwardDiff.partials(v)[1], fd_deriv(f); atol = 1.0e-5)
     end
 
     @testset "hermite_interp — ForwardDiff.derivative MWE" begin
         deriv = ForwardDiff.derivative(
-            t -> hermite_interp(t .* x_base, y_base, dy_base, xq_scalar; extrap=ExtendExtrap()), 1.0
+            t -> hermite_interp(t .* x_base, y_base, dy_base, xq_scalar; extrap = ExtendExtrap()), 1.0
         )
-        fd = fd_deriv(t -> hermite_interp(t .* x_base, y_base, dy_base, xq_scalar; extrap=ExtendExtrap()))
-        @test isapprox(deriv, fd; atol=1e-5)
+        fd = fd_deriv(t -> hermite_interp(t .* x_base, y_base, dy_base, xq_scalar; extrap = ExtendExtrap()))
+        @test isapprox(deriv, fd; atol = 1.0e-5)
     end
 
     @testset "hermite_interp — interpolant with Dual grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        itp = hermite_interp(d .* x_base, y_base, dy_base; extrap=ExtendExtrap())
+        itp = hermite_interp(d .* x_base, y_base, dy_base; extrap = ExtendExtrap())
         @test itp isa FI.CubicHermiteInterpolant1D
         v = itp(xq_scalar)
         @test v isa ForwardDiff.Dual
-        itp_f = hermite_interp(x_base, y_base, dy_base; extrap=ExtendExtrap())
+        itp_f = hermite_interp(x_base, y_base, dy_base; extrap = ExtendExtrap())
         @test ForwardDiff.value(v) ≈ itp_f(xq_scalar)
     end
 
     @testset "hermite_interp — vector oneshot with Dual grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        result = hermite_interp(d .* x_base, y_base, dy_base, xq_vec; extrap=ExtendExtrap())
+        result = hermite_interp(d .* x_base, y_base, dy_base, xq_vec; extrap = ExtendExtrap())
         @test eltype(result) <: ForwardDiff.Dual
-        ref = hermite_interp(x_base, y_base, dy_base, xq_vec; extrap=ExtendExtrap())
+        ref = hermite_interp(x_base, y_base, dy_base, xq_vec; extrap = ExtendExtrap())
         @test ForwardDiff.value.(result) ≈ ref
     end
 
     @testset "hermite_interp — adjoint with Dual grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
         x_dual = d .* x_base
-        adj = hermite_adjoint(x_dual, xq_vec; extrap=ExtendExtrap())
+        adj = hermite_adjoint(x_dual, xq_vec; extrap = ExtendExtrap())
         @test adj isa FI.HermiteAdjoint1D
         y_bar = randn(length(xq_vec))
         f_bar = adj(y_bar)
@@ -81,10 +81,10 @@ const FI = FastInterpolations
 
     @testset "hermite_interp — integrate with Dual grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        itp = hermite_interp(d .* x_base, y_base, dy_base; extrap=ExtendExtrap())
+        itp = hermite_interp(d .* x_base, y_base, dy_base; extrap = ExtendExtrap())
         I = integrate(itp, x_base[5], x_base[20])
         @test I isa ForwardDiff.Dual
-        itp_f = hermite_interp(x_base, y_base, dy_base; extrap=ExtendExtrap())
+        itp_f = hermite_interp(x_base, y_base, dy_base; extrap = ExtendExtrap())
         @test ForwardDiff.value(I) ≈ integrate(itp_f, x_base[5], x_base[20])
     end
 
@@ -93,25 +93,25 @@ const FI = FastInterpolations
     # ╚═══════════════════════════════════════════════════════════════════════╝
 
     @testset "pchip_interp — scalar oneshot with Dual grid" begin
-        f = t -> pchip_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        f = t -> pchip_interp(t .* x_base, y_base, xq_scalar; extrap = ExtendExtrap())
         v = f(ForwardDiff.Dual{:tag}(1.0, 1.0))
         @test v isa ForwardDiff.Dual
-        @test ForwardDiff.value(v) ≈ pchip_interp(x_base, y_base, xq_scalar; extrap=ExtendExtrap())
-        @test isapprox(ForwardDiff.partials(v)[1], fd_deriv(f); atol=1e-5)
+        @test ForwardDiff.value(v) ≈ pchip_interp(x_base, y_base, xq_scalar; extrap = ExtendExtrap())
+        @test isapprox(ForwardDiff.partials(v)[1], fd_deriv(f); atol = 1.0e-5)
     end
 
     @testset "pchip_interp — ForwardDiff.derivative MWE" begin
         deriv = ForwardDiff.derivative(
-            t -> pchip_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap()), 1.0
+            t -> pchip_interp(t .* x_base, y_base, xq_scalar; extrap = ExtendExtrap()), 1.0
         )
-        fd = fd_deriv(t -> pchip_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap()))
-        @test isapprox(deriv, fd; atol=1e-5)
+        fd = fd_deriv(t -> pchip_interp(t .* x_base, y_base, xq_scalar; extrap = ExtendExtrap()))
+        @test isapprox(deriv, fd; atol = 1.0e-5)
     end
 
     @testset "pchip_interp — interpolant (PreCompute + OnTheFly)" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        itp_pre = pchip_interp(d .* x_base, y_base; coeffs=PreCompute(), extrap=ExtendExtrap())
-        itp_otf = pchip_interp(d .* x_base, y_base; coeffs=OnTheFly(), extrap=ExtendExtrap())
+        itp_pre = pchip_interp(d .* x_base, y_base; coeffs = PreCompute(), extrap = ExtendExtrap())
+        itp_otf = pchip_interp(d .* x_base, y_base; coeffs = OnTheFly(), extrap = ExtendExtrap())
         v_pre = itp_pre(xq_scalar)
         v_otf = itp_otf(xq_scalar)
         @test v_pre isa ForwardDiff.Dual
@@ -122,15 +122,15 @@ const FI = FastInterpolations
 
     @testset "pchip_interp — vector oneshot with Dual grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        result = pchip_interp(d .* x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        result = pchip_interp(d .* x_base, y_base, xq_vec; extrap = ExtendExtrap())
         @test eltype(result) <: ForwardDiff.Dual
-        ref = pchip_interp(x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        ref = pchip_interp(x_base, y_base, xq_vec; extrap = ExtendExtrap())
         @test ForwardDiff.value.(result) ≈ ref
     end
 
     @testset "pchip_interp — adjoint with Dual grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        adj = pchip_adjoint(d .* x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        adj = pchip_adjoint(d .* x_base, y_base, xq_vec; extrap = ExtendExtrap())
         @test adj isa FI.PchipAdjoint1D
         y_bar = randn(length(xq_vec))
         f_bar = adj(y_bar)
@@ -141,9 +141,9 @@ const FI = FastInterpolations
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
         x_range = d .* range(0.0, 2π, 30)
         y_r = sin.(range(0.0, 2π, 30))
-        v = pchip_interp(x_range, y_r, xq_scalar; extrap=ExtendExtrap())
+        v = pchip_interp(x_range, y_r, xq_scalar; extrap = ExtendExtrap())
         @test v isa ForwardDiff.Dual
-        @test ForwardDiff.value(v) ≈ pchip_interp(collect(range(0.0, 2π, 30)), y_r, xq_scalar; extrap=ExtendExtrap())
+        @test ForwardDiff.value(v) ≈ pchip_interp(collect(range(0.0, 2π, 30)), y_r, xq_scalar; extrap = ExtendExtrap())
     end
 
     # ╔═══════════════════════════════════════════════════════════════════════╗
@@ -151,25 +151,25 @@ const FI = FastInterpolations
     # ╚═══════════════════════════════════════════════════════════════════════╝
 
     @testset "cardinal_interp — scalar oneshot with Dual grid" begin
-        f = t -> cardinal_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        f = t -> cardinal_interp(t .* x_base, y_base, xq_scalar; extrap = ExtendExtrap())
         v = f(ForwardDiff.Dual{:tag}(1.0, 1.0))
         @test v isa ForwardDiff.Dual
-        @test ForwardDiff.value(v) ≈ cardinal_interp(x_base, y_base, xq_scalar; extrap=ExtendExtrap())
-        @test isapprox(ForwardDiff.partials(v)[1], fd_deriv(f); atol=1e-5)
+        @test ForwardDiff.value(v) ≈ cardinal_interp(x_base, y_base, xq_scalar; extrap = ExtendExtrap())
+        @test isapprox(ForwardDiff.partials(v)[1], fd_deriv(f); atol = 1.0e-5)
     end
 
     @testset "cardinal_interp — ForwardDiff.derivative MWE" begin
         deriv = ForwardDiff.derivative(
-            t -> cardinal_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap()), 1.0
+            t -> cardinal_interp(t .* x_base, y_base, xq_scalar; extrap = ExtendExtrap()), 1.0
         )
-        fd = fd_deriv(t -> cardinal_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap()))
-        @test isapprox(deriv, fd; atol=1e-5)
+        fd = fd_deriv(t -> cardinal_interp(t .* x_base, y_base, xq_scalar; extrap = ExtendExtrap()))
+        @test isapprox(deriv, fd; atol = 1.0e-5)
     end
 
     @testset "cardinal_interp — interpolant (PreCompute + OnTheFly)" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        itp_pre = cardinal_interp(d .* x_base, y_base; coeffs=PreCompute(), extrap=ExtendExtrap())
-        itp_otf = cardinal_interp(d .* x_base, y_base; coeffs=OnTheFly(), extrap=ExtendExtrap())
+        itp_pre = cardinal_interp(d .* x_base, y_base; coeffs = PreCompute(), extrap = ExtendExtrap())
+        itp_otf = cardinal_interp(d .* x_base, y_base; coeffs = OnTheFly(), extrap = ExtendExtrap())
         v_pre = itp_pre(xq_scalar)
         v_otf = itp_otf(xq_scalar)
         @test v_pre isa ForwardDiff.Dual
@@ -179,14 +179,14 @@ const FI = FastInterpolations
 
     @testset "cardinal_interp — with tension parameter" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        v = cardinal_interp(d .* x_base, y_base, xq_scalar; tension=0.5, extrap=ExtendExtrap())
+        v = cardinal_interp(d .* x_base, y_base, xq_scalar; tension = 0.5, extrap = ExtendExtrap())
         @test v isa ForwardDiff.Dual
-        @test ForwardDiff.value(v) ≈ cardinal_interp(x_base, y_base, xq_scalar; tension=0.5, extrap=ExtendExtrap())
+        @test ForwardDiff.value(v) ≈ cardinal_interp(x_base, y_base, xq_scalar; tension = 0.5, extrap = ExtendExtrap())
     end
 
     @testset "cardinal_interp — adjoint with Dual grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        adj = cardinal_adjoint(d .* x_base, xq_vec; tension=0.0, extrap=ExtendExtrap())
+        adj = cardinal_adjoint(d .* x_base, xq_vec; tension = 0.0, extrap = ExtendExtrap())
         @test adj isa FI.CardinalAdjoint1D
         y_bar = randn(length(xq_vec))
         f_bar = adj(y_bar)
@@ -198,25 +198,25 @@ const FI = FastInterpolations
     # ╚═══════════════════════════════════════════════════════════════════════╝
 
     @testset "akima_interp — scalar oneshot with Dual grid" begin
-        f = t -> akima_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        f = t -> akima_interp(t .* x_base, y_base, xq_scalar; extrap = ExtendExtrap())
         v = f(ForwardDiff.Dual{:tag}(1.0, 1.0))
         @test v isa ForwardDiff.Dual
-        @test ForwardDiff.value(v) ≈ akima_interp(x_base, y_base, xq_scalar; extrap=ExtendExtrap())
-        @test isapprox(ForwardDiff.partials(v)[1], fd_deriv(f); atol=1e-5)
+        @test ForwardDiff.value(v) ≈ akima_interp(x_base, y_base, xq_scalar; extrap = ExtendExtrap())
+        @test isapprox(ForwardDiff.partials(v)[1], fd_deriv(f); atol = 1.0e-5)
     end
 
     @testset "akima_interp — ForwardDiff.derivative MWE" begin
         deriv = ForwardDiff.derivative(
-            t -> akima_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap()), 1.0
+            t -> akima_interp(t .* x_base, y_base, xq_scalar; extrap = ExtendExtrap()), 1.0
         )
-        fd = fd_deriv(t -> akima_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap()))
-        @test isapprox(deriv, fd; atol=1e-5)
+        fd = fd_deriv(t -> akima_interp(t .* x_base, y_base, xq_scalar; extrap = ExtendExtrap()))
+        @test isapprox(deriv, fd; atol = 1.0e-5)
     end
 
     @testset "akima_interp — interpolant (PreCompute + OnTheFly)" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        itp_pre = akima_interp(d .* x_base, y_base; coeffs=PreCompute(), extrap=ExtendExtrap())
-        itp_otf = akima_interp(d .* x_base, y_base; coeffs=OnTheFly(), extrap=ExtendExtrap())
+        itp_pre = akima_interp(d .* x_base, y_base; coeffs = PreCompute(), extrap = ExtendExtrap())
+        itp_otf = akima_interp(d .* x_base, y_base; coeffs = OnTheFly(), extrap = ExtendExtrap())
         v_pre = itp_pre(xq_scalar)
         v_otf = itp_otf(xq_scalar)
         @test v_pre isa ForwardDiff.Dual
@@ -226,7 +226,7 @@ const FI = FastInterpolations
 
     @testset "akima_interp — adjoint with Dual grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        adj = akima_adjoint(d .* x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        adj = akima_adjoint(d .* x_base, y_base, xq_vec; extrap = ExtendExtrap())
         @test adj isa FI.AkimaAdjoint1D
         y_bar = randn(length(xq_vec))
         f_bar = adj(y_bar)

--- a/test/ext/test_linear_dual_grid.jl
+++ b/test/ext/test_linear_dual_grid.jl
@@ -187,49 +187,28 @@ const FI = FastInterpolations
         end
     end
 
-    @testset "Domain boundary: partial sign determines NoExtrap behavior" begin
+    @testset "Domain boundary: primal-based NoExtrap check (partial-independent)" begin
+        # Domain check uses _extract_primal — partial sign does NOT affect boundary.
+        # Endpoints with matching primal are always in-domain regardless of partials.
         x = [1.0, 2.0, 3.0]
         y = [10.0, 20.0, 15.0]
 
-        @testset "Left boundary (first grid point)" begin
-            # positive partial: Dual(1, +1) > 1.0 → query 1.0 is OOB_LEFT → throw
-            x_pos = [ForwardDiff.Dual{:tag}(xi, +1.0) for xi in x]
-            itp_pos = linear_interp(x_pos, y)  # NoExtrap default
-            @test_throws DomainError itp_pos(1.0)
-
-            # negative partial: Dual(1, -1) < 1.0 → query 1.0 is IN_DOMAIN → works
-            x_neg = [ForwardDiff.Dual{:tag}(xi, -1.0) for xi in x]
-            itp_neg = linear_interp(x_neg, y)
-            r = itp_neg(1.0)
-            @test ForwardDiff.value(r) ≈ 10.0
-
-            # zero partial: Dual(1, 0) == 1.0 → same as Float, IN_DOMAIN → works
-            x_zero = [ForwardDiff.Dual{:tag}(xi, 0.0) for xi in x]
-            itp_zero = linear_interp(x_zero, y)
-            r = itp_zero(1.0)
-            @test ForwardDiff.value(r) ≈ 10.0
+        @testset "Left boundary — all partial signs work" begin
+            for sign in (+1.0, -1.0, 0.0)
+                x_dual = [ForwardDiff.Dual{:tag}(xi, sign) for xi in x]
+                itp = linear_interp(x_dual, y)
+                r = itp(1.0)
+                @test ForwardDiff.value(r) ≈ 10.0
+            end
         end
 
-        @testset "Right boundary (last grid point)" begin
-            # positive partial: Dual(3, +1) > 3.0, so 3.0 > Dual(3, +1) = false
-            # → NOT OOB_RIGHT → domain check passes → works.
-            # (The grid "expanded" rightward in the Dual sense, so query is inside.)
-            x_pos = [ForwardDiff.Dual{:tag}(xi, +1.0) for xi in x]
-            itp_pos = linear_interp(x_pos, y)
-            r = itp_pos(3.0)
-            @test ForwardDiff.value(r) ≈ 15.0
-
-            # negative partial: Dual(3, -1) < 3.0, so 3.0 > Dual(3, -1) = true
-            # → OOB_RIGHT → throw. (The grid "contracted" rightward, query fell outside.)
-            x_neg = [ForwardDiff.Dual{:tag}(xi, -1.0) for xi in x]
-            itp_neg = linear_interp(x_neg, y)
-            @test_throws DomainError itp_neg(3.0)
-
-            # zero partial: same as Float, IN_DOMAIN → works
-            x_zero = [ForwardDiff.Dual{:tag}(xi, 0.0) for xi in x]
-            itp_zero = linear_interp(x_zero, y)
-            r = itp_zero(3.0)
-            @test ForwardDiff.value(r) ≈ 15.0
+        @testset "Right boundary — all partial signs work" begin
+            for sign in (+1.0, -1.0, 0.0)
+                x_dual = [ForwardDiff.Dual{:tag}(xi, sign) for xi in x]
+                itp = linear_interp(x_dual, y)
+                r = itp(3.0)
+                @test ForwardDiff.value(r) ≈ 15.0
+            end
         end
     end
 

--- a/test/test_akima_1d.jl
+++ b/test/test_akima_1d.jl
@@ -312,14 +312,6 @@
         @test all(isfinite, out)
     end
 
-    @testset "Coverage — output eltype validation error" begin
-        x_int = collect(0:9)
-        y_int = x_int .^ 2
-        xq_int = [2, 4, 6]
-        out_narrow = Vector{Float32}(undef, length(xq_int))
-        @test_throws ArgumentError akima_interp!(out_narrow, x_int, y_int, xq_int)
-    end
-
     @testset "Coverage — WrapExtrap vector path" begin
         x = collect(range(0.0, 2π, 20))
         y = sin.(x)

--- a/test/test_cardinal_1d.jl
+++ b/test/test_cardinal_1d.jl
@@ -304,14 +304,6 @@
         @test all(isfinite, out)
     end
 
-    @testset "Coverage — output eltype validation error" begin
-        x_int = collect(0:9)
-        y_int = x_int .^ 2
-        xq_int = [2, 4, 6]
-        out_narrow = Vector{Float32}(undef, length(xq_int))
-        @test_throws ArgumentError cardinal_interp!(out_narrow, x_int, y_int, xq_int)
-    end
-
     @testset "Coverage — WrapExtrap vector path" begin
         x = collect(range(0.0, 2π, 20))
         y = sin.(x)

--- a/test/test_hermite_1d.jl
+++ b/test/test_hermite_1d.jl
@@ -546,14 +546,6 @@
         @test all(isfinite, result)
     end
 
-    @testset "Coverage — Hermite output eltype validation error" begin
-        x_int = collect(0:5)
-        y_int = x_int .^ 2
-        dy_int = 2 .* x_int
-        out_narrow = Vector{Float32}(undef, 3)
-        @test_throws ArgumentError hermite_interp!(out_narrow, x_int, y_int, dy_int, [1, 2, 3])
-    end
-
     @testset "Coverage — generic wrapper Integer promotion" begin
         x_int = collect(0:5)
         y_int = x_int .^ 2

--- a/test/test_pchip_1d.jl
+++ b/test/test_pchip_1d.jl
@@ -360,16 +360,6 @@
         @test isfinite(pchip_interp(x, y, 1.5))
     end
 
-    @testset "Coverage — output eltype validation error" begin
-        # Integer inputs trigger generic wrapper which validates output eltype
-        x_int = collect(0:9)
-        y_int = x_int .^ 2
-        xq_int = [2, 4, 6]
-        out_narrow = Vector{Float32}(undef, length(xq_int))
-        # Int → Float64 result into Float32 output → should throw
-        @test_throws ArgumentError pchip_interp!(out_narrow, x_int, y_int, xq_int)
-    end
-
     @testset "Coverage — WrapExtrap vector path" begin
         x = collect(range(0.0, 2π, 20))
         y = sin.(x)


### PR DESCRIPTION
Motivated by #81 — this PR opens the **Hermite family** (hermite_interp, pchip_interp, cardinal_interp, akima_interp) to duck-typed grid element types, following the pattern established in the Linear Dual-grid PR (#116).

## Summary

```julia
# All four methods now work with Dual grids
ForwardDiff.derivative(t -> pchip_interp(t .* x, y, xq), 1.0)
ForwardDiff.derivative(t -> cardinal_interp(t .* x, y, xq; tension=0.5), 1.0)
ForwardDiff.derivative(t -> akima_interp(t .* x, y, xq), 1.0)
ForwardDiff.derivative(t -> hermite_interp(t .* x, y, dy, xq), 1.0)
```

## What changed

**Hermite-specific (beyond mechanical `Tg <: AbstractFloat` → `Tg` relaxation):**

| Pattern | Change | Why |
|---|---|---|
| `_hermite_kernel_1d` | `yL::Tv, yR::Tv, dyL::Tv, dyR::Tv` → untyped args | Dual grid makes slopes Dual while y stays Float — can't unify to one `Tv` |
| `_promote_hermite_inputs` | Added `Tg <: AbstractFloat` guard before `_promote_value_type` | `_promote_value_type` requires AbstractFloat target |
| Slope buffer allocation | `similar!(pool, y)` → `acquire!(pool, _output_eltype(Tv, Tg), n)` | Slopes are `promote_type(Tv, Tg)` — Dual when grid is Dual |
| `_*_slopes!` signatures | `dy::AbstractVector{Tv}` → `dy::AbstractVector` | dy/y may differ in element type |
| Slope adjoint `Tv(...)` casts | Removed ~25 explicit `Tv(expr)` casts | Redundant (constructor already promotes y to Float), blocks Dual grid geometry |
| Adjoint query promotion | `_to_float(xq, Tg)` → `Tq_float` pattern | Queries stay Float — don't carry grid-parameter partials |
| Vector query promotion | `_to_float(xq, Tg_actual)` → `Tq_float` pattern | Same — consistent with adjoint paths |
| Real wrappers | 12 deleted (3 per method) | `Dual <: Real` → infinite recursion |

**Core infrastructure fix (affects all methods):**

| Component | Change |
|---|---|
| `_check_domain` (4 overloads) | `first(x)` → `_extract_primal(first(x))` for boundary comparison |
| `_fixup_linear_anchor_state!` | Relaxed signature, use `typeof(aq)` + primal boundaries |

The `_check_domain` fix resolves a bug where `linear_interp(Dual.(1:3, 1), y)(1.0)` threw `DomainError` at the left endpoint — ForwardDiff lexicographic ordering made `1.0 < Dual(1.0, +1.0)` true.

## Key design decisions

1. **Kernel Tv decoupling** — Hermite kernel now accepts heterogeneous `(yL, yR, dyL, dyR)` types. Julia's arithmetic promotion handles `Float * Dual → Dual` in the kernel body. No inference regression on Float paths (all args are same type → compiler specializes identically).

2. **Primal-based domain check** — `_check_domain` uses `_extract_primal` on grid boundaries. Search comparisons intentionally keep Dual — lexicographic tiebreaking selects a valid sub-gradient cell. Domain check is a binary in/out decision where primal equality must mean "in-domain."

3. **Slope adjoint without `Tv(...)` casts** — Originally added for Int y-value protection, but adjoint constructors already promote y to Float via `_promote_itp_inputs`. Removing casts lets Julia auto-promote `Dual_inv_h * Float_dy_bar → Dual`.

## Performance

Zero regression on Float paths — verified via existing allocation tests and `@allocated` gates in the new test file.

## Tests

**`test/ext/test_hermite_dual_grid.jl`** (ForwardDiff, 49 tests):
- All 4 methods × scalar/vector oneshot, ForwardDiff.derivative MWE, FD cross-check
- Interpolant construction (PreCompute + OnTheFly)
- Adjoint construction + `adj(y_bar)` (Hermite, PCHIP, Cardinal, Akima)
- Integration with Dual grid
- Range{Dual} grid
- Cardinal tension parameter on Dual grid
- Float scalar path zero-alloc regression gate

**Updated**: `test_linear_dual_grid.jl` — endpoint tests changed from "partial-dependent" to "primal-based" (matches `_check_domain` fix).

## Scope

This PR opens **Hermite family only** (1D). Constant, Quadratic, Cubic follow the same pattern in separate PRs — the core infrastructure (`_check_domain`, spacing, search, `_output_eltype`) is already prepared.

**33 files changed, +596 −633 (net −37). ~250 lines are tests.**
