### PR TITLE
(feat): Constant + Quadratic duck-typed grid support 

### DIFF
--- a/src/constant/constant_adjoint.jl
+++ b/src/constant/constant_adjoint.jl
@@ -55,7 +55,7 @@ itp = constant_interp(x, f; side=NearestSide())
 @assert dot(itp.(xq), y_bar) ≈ dot(f, adj(y_bar))
 ```
 """
-struct ConstantAdjoint{Tg <: AbstractFloat, SD <: AbstractSide, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
+struct ConstantAdjoint{Tg, SD <: AbstractSide, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
     anchors::Vector{_ConstantAnchoredQuery{Tg}}
     grid_size::Int
     x_hi::Tg
@@ -164,8 +164,8 @@ original query position, so scatter can skip OOB contributions.
 """
 function _fixup_constant_anchor_state!(
         anchors::Vector{_ConstantAnchoredQuery{Tg}},
-        xq_original::AbstractVector{Tg},
-        x_lo::Tg, x_hi::Tg
+        xq_original::AbstractVector,
+        x_lo, x_hi
     ) where {Tg}
     @inbounds for i in eachindex(anchors)
         xq_i = xq_original[i]
@@ -227,19 +227,22 @@ function constant_adjoint(
     )
     Tg = _promote_grid_float(eltype(x), eltype(x_query))
     x_p = _to_float(x, Tg)
-    xq_p = _to_float(x_query, Tg)
+    # Query normalization: convert to the grid's float base type, not to Tg itself.
+    # When Tg is a duck type (e.g. Dual), queries stay plain Float.
+    Tq_float = Tg <: AbstractFloat ? Tg : float(eltype(x_query))
+    xq_p = _to_float(x_query, Tq_float)
 
     length(x_p) >= 2 || _throw_adjoint_grid_too_small(length(x_p))
 
     x_hi = last(x_p)
 
-    # NoExtrap: validate all queries in-domain
+    # NoExtrap: validate all queries in-domain (use primal for Dual grid boundaries)
     if extrap isa NoExtrap
-        x_lo = first(x_p)
+        x_lo_p, x_hi_p = _extract_primal(first(x_p)), _extract_primal(last(x_p))
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
-            (x_lo <= xq_i <= x_hi) || throw(
-                DomainError(xq_i, "query point outside domain [$x_lo, $x_hi]")
+            (x_lo_p <= xq_i <= x_hi_p) || throw(
+                DomainError(xq_i, "query point outside domain [$x_lo_p, $x_hi_p]")
             )
         end
     end
@@ -250,10 +253,10 @@ function constant_adjoint(
         # For constant interp, ExtendExtrap == ClampExtrap (slope=0).
         # Clamp OOB queries to boundary for correct anchor geometry.
         # Then restore side flags so scatter can skip OOB contributions.
-        x_lo = first(x_p)
-        xq_clamped = clamp.(xq_p, x_lo, x_hi)
+        x_lo_p, x_hi_p = _extract_primal(first(x_p)), _extract_primal(last(x_p))
+        xq_clamped = clamp.(xq_p, x_lo_p, x_hi_p)
         anchors = _anchor_query(x_p, xq_clamped, Val(:constant), false)
-        _fixup_constant_anchor_state!(anchors, xq_p, x_lo, x_hi)
+        _fixup_constant_anchor_state!(anchors, xq_p, x_lo_p, x_hi_p)
     else
         # WrapExtrap: wraps to domain (correct)
         # NoExtrap: already validated in-domain above

--- a/src/constant/constant_adjoint.jl
+++ b/src/constant/constant_adjoint.jl
@@ -28,7 +28,7 @@ Constructed from grid and query points (query-baked, data-free).
 The same adjoint can be applied to any `ȳ` vector.
 
 # Type Parameters
-- `Tg`: Grid float type (Float32 or Float64)
+- `Tg`: Grid type (unconstrained — supports duck types like ForwardDiff.Dual)
 - `SD`: Side selection mode (`NearestSide`, `LeftSide`, `RightSide`)
 - `EP`: Extrapolation policy type (`NoExtrap`, `ExtendExtrap`, `ClampExtrap`, `FillExtrap`, `WrapExtrap`)
 

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -19,7 +19,7 @@ Internal API: no runtime grid validation; callers must ensure the anchor
 matches the interpolant grid.
 
 # Type Parameters
-- `T`: Float type (Float32 or Float64)
+- `T`: Grid type (unconstrained)
 
 # Fields
 - `idx`: Interval index where xq falls

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -44,7 +44,7 @@ itp2(aq)              # Reuses same anchor
 Anchored evaluation is faster than `itp(xq)` for non-uniform grids,
 as it eliminates O(log n) binary search.
 """
-struct _ConstantAnchoredQuery{T <: AbstractFloat}
+struct _ConstantAnchoredQuery{T}
     idx::Int                   # interval index
     xq::T                      # query point (possibly wrapped)
     state::UInt8               # IN_DOMAIN / OOB_LEFT / OOB_RIGHT
@@ -83,25 +83,16 @@ itp1(aq)              # Ultra-fast: skips interval search
 itp2(aq)              # Reuses same anchor
 ```
 """
+# Unified scalar anchor construction. _constant_anchor_query_impl handles
+# Tg conversion internally, so no separate Real wrapper is needed.
 @inline function _anchor_query(
         x::AbstractVector{T},
-        xq::T,
+        xq,
         ::Val{:constant},
         wrap::Bool = false,
         searcher::P = DEFAULT_SEARCHER
-    ) where {T <: AbstractFloat, P <: Searcher}
-    return _constant_anchor_query_impl(x, xq, wrap, _resolve_searcher_for_grid(x, searcher))
-end
-
-# Real wrapper for convenience (scalar)
-@inline function _anchor_query(
-        x::AbstractVector{T},
-        xq::Tq,
-        tag::Val{:constant},
-        wrap::Bool = false,
-        searcher::P = DEFAULT_SEARCHER
-    ) where {T <: AbstractFloat, Tq <: Real, P <: Searcher}
-    return _anchor_query(x, T(xq), tag, wrap, searcher)
+    ) where {T, P <: Searcher}
+    return _constant_anchor_query_impl(x, T(xq), wrap, _resolve_searcher_for_grid(x, searcher))
 end
 
 """
@@ -136,7 +127,7 @@ function _anchor_query(
         ::Val{:constant},
         wrap::Bool = false,
         searcher::P = _to_searcher(LinearBinarySearch())
-    ) where {T <: AbstractFloat, S <: Real, P <: Searcher}
+    ) where {T, S <: Real, P <: Searcher}
     searcher_resolved = _resolve_searcher_for_grid(x, searcher)
     output = Vector{_ConstantAnchoredQuery{T}}(undef, length(xq))
 
@@ -169,7 +160,7 @@ The same `buffer` object, filled with anchored queries.
         ::Val{:constant},
         wrap::Bool = false,
         searcher::P = _to_searcher(LinearBinarySearch())
-    ) where {T <: AbstractFloat, S <: Real, P <: Searcher}
+    ) where {T, S <: Real, P <: Searcher}
     @assert length(buffer) >= length(xq) "Buffer too small: $(length(buffer)) < $(length(xq))"
     searcher_resolved = _resolve_searcher_for_grid(x, searcher)
 
@@ -195,7 +186,7 @@ Internal implementation of _anchor_query for constant interpolation.
         xq::T,
         wrap::Bool,
         policy::P = DEFAULT_SEARCHER
-    ) where {T <: AbstractFloat, P <: Searcher}
+    ) where {T, P <: Searcher}
     loc = _anchor_loc(x, xq, wrap, policy)
 
     # Compute geometry (constant-internal concern)
@@ -227,7 +218,7 @@ aq = _anchor_query(x, 0.5, Val(:constant))
 val = itp(aq)           # Value
 ```
 """
-@inline function (itp::ConstantInterpolant{T})(aq::_ConstantAnchoredQuery{T}; deriv::DerivOp = EvalValue()) where {T <: AbstractFloat}
+@inline function (itp::ConstantInterpolant{T})(aq::_ConstantAnchoredQuery{T}; deriv::DerivOp = EvalValue()) where {T}
     return _constant_eval_with_anchor(itp, aq, deriv)
 end
 
@@ -235,7 +226,7 @@ end
         itp::ConstantInterpolant{T},
         aq::_ConstantAnchoredQuery{T},
         op::O
-    ) where {T <: AbstractFloat, O <: AbstractEvalOp}
+    ) where {T, O <: AbstractEvalOp}
     # Handle extrapolation based on mode and side
     return _constant_anchor_dispatch(itp, aq, op, itp.extrap)
 end
@@ -296,7 +287,7 @@ end
         aq::_ConstantAnchoredQuery{T},
         op::O,
         ::NoExtrap
-    ) where {T <: AbstractFloat, O <: AbstractEvalOp}
+    ) where {T, O <: AbstractEvalOp}
     if aq.state != IN_DOMAIN
         x_min, x_max = first(itp.x), last(itp.x)
         throw(DomainError(aq.xq, "query point outside domain [$x_min, $x_max]"))
@@ -330,7 +321,7 @@ Returns newly allocated vector.
 function (itp::ConstantInterpolant{T})(
         aq_vec::AbstractVector{_ConstantAnchoredQuery{T}};
         deriv::DerivOp = EvalValue()
-    ) where {T <: AbstractFloat}
+    ) where {T}
     output = Vector{T}(undef, length(aq_vec))
     @inbounds for i in eachindex(aq_vec)
         output[i] = _constant_eval_with_anchor(itp, aq_vec[i], deriv)
@@ -347,7 +338,7 @@ function (itp::ConstantInterpolant{T})(
         output::AbstractVector{T},
         aq_vec::AbstractVector{_ConstantAnchoredQuery{T}};
         deriv::DerivOp = EvalValue()
-    ) where {T <: AbstractFloat}
+    ) where {T}
     @assert length(output) == length(aq_vec) "output length must match aq_vec length"
     @inbounds for i in eachindex(aq_vec)
         output[i] = _constant_eval_with_anchor(itp, aq_vec[i], deriv)

--- a/src/constant/constant_interpolant.jl
+++ b/src/constant/constant_interpolant.jl
@@ -36,7 +36,7 @@ end
         side::SD,
         deriv::O,
         searcher::P
-    ) where {Tg <: AbstractFloat, Tv, E <: AbstractExtrap, SD <: AbstractSide, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg, Tv, E <: AbstractExtrap, SD <: AbstractSide, O <: AbstractEvalOp, P <: Searcher}
     extrap = _check_domain(x, xq, extrap)
     return @inbounds for i in eachindex(xq, output)
         output[i] = _constant_eval_at_point(x, y, xq[i], extrap, side, deriv, searcher)
@@ -108,7 +108,7 @@ end
         extrap::AbstractExtrap = NoExtrap(),
         side::AbstractSide = NearestSide(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {TX <: Real, TY}
+    ) where {TX, TY}
     x_p, y_p = _promote_itp_inputs(x, y)
     extrap_p = _promote_extrap(extrap, eltype(y_p))
     return ConstantInterpolant(x_p, y_p; extrap = extrap_p, side, search)

--- a/src/constant/constant_kernels.jl
+++ b/src/constant/constant_kernels.jl
@@ -11,7 +11,7 @@
 # - side = NearestSide() | LeftSide() | RightSide()
 #
 # Type parameters:
-# - Tg<:AbstractFloat: Grid type (geometry)
+# - Tg: Grid type (geometry, unconstrained)
 # - Tv: Value type (unconstrained)
 #
 # AD Support:

--- a/src/constant/constant_kernels.jl
+++ b/src/constant/constant_kernels.jl
@@ -29,7 +29,7 @@ Constant interpolation with left-continuous (floor) convention.
 Always returns the left boundary value `y_left`.
 dL can be any Real (including ForwardDiff.Dual for AD).
 """
-@inline function _constant_kernel(::EvalValue, y_left::Tv, ::Tv, ::Tg, dL::Td, ::LeftSide) where {Tv, Tg <: AbstractFloat, Td <: Real}
+@inline function _constant_kernel(::EvalValue, y_left::Tv, ::Tv, ::Tg, dL::Td, ::LeftSide) where {Tv, Tg, Td <: Real}
     return y_left
 end
 
@@ -40,7 +40,7 @@ Constant interpolation with right-continuous (ceiling) convention.
 Returns `y_left` at grid point (dL == 0), `y_right` otherwise.
 dL can be any Real (including ForwardDiff.Dual for AD).
 """
-@inline function _constant_kernel(::EvalValue, y_left::Tv, y_right::Tv, ::Tg, dL::Td, ::RightSide) where {Tv, Tg <: AbstractFloat, Td <: Real}
+@inline function _constant_kernel(::EvalValue, y_left::Tv, y_right::Tv, ::Tg, dL::Td, ::RightSide) where {Tv, Tg, Td <: Real}
     # Use primal value for comparison (supports ForwardDiff.Dual)
     dL_primal = _extract_primal(dL)
     return iszero(dL_primal) ? y_left : y_right
@@ -53,7 +53,7 @@ Constant interpolation with nearest-neighbor convention and left tie-breaking.
 Returns `y_left` if dL <= h/2 (including midpoint), `y_right` otherwise.
 dL can be any Real (including ForwardDiff.Dual for AD).
 """
-@inline function _constant_kernel(::EvalValue, y_left::Tv, y_right::Tv, h::Tg, dL::Td, ::NearestSide) where {Tv, Tg <: AbstractFloat, Td <: Real}
+@inline function _constant_kernel(::EvalValue, y_left::Tv, y_right::Tv, h::Tg, dL::Td, ::NearestSide) where {Tv, Tg, Td <: Real}
     # Use primal value for comparison (supports ForwardDiff.Dual)
     dL_primal = _extract_primal(dL)
     return dL_primal <= h / 2 ? y_left : y_right
@@ -66,7 +66,7 @@ First derivative of constant interpolation.
 Always returns zero (constant function has no slope).
 Uses `0 * y_left` for duck-typing support and NaN propagation.
 """
-@inline function _constant_kernel(::EvalDeriv1, y_left::Tv, ::Tv, ::Tg, dL::Td, ::AbstractSide) where {Tv, Tg <: AbstractFloat, Td <: Real}
+@inline function _constant_kernel(::EvalDeriv1, y_left::Tv, ::Tv, ::Tg, dL::Td, ::AbstractSide) where {Tv, Tg, Td <: Real}
     return 0 * y_left
 end
 
@@ -76,7 +76,7 @@ end
 Second derivative of constant interpolation.
 Always returns zero (constant function has no curvature).
 """
-@inline function _constant_kernel(::EvalDeriv2, y_left::Tv, ::Tv, ::Tg, dL::Td, ::AbstractSide) where {Tv, Tg <: AbstractFloat, Td <: Real}
+@inline function _constant_kernel(::EvalDeriv2, y_left::Tv, ::Tv, ::Tg, dL::Td, ::AbstractSide) where {Tv, Tg, Td <: Real}
     return 0 * y_left
 end
 
@@ -85,12 +85,12 @@ end
 
 Third derivative of constant interpolation is always zero.
 """
-@inline function _constant_kernel(::EvalDeriv3, y_left::Tv, ::Tv, ::Tg, dL::Td, ::AbstractSide) where {Tv, Tg <: AbstractFloat, Td <: Real}
+@inline function _constant_kernel(::EvalDeriv3, y_left::Tv, ::Tv, ::Tg, dL::Td, ::AbstractSide) where {Tv, Tg, Td <: Real}
     return 0 * y_left
 end
 
 """Generic fallback: N-th derivative of degree-0 (constant) is zero for N ≥ 1."""
-@inline function _constant_kernel(::DerivOp{N}, y_left::Tv, ::Tv, ::Tg, ::Td, ::AbstractSide) where {N, Tv, Tg <: AbstractFloat, Td <: Real}
+@inline function _constant_kernel(::DerivOp{N}, y_left::Tv, ::Tv, ::Tg, ::Td, ::AbstractSide) where {N, Tv, Tg, Td <: Real}
     return 0 * y_left
 end
 

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -26,7 +26,7 @@
         side::AbstractSide,
         op::AbstractEvalOp,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real, S <: Searcher}
+    ) where {Tg, Tv, Tq <: Real, S <: Searcher}
     xi_primal = _extract_primal(xi)
     xi_typed = Tg(xi_primal)
     @boundscheck _check_domain(x, xi_typed, extrap)
@@ -48,7 +48,7 @@ end
         side::AbstractSide,
         op::AbstractEvalOp,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real, S <: Searcher}
+    ) where {Tg, Tv, Tq <: Real, S <: Searcher}
     return _constant_eval_at_point(x, y, xi, ClampExtrap(), side, op, searcher)
 end
 
@@ -61,11 +61,11 @@ end
         side::AbstractSide,
         op::AbstractEvalOp,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real, S <: Searcher}
+    ) where {Tg, Tv, Tq <: Real, S <: Searcher}
     xi_primal = _extract_primal(xi)
     xi_typed = Tg(xi_primal)
-    xi_typed < first(x) && return _eval_extrapolation(op, first(y), extrap, xi)
-    xi_typed > last(x) && return _eval_extrapolation(op, last(y), extrap, xi)
+    xi_typed < _extract_primal(first(x)) && return _eval_extrapolation(op, first(y), extrap, xi)
+    xi_typed > _extract_primal(last(x)) && return _eval_extrapolation(op, last(y), extrap, xi)
     if xi_typed == last(x)
         return op isa EvalValue ? last(y) : 0 * first(y)
     end
@@ -83,7 +83,7 @@ end
         side::AbstractSide,
         op::AbstractEvalOp,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real, S <: Searcher}
+    ) where {Tg, Tv, Tq <: Real, S <: Searcher}
     xi_primal = _extract_primal(xi)
     xi_typed = Tg(xi_primal)
     xi_wrapped = _wrap_to_domain(xi_typed, first(x), last(x))
@@ -95,7 +95,7 @@ end
 
 # ╔═══════════════════════════════════════════════════════════════════════════╗
 # ║                         PUBLIC API - HOT PATH                             ║
-# ║                 Tg<:AbstractFloat grid, Tv value type                     ║
+# ║                  Generic grid (supports duck types), Tv value type         ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
 # ========================================
@@ -145,8 +145,10 @@ sorted_queries = sort(rand(1000))
 vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_window=8))
 ```
 """
-# AD Support: xi can be any Real (including ForwardDiff.Dual)
-# Note: Tq<:Real constraint resolves method ambiguity with generic Real wrapper
+# Public scalar one-shot API.
+# Single unified entry point for every grid eltype. `_promote_itp_inputs` handles
+# grid normalization (Range -> _CachedRange, Int -> Float64, Dual -> Dual{Float64},
+# etc.) and optional y-value promotion for standard numeric types.
 @inline function constant_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
@@ -156,12 +158,12 @@ vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_wi
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     @boundscheck length(y) == length(x) || throw(ArgumentError("x and y must have same length"))
 
-    x = _to_float(x, Tg)
-    searcher = _resolve_search(x, xi, search, hint)
-    return _constant_eval_at_point(x, y, xi, extrap, side, deriv, searcher)
+    x_typed, y_typed = _promote_itp_inputs(x, y)
+    searcher = _resolve_search(x_typed, xi, search, hint)
+    return _constant_eval_at_point(x_typed, y_typed, xi, extrap, side, deriv, searcher)
 end
 
 # ========================================
@@ -193,23 +195,24 @@ output = zeros(1000)
 constant_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear_window=8))
 ```
 """
+# Unified in-place entry point. Handles promotion internally via _promote_itp_inputs,
+# so no separate Real/Mixed-type wrapper is needed (same pattern as the scalar API).
 function constant_interp!(
-        output::AbstractVector{Tv},
-        x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        x_targets::AbstractVector{Tg};
+        output::AbstractVector,
+        x::AbstractVector,
+        y::AbstractVector,
+        x_targets::AbstractVector;
         extrap::AbstractExtrap = NoExtrap(),
         side::AbstractSide = NearestSide(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv}
+    )
     @assert length(y) == length(x) "x and y must have same length"
     @assert length(output) == length(x_targets) "output must match x_targets length"
 
-    x = _to_float(x, Tg)
-    x_targets = _to_float(x_targets, Tg)
-    searcher = _resolve_search(x, x_targets, search, nothing)
-    _constant_vector_loop!(output, x, y, x_targets, extrap, side, deriv, searcher)
+    x_typed, y_typed, xq_typed = _promote_itp_inputs(x, y, x_targets)
+    searcher = _resolve_search(x_typed, xq_typed, search, nothing)
+    _constant_vector_loop!(output, x_typed, y_typed, xq_typed, extrap, side, deriv, searcher)
     return output
 end
 
@@ -234,83 +237,22 @@ sorted_queries = sort(rand(1000))
 vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_window=8))
 ```
 """
+# Unified allocating vector one-shot. Calls the unified constant_interp! which
+# handles promotion internally. Output type includes Tg for duck grids.
 function constant_interp(
-        x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        x_targets::AbstractVector{Tg};
+        x::AbstractVector,
+        y::AbstractVector,
+        x_targets::AbstractVector;
         extrap::AbstractExtrap = NoExtrap(),
         side::AbstractSide = NearestSide(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv}
-    output = Vector{Tv}(undef, length(x_targets))
-    constant_interp!(output, x, y, x_targets; extrap, side, deriv, search)
-    return output
-end
-
-
-# ╔═══════════════════════════════════════════════════════════════════════════╗
-# ║                     GENERIC WRAPPERS - CONVENIENCE                        ║
-# ║              Auto-promote Real types to Float (type conversion)           ║
-# ╚═══════════════════════════════════════════════════════════════════════════╝
-
-# ========================================
-# Scalar → typed wrappers
-# ========================================
-# Unified wrapper for non-AbstractFloat inputs (Int, mixed types, Complex, etc.)
-# POLICY: Tg is computed from x/y ONLY, not from xq
-# AD Support: Pass xi directly without Tg conversion to preserve Dual type
-
-@inline function constant_interp(
-        x::AbstractVector{Tg}, y::AbstractVector{Tv}, xi::Tq; kwargs...
-    ) where {Tg <: Real, Tv, Tq <: Real}
-    x_typed, y_typed = _promote_itp_inputs(x, y)
-    # Pass xi directly (not converted) to preserve ForwardDiff.Dual for AD
-    return constant_interp(x_typed, y_typed, xi; kwargs...)
-end
-
-# ========================================
-# Vector → typed wrappers (allocating)
-# ========================================
-# POLICY: Tg is computed from x/y ONLY, not from x_targets
-
-function constant_interp(
-        x::AbstractVector{Tg}, y::AbstractVector{Tv}, x_targets::AbstractVector{Tq}; kwargs...
-    ) where {Tg <: Real, Tv, Tq <: Real}
+    )
     x_typed, y_typed, xq_typed = _promote_itp_inputs(x, y, x_targets)
-    Tv_float = eltype(y_typed)
-    output = Vector{Tv_float}(undef, length(x_targets))
-    constant_interp!(output, x_typed, y_typed, xq_typed; kwargs...)
+    Tg = eltype(x_typed)
+    Tv = eltype(y_typed)
+    T_out = _output_eltype(Tv, Tg)
+    output = Vector{T_out}(undef, length(x_targets))
+    constant_interp!(output, x_typed, y_typed, xq_typed; extrap, side, deriv, search)
     return output
-end
-
-# ========================================
-# Vector → typed wrappers (in-place)
-# ========================================
-
-function constant_interp!(
-        output::AbstractVector,
-        x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        x_targets::AbstractVector{Tq};
-        kwargs...
-    ) where {Tg <: Real, Tv, Tq <: Real}
-    @assert length(y) == length(x) "x and y must have same length"
-    @assert length(output) == length(x_targets) "output must match x_targets length"
-
-    x_typed, y_typed, xq_typed = _promote_itp_inputs(x, y, x_targets)
-    Tv_float = eltype(y_typed)
-
-    # Validate output can hold result type
-    Tout = eltype(output)
-    if promote_type(Tout, Tv_float) !== Tout
-        throw(
-            ArgumentError(
-                "output eltype $Tout cannot hold interpolation result type $Tv_float. " *
-                    "Use Vector{$Tv_float} or a wider type."
-            )
-        )
-    end
-
-    return constant_interp!(output, x_typed, y_typed, xq_typed; kwargs...)
 end

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -27,8 +27,7 @@
         op::AbstractEvalOp,
         searcher::S
     ) where {Tg, Tv, Tq <: Real, S <: Searcher}
-    xi_primal = _extract_primal(xi)
-    xi_typed = Tg(xi_primal)
+    xi_typed = _to_grid_type(xi, Tg)
     @boundscheck _check_domain(x, xi_typed, extrap)
     if xi_typed == last(x)
         return op isa EvalValue ? last(y) : 0 * first(y)
@@ -62,8 +61,7 @@ end
         op::AbstractEvalOp,
         searcher::S
     ) where {Tg, Tv, Tq <: Real, S <: Searcher}
-    xi_primal = _extract_primal(xi)
-    xi_typed = Tg(xi_primal)
+    xi_typed = _to_grid_type(xi, Tg)
     xi_typed < _extract_primal(first(x)) && return _eval_extrapolation(op, first(y), extrap, xi)
     xi_typed > _extract_primal(last(x)) && return _eval_extrapolation(op, last(y), extrap, xi)
     if xi_typed == last(x)
@@ -84,8 +82,7 @@ end
         op::AbstractEvalOp,
         searcher::S
     ) where {Tg, Tv, Tq <: Real, S <: Searcher}
-    xi_primal = _extract_primal(xi)
-    xi_typed = Tg(xi_primal)
+    xi_typed = _to_grid_type(xi, Tg)
     xi_wrapped = _wrap_to_domain(xi_typed, first(x), last(x))
     idx, xL, xR = search_interval(searcher, x, xi_wrapped)
     dL = xi_wrapped - xL

--- a/src/constant/constant_oneshot_series.jl
+++ b/src/constant/constant_oneshot_series.jl
@@ -21,7 +21,7 @@
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tq <: Real}
+    ) where {Tg, Tq <: Real}
     _validate_series_lengths(s, length(x))
     x = _to_float(x, Tg)
     _check_domain(x, xq, extrap)
@@ -50,7 +50,7 @@ end
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tq <: Real}
+    ) where {Tg, Tq <: Real}
     _validate_series_lengths(s, length(x))
     length(output) == n_series(s) || _throw_series_dim_mismatch(length(output), n_series(s))
     x = _to_float(x, Tg)
@@ -78,7 +78,7 @@ end
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tq <: Real}
+    ) where {Tg, Tq <: Real}
     _validate_series_lengths(s, length(x))
     x = _to_float(x, Tg)
     K = n_series(s)
@@ -108,7 +108,7 @@ function constant_interp(
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tq <: Real}
+    ) where {Tg, Tq <: Real}
     K = n_series(s)
     Tv_out = _value_type(_series_eltype(s), Tg)
     outputs = [Vector{Tv_out}(undef, length(xqs)) for _ in 1:K]
@@ -116,35 +116,7 @@ function constant_interp(
     return outputs
 end
 
-# ╔═══════════════════════════════════════════════════════════════════════════╗
-# ║                     REAL TYPE PROMOTION WRAPPERS                         ║
-# ╚═══════════════════════════════════════════════════════════════════════════╝
-
-@inline function constant_interp(
-        x::AbstractVector{Tg}, s::Series, xq::Tq; kwargs...
-    ) where {Tg <: Real, Tq <: Real}
-    x_typed = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
-    return constant_interp(x_typed, s, xq; kwargs...)
-end
-
-@inline function constant_interp!(
-        output::AbstractVector, x::AbstractVector{Tg}, s::Series, xq::Tq; kwargs...
-    ) where {Tg <: Real, Tq <: Real}
-    x_typed = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
-    return constant_interp!(output, x_typed, s, xq; kwargs...)
-end
-
-function constant_interp!(
-        outputs::AbstractVector{<:AbstractVector},
-        x::AbstractVector{Tg}, s::Series, xqs::AbstractVector{Tq}; kwargs...
-    ) where {Tg <: Real, Tq <: Real}
-    Tg_float = _promote_grid_float(Tg, _series_eltype(s))
-    return constant_interp!(outputs, _to_float(x, Tg_float), s, xqs; kwargs...)
-end
-
-function constant_interp(
-        x::AbstractVector{Tg}, s::Series, xqs::AbstractVector{Tq}; kwargs...
-    ) where {Tg <: Real, Tq <: Real}
-    Tg_float = _promote_grid_float(Tg, _series_eltype(s))
-    return constant_interp(_to_float(x, Tg_float), s, xqs; kwargs...)
-end
+# NOTE: the former Real type promotion wrappers (Tg <: Real) have been removed.
+# The hot-path methods above now use unconstrained Tg, and _to_float handles
+# grid normalization for all types (Int, Float, Dual, etc.), preventing
+# infinite recursion on duck types like ForwardDiff.Dual <: Real.

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -20,7 +20,7 @@ Multi-series constant (step) interpolant with unified matrix storage and SIMD op
 Shares a single x-grid across N y-series for efficient batch evaluation.
 
 # Type Parameters
-- `Tg`: Grid type (Float32 or Float64)
+- `Tg`: Grid type (unconstrained — supports duck types like ForwardDiff.Dual)
 - `Tv`: Value type (unconstrained)
 - `P`: Search policy type
 - `X`: Grid container type (Vector or Range)

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -64,7 +64,7 @@ sitp_complex = constant_interp(x, y_complex)
 This type uses `mutable struct` with all `const` fields (Julia 1.8+) instead of
 plain `struct` for performance reasons. See CubicSeriesInterpolant for details.
 """
-mutable struct ConstantSeriesInterpolant{Tg <: AbstractFloat, Tv, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, SD <: AbstractSide, P <: AbstractSearchPolicy, X <: AbstractVector{Tg}} <: AbstractSeriesInterpolant{Tg, Tv}
+mutable struct ConstantSeriesInterpolant{Tg, Tv, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, SD <: AbstractSide, P <: AbstractSearchPolicy, X <: AbstractVector{Tg}} <: AbstractSeriesInterpolant{Tg, Tv}
     const x::X                            # Shared x-grid (Range or Vector)
     const y::Matrix{Tv}                   # Series-contiguous y (n_points × n_series)
     const _transpose::LazyTranspose{Tv}   # Lazy point-contiguous layout
@@ -79,7 +79,7 @@ mutable struct ConstantSeriesInterpolant{Tg <: AbstractFloat, Tv, S <: AbstractG
             extrap::E,
             side::SD,
             search::P = AutoSearch()
-        ) where {Tg <: AbstractFloat, Tv, E <: AbstractExtrap, SD <: AbstractSide, P <: AbstractSearchPolicy}
+        ) where {Tg, Tv, E <: AbstractExtrap, SD <: AbstractSide, P <: AbstractSearchPolicy}
         # _to_float(copy(x), Tg): Range → _CachedRange (O(1) search + no TwicePrecision overhead);
         # Vector → defensive copy. copy() on Range is identity (zero alloc).
         # typeof(xc) rebinds X after conversion (view → Vector, TwicePrecision → _CachedRange).
@@ -136,7 +136,7 @@ Uses point-contiguous layout for SIMD optimization.
         sitp::ConstantSeriesInterpolant{Tg, Tv},
         aq::_ConstantAnchoredQuery{Tg},
         op::AbstractEvalOp
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     y_point = _ensure_point_layout!(sitp)
     n_pts = n_points(sitp)
     x_min, x_max = Tg(first(sitp.x)), Tg(last(sitp.x))
@@ -199,7 +199,7 @@ Outside-domain delegates to `_eval_series_at_anchor!` for extrapolation.
         aq::_ConstantAnchoredQuery{Tg},
         xq,  # Original xq (any Real, including Dual)
         op::AbstractEvalOp
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     # Outside domain: delegate to extrapolation handler (trait method)
     if aq.state != IN_DOMAIN
         return _eval_series_at_anchor!(output, sitp, aq, op)
@@ -255,7 +255,7 @@ end
         ::AbstractSide,
         ::AbstractEvalOp,
         ::UInt8
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     _throw_extrap_domain_error(aq.xq, x_min, x_max)
 end
 
@@ -272,7 +272,7 @@ end
         ::AbstractSide,
         op::AbstractEvalOp,
         side::UInt8
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     return _fill_constant_extrap_simd!(out, y_point, side, n_pts, op, extrap)
 end
 
@@ -289,7 +289,7 @@ end
         side_val::AbstractSide,
         op::AbstractEvalOp,
         ::UInt8
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     # Use boundary interval for extension (inline evaluation, no xq needed)
     idx = aq.idx
     idx1 = idx + 1
@@ -340,7 +340,7 @@ function constant_interp(
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat}
+    ) where {Tg}
     # Type promotion: widen grid if y's float base is wider than Tg
     Tv = _series_eltype(s)
     Tg_new = _promote_grid_float(Tg, Tv)
@@ -356,17 +356,8 @@ function constant_interp(
     return ConstantSeriesInterpolant(x, y_mat, extrap_p, side, search)
 end
 
-# Real grid promotion (Int, etc.) → convert to float and delegate
-function constant_interp(
-        x::AbstractVector{Tg},
-        s::Series;
-        side::AbstractSide = NearestSide(),
-        extrap::AbstractExtrap = NoExtrap(),
-        search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: Real}
-    Tg_float = _promote_grid_float(Tg, _series_eltype(s))
-    return constant_interp(_to_float(x, Tg_float), s; side, extrap, search)
-end
+# NOTE: the former Real grid promotion wrapper (Tg <: Real) has been removed.
+# The constructor above now uses unconstrained Tg and handles promotion internally.
 
 # ========================================
 # Scalar Evaluation
@@ -392,7 +383,7 @@ function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, P, Tq <: Real}
+    ) where {Tg, Tv, P, Tq <: Real}
     T_out = _series_output_type(Tv, Tq)
     out = Vector{T_out}(undef, n_series(sitp))
     return sitp(out, xq; deriv = deriv, search = search, hint = hint)
@@ -409,7 +400,7 @@ function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, P, Tq <: Real}
+    ) where {Tg, Tv, P, Tq <: Real}
     n_ser = n_series(sitp)
 
     # Validate output length
@@ -443,7 +434,7 @@ function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, P, Tq <: Real}
+    ) where {Tg, Tv, P, Tq <: Real}
     xq_typed = _to_float(xq, Tg)
     n_query = length(xq_typed)
     n_ser = n_series(sitp)
@@ -473,21 +464,22 @@ Uses task-local pool for anchor vector to achieve zero allocation after warmup.
 """
 @with_pool pool function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
         outputs::AbstractVector{<:AbstractVector{Tv}},
-        xq::AbstractVector{Tg};
+        xq::AbstractVector{<:Real};
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, P}
-    n_query = length(xq)
+    ) where {Tg, Tv, P}
+    xq_typed = _to_float(xq, Tg)
+    n_query = length(xq_typed)
     n_ser = n_series(sitp)
 
     # Validate dimensions
     _validate_series_outputs(outputs, n_ser, n_query)
 
     # Build anchors from pool (zero allocation after warmup)
-    aq_vec = acquire!(pool, _ConstantAnchoredQuery{Tg}, length(xq))
-    searcher = _resolve_search(sitp.x, xq, search, hint)
-    _fill_anchors!(aq_vec, sitp.x, xq, Val(:constant), _should_wrap(sitp), searcher)
+    aq_vec = acquire!(pool, _ConstantAnchoredQuery{Tg}, length(xq_typed))
+    searcher = _resolve_search(sitp.x, xq_typed, search, hint)
+    _fill_anchors!(aq_vec, sitp.x, xq_typed, Val(:constant), _should_wrap(sitp), searcher)
 
     # Extract matrices for argument-passing pattern
     y = sitp.y
@@ -503,18 +495,6 @@ Uses task-local pool for anchor vector to achieve zero allocation after warmup.
         _eval_constant_series_vector!(outputs[k], y, x_grid, n_pts, x_min, x_max, k, aq_vec, extrap, side_val, deriv)
     end
     return outputs
-end
-
-# Real type wrapper for in-place vector
-function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
-        outputs::AbstractVector{<:AbstractVector{Tv}},
-        xq::AbstractVector{Tq};
-        deriv::DerivOp = EvalValue(),
-        search::AbstractSearchPolicy = sitp.search_policy,
-        hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, P, Tq <: Real}
-    xq_typed = _to_float(xq, Tg)
-    return sitp(outputs, xq_typed; deriv = deriv, search = search, hint = hint)
 end
 
 """
@@ -533,7 +513,7 @@ Uses argument-passing pattern for optimal performance.
         extrap::AbstractExtrap,
         side_val::AbstractSide,
         op::AbstractEvalOp
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     @inbounds for j in eachindex(out, aq_vec)
         out[j] = _eval_constant_series_with_extrap(y, x, n_pts, x_min, x_max, k, aq_vec[j], extrap, side_val, op)
     end
@@ -554,7 +534,7 @@ Internal: Evaluate single series at single query point with extrapolation handli
         extrap::AbstractExtrap,
         side_val::AbstractSide,
         op::AbstractEvalOp
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     # Special case: at right boundary (MUST be preserved!)
     if aq.xq == x_max
         if op isa EvalValue
@@ -588,7 +568,7 @@ Internal: Core constant evaluation for series k at anchored query point.
         aq::_ConstantAnchoredQuery{Tg},
         side_val::AbstractSide,
         op::AbstractEvalOp
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     # Derivatives of constant (step) function are zero
     if !(op isa EvalValue)
         return 0 * first(y)

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -211,7 +211,7 @@ Outside-domain delegates to `_eval_series_at_anchor!` for extrapolation.
 
     # Special case: at right boundary (use primal for comparison)
     xq_primal = _extract_primal(xq)
-    if Tg(xq_primal) == Tg(last(sitp.x))
+    if xq_primal == _extract_primal(last(sitp.x))
         if op isa EvalValue
             @inbounds @simd for k in axes(output, 1)
                 output[k] = y_point[k, n_pts]
@@ -406,9 +406,8 @@ function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
     # Validate output length
     _validate_scalar_output(output, n_ser)
 
-    # AD Support: Extract primal for anchor building, pass original xq for AD
-    xq_primal = _extract_primal(xq)
-    xq_typed = Tg(xq_primal)
+    # AD Support: Convert to grid type for anchor building, pass original xq for AD
+    xq_typed = _to_grid_type(xq, Tg)
 
     # Build anchor using primal value
     aq = _make_anchor(sitp, xq_typed, _resolve_search(sitp.x, xq, search, hint))
@@ -435,7 +434,9 @@ function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, P, Tq <: Real}
-    xq_typed = _to_float(xq, Tg)
+    # Normalize queries to the grid's base float type (not Tg itself, which may be Dual)
+    Tg_float = Tg <: AbstractFloat ? Tg : float(Tq)
+    xq_typed = _to_float(xq, Tg_float)
     n_query = length(xq_typed)
     n_ser = n_series(sitp)
 
@@ -469,7 +470,9 @@ Uses task-local pool for anchor vector to achieve zero allocation after warmup.
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, P}
-    xq_typed = _to_float(xq, Tg)
+    # Normalize queries to the grid's base float type (not Tg itself, which may be Dual)
+    Tg_float = Tg <: AbstractFloat ? Tg : float(eltype(xq))
+    xq_typed = _to_float(xq, Tg_float)
     n_query = length(xq_typed)
     n_ser = n_series(sitp)
 

--- a/src/constant/constant_types.jl
+++ b/src/constant/constant_types.jl
@@ -52,7 +52,7 @@ itp = constant_interp(x, y; search=LinearBinarySearch())  # explicit override
 val = itp(0.5; search=BinarySearch())  # per-call override
 ```
 """
-struct ConstantInterpolant{Tg <: AbstractFloat, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, SD <: AbstractSide, P <: AbstractSearchPolicy} <: AbstractInterpolant1D{Tg, Tv}
+struct ConstantInterpolant{Tg, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, SD <: AbstractSide, P <: AbstractSearchPolicy} <: AbstractInterpolant1D{Tg, Tv}
     x::X
     y::Y
     spacing::S       # Grid spacing (ScalarSpacing for Range, VectorSpacing for Vector)
@@ -63,7 +63,7 @@ struct ConstantInterpolant{Tg <: AbstractFloat, Tv, X <: AbstractVector{Tg}, Y <
     # Inner constructor: parametric, only calls new (handles validation only)
     function ConstantInterpolant{Tg, Tv, X, Y, S, E, SD, P}(
             x::AbstractVector{Tg}, y::AbstractVector{Tv}, spacing::S, ev::E, sv::SD, search::P
-        ) where {Tg <: AbstractFloat, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, SD <: AbstractSide, P <: AbstractSearchPolicy}
+        ) where {Tg, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, SD <: AbstractSide, P <: AbstractSearchPolicy}
         length(x) == length(y) || _throw_length_mismatch(length(x), length(y))
         length(x) >= 2 || _throw_grid_too_small(length(x))
         # Copy to ensure immutability: once constructed, the interpolant owns
@@ -88,7 +88,7 @@ end
         extrap::AbstractExtrap = NoExtrap(),
         side::AbstractSide = NearestSide(),
         search::P = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, P <: AbstractSearchPolicy}
+    ) where {Tg, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, P <: AbstractSearchPolicy}
     E = typeof(extrap)
     SD = typeof(side)
     spacing = _create_spacing(x)

--- a/src/constant/constant_types.jl
+++ b/src/constant/constant_types.jl
@@ -12,7 +12,7 @@ Lightweight callable interpolant for constant (step) interpolation.
 Returned by `constant_interp(x, y)` (2-argument form).
 
 # Type Parameters
-- `Tg<:AbstractFloat`: Grid type (Float32, Float64) for x-coordinates
+- `Tg`: Grid type (unconstrained) for x-coordinates
 - `Tv`: Value type (unconstrained)
 - `X<:AbstractVector{Tg}`: Type of x-coordinates
 - `Y<:AbstractVector{Tv}`: Type of y-values

--- a/src/constant/nd/constant_nd_adjoint.jl
+++ b/src/constant/nd/constant_nd_adjoint.jl
@@ -33,7 +33,7 @@ function _bake_constant_nd_anchors(
         spacings::NTuple{N, AbstractGridSpacing{Tg}},
         queries,
         extraps::Tuple{Vararg{AbstractExtrap, N}}
-    ) where {N, Tg <: AbstractFloat}
+    ) where {N, Tg}
     nq = _query_length(queries)
     _query_validate(queries)
     _validate_nd_domain(grids, queries, extraps)
@@ -184,7 +184,7 @@ function constant_adjoint(
     ) where {N}
     length(queries) == N || _throw_ndims_mismatch("query vectors", N, length(queries))
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     extraps = _resolve_extrap_nd(extrap, nothing, Val(N), Tg)
     sides = _resolve_side_nd(side, Val(N))
@@ -225,7 +225,7 @@ function constant_adjoint(
     ) where {N}
     _query_check_ndims(queries, Val(N))
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     extraps = _resolve_extrap_nd(extrap, nothing, Val(N), Tg)
     sides = _resolve_side_nd(side, Val(N))
@@ -243,7 +243,7 @@ function _build_constant_nd_adjoint(
         queries,
         extraps::Tuple{Vararg{AbstractExtrap, N}},
         sides::Tuple{Vararg{AbstractSide, N}}
-    ) where {N, Tg <: AbstractFloat}
+    ) where {N, Tg}
     # Validate all axes have at least 2 points
     @inbounds for d in 1:N
         length(grids[d]) >= 2 || _throw_adjoint_grid_too_small(d, length(grids[d]))

--- a/src/constant/nd/constant_nd_adjoint_types.jl
+++ b/src/constant/nd/constant_nd_adjoint_types.jl
@@ -45,7 +45,7 @@ adj(f_bar, y_bar)               # in-place (zero-allocation)
 ```
 """
 struct ConstantAdjointND{
-        Tg <: AbstractFloat,
+        Tg,
         N,
         G <: NTuple{N, AbstractVector{Tg}},
         S <: NTuple{N, AbstractGridSpacing{Tg}},
@@ -66,7 +66,7 @@ struct ConstantAdjointND{
             grids::NTuple{N, AbstractVector{Tg}}, spacings::S, extraps::EP, sides::SD,
             anchors::Vector{NTuple{N, _ConstantAnchoredQuery{Tg}}}, grid_size::NTuple{N, Int}
         ) where {
-            Tg <: AbstractFloat, N, S <: NTuple{N, AbstractGridSpacing{Tg}},
+            Tg, N, S <: NTuple{N, AbstractGridSpacing{Tg}},
             EP <: Tuple{Vararg{AbstractExtrap, N}}, SD <: Tuple{Vararg{AbstractSide, N}},
         }
         grids_c = map(copy, grids)

--- a/src/constant/nd/constant_nd_adjoint_types.jl
+++ b/src/constant/nd/constant_nd_adjoint_types.jl
@@ -25,7 +25,7 @@ Constructed from grids and query points (query-baked, data-free).
 The same adjoint can be applied to any `ȳ` vector.
 
 # Type Parameters
-- `Tg`:  Grid float type (Float32 or Float64)
+- `Tg`: Grid type (unconstrained — supports duck types)
 - `N`:   Number of dimensions
 - `G`:   Grid tuple type
 - `S`:   Spacing tuple type

--- a/src/constant/nd/constant_nd_interpolant.jl
+++ b/src/constant/nd/constant_nd_interpolant.jl
@@ -58,7 +58,7 @@ function constant_interp(
 
     # Determine grid type (promote Int → Float64 for consistency with 1D API)
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
 
     # Convert grids to target type (preserving Range structure)
     grids_typed = _convert_grids_typed(grids, Tg)

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -26,7 +26,7 @@ Evaluates directly from grids + data without constructing a ConstantInterpolantN
         side_vals::Tuple{Vararg{AbstractSide, N}},
         searches::NTuple{N, AbstractSearchPolicy},
         hints = nothing
-    ) where {Tg <: AbstractFloat, Tv, N}
+    ) where {Tg, Tv, N}
     # NoExtrap domain check must precede FillExtrap short-circuit
     _validate_nd_domain(grids, query, extraps_val)
     oob_result = _try_fill_oob(query, grids, extraps_val, EvalValue(), @inbounds first(data))
@@ -54,7 +54,7 @@ Writes results into `output`. No heap allocation beyond spacings.
         side_vals::Tuple{Vararg{AbstractSide, N}},
         searches::NTuple{N, AbstractSearchPolicy},
         hints = nothing
-    ) where {Tg <: AbstractFloat, Tv, N}
+    ) where {Tg, Tv, N}
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
@@ -86,7 +86,7 @@ function _constant_interp_nd_oneshot_batch(
         side_vals::Tuple{Vararg{AbstractSide, N}},
         searches::NTuple{N, AbstractSearchPolicy},
         hints = nothing
-    ) where {Tg <: AbstractFloat, Tv, N}
+    ) where {Tg, Tv, N}
     output = Vector{Tv}(undef, _query_length(queries))
     return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, extraps_val, side_vals, searches, hints)
 end
@@ -133,7 +133,7 @@ function constant_interp(
     end
 
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     _validate_nd_grids(grids_typed, data)
 
@@ -168,7 +168,7 @@ function constant_interp(
     end
 
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     _validate_nd_grids(grids_typed, data)
 
@@ -210,7 +210,7 @@ function constant_interp!(
     end
 
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     _validate_nd_grids(grids_typed, data)
 

--- a/src/constant/nd/constant_nd_types.jl
+++ b/src/constant/nd/constant_nd_types.jl
@@ -11,7 +11,7 @@
 N-dimensional constant (step) interpolation with per-axis configuration.
 
 # Type Parameters
-- `Tg<:AbstractFloat`: Grid coordinate type
+- `Tg`: Grid coordinate type (unconstrained)
 - `Tv`: Value type (unconstrained)
 - `N`: Number of dimensions
 - `G<:NTuple{N, AbstractVector{Tg}}`: Grid tuple type

--- a/src/constant/nd/constant_nd_types.jl
+++ b/src/constant/nd/constant_nd_types.jl
@@ -46,7 +46,7 @@ itp = constant_interp((x, y), data; side=(LeftSide(), RightSide()), extrap=(NoEx
 ```
 """
 struct ConstantInterpolantND{
-        Tg <: AbstractFloat,
+        Tg,
         Tv,
         N,
         G <: NTuple{N, AbstractVector{Tg}},
@@ -65,7 +65,7 @@ struct ConstantInterpolantND{
     function ConstantInterpolantND{Tg, Tv, N, G, S, E, SD, P}(
             grids::Tuple{Vararg{AbstractVector, N}}, spacings::S, data::AbstractArray{Tv, N}, extraps::E, sides::SD, searches::P
         ) where {
-            Tg <: AbstractFloat, Tv, N, G <: NTuple{N, AbstractVector{Tg}},
+            Tg, Tv, N, G <: NTuple{N, AbstractVector{Tg}},
             S <: NTuple{N, AbstractGridSpacing{Tg}}, E,
             SD <: Tuple{Vararg{AbstractSide, N}}, P <: NTuple{N, AbstractSearchPolicy},
         }

--- a/src/core/bc_types.jl
+++ b/src/core/bc_types.jl
@@ -827,9 +827,9 @@ See also: [`PolyFit`](@ref), [`_estimate_endpoint_derivative`](@ref)
 """
 @inline function materialize_bc(
         ::PolyFit{D}, xs::AbstractVector{Tg}, ys::AbstractVector{Tv}, endpoint::AbstractSide
-    ) where {D, Tg <: AbstractFloat, Tv}
+    ) where {D, Tg, Tv}
     val = _estimate_endpoint_derivative(xs, ys, endpoint, PolyFit{D}())
-    return Deriv1{Tv}(val)  # Natural Deriv1{Tv} return - no workaround needed!
+    return Deriv1(val)
 end
 
 # Passthrough for already-concrete BCs (no materialization needed)

--- a/src/core/polyfit_kernels.jl
+++ b/src/core/polyfit_kernels.jl
@@ -44,21 +44,21 @@ coefficients to function values.
 # Operation Count
     N-1 fmadd + 1 fmul = N FP ops
 """
-@inline function _weighted_sum(c::NTuple{2, T}, f::NTuple{2, T}) where {T <: AbstractFloat}
+@inline function _weighted_sum(c::NTuple{2, T}, f::NTuple{2, T}) where {T}
     return muladd(c[1], f[1], c[2] * f[2])
 end
 
-@inline function _weighted_sum(c::NTuple{3, T}, f::NTuple{3, T}) where {T <: AbstractFloat}
+@inline function _weighted_sum(c::NTuple{3, T}, f::NTuple{3, T}) where {T}
     return muladd(c[1], f[1], muladd(c[2], f[2], c[3] * f[3]))
 end
 
-@inline function _weighted_sum(c::NTuple{4, T}, f::NTuple{4, T}) where {T <: AbstractFloat}
+@inline function _weighted_sum(c::NTuple{4, T}, f::NTuple{4, T}) where {T}
     return muladd(c[1], f[1], muladd(c[2], f[2], muladd(c[3], f[3], c[4] * f[4])))
 end
 
 # Generic fallback for N > 4 (PolyFit{D} where D > 3)
 # Uses @generated to produce unrolled muladd chain at compile time
-@generated function _weighted_sum(c::NTuple{N, T}, f::NTuple{N, T}) where {N, T <: AbstractFloat}
+@generated function _weighted_sum(c::NTuple{N, T}, f::NTuple{N, T}) where {N, T}
     # Build muladd chain: muladd(c[1], f[1], muladd(c[2], f[2], ...c[N]*f[N]...))
     expr = :(c[$N] * f[$N])
     for i in (N - 1):-1:1
@@ -73,19 +73,19 @@ end
 # f::NTuple{N,Tv} values (can be Complex)
 # Returns Tv (same as value type)
 # ----------------------------------------
-@inline function _weighted_sum(c::NTuple{2, Tg}, f::NTuple{2, Tv}) where {Tg <: AbstractFloat, Tv}
+@inline function _weighted_sum(c::NTuple{2, Tg}, f::NTuple{2, Tv}) where {Tg, Tv}
     return muladd(c[1], f[1], c[2] * f[2])  # Tg * Tv + Tg * Tv → Tv
 end
 
-@inline function _weighted_sum(c::NTuple{3, Tg}, f::NTuple{3, Tv}) where {Tg <: AbstractFloat, Tv}
+@inline function _weighted_sum(c::NTuple{3, Tg}, f::NTuple{3, Tv}) where {Tg, Tv}
     return muladd(c[1], f[1], muladd(c[2], f[2], c[3] * f[3]))
 end
 
-@inline function _weighted_sum(c::NTuple{4, Tg}, f::NTuple{4, Tv}) where {Tg <: AbstractFloat, Tv}
+@inline function _weighted_sum(c::NTuple{4, Tg}, f::NTuple{4, Tv}) where {Tg, Tv}
     return muladd(c[1], f[1], muladd(c[2], f[2], muladd(c[3], f[3], c[4] * f[4])))
 end
 
-@generated function _weighted_sum(c::NTuple{N, Tg}, f::NTuple{N, Tv}) where {N, Tg <: AbstractFloat, Tv}
+@generated function _weighted_sum(c::NTuple{N, Tg}, f::NTuple{N, Tv}) where {N, Tg, Tv}
     expr = :(c[$N] * f[$N])
     for i in (N - 1):-1:1
         expr = :(muladd(c[$i], f[$i], $expr))
@@ -116,35 +116,35 @@ Compute first derivative on uniform grid using D+1 point stencil.
 - PolyFit{3} (CubicFit): 4 points, O(h³) accuracy
 """
 # PolyFit{1} (LinearFit) - 2 points, O(h)
-@inline function _compute_deriv1(::PolyFit{1}, ::LeftSide, f::NTuple{2, T}, inv_h::T) where {T <: AbstractFloat}
+@inline function _compute_deriv1(::PolyFit{1}, ::LeftSide, f::NTuple{2, T}, inv_h::T) where {T}
     return (f[2] - f[1]) * inv_h
 end
 
-@inline function _compute_deriv1(::PolyFit{1}, ::RightSide, f::NTuple{2, T}, inv_h::T) where {T <: AbstractFloat}
+@inline function _compute_deriv1(::PolyFit{1}, ::RightSide, f::NTuple{2, T}, inv_h::T) where {T}
     return (f[2] - f[1]) * inv_h  # Same as left for linear
 end
 
 # PolyFit{2} (QuadraticFit) - 3 points, O(h²)
-@inline function _compute_deriv1(::PolyFit{2}, ::LeftSide, f::NTuple{3, T}, inv_h::T) where {T <: AbstractFloat}
+@inline function _compute_deriv1(::PolyFit{2}, ::LeftSide, f::NTuple{3, T}, inv_h::T) where {T}
     # Coefficients: -(3, -4, 1) / 2
     coeff = -inv_h / 2
     return muladd(3, f[1], muladd(-4, f[2], f[3])) * coeff
 end
 
-@inline function _compute_deriv1(::PolyFit{2}, ::RightSide, f::NTuple{3, T}, inv_h::T) where {T <: AbstractFloat}
+@inline function _compute_deriv1(::PolyFit{2}, ::RightSide, f::NTuple{3, T}, inv_h::T) where {T}
     # Coefficients: (1, -4, 3) / 2
     coeff = inv_h / 2
     return muladd(1, f[1], muladd(-4, f[2], 3 * f[3])) * coeff
 end
 
 # PolyFit{3} (CubicFit) - 4 points, O(h³)
-@inline function _compute_deriv1(::PolyFit{3}, ::LeftSide, f::NTuple{4, T}, inv_h::T) where {T <: AbstractFloat}
+@inline function _compute_deriv1(::PolyFit{3}, ::LeftSide, f::NTuple{4, T}, inv_h::T) where {T}
     # Coefficients: (-11, 18, -9, 2) / 6
     coeff = inv_h / 6
     return muladd(-11, f[1], muladd(18, f[2], muladd(-9, f[3], 2 * f[4]))) * coeff
 end
 
-@inline function _compute_deriv1(::PolyFit{3}, ::RightSide, f::NTuple{4, T}, inv_h::T) where {T <: AbstractFloat}
+@inline function _compute_deriv1(::PolyFit{3}, ::RightSide, f::NTuple{4, T}, inv_h::T) where {T}
     # Coefficients: (-2, 9, -18, 11) / 6
     coeff = inv_h / 6
     return muladd(-2, f[1], muladd(9, f[2], muladd(-18, f[3], 11 * f[4]))) * coeff
@@ -158,35 +158,35 @@ end
 # ----------------------------------------
 
 # PolyFit{1} (LinearFit) - 2 points, O(h) - Mixed type
-@inline function _compute_deriv1(::PolyFit{1}, ::LeftSide, f::NTuple{2, Tv}, inv_h::Tg) where {Tv, Tg <: AbstractFloat}
+@inline function _compute_deriv1(::PolyFit{1}, ::LeftSide, f::NTuple{2, Tv}, inv_h::Tg) where {Tv, Tg}
     return (f[2] - f[1]) * inv_h  # Tv * Tg → Tv
 end
 
-@inline function _compute_deriv1(::PolyFit{1}, ::RightSide, f::NTuple{2, Tv}, inv_h::Tg) where {Tv, Tg <: AbstractFloat}
+@inline function _compute_deriv1(::PolyFit{1}, ::RightSide, f::NTuple{2, Tv}, inv_h::Tg) where {Tv, Tg}
     return (f[2] - f[1]) * inv_h
 end
 
 # PolyFit{2} (QuadraticFit) - 3 points, O(h²) - Mixed type
-@inline function _compute_deriv1(::PolyFit{2}, ::LeftSide, f::NTuple{3, Tv}, inv_h::Tg) where {Tv, Tg <: AbstractFloat}
+@inline function _compute_deriv1(::PolyFit{2}, ::LeftSide, f::NTuple{3, Tv}, inv_h::Tg) where {Tv, Tg}
     # Coefficients: -(3, -4, 1) / 2
     coeff = -inv_h / 2
     return muladd(3, f[1], muladd(-4, f[2], f[3])) * coeff
 end
 
-@inline function _compute_deriv1(::PolyFit{2}, ::RightSide, f::NTuple{3, Tv}, inv_h::Tg) where {Tv, Tg <: AbstractFloat}
+@inline function _compute_deriv1(::PolyFit{2}, ::RightSide, f::NTuple{3, Tv}, inv_h::Tg) where {Tv, Tg}
     # Coefficients: (1, -4, 3) / 2
     coeff = inv_h / 2
     return muladd(1, f[1], muladd(-4, f[2], 3 * f[3])) * coeff
 end
 
 # PolyFit{3} (CubicFit) - 4 points, O(h³) - Mixed type
-@inline function _compute_deriv1(::PolyFit{3}, ::LeftSide, f::NTuple{4, Tv}, inv_h::Tg) where {Tv, Tg <: AbstractFloat}
+@inline function _compute_deriv1(::PolyFit{3}, ::LeftSide, f::NTuple{4, Tv}, inv_h::Tg) where {Tv, Tg}
     # Coefficients: (-11, 18, -9, 2) / 6
     coeff = inv_h / 6
     return muladd(-11, f[1], muladd(18, f[2], muladd(-9, f[3], 2 * f[4]))) * coeff
 end
 
-@inline function _compute_deriv1(::PolyFit{3}, ::RightSide, f::NTuple{4, Tv}, inv_h::Tg) where {Tv, Tg <: AbstractFloat}
+@inline function _compute_deriv1(::PolyFit{3}, ::RightSide, f::NTuple{4, Tv}, inv_h::Tg) where {Tv, Tg}
     # Coefficients: (-2, 9, -18, 11) / 6
     coeff = inv_h / 6
     return muladd(-2, f[1], muladd(9, f[2], muladd(-18, f[3], 11 * f[4]))) * coeff
@@ -196,7 +196,7 @@ end
 # Julia dispatch ensures D=1,2,3 use the specialized methods above.
 @inline @with_pool pool function _compute_deriv1(
         pf::PolyFit{D}, side::AbstractSide, f::NTuple{N, T}, inv_h::T
-    ) where {D, N, T <: AbstractFloat}
+    ) where {D, N, T}
     # Compute coefficients on reference grid t = 0, 1, ..., D
     coeffs = acquire!(pool, T, N)
     β = acquire!(pool, T, N)
@@ -232,18 +232,18 @@ Use with `_weighted_sum(coeffs, f_values)` to compute the derivative.
 - `x::NTuple{D+1,T}`: Grid coordinates at stencil points
 """
 # PolyFit{1} (LinearFit) - 2 points
-@inline function _compute_deriv1_coeffs(::PolyFit{1}, ::LeftSide, x::NTuple{2, T}) where {T <: AbstractFloat}
+@inline function _compute_deriv1_coeffs(::PolyFit{1}, ::LeftSide, x::NTuple{2, T}) where {T}
     inv_dx = inv(x[2] - x[1])
     return (-inv_dx, inv_dx)
 end
 
-@inline function _compute_deriv1_coeffs(::PolyFit{1}, ::RightSide, x::NTuple{2, T}) where {T <: AbstractFloat}
+@inline function _compute_deriv1_coeffs(::PolyFit{1}, ::RightSide, x::NTuple{2, T}) where {T}
     inv_dx = inv(x[2] - x[1])
     return (-inv_dx, inv_dx)  # Same as left for linear
 end
 
 # PolyFit{2} (QuadraticFit) - 3 points
-@inline function _compute_deriv1_coeffs(::PolyFit{2}, ::LeftSide, x::NTuple{3, T}) where {T <: AbstractFloat}
+@inline function _compute_deriv1_coeffs(::PolyFit{2}, ::LeftSide, x::NTuple{3, T}) where {T}
     x1, x2, x3 = x
     d12, d13 = x1 - x2, x1 - x3
     d23 = x2 - x3
@@ -253,7 +253,7 @@ end
     return (c1, c2, c3)
 end
 
-@inline function _compute_deriv1_coeffs(::PolyFit{2}, ::RightSide, x::NTuple{3, T}) where {T <: AbstractFloat}
+@inline function _compute_deriv1_coeffs(::PolyFit{2}, ::RightSide, x::NTuple{3, T}) where {T}
     x1, x2, x3 = x
     d12, d13, d23 = x1 - x2, x1 - x3, x2 - x3
     c1 = (-d23) / (d12 * d13)
@@ -263,7 +263,7 @@ end
 end
 
 # PolyFit{3} (CubicFit) - 4 points
-@inline function _compute_deriv1_coeffs(::PolyFit{3}, ::LeftSide, x::NTuple{4, T}) where {T <: AbstractFloat}
+@inline function _compute_deriv1_coeffs(::PolyFit{3}, ::LeftSide, x::NTuple{4, T}) where {T}
     x1, x2, x3, x4 = x
     d12, d13, d14 = x1 - x2, x1 - x3, x1 - x4
     d23, d24, d34 = x2 - x3, x2 - x4, x3 - x4
@@ -275,7 +275,7 @@ end
     return (c1, c2, c3, c4)
 end
 
-@inline function _compute_deriv1_coeffs(::PolyFit{3}, ::RightSide, x::NTuple{4, T}) where {T <: AbstractFloat}
+@inline function _compute_deriv1_coeffs(::PolyFit{3}, ::RightSide, x::NTuple{4, T}) where {T}
     x1, x2, x3, x4 = x
     d12, d13, d14 = x1 - x2, x1 - x3, x1 - x4
     d23, d24, d34 = x2 - x3, x2 - x4, x3 - x4
@@ -292,7 +292,7 @@ end
 # Julia dispatch ensures D=1,2,3 use the specialized methods above.
 @inline @with_pool pool function _compute_deriv1_coeffs(
         pf::PolyFit{D}, side::Union{LeftSide, RightSide}, x::NTuple{N, T}
-    ) where {D, N, T <: AbstractFloat}
+    ) where {D, N, T}
     c = acquire!(pool, T, N)
     β = acquire!(pool, T, N)
     _compute_deriv1_coeffs!(c, β, pf, side, x)
@@ -328,7 +328,7 @@ In-place computation of barycentric weights β_i = 1 / Π_{j≠i} (x_i - x_j).
 """
 @inline function _barycentric_weights!(
         β::AbstractVector{T}, x::NTuple{N, T}, ::Val{N}
-    ) where {N, T <: AbstractFloat}
+    ) where {N, T}
     @assert length(β) >= N "Buffer β must have length ≥ $N"
     @inbounds for i in 1:N
         xi = x[i]
@@ -363,7 +363,7 @@ Uses barycentric formula:
 """
 @inline function _d1_coeffs_at_node!(
         coeffs::AbstractVector{T}, β::AbstractVector{T}, x::NTuple{N, T}, k::Int, ::Val{N}
-    ) where {N, T <: AbstractFloat}
+    ) where {N, T}
     @assert length(coeffs) >= N "Buffer coeffs must have length ≥ $N"
     @assert length(β) >= N "Buffer β must have length ≥ $N"
     @assert 1 <= k <= N "Node index k=$k must be in 1:$N"
@@ -418,7 +418,7 @@ This is the generic fallback for D > 3. For D = 1, 2, 3, the specialized
 @inline function _compute_deriv1_coeffs!(
         coeffs::AbstractVector{T}, β::AbstractVector{T},
         ::PolyFit{D}, side::Union{LeftSide, RightSide}, x::NTuple{N, T}
-    ) where {D, N, T <: AbstractFloat}
+    ) where {D, N, T}
     k = side isa LeftSide ? 1 : N
     return _d1_coeffs_at_node!(coeffs, β, x, k, Val(N))
 end
@@ -538,7 +538,7 @@ Estimate first derivative at endpoint using D+1 point polynomial fit.
 """
 @inline function _estimate_endpoint_derivative(
         xs::AbstractRange{T}, ys::AbstractVector{T}, side::AbstractSide, pf::PolyFit{D}
-    ) where {T <: AbstractFloat, D}
+    ) where {T, D}
     _check_polyfit_requirements(D, length(ys))
     @inbounds begin
         f = _extract_stencil_values(ys, side, Val(D + 1))
@@ -549,7 +549,7 @@ end
 
 @inline function _estimate_endpoint_derivative(
         xs::AbstractVector{T}, ys::AbstractVector{T}, side::AbstractSide, pf::PolyFit{D}
-    ) where {T <: AbstractFloat, D}
+    ) where {T, D}
     @assert length(xs) == length(ys) "xs and ys must have same length"
     _check_polyfit_requirements(D, length(ys))
     @inbounds begin
@@ -568,7 +568,7 @@ end
 # ----------------------------------------
 @inline function _estimate_endpoint_derivative(
         xs::AbstractRange{Tg}, ys::AbstractVector{Tv}, side::AbstractSide, pf::PolyFit{D}
-    ) where {Tg <: AbstractFloat, Tv, D}
+    ) where {Tg, Tv, D}
     _check_polyfit_requirements(D, length(ys))
     @inbounds begin
         f = _extract_stencil_values(ys, side, Val(D + 1))
@@ -579,7 +579,7 @@ end
 
 @inline function _estimate_endpoint_derivative(
         xs::AbstractVector{Tg}, ys::AbstractVector{Tv}, side::AbstractSide, pf::PolyFit{D}
-    ) where {Tg <: AbstractFloat, Tv, D}
+    ) where {Tg, Tv, D}
     @assert length(xs) == length(ys) "xs and ys must have same length"
     _check_polyfit_requirements(D, length(ys))
     @inbounds begin

--- a/src/quadratic/nd/quadratic_nd_adjoint.jl
+++ b/src/quadratic/nd/quadratic_nd_adjoint.jl
@@ -52,7 +52,7 @@ function _bake_nd_quadratic_anchors(
         spacings::NTuple{N, AbstractGridSpacing{Tg}},
         queries,
         extraps::Tuple{Vararg{AbstractExtrap, N}}
-    ) where {N, Tg <: AbstractFloat}
+    ) where {N, Tg}
     return _bake_nd_anchors_generic(
         grids, spacings, queries, extraps,
         (d, t, h, inv_h, dL) -> _compute_nd_quadratic_anchor_weights(t, h, inv_h)
@@ -141,7 +141,7 @@ Simpler than cubic: no dual caches, no periodic handling.
         grids::NTuple{N, AbstractVector{Tg}},
         grid_size::NTuple{N, Int},
         mincurv_Cs::NTuple{N, Tg}
-    ) where {Tv, Tg <: AbstractFloat, N}
+    ) where {Tv, Tg, N}
     for d in N:-1:1
         bit_d = 1 << (d - 1)
         n_d = grid_size[d]
@@ -251,7 +251,7 @@ function quadratic_adjoint(
     ) where {N}
     length(queries) == N || _throw_ndims_mismatch("query vectors", N, length(queries))
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     bcs = _resolve_bcs_nd(bc, Val(N))
     extraps = _resolve_extrap_nd(extrap, bcs, Val(N), Tg)
@@ -292,7 +292,7 @@ function quadratic_adjoint(
     ) where {N}
     _query_check_ndims(queries, Val(N))
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     bcs = _resolve_bcs_nd(bc, Val(N))
     extraps = _resolve_extrap_nd(extrap, bcs, Val(N), Tg)
@@ -314,7 +314,7 @@ function _build_nd_quadratic_adjoint(
         queries,
         bcs::NTuple{N, AbstractBC},
         extraps::Tuple{Vararg{AbstractExtrap, N}}
-    ) where {N, Tg <: AbstractFloat}
+    ) where {N, Tg}
     # Validate grid sizes
     for d in 1:N
         length(grids[d]) >= 2 || _throw_adjoint_grid_too_small(d, length(grids[d]))

--- a/src/quadratic/nd/quadratic_nd_adjoint_types.jl
+++ b/src/quadratic/nd/quadratic_nd_adjoint_types.jl
@@ -66,7 +66,7 @@ f_bar = adj(y_bar)   # returns 20×15 matrix
 ```
 """
 struct QuadraticAdjointND{
-        Tg <: AbstractFloat,
+        Tg,
         N,
         G <: NTuple{N, AbstractVector{Tg}},
         S <: NTuple{N, AbstractGridSpacing{Tg}},
@@ -87,7 +87,7 @@ struct QuadraticAdjointND{
             anchors::Vector{_NDAdjointAnchor{Tg, N}}, grid_size::NTuple{N, Int},
             mincurv_Cs::NTuple{N, Tg}
         ) where {
-            Tg <: AbstractFloat, N, S <: NTuple{N, AbstractGridSpacing{Tg}},
+            Tg, N, S <: NTuple{N, AbstractGridSpacing{Tg}},
             BP <: NTuple{N, AbstractBC},
         }
         grids_c = map(copy, grids)

--- a/src/quadratic/nd/quadratic_nd_adjoint_types.jl
+++ b/src/quadratic/nd/quadratic_nd_adjoint_types.jl
@@ -44,7 +44,7 @@ Adjoint (transpose) operator for N-dimensional quadratic spline interpolation.
 Computes `f̄ = Wᵀȳ` where `W` is the forward ND interpolation weight matrix.
 
 # Type Parameters
-- `Tg`: Grid float type (Float32 or Float64)
+- `Tg`: Grid type (unconstrained — supports duck types like ForwardDiff.Dual)
 - `N`: Number of dimensions
 - `G`: Grid tuple type (after copy for mutation safety)
 - `S`: Spacing tuple type

--- a/src/quadratic/nd/quadratic_nd_build.jl
+++ b/src/quadratic/nd/quadratic_nd_build.jl
@@ -42,7 +42,7 @@ spline recurrence. This is the quadratic analog of the cubic `_deriv_1d!`.
         values::AbstractVector{Tv},
         grid::AbstractVector{Tg},
         bc::QuadraticBC
-    ) where {Tv, Tg <: AbstractFloat}
+    ) where {Tv, Tg}
     n = length(values)
     @assert n == length(grid) "values and grid must have same length"
     @assert n >= 2 "Need at least 2 points"
@@ -71,21 +71,21 @@ end
 @inline function _slope_1d_quadratic!(
         d_out::AbstractVector{Tv}, values::AbstractVector{Tv},
         grid::AbstractVector{Tg}, ::ZeroCurvBC
-    ) where {Tv, Tg <: AbstractFloat}
+    ) where {Tv, Tg}
     return _slope_1d_quadratic!(d_out, values, grid, Right(Deriv2(0 * first(values))))
 end
 
 @inline function _slope_1d_quadratic!(
         d_out::AbstractVector{Tv}, values::AbstractVector{Tv},
         grid::AbstractVector{Tg}, ::ZeroSlopeBC
-    ) where {Tv, Tg <: AbstractFloat}
+    ) where {Tv, Tg}
     return _slope_1d_quadratic!(d_out, values, grid, Left(Deriv1(0 * first(values))))
 end
 
 @inline function _slope_1d_quadratic!(
         d_out::AbstractVector{Tv}, values::AbstractVector{Tv},
         grid::AbstractVector{Tg}, bc::PolyFit
-    ) where {Tv, Tg <: AbstractFloat}
+    ) where {Tv, Tg}
     return _slope_1d_quadratic!(d_out, values, grid, Right(bc))
 end
 
@@ -148,7 +148,7 @@ Uses the same "reshape to 3D" trick as the cubic version:
         grid::AbstractVector{Tg},
         bc::AbstractBC,
         d::Int
-    ) where {Tv, Tg <: AbstractFloat, N}
+    ) where {Tv, Tg, N}
     @boundscheck begin
         1 ≤ d ≤ N || throw(ArgumentError("dimension d=$d out of range 1:$N"))
         size(out) == size(data) || throw(DimensionMismatch("out and data must have same size"))
@@ -259,7 +259,7 @@ end
     grids::NTuple{N, AbstractVector{Tg}},
     bcs::NTuple{N, AbstractBC},
     ::Val{N}
-) where {Tv, Tg <: AbstractFloat, N, NP1} =
+) where {Tv, Tg, N, NP1} =
     _build_nd_partials_dim_quadratic!(partials, grids, bcs, Val(1), Val(N))
 
 @inline function _build_nd_partials_dim_quadratic!(
@@ -268,7 +268,7 @@ end
         bcs::NTuple{N, AbstractBC},
         ::Val{D},
         ::Val{N}
-    ) where {Tv, Tg <: AbstractFloat, D, N, NP1}
+    ) where {Tv, Tg, D, N, NP1}
     bit_d = 1 << (D - 1)
     @inbounds for p_src in 1:bit_d
         p_dst = p_src + bit_d
@@ -296,7 +296,7 @@ function _compute_nd_partials_quadratic!(
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
-    ) where {Tv, Tg <: AbstractFloat, N, NP1}
+    ) where {Tv, Tg, N, NP1}
     # Validate dimensions
     @boundscheck begin
         NP1 == N + 1 || throw(DimensionMismatch("partials must have N+1 dimensions"))
@@ -334,7 +334,7 @@ function _build_nd_coeffs_quadratic(
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
-    ) where {Tg <: AbstractFloat, Tv, N}
+    ) where {Tg, Tv, N}
     # Allocate partials array: (2^N, n₁, n₂, ..., nₙ)
     n_partials = 1 << N
     partials_shape = (n_partials, size(data)...)

--- a/src/quadratic/nd/quadratic_nd_interpolant.jl
+++ b/src/quadratic/nd/quadratic_nd_interpolant.jl
@@ -59,7 +59,7 @@ function quadratic_interp(
 
     # Zero-allocation type promotion
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
 
     # Zero-allocation grid conversion
     grids_typed = _convert_grids_typed(grids, Tg)
@@ -89,7 +89,7 @@ function _build_nd_quadratic_interpolant(
         bcs::NTuple{N, AbstractBC},
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
         searches::NTuple{N, AbstractSearchPolicy}
-    ) where {Tg <: AbstractFloat, Tv, N}
+    ) where {Tg, Tv, N}
     # Build nodal derivatives using quadratic recurrence
     nodal_derivs = _build_nd_coeffs_quadratic(grids, data, bcs)
 

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -29,7 +29,7 @@ Zero-allocation after warmup (pool reuse).
         searches::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
         hints = nothing
-    ) where {Tg <: AbstractFloat, Tv, N}
+    ) where {Tg, Tv, N}
     # 0. NoExtrap domain check must precede FillExtrap short-circuit
     _validate_nd_domain(grids, query, extraps_val)
     oob_result = _try_fill_oob(query, grids, extraps_val, ops, @inbounds first(data))
@@ -71,7 +71,7 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
         searches::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
         hints = nothing
-    ) where {Tg <: AbstractFloat, Tv, N}
+    ) where {Tg, Tv, N}
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
@@ -145,7 +145,7 @@ function quadratic_interp(
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     _validate_nd_grids(grids_typed, data)
     Tr = _output_eltype(Tv, Tg, typeof.(query)...)
@@ -188,7 +188,7 @@ function quadratic_interp(
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     Tq = _query_eltype(queries)
     Tr = _output_eltype(Tv, Tg, Tq)
     output = Vector{Tr}(undef, _query_length(queries))
@@ -221,7 +221,7 @@ function quadratic_interp!(
     ) where {Tv, N}
     _query_check_ndims(queries, Val(N))
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     _validate_nd_grids(grids_typed, data)
 

--- a/src/quadratic/nd/quadratic_nd_types.jl
+++ b/src/quadratic/nd/quadratic_nd_types.jl
@@ -25,7 +25,7 @@ Stores function values AND all partial derivatives at grid nodes, enabling
 ultra-fast O(1) evaluation via tensor-product quadratic polynomials.
 
 # Type Parameters
-- `Tg`: Grid/coordinate type (Float32 or Float64)
+- `Tg`: Grid/coordinate type (unconstrained)
 - `Tv`: Value type (unconstrained)
 - `N`: Number of dimensions
 - `NP1`: N + 1 (partials array dimensionality)

--- a/src/quadratic/nd/quadratic_nd_types.jl
+++ b/src/quadratic/nd/quadratic_nd_types.jl
@@ -63,7 +63,7 @@ itp((1.0, 0.5); deriv=(1, 0))   # dfdx
 ```
 """
 struct QuadraticInterpolantND{
-        Tg <: AbstractFloat,
+        Tg,
         Tv,
         N,
         NP1,

--- a/src/quadratic/quadratic_adjoint.jl
+++ b/src/quadratic/quadratic_adjoint.jl
@@ -153,7 +153,7 @@ Computes `f̄ = Wᵀȳ` where `W` is the forward interpolation weight matrix.
 Constructed from a grid and query points (query-baked, data-free).
 
 # Type Parameters
-- `Tg`: Grid float type (Float32 or Float64)
+- `Tg`: Grid type (unconstrained — supports duck types like ForwardDiff.Dual)
 - `S`: Grid spacing type (for fast inv_h access)
 - `X`: Grid vector type (after copy for mutation safety)
 - `BC`: Boundary condition type (Left, Right, or MinCurvFit)

--- a/src/quadratic/quadratic_adjoint.jl
+++ b/src/quadratic/quadratic_adjoint.jl
@@ -33,7 +33,7 @@ Each weight 3-tuple represents: (w_fL, w_fR, w_d) — contributions to
 Forward eval: S(x) = a·dL² + d·dL + y  where a = (s-d)/h, s = (y_{R}-y_{L})/h.
 Rewritten:  S = y_L·(1-t²) + y_R·t² + d·h·t·(1-t)  where t = dL/h.
 """
-struct _QuadraticAdjointAnchor1D{Tg <: AbstractFloat}
+struct _QuadraticAdjointAnchor1D{Tg}
     idx::Int              # Interval index
     w0::NTuple{3, Tg}     # (w_fL, w_fR, w_d) for EvalValue
     w1::NTuple{3, Tg}     # for EvalDeriv1
@@ -88,7 +88,7 @@ function _bake_quadratic_adjoint_anchors(
         spacing::AbstractGridSpacing{Tg},
         xq::AbstractVector{Tg},
         extrap::AbstractExtrap
-    ) where {Tg <: AbstractFloat}
+    ) where {Tg}
     x_lo, x_hi = first(x), last(x)
 
     # For ClampExtrap/FillExtrap, clamp queries to domain before anchoring
@@ -183,7 +183,7 @@ No tridiagonal solve needed (unlike cubic) — the slope recurrence
 `d[i+1] = 2s[i] - d[i]` has a simple O(n) adjoint.
 """
 struct QuadraticAdjoint{
-        Tg <: AbstractFloat,
+        Tg,
         S <: AbstractGridSpacing{Tg},
         BC <: QuadraticBC,
         X <: AbstractVector{Tg},
@@ -201,7 +201,7 @@ struct QuadraticAdjoint{
     function QuadraticAdjoint(
             spacing::S, anchors::Vector{_QuadraticAdjointAnchor1D{Tg}},
             bc::BC, grid_size::Int, grid::AbstractVector{Tg}
-        ) where {Tg <: AbstractFloat, S <: AbstractGridSpacing{Tg}, BC <: QuadraticBC}
+        ) where {Tg, S <: AbstractGridSpacing{Tg}, BC <: QuadraticBC}
         gc = copy(grid)
         C = bc isa MinCurvFit ? _compute_mincurv_C(spacing, grid_size) : zero(Tg)
         return new{Tg, S, BC, typeof(gc)}(spacing, anchors, bc, grid_size, gc, C)

--- a/src/quadratic/quadratic_anchor.jl
+++ b/src/quadratic/quadratic_anchor.jl
@@ -49,7 +49,7 @@ When `xq` is a `ForwardDiff.Dual`, the anchor preserves the Dual type
 in both `xq` and `dL` fields, enabling automatic differentiation through
 series interpolant evaluation.
 """
-struct _QuadraticAnchoredQuery{Tg <: AbstractFloat, Tq <: Real}
+struct _QuadraticAnchoredQuery{Tg, Tq <: Real}
     idx::Int                   # interval index
     xq::Tq                     # query point (possibly wrapped), Float or Dual
     state::UInt8               # IN_DOMAIN / OOB_LEFT / OOB_RIGHT
@@ -93,7 +93,7 @@ itp2(aq; deriv=DerivOp(1))  # Reuses same anchor for derivative
         ::Val{:quadratic},
         wrap::Bool = false,
         searcher::P = DEFAULT_SEARCHER
-    ) where {Tg <: AbstractFloat, Tq <: Real, P <: Searcher}
+    ) where {Tg, Tq <: Real, P <: Searcher}
     return _quadratic_anchor_query_impl(x, xq, wrap, _resolve_searcher_for_grid(x, searcher))
 end
 
@@ -171,7 +171,7 @@ When buffer element type is `{Tg, Tq}` and `xq` element type is `S`:
         ::Val{:quadratic},
         wrap::Bool = false,
         searcher::P = _to_searcher(LinearBinarySearch())
-    ) where {Tg <: AbstractFloat, Tq <: Real, S <: Real, P <: Searcher}
+    ) where {Tg, Tq <: Real, S <: Real, P <: Searcher}
     @assert length(buffer) >= length(xq) "Buffer too small: $(length(buffer)) < $(length(xq))"
     searcher_resolved = _resolve_searcher_for_grid(x, searcher)
 
@@ -204,7 +204,7 @@ while preserving the full Dual value for `dL` computation.
         xq::Tq,
         wrap::Bool,
         policy::P = DEFAULT_SEARCHER
-    ) where {Tg <: AbstractFloat, Tq <: Real, P <: Searcher}
+    ) where {Tg, Tq <: Real, P <: Searcher}
     loc = _anchor_loc(x, xq, wrap, policy)
 
     # Compute dL: offset from interval start (preserves Dual type)

--- a/src/quadratic/quadratic_anchor.jl
+++ b/src/quadratic/quadratic_anchor.jl
@@ -257,26 +257,26 @@ end
 
 # Default case (extension, wrap, inbounds): direct kernel evaluation
 @inline function _quadratic_eval_at_anchor(
-        y::AbstractVector, a::AbstractVector, d::AbstractVector,
+        y::AbstractVector{Tv}, a::AbstractVector{Tc}, d::AbstractVector{Tc},
         aq::_QuadraticAnchoredQuery, op::AbstractEvalOp, ::AbstractExtrap
-    )
+    ) where {Tv, Tc}
     @inbounds return _quadratic_kernel(op, a[aq.idx], d[aq.idx], y[aq.idx], aq.dL)
 end
 
 # No extrapolation: throw DomainError if outside domain
 @inline function _quadratic_eval_at_anchor(
-        y::AbstractVector, a::AbstractVector, d::AbstractVector,
+        y::AbstractVector{Tv}, a::AbstractVector{Tc}, d::AbstractVector{Tc},
         aq::_QuadraticAnchoredQuery, op::AbstractEvalOp, ::NoExtrap
-    )
+    ) where {Tv, Tc}
     aq.state != IN_DOMAIN && throw(DomainError(aq.xq, "query point outside domain"))
     @inbounds return _quadratic_kernel(op, a[aq.idx], d[aq.idx], y[aq.idx], aq.dL)
 end
 
 # Clamp/Fill extrapolation: boundary value if OOB
 @inline function _quadratic_eval_at_anchor(
-        y::AbstractVector, a::AbstractVector, d::AbstractVector,
+        y::AbstractVector{Tv}, a::AbstractVector{Tc}, d::AbstractVector{Tc},
         aq::_QuadraticAnchoredQuery, op::AbstractEvalOp, extrap::_ClampOrFill
-    )
+    ) where {Tv, Tc}
     if aq.state != IN_DOMAIN
         y_bnd = aq.state == OOB_LEFT ? first(y) : last(y)
         return _eval_extrapolation(op, y_bnd, extrap, aq.xq)

--- a/src/quadratic/quadratic_anchor.jl
+++ b/src/quadratic/quadratic_anchor.jl
@@ -19,7 +19,7 @@ Internal API: no runtime grid validation; callers must ensure the anchor
 matches the interpolant grid.
 
 # Type Parameters
-- `Tg`: Grid float type (Float32 or Float64)
+- `Tg`: Grid type (unconstrained — supports duck types like ForwardDiff.Dual)
 - `Tq`: Query type (Float or ForwardDiff.Dual for AD support)
 
 # Fields

--- a/src/quadratic/quadratic_anchor.jl
+++ b/src/quadratic/quadratic_anchor.jl
@@ -236,7 +236,7 @@ d1 = itp(aq; deriv=DerivOp(1))   # First derivative
 d2 = itp(aq; deriv=DerivOp(2))   # Second derivative
 ```
 """
-@inline function (itp::QuadraticInterpolant{T})(aq::_QuadraticAnchoredQuery{T, Tq}; deriv::DerivOp = EvalValue()) where {T <: AbstractFloat, Tq <: Real}
+@inline function (itp::QuadraticInterpolant{T})(aq::_QuadraticAnchoredQuery{T, Tq}; deriv::DerivOp = EvalValue()) where {T, Tq <: Real}
     return _quadratic_eval_with_anchor(itp, aq, deriv)
 end
 
@@ -244,7 +244,7 @@ end
         itp::QuadraticInterpolant{T},
         aq::_QuadraticAnchoredQuery{T, Tq},
         op::O
-    ) where {T <: AbstractFloat, Tq <: Real, O <: AbstractEvalOp}
+    ) where {T, Tq <: Real, O <: AbstractEvalOp}
     # Handle extrapolation based on mode and side
     return _quadratic_anchor_dispatch(itp, aq, op, itp.extrap)
 end
@@ -294,7 +294,7 @@ end
         aq::_QuadraticAnchoredQuery{T, Tq},
         op::O,
         ::NoExtrap
-    ) where {T <: AbstractFloat, Tq <: Real, O <: AbstractEvalOp}
+    ) where {T, Tq <: Real, O <: AbstractEvalOp}
     if aq.state != IN_DOMAIN
         x_min, x_max = first(itp.x), last(itp.x)
         throw(DomainError(aq.xq, "query point outside domain [$x_min, $x_max]"))
@@ -325,7 +325,7 @@ Returns newly allocated vector.
 function (itp::QuadraticInterpolant{T})(
         aq_vec::AbstractVector{<:_QuadraticAnchoredQuery{T}};
         deriv::DerivOp = EvalValue()
-    ) where {T <: AbstractFloat}
+    ) where {T}
     output = Vector{T}(undef, length(aq_vec))
     @inbounds for i in eachindex(aq_vec)
         output[i] = _quadratic_eval_with_anchor(itp, aq_vec[i], deriv)
@@ -342,7 +342,7 @@ function (itp::QuadraticInterpolant{T})(
         output::AbstractVector{T},
         aq_vec::AbstractVector{<:_QuadraticAnchoredQuery{T}};
         deriv::DerivOp = EvalValue()
-    ) where {T <: AbstractFloat}
+    ) where {T}
     @assert length(output) == length(aq_vec) "output length must match aq_vec length"
     @inbounds for i in eachindex(aq_vec)
         output[i] = _quadratic_eval_with_anchor(itp, aq_vec[i], deriv)

--- a/src/quadratic/quadratic_interpolant.jl
+++ b/src/quadratic/quadratic_interpolant.jl
@@ -30,14 +30,14 @@ end
 @inline function _quadratic_vector_loop!(
         output::AbstractVector,
         x::AbstractVector{Tg},
-        y::AbstractVector,
-        a::AbstractVector,
-        d::AbstractVector,
+        y::AbstractVector{Tv},
+        a::AbstractVector{Tc},
+        d::AbstractVector{Tc},
         xq::AbstractVector{<:Real},
         extrap::E,
         deriv::O,
         searcher::P
-    ) where {Tg, E <: AbstractExtrap, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg, Tv, Tc, E <: AbstractExtrap, O <: AbstractEvalOp, P <: Searcher}
     extrap = _check_domain(x, xq, extrap)
     return @inbounds for i in eachindex(xq, output)
         output[i] = _quadratic_eval_at_point(x, y, a, d, xq[i], extrap, deriv, searcher)

--- a/src/quadratic/quadratic_interpolant.jl
+++ b/src/quadratic/quadratic_interpolant.jl
@@ -61,8 +61,8 @@ Create a callable interpolant for broadcast fusion and reuse.
 - `search::AbstractSearchPolicy`: Default search policy (default: `AutoSearch()`)
 
 # Returns
-`QuadraticInterpolant{Tg, Tv}` object for scalar/broadcast evaluation.
-- `Tg`: Grid type (Float32/Float64)
+`QuadraticInterpolant` object for scalar/broadcast evaluation.
+- `Tg`: Grid type (unconstrained — supports duck types like ForwardDiff.Dual)
 - `Tv`: Value type (unconstrained)
 
 # Example
@@ -121,7 +121,7 @@ end
     # Compute spacing once: used for both coefficients and struct storage
     spacing = _create_spacing(x_p)
 
-    # Compute coefficients (d::Tv, a::Tv)
+    # Compute coefficients (d::Tc, a::Tc where Tc = _output_eltype(Tv, Tg))
     d, a = _compute_quadratic_coeffs(x_p, y_p, bc_p, spacing)
 
     extrap_p = _promote_extrap(extrap, eltype(y_p))

--- a/src/quadratic/quadratic_interpolant.jl
+++ b/src/quadratic/quadratic_interpolant.jl
@@ -30,14 +30,14 @@ end
 @inline function _quadratic_vector_loop!(
         output::AbstractVector,
         x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        a::AbstractVector{Tv},
-        d::AbstractVector{Tv},
+        y::AbstractVector,
+        a::AbstractVector,
+        d::AbstractVector,
         xq::AbstractVector{<:Real},
         extrap::E,
         deriv::O,
         searcher::P
-    ) where {Tg <: AbstractFloat, Tv, E <: AbstractExtrap, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg, E <: AbstractExtrap, O <: AbstractEvalOp, P <: Searcher}
     extrap = _check_domain(x, xq, extrap)
     return @inbounds for i in eachindex(xq, output)
         output[i] = _quadratic_eval_at_point(x, y, a, d, xq[i], extrap, deriv, searcher)
@@ -111,7 +111,7 @@ end
         bc::QuadraticBC = Left(QuadraticFit()),
         extrap::AbstractExtrap = NoExtrap(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {TX <: Real, TY}
+    ) where {TX, TY}
     x_p, y_p = _promote_itp_inputs(x, y)
     bc_p = _normalize_bc(bc, first(y_p))
 

--- a/src/quadratic/quadratic_kernels.jl
+++ b/src/quadratic/quadratic_kernels.jl
@@ -14,8 +14,10 @@
 #   - dL = xq - x_i (offset from interval start)
 #
 # Type parameters:
-# - Td<:Real: Offset type for dL (can be Tg or ForwardDiff.Dual for AD)
-# - Tv: Value type (unconstrained) for a, d, y
+# - Td: Offset type for dL (can be Tg, or promoted Tg×Tq for AD)
+# - Value args (a, d, y) are untyped for duck-type support (Dual coefficients
+#   on duck grids). The typed `dL::Td` provides the LLVM specialization anchor
+#   (same pattern as _hermite_kernel_1d's h::Tg, inv_h::Tg, dL::Tq).
 
 """
     _quadratic_kernel(::EvalValue, a, d, y, dL) -> value
@@ -24,13 +26,13 @@ Evaluate quadratic polynomial at offset dL from interval start.
 
 Formula: S(x) = a*dL² + d*dL + y = muladd(muladd(a, dL, d), dL, y)
 # Arguments
-- `a::Tv`: Quadratic coefficient (value-derived)
-- `d::Tv`: Slope at interval start (value-derived)
-- `y::Tv`: Value at interval start
-- `dL::Td`: Offset from interval start (x - x_i, can be Float or Dual for AD)
+- `a`: Quadratic coefficient (value-derived, may be Dual for duck grids)
+- `d`: Slope at interval start (value-derived)
+- `y`: Value at interval start
+- `dL::Td`: Offset from interval start (x - x_i, typed for specialization)
 """
-@inline function _quadratic_kernel(::EvalValue, a, d, y, dL)
-    return muladd(muladd(a, dL, d), dL, y)  # a*dL² + d*dL + y, returns Tv
+@inline function _quadratic_kernel(::EvalValue, a, d, y, dL::Td) where {Td}
+    return muladd(muladd(a, dL, d), dL, y)  # a*dL² + d*dL + y
 end
 
 """
@@ -40,8 +42,8 @@ Evaluate first derivative of quadratic polynomial.
 
 Formula: S'(x) = 2*a*dL + d = muladd(2*a, dL, d)
 """
-@inline function _quadratic_kernel(::EvalDeriv1, a, d, _, dL)
-    return muladd(2 * a, dL, d)  # 2*a*dL + d, returns Tv (2 promotes naturally)
+@inline function _quadratic_kernel(::EvalDeriv1, a, d, _, dL::Td) where {Td}
+    return muladd(2 * a, dL, d)  # 2*a*dL + d
 end
 
 """
@@ -51,8 +53,8 @@ Evaluate second derivative of quadratic polynomial.
 
 Formula: S''(x) = 2*a (constant within interval)
 """
-@inline function _quadratic_kernel(::EvalDeriv2, a, _, _, _)
-    return a + a  # 2*a, returns Tv (avoids type conversion issues)
+@inline function _quadratic_kernel(::EvalDeriv2, a, _, _, _::Td) where {Td}
+    return a + a  # 2*a (avoids type conversion issues)
 end
 
 """
@@ -61,11 +63,11 @@ end
 Third derivative of quadratic spline is always zero.
 Uses `0 * a` for duck-typing support and NaN propagation.
 """
-@inline function _quadratic_kernel(::EvalDeriv3, a, _, _, _)
+@inline function _quadratic_kernel(::EvalDeriv3, a, _, _, _::Td) where {Td}
     return 0 * a
 end
 
 """Generic fallback: N-th derivative of degree-2 polynomial is zero for N ≥ 3."""
-@inline function _quadratic_kernel(::DerivOp{N}, a, _, _, _) where {N}
+@inline function _quadratic_kernel(::DerivOp{N}, a, _, _, _::Td) where {N, Td}
     return 0 * a
 end

--- a/src/quadratic/quadratic_kernels.jl
+++ b/src/quadratic/quadratic_kernels.jl
@@ -29,7 +29,7 @@ Formula: S(x) = a*dL² + d*dL + y = muladd(muladd(a, dL, d), dL, y)
 - `y::Tv`: Value at interval start
 - `dL::Td`: Offset from interval start (x - x_i, can be Float or Dual for AD)
 """
-@inline function _quadratic_kernel(::EvalValue, a::Tv, d::Tv, y::Tv, dL::Td) where {Tv, Td <: Real}
+@inline function _quadratic_kernel(::EvalValue, a, d, y, dL)
     return muladd(muladd(a, dL, d), dL, y)  # a*dL² + d*dL + y, returns Tv
 end
 
@@ -40,7 +40,7 @@ Evaluate first derivative of quadratic polynomial.
 
 Formula: S'(x) = 2*a*dL + d = muladd(2*a, dL, d)
 """
-@inline function _quadratic_kernel(::EvalDeriv1, a::Tv, d::Tv, ::Tv, dL::Td) where {Tv, Td <: Real}
+@inline function _quadratic_kernel(::EvalDeriv1, a, d, _, dL)
     return muladd(2 * a, dL, d)  # 2*a*dL + d, returns Tv (2 promotes naturally)
 end
 
@@ -51,7 +51,7 @@ Evaluate second derivative of quadratic polynomial.
 
 Formula: S''(x) = 2*a (constant within interval)
 """
-@inline function _quadratic_kernel(::EvalDeriv2, a::Tv, ::Tv, ::Tv, ::Td) where {Tv, Td <: Real}
+@inline function _quadratic_kernel(::EvalDeriv2, a, _, _, _)
     return a + a  # 2*a, returns Tv (avoids type conversion issues)
 end
 
@@ -61,11 +61,11 @@ end
 Third derivative of quadratic spline is always zero.
 Uses `0 * a` for duck-typing support and NaN propagation.
 """
-@inline function _quadratic_kernel(::EvalDeriv3, a::Tv, ::Tv, ::Tv, ::Td) where {Tv, Td <: Real}
+@inline function _quadratic_kernel(::EvalDeriv3, a, _, _, _)
     return 0 * a
 end
 
 """Generic fallback: N-th derivative of degree-2 polynomial is zero for N ≥ 3."""
-@inline function _quadratic_kernel(::DerivOp{N}, a::Tv, ::Tv, ::Tv, ::Td) where {N, Tv, Td <: Real}
+@inline function _quadratic_kernel(::DerivOp{N}, a, _, _, _) where {N}
     return 0 * a
 end

--- a/src/quadratic/quadratic_oneshot.jl
+++ b/src/quadratic/quadratic_oneshot.jl
@@ -78,7 +78,7 @@ end
 
 # ╔═══════════════════════════════════════════════════════════════════════════╗
 # ║                         PUBLIC API - HOT PATH                             ║
-# ║                 Tg<:AbstractFloat grid, Tv value type                     ║
+# ║                 TYPED CORE — all grid types                                ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
 # ========================================
@@ -249,7 +249,7 @@ function quadratic_interp(
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg, Tv, Tq <: Real}
+    ) where {Tg, Tq <: Real}
     x_p, y_p = _promote_itp_inputs(x, y)
     Tr = _output_eltype(eltype(y_p), eltype(x_p), Tq)
     output = Vector{Tr}(undef, length(x_targets))

--- a/src/quadratic/quadratic_oneshot.jl
+++ b/src/quadratic/quadratic_oneshot.jl
@@ -256,5 +256,3 @@ function quadratic_interp(
     quadratic_interp!(output, x_p, y_p, x_targets; bc, extrap, deriv, search)
     return output
 end
-
-

--- a/src/quadratic/quadratic_oneshot.jl
+++ b/src/quadratic/quadratic_oneshot.jl
@@ -25,14 +25,14 @@
 # _check_domain(::NoExtrap) throws if OOB; search_interval clamps idx for ExtendExtrap.
 @inline function _quadratic_eval_at_point(
         x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        a::AbstractVector{Tv},
-        d::AbstractVector{Tv},
+        y::AbstractVector,
+        a::AbstractVector,
+        d::AbstractVector,
         xq::Tq,
         extrap::AbstractExtrap,
         op::AbstractEvalOp,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, S <: Searcher}
+    ) where {Tg, Tq, S <: Searcher}
     @boundscheck _check_domain(x, xq, extrap)
     idx, xL, _ = search_interval(searcher, x, xq)
     dt = xq - xL  # Can be Dual for AD
@@ -42,17 +42,17 @@ end
 # ClampExtrap / FillExtrap: boundary check → extrap value or kernel.
 @inline function _quadratic_eval_at_point(
         x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        a::AbstractVector{Tv},
-        d::AbstractVector{Tv},
+        y::AbstractVector,
+        a::AbstractVector,
+        d::AbstractVector,
         xq::Tq,
         extrap::_ClampOrFill,
         op::AbstractEvalOp,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, S <: Searcher}
+    ) where {Tg, Tq, S <: Searcher}
     xq_primal = _extract_primal(xq)
-    xq_primal < first(x) && return _eval_extrapolation(op, first(y), extrap, xq)
-    xq_primal > last(x) && return _eval_extrapolation(op, last(y), extrap, xq)
+    xq_primal < _extract_primal(first(x)) && return _eval_extrapolation(op, first(y), extrap, xq)
+    xq_primal > _extract_primal(last(x)) && return _eval_extrapolation(op, last(y), extrap, xq)
     idx, xL, _ = search_interval(searcher, x, xq)
     dt = xq - xL
     @inbounds return _quadratic_kernel(op, a[idx], d[idx], y[idx], dt)
@@ -61,14 +61,14 @@ end
 # WrapExtrap: wrap query to domain → search + kernel.
 @inline function _quadratic_eval_at_point(
         x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        a::AbstractVector{Tv},
-        d::AbstractVector{Tv},
+        y::AbstractVector,
+        a::AbstractVector,
+        d::AbstractVector,
         xq::Tq,
         ::WrapExtrap,
         op::AbstractEvalOp,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, S <: Searcher}
+    ) where {Tg, Tq, S <: Searcher}
     xq_wrapped = _wrap_to_domain(xq, first(x), last(x))
     idx, xL, _ = search_interval(searcher, x, xq_wrapped)
     dt = xq_wrapped - xL
@@ -141,17 +141,19 @@ vals = quadratic_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_w
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     @boundscheck length(y) == length(x) || throw(ArgumentError("x and y must have same length"))
     @boundscheck length(x) >= 2 || throw(ArgumentError("x must have at least 2 elements"))
 
-    x = _to_float(x, Tg)
+    x = _to_float(x, _promote_grid_float(Tg, Tv))
+    Tg_actual = eltype(x)
     # Compute coefficients using temporary arrays from pool
     # spacing is pooled (zero-alloc for Range, pool-acquired for Vector)
     nx = length(x)
     spacing = _create_spacing_pooled(pool, x)
-    d = acquire!(pool, Tv, nx)
-    a = acquire!(pool, Tv, nx - 1)
+    Tcoeff = _output_eltype(eltype(y), Tg_actual)
+    d = acquire!(pool, Tcoeff, nx)
+    a = acquire!(pool, Tcoeff, nx - 1)
     bc_promoted = _normalize_bc(bc, first(y))
     _compute_quadratic_coeffs!(d, a, spacing, x, y, bc_promoted)
 
@@ -187,32 +189,34 @@ quadratic_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear
 ```
 """
 @with_pool pool function quadratic_interp!(
-        output::AbstractVector{Tv},
+        output::AbstractVector,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_targets::AbstractVector{Tg};
+        x_targets::AbstractVector{Tq};
         bc::QuadraticBC = Left(QuadraticFit()),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv, Tq <: Real}
     @assert length(y) == length(x) "x and y must have same length"
     @assert length(output) == length(x_targets) "output must match x_targets length"
     @assert length(x) >= 2 "x must have at least 2 elements"
 
-    x = _to_float(x, Tg)
-    x_targets = _to_float(x_targets, Tg)
+    x = _to_float(x, _promote_grid_float(Tg, Tv))
+    Tg_actual = eltype(x)
+    Tq_float = Tg_actual <: AbstractFloat ? Tg_actual : float(Tq)
+    xq_p = _to_float(x_targets, Tq_float)
     # Compute coefficients using temporary arrays from pool
-    # spacing is pooled (zero-alloc for Range, pool-acquired for Vector)
     nx = length(x)
     spacing = _create_spacing_pooled(pool, x)
-    d = acquire!(pool, Tv, nx)
-    a = acquire!(pool, Tv, nx - 1)
+    Tcoeff = _output_eltype(eltype(y), Tg_actual)
+    d = acquire!(pool, Tcoeff, nx)
+    a = acquire!(pool, Tcoeff, nx - 1)
     bc_promoted = _normalize_bc(bc, first(y))
     _compute_quadratic_coeffs!(d, a, spacing, x, y, bc_promoted)
 
-    searcher = _resolve_search(x, x_targets, search, nothing)
-    _quadratic_vector_loop!(output, x, y, a, d, x_targets, extrap, deriv, searcher)
+    searcher = _resolve_search(x, xq_p, search, nothing)
+    _quadratic_vector_loop!(output, x, y, a, d, xq_p, extrap, deriv, searcher)
     return output
 end
 
@@ -239,89 +243,18 @@ vals = quadratic_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_w
 """
 function quadratic_interp(
         x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        x_targets::AbstractVector{Tg};
+        y::AbstractVector,
+        x_targets::AbstractVector{Tq};
         bc::QuadraticBC = Left(QuadraticFit()),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv}
-    output = Vector{Tv}(undef, length(x_targets))
-    quadratic_interp!(output, x, y, x_targets; bc, extrap, deriv, search)
+    ) where {Tg, Tv, Tq <: Real}
+    x_p, y_p = _promote_itp_inputs(x, y)
+    Tr = _output_eltype(eltype(y_p), eltype(x_p), Tq)
+    output = Vector{Tr}(undef, length(x_targets))
+    quadratic_interp!(output, x_p, y_p, x_targets; bc, extrap, deriv, search)
     return output
 end
 
 
-# ╔═══════════════════════════════════════════════════════════════════════════╗
-# ║                     GENERIC WRAPPERS - CONVENIENCE                        ║
-# ║              Auto-promote Real types to Float (type conversion)           ║
-# ╚═══════════════════════════════════════════════════════════════════════════╝
-
-# BC promotion uses _normalize_bc(Left/Right/MinCurvFit, Tv) from core/bc_types.jl
-
-# ========================================
-# Scalar → typed wrappers
-# ========================================
-# Unified wrapper for non-AbstractFloat inputs (Int, mixed types, Complex, etc.)
-# POLICY: Tg is computed from x/y ONLY, not from xq
-
-# Wrapper for non-AbstractFloat inputs (Int, mixed types, etc.)
-# Preserves original xq type for AD support (Dual types flow through)
-@inline function quadratic_interp(
-        x::AbstractVector{Tg}, y::AbstractVector{Tv}, xq::Tq;
-        bc::QuadraticBC = Left(QuadraticFit()), kwargs...
-    ) where {Tg <: Real, Tv, Tq <: Real}
-    x_typed, y_typed = _promote_itp_inputs(x, y)
-    bc_promoted = _normalize_bc(bc, first(y_typed))
-    # Pass xq directly to preserve Dual type for AD
-    return quadratic_interp(x_typed, y_typed, xq; bc = bc_promoted, kwargs...)
-end
-
-# ========================================
-# Vector → typed wrappers (allocating)
-# ========================================
-# POLICY: Tg is computed from x/y ONLY, not from x_targets
-
-function quadratic_interp(
-        x::AbstractVector{Tg}, y::AbstractVector{Tv}, x_targets::AbstractVector{Tq};
-        bc::QuadraticBC = Left(QuadraticFit()), kwargs...
-    ) where {Tg <: Real, Tv, Tq <: Real}
-    x_typed, y_typed, xq_typed = _promote_itp_inputs(x, y, x_targets)
-    Tv_float = eltype(y_typed)
-    output = Vector{Tv_float}(undef, length(x_targets))
-    bc_promoted = _normalize_bc(bc, first(y_typed))
-    quadratic_interp!(output, x_typed, y_typed, xq_typed; bc = bc_promoted, kwargs...)
-    return output
-end
-
-# ========================================
-# Vector → typed wrappers (in-place)
-# ========================================
-
-function quadratic_interp!(
-        output::AbstractVector,
-        x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        x_targets::AbstractVector{Tq};
-        bc::QuadraticBC = Left(QuadraticFit()), kwargs...
-    ) where {Tg <: Real, Tv, Tq <: Real}
-    @assert length(y) == length(x) "x and y must have same length"
-    @assert length(output) == length(x_targets) "output must match x_targets length"
-
-    x_typed, y_typed, xq_typed = _promote_itp_inputs(x, y, x_targets)
-    Tv_float = eltype(y_typed)
-
-    # Validate output can hold result type
-    Tout = eltype(output)
-    if promote_type(Tout, Tv_float) !== Tout
-        throw(
-            ArgumentError(
-                "output eltype $Tout cannot hold interpolation result type $Tv_float. " *
-                    "Use Vector{$Tv_float} or a wider type."
-            )
-        )
-    end
-
-    bc_promoted = _normalize_bc(bc, first(y_typed))
-    return quadratic_interp!(output, x_typed, y_typed, xq_typed; bc = bc_promoted, kwargs...)
-end

--- a/src/quadratic/quadratic_oneshot.jl
+++ b/src/quadratic/quadratic_oneshot.jl
@@ -25,14 +25,14 @@
 # _check_domain(::NoExtrap) throws if OOB; search_interval clamps idx for ExtendExtrap.
 @inline function _quadratic_eval_at_point(
         x::AbstractVector{Tg},
-        y::AbstractVector,
-        a::AbstractVector,
-        d::AbstractVector,
+        y::AbstractVector{Tv},
+        a::AbstractVector{Tc},
+        d::AbstractVector{Tc},
         xq::Tq,
         extrap::AbstractExtrap,
         op::AbstractEvalOp,
         searcher::S
-    ) where {Tg, Tq, S <: Searcher}
+    ) where {Tg, Tv, Tc, Tq, S <: Searcher}
     @boundscheck _check_domain(x, xq, extrap)
     idx, xL, _ = search_interval(searcher, x, xq)
     dt = xq - xL  # Can be Dual for AD
@@ -42,14 +42,14 @@ end
 # ClampExtrap / FillExtrap: boundary check → extrap value or kernel.
 @inline function _quadratic_eval_at_point(
         x::AbstractVector{Tg},
-        y::AbstractVector,
-        a::AbstractVector,
-        d::AbstractVector,
+        y::AbstractVector{Tv},
+        a::AbstractVector{Tc},
+        d::AbstractVector{Tc},
         xq::Tq,
         extrap::_ClampOrFill,
         op::AbstractEvalOp,
         searcher::S
-    ) where {Tg, Tq, S <: Searcher}
+    ) where {Tg, Tv, Tc, Tq, S <: Searcher}
     xq_primal = _extract_primal(xq)
     xq_primal < _extract_primal(first(x)) && return _eval_extrapolation(op, first(y), extrap, xq)
     xq_primal > _extract_primal(last(x)) && return _eval_extrapolation(op, last(y), extrap, xq)
@@ -61,14 +61,14 @@ end
 # WrapExtrap: wrap query to domain → search + kernel.
 @inline function _quadratic_eval_at_point(
         x::AbstractVector{Tg},
-        y::AbstractVector,
-        a::AbstractVector,
-        d::AbstractVector,
+        y::AbstractVector{Tv},
+        a::AbstractVector{Tc},
+        d::AbstractVector{Tc},
         xq::Tq,
         ::WrapExtrap,
         op::AbstractEvalOp,
         searcher::S
-    ) where {Tg, Tq, S <: Searcher}
+    ) where {Tg, Tv, Tc, Tq, S <: Searcher}
     xq_wrapped = _wrap_to_domain(xq, first(x), last(x))
     idx, xL, _ = search_interval(searcher, x, xq_wrapped)
     dt = xq_wrapped - xL

--- a/src/quadratic/quadratic_oneshot_series.jl
+++ b/src/quadratic/quadratic_oneshot_series.jl
@@ -21,9 +21,9 @@
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tq <: Real}
+    ) where {Tg, Tq <: Real}
     _validate_series_lengths(s, length(x))
-    x = _to_float(x, Tg)
+    x = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
     _check_domain(x, xq, extrap)
     nx = length(x)
     K = n_series(s)
@@ -57,10 +57,10 @@ end
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tq <: Real}
+    ) where {Tg, Tq <: Real}
     _validate_series_lengths(s, length(x))
     length(output) == n_series(s) || _throw_series_dim_mismatch(length(output), n_series(s))
-    x = _to_float(x, Tg)
+    x = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
     _check_domain(x, xq, extrap)
     nx = length(x)
     vecs = _series_vectors(s)
@@ -95,9 +95,9 @@ end
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tq <: Real}
+    ) where {Tg, Tq <: Real}
     _validate_series_lengths(s, length(x))
-    x = _to_float(x, Tg)
+    x = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
     K = n_series(s)
     _validate_series_outputs(outputs, K, length(xqs))
     # Domain check: NoExtrap → throws if OOB, returns InBounds(); others → pass-through
@@ -134,7 +134,7 @@ function quadratic_interp(
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tq <: Real}
+    ) where {Tg, Tq <: Real}
     K = n_series(s)
     Tv_out = _series_output_type(_value_type(_series_eltype(s), Tg), Tq)
     outputs = [Vector{Tv_out}(undef, length(xqs)) for _ in 1:K]
@@ -142,35 +142,3 @@ function quadratic_interp(
     return outputs
 end
 
-# ╔═══════════════════════════════════════════════════════════════════════════╗
-# ║                     REAL TYPE PROMOTION WRAPPERS                         ║
-# ╚═══════════════════════════════════════════════════════════════════════════╝
-
-@inline function quadratic_interp(
-        x::AbstractVector{Tg}, s::Series, xq::Tq; kwargs...
-    ) where {Tg <: Real, Tq <: Real}
-    x_typed = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
-    return quadratic_interp(x_typed, s, xq; kwargs...)
-end
-
-@inline function quadratic_interp!(
-        output::AbstractVector, x::AbstractVector{Tg}, s::Series, xq::Tq; kwargs...
-    ) where {Tg <: Real, Tq <: Real}
-    x_typed = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
-    return quadratic_interp!(output, x_typed, s, xq; kwargs...)
-end
-
-function quadratic_interp!(
-        outputs::AbstractVector{<:AbstractVector},
-        x::AbstractVector{Tg}, s::Series, xqs::AbstractVector{Tq}; kwargs...
-    ) where {Tg <: Real, Tq <: Real}
-    Tg_float = _promote_grid_float(Tg, _series_eltype(s))
-    return quadratic_interp!(outputs, _to_float(x, Tg_float), s, xqs; kwargs...)
-end
-
-function quadratic_interp(
-        x::AbstractVector{Tg}, s::Series, xqs::AbstractVector{Tq}; kwargs...
-    ) where {Tg <: Real, Tq <: Real}
-    Tg_float = _promote_grid_float(Tg, _series_eltype(s))
-    return quadratic_interp(_to_float(x, Tg_float), s, xqs; kwargs...)
-end

--- a/src/quadratic/quadratic_oneshot_series.jl
+++ b/src/quadratic/quadratic_oneshot_series.jl
@@ -141,4 +141,3 @@ function quadratic_interp(
     quadratic_interp!(outputs, x, s, xqs; bc, extrap, deriv, search)
     return outputs
 end
-

--- a/src/quadratic/quadratic_series_interp.jl
+++ b/src/quadratic/quadratic_series_interp.jl
@@ -76,7 +76,7 @@ sitp_complex = quadratic_interp(x, y_complex)
 This type uses `mutable struct` with all `const` fields (Julia 1.8+) instead of
 plain `struct` for performance reasons. See CubicSeriesInterpolant for details.
 """
-mutable struct QuadraticSeriesInterpolant{Tg <: AbstractFloat, Tv, E <: AbstractExtrap, P <: AbstractSearchPolicy, X <: AbstractVector{Tg}, S <: AbstractGridSpacing{Tg}} <: AbstractSeriesInterpolant{Tg, Tv}
+mutable struct QuadraticSeriesInterpolant{Tg, Tv, E <: AbstractExtrap, P <: AbstractSearchPolicy, X <: AbstractVector{Tg}, S <: AbstractGridSpacing{Tg}} <: AbstractSeriesInterpolant{Tg, Tv}
     const x::X                                # Grid points (Range or Vector)
     const y::Matrix{Tv}                       # Series-contiguous y (n_points × n_series)
     const a::Matrix{Tv}                       # Series-contiguous a (n_points × n_series)
@@ -94,7 +94,7 @@ mutable struct QuadraticSeriesInterpolant{Tg <: AbstractFloat, Tv, E <: Abstract
             spacing::S,
             extrap::E,
             search::P = AutoSearch()
-        ) where {Tg <: AbstractFloat, Tv, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy}
+        ) where {Tg, Tv, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy}
         # _to_float(copy(x), Tg): Range → _CachedRange (O(1) search + no TwicePrecision overhead);
         # Vector → defensive copy. copy() on Range is identity (zero alloc).
         # typeof(xc) rebinds X after conversion (view → Vector, TwicePrecision → _CachedRange).
@@ -156,7 +156,7 @@ Anchor can contain ForwardDiff.Dual in `xq` and `dL` fields for AD propagation.
         sitp::QuadraticSeriesInterpolant{Tg, Tv},
         aq::_QuadraticAnchoredQuery{Tg, Tq},
         op::AbstractEvalOp
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     y_point, a_point, d_point = _ensure_point_layout!(sitp)
     n_pts = n_points(sitp)
     x_min, x_max = Tg(first(sitp.x)), Tg(last(sitp.x))
@@ -198,7 +198,7 @@ SIMD kernel for evaluating all series at a single anchor point with extrapolatio
         aq::_QuadraticAnchoredQuery{Tg, Tq},
         extrap::NoExtrap,
         op::AbstractEvalOp
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     if aq.state != IN_DOMAIN
         _throw_extrap_domain_error(aq.xq, x_min, x_max)
     end
@@ -216,7 +216,7 @@ end
         aq::_QuadraticAnchoredQuery{Tg, Tq},
         extrap::_ClampOrFill,
         op::AbstractEvalOp
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     return if aq.state != IN_DOMAIN  # outside domain
         _fill_constant_extrap_simd!(output, y_point, aq.state, n_pts, op, extrap)
     else
@@ -235,7 +235,7 @@ end
         aq::_QuadraticAnchoredQuery{Tg, Tq},
         extrap::AbstractExtrap,  # ExtendExtrap, WrapExtrap, or anything else
         op::AbstractEvalOp
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     return _eval_quadratic_series_point_kernel!(output, y_point, a_point, d_point, aq, op)
 end
 
@@ -259,7 +259,7 @@ When `aq.dL` is a ForwardDiff.Dual, the output will also be Dual.
         d_point::Matrix{Tv},
         aq::_QuadraticAnchoredQuery{Tg, Tq},
         op::EvalValue
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     idx = aq.idx
     dL = aq.dL
 
@@ -280,7 +280,7 @@ end
         d_point::Matrix{Tv},
         aq::_QuadraticAnchoredQuery{Tg, Tq},
         op::EvalDeriv1
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     idx = aq.idx
     dL = aq.dL
 
@@ -300,7 +300,7 @@ end
         d_point::Matrix{Tv},
         aq::_QuadraticAnchoredQuery{Tg, Tq},
         op::EvalDeriv2
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     idx = aq.idx
 
     @inbounds @simd for k in eachindex(output)
@@ -318,7 +318,7 @@ end
         d_point::Matrix{Tv},
         aq::_QuadraticAnchoredQuery{Tg, Tq},
         op::DerivOp{N}
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real, N}
+    ) where {Tg, Tv, Tq <: Real, N}
     z = 0 * (@inbounds y_point[first(eachindex(output)), aq.idx])
     @inbounds @simd for k in eachindex(output)
         output[k] = z
@@ -360,7 +360,7 @@ function quadratic_interp(
         bc::QuadraticBC = Left(QuadraticFit()),
         extrap::AbstractExtrap = NoExtrap(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat}
+    ) where {Tg}
     # Type promotion: widen grid if y's float base is wider than Tg
     Tv = _series_eltype(s)
     Tg_new = _promote_grid_float(Tg, Tv)
@@ -404,17 +404,6 @@ function quadratic_interp(
     return QuadraticSeriesInterpolant(x, y_mat, a_mat, d_mat, spacing, extrap_p, search)
 end
 
-# Real grid promotion (Int, etc.) → convert to float and delegate
-function quadratic_interp(
-        x::AbstractVector{Tg},
-        s::Series;
-        bc::QuadraticBC = Left(QuadraticFit()),
-        extrap::AbstractExtrap = NoExtrap(),
-        search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: Real}
-    Tg_float = _promote_grid_float(Tg, _series_eltype(s))
-    return quadratic_interp(_to_float(x, Tg_float), s; bc = _normalize_bc(bc, Tg_float), extrap, search)
-end
 
 # ========================================
 # Callable Interface (via Default + Override)
@@ -435,7 +424,7 @@ function (sitp::QuadraticSeriesInterpolant{Tg, Tv, P})(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, P, Tq <: Real}
+    ) where {Tg, Tv, P, Tq <: Real}
     # Promote for anchor: Int→Float, Int-backed Dual→Float-backed Dual (no-op for Float/Float-backed Dual)
     xq_promoted = _promote_for_anchor(xq, Tg)
     T_out = _series_output_type(Tv, typeof(xq_promoted))
@@ -461,7 +450,7 @@ function (sitp::QuadraticSeriesInterpolant{Tg, Tv, P})(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, P, Tq <: Real}
+    ) where {Tg, Tv, P, Tq <: Real}
     _validate_scalar_output(output, n_series(sitp))
 
     # Promote for anchor: Int→Float, Int-backed Dual→Float-backed Dual
@@ -489,7 +478,7 @@ function (sitp::QuadraticSeriesInterpolant{Tg, Tv, P})(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, P, Tq <: Real}
+    ) where {Tg, Tv, P, Tq <: Real}
     n_query = length(xq)
     n_ser = n_series(sitp)
     T_out = _series_output_type(Tv, Tq)
@@ -520,7 +509,7 @@ Pool handles both same-type and mixed-type cases efficiently.
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, P, Tq <: Real}
+    ) where {Tg, Tv, P, Tq <: Real}
     n_query = length(xq)
     _validate_series_outputs(outputs, n_series(sitp), n_query)
 
@@ -551,7 +540,7 @@ function _eval_series_anchored!(
         sitp::QuadraticSeriesInterpolant{Tg, Tv},
         aq_vec::AbstractVector{<:_QuadraticAnchoredQuery{Tg}},
         op::AbstractEvalOp
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     x_grid = sitp.x
     n_pts = length(x_grid)
     x_min, x_max = Tg(first(x_grid)), Tg(last(x_grid))
@@ -590,7 +579,7 @@ Takes `dL` as a parameter to allow caller to compute with original xq precision.
         dL::Tq,  # Passed by caller for precision control
         extrap::NoExtrap,
         op::AbstractEvalOp
-    ) where {Tg <: AbstractFloat, Tv, Taq <: Real, Tq <: Real}
+    ) where {Tg, Tv, Taq <: Real, Tq <: Real}
     if aq.state != IN_DOMAIN
         _throw_extrap_domain_error(aq.xq, x_min, x_max)
     end
@@ -608,7 +597,7 @@ end
         dL::Tq,
         extrap::_ClampOrFill,
         op::EvalValue
-    ) where {Tg <: AbstractFloat, Tv, Taq <: Real, Tq <: Real}
+    ) where {Tg, Tv, Taq <: Real, Tq <: Real}
     if aq.state != IN_DOMAIN  # outside domain
         y_bnd = @inbounds y[_boundary_point_index(aq.state, n_pts)]
         return _eval_extrapolation(op, y_bnd, extrap, aq.xq)
@@ -628,7 +617,7 @@ end
         dL::Tq,
         extrap::_ClampOrFill,
         op::Union{EvalDeriv1, EvalDeriv2, EvalDeriv3}
-    ) where {Tg <: AbstractFloat, Tv, Taq <: Real, Tq <: Real}
+    ) where {Tg, Tv, Taq <: Real, Tq <: Real}
     if aq.state != IN_DOMAIN  # outside domain
         return _eval_extrapolation(op, first(y), extrap, aq.xq)
     else
@@ -648,7 +637,7 @@ end
         ::Tq,
         ::_ClampOrFill,
         ::DerivOp{N}
-    ) where {Tg <: AbstractFloat, Tv, Taq <: Real, Tq <: Real, N}
+    ) where {Tg, Tv, Taq <: Real, Tq <: Real, N}
     return 0 * first(y)
 end
 
@@ -663,7 +652,7 @@ end
         dL::Tq,
         extrap::AbstractExtrap,  # ExtendExtrap, WrapExtrap, etc.
         op::AbstractEvalOp
-    ) where {Tg <: AbstractFloat, Tv, Taq <: Real, Tq <: Real}
+    ) where {Tg, Tv, Taq <: Real, Tq <: Real}
     return _quadratic_kernel(op, a[aq.idx], d[aq.idx], y[aq.idx], dL)
 end
 
@@ -680,7 +669,7 @@ function (sitp::QuadraticSeriesInterpolant{Tg, Tv})(
         outputs::AbstractVector{<:AbstractVector{Tv}},
         aq_vec::AbstractVector{<:_QuadraticAnchoredQuery{Tg, Tq}};
         deriv::DerivOp = EvalValue()
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     _validate_series_outputs(outputs, n_series(sitp), length(aq_vec))
 
     _eval_series_anchored!(outputs, sitp, aq_vec, deriv)

--- a/src/quadratic/quadratic_series_interp.jl
+++ b/src/quadratic/quadratic_series_interp.jl
@@ -20,7 +20,7 @@ Multi-series quadratic spline interpolant with unified matrix storage and SIMD o
 Shares a single x-grid across N y-series for efficient batch evaluation.
 
 # Type Parameters
-- `Tg`: Grid type (Float32 or Float64)
+- `Tg`: Grid type (unconstrained — supports duck types like ForwardDiff.Dual)
 - `Tv`: Value type (unconstrained)
 - `E`: Extrapolation mode type (compile-time specialized)
 - `P`: Search policy type

--- a/src/quadratic/quadratic_solver.jl
+++ b/src/quadratic/quadratic_solver.jl
@@ -39,7 +39,7 @@ Compute secant slopes: s[i] = (y[i+1] - y[i]) * inv_h[i]
 - `y::AbstractVector`: Values at grid points (length n)
 - `spacing::AbstractGridSpacing{Tg}`: Grid spacing (ScalarSpacing or VectorSpacing)
 """
-@inline function _compute_quadratic_secants!(s::AbstractVector, y::AbstractVector, spacing::AbstractGridSpacing)
+@inline function _compute_quadratic_secants!(s::AbstractVector{Tc}, y::AbstractVector, spacing::AbstractGridSpacing{Tg}) where {Tc, Tg}
     n = length(y) - 1
     @inbounds for i in 1:n
         s[i] = (y[i + 1] - y[i]) * _get_inv_h(spacing, i)  # Tv * Tg → Tv
@@ -62,7 +62,7 @@ d[i+1] = 2*s[i] - d[i]
 - `s::AbstractVector`: Secant slopes (length n-1)
 - `d1`: Initial slope d[1]
 """
-@inline function _forward_recurrence!(d::AbstractVector, s::AbstractVector, d1)
+@inline function _forward_recurrence!(d::AbstractVector{Tc}, s::AbstractVector{Tc}, d1) where {Tc}
     d[1] = d1
     n = length(d)
     @inbounds for i in 1:(n - 1)
@@ -82,7 +82,7 @@ d[i] = 2*s[i] - d[i+1]
 - `s::AbstractVector`: Secant slopes (length n-1)
 - `dn`: Final slope d[n]
 """
-@inline function _backward_recurrence!(d::AbstractVector, s::AbstractVector, dn)
+@inline function _backward_recurrence!(d::AbstractVector{Tc}, s::AbstractVector{Tc}, dn) where {Tc}
     n = length(d)
     d[n] = dn
     @inbounds for i in (n - 1):-1:1
@@ -113,39 +113,39 @@ derivatives from data. For other BC types, they are ignored.
 # Left(Deriv1): d[1] given directly, forward recurrence
 # convert() is a no-op when types match (optimized away at compile time)
 @inline function _fill_slopes!(
-        d::AbstractVector, s::AbstractVector, spacing::AbstractGridSpacing{Tg},
+        d::AbstractVector{Tc}, s::AbstractVector{Tc}, spacing::AbstractGridSpacing{Tg},
         bc::Left{<:Deriv1}, ::AbstractVector{Tg}, ::AbstractVector
-    ) where {Tg}
-    d1 = convert(eltype(d), bc.bc.val)
+    ) where {Tc, Tg}
+    d1 = convert(Tc, bc.bc.val)
     return _forward_recurrence!(d, s, d1)
 end
 
 # Left(Deriv2): d[1] = s[1] - (κ/2)*h[1], forward recurrence
 @inline function _fill_slopes!(
-        d::AbstractVector, s::AbstractVector, spacing::AbstractGridSpacing{Tg},
+        d::AbstractVector{Tc}, s::AbstractVector{Tc}, spacing::AbstractGridSpacing{Tg},
         bc::Left{<:Deriv2}, ::AbstractVector{Tg}, ::AbstractVector
-    ) where {Tg}
-    κ = convert(eltype(d), bc.bc.val)
+    ) where {Tc, Tg}
+    κ = convert(Tc, bc.bc.val)
     d1 = s[1] - κ * (_get_h(spacing, 1) / 2)  # Tv - Tv*Tg → Tv (no /(Tv,Int) needed)
     return _forward_recurrence!(d, s, d1)
 end
 
 # Right(Deriv1): d[n] given directly, backward recurrence
 @inline function _fill_slopes!(
-        d::AbstractVector, s::AbstractVector, spacing::AbstractGridSpacing{Tg},
+        d::AbstractVector{Tc}, s::AbstractVector{Tc}, spacing::AbstractGridSpacing{Tg},
         bc::Right{<:Deriv1}, ::AbstractVector{Tg}, ::AbstractVector
-    ) where {Tg}
-    dn = convert(eltype(d), bc.bc.val)
+    ) where {Tc, Tg}
+    dn = convert(Tc, bc.bc.val)
     return _backward_recurrence!(d, s, dn)
 end
 
 # Right(Deriv2): compute d[n] from curvature, backward recurrence
 # d[n] = s[n-1] + (κ/2)*h[n-1]  (derived from a[n-1] = κ/2)
 @inline function _fill_slopes!(
-        d::AbstractVector, s::AbstractVector, spacing::AbstractGridSpacing{Tg},
+        d::AbstractVector{Tc}, s::AbstractVector{Tc}, spacing::AbstractGridSpacing{Tg},
         bc::Right{<:Deriv2}, ::AbstractVector{Tg}, ::AbstractVector
-    ) where {Tg}
-    κ = convert(eltype(d), bc.bc.val)
+    ) where {Tc, Tg}
+    κ = convert(Tc, bc.bc.val)
     n_intervals = length(s)
     dn = s[end] + κ * (_get_h(spacing, n_intervals) / 2)  # Tv + Tv*Tg → Tv (no /(Tv,Int) needed)
     return _backward_recurrence!(d, s, dn)
@@ -174,9 +174,9 @@ element-wise on real and imaginary parts.
 O(n) time, O(1) extra space (on-the-fly β computation).
 """
 @inline function _fill_slopes!(
-        d::AbstractVector, s::AbstractVector, spacing::AbstractGridSpacing{Tg},
+        d::AbstractVector{Tc}, s::AbstractVector{Tc}, spacing::AbstractGridSpacing{Tg},
         ::MinCurvFit, ::AbstractVector{Tg}, ::AbstractVector
-    ) where {Tg}
+    ) where {Tc, Tg}
     n = length(d)
     n_intervals = n - 1  # = length(s)
 
@@ -236,9 +236,9 @@ QuadraticFit (D=2), CubicFit (D=3), etc.
 For Complex y values, materialize_bc returns Deriv1{ComplexF64} naturally.
 """
 @inline function _fill_slopes!(
-        d::AbstractVector, s::AbstractVector, ::AbstractGridSpacing{Tg},
+        d::AbstractVector{Tc}, s::AbstractVector{Tc}, ::AbstractGridSpacing{Tg},
         bc::Left{PolyFit{D}}, x::AbstractVector{Tg}, y::AbstractVector
-    ) where {D, Tg}
+    ) where {D, Tc, Tg}
     # Materialize PolyFit{D} → Deriv1{Tv} using estimated derivative
     concrete_bc = materialize_bc(bc.bc, x, y, LeftSide())
     d1 = concrete_bc.val  # Already Tv type from polynomial fit on y values
@@ -254,9 +254,9 @@ Materializes PolyFit{D} to Deriv1{Tv} using `materialize_bc`, then uses the
 estimated derivative directly.
 """
 @inline function _fill_slopes!(
-        d::AbstractVector, s::AbstractVector, ::AbstractGridSpacing{Tg},
+        d::AbstractVector{Tc}, s::AbstractVector{Tc}, ::AbstractGridSpacing{Tg},
         bc::Right{PolyFit{D}}, x::AbstractVector{Tg}, y::AbstractVector
-    ) where {D, Tg}
+    ) where {D, Tc, Tg}
     # Materialize PolyFit{D} → Deriv1{Tv} using estimated derivative
     concrete_bc = materialize_bc(bc.bc, x, y, RightSide())
     dn = concrete_bc.val  # Already Tv type from polynomial fit on y values
@@ -282,7 +282,7 @@ Compute quadratic coefficients: a[i] = (s[i] - d[i]) * inv_h[i]
 - `Tv`: Value type (unconstrained)
 - `Tg`: Grid type
 """
-@inline function _compute_quadratic_coefficients!(a::AbstractVector, d::AbstractVector, s::AbstractVector, spacing::AbstractGridSpacing{Tg}) where {Tg}
+@inline function _compute_quadratic_coefficients!(a::AbstractVector{Tc}, d::AbstractVector{Tc}, s::AbstractVector{Tc}, spacing::AbstractGridSpacing{Tg}) where {Tc, Tg}
     @inbounds for i in eachindex(a)
         a[i] = (s[i] - d[i]) * _get_inv_h(spacing, i)  # (Tv - Tv) * Tg → Tv
     end
@@ -324,13 +324,8 @@ Uses AdaptiveArrayPools internally for temporary `secant` array.
     Tcoeff = eltype(d)
     secant = acquire!(pool, Tcoeff, nx - 1)
 
-    # 1. Compute secants using spacing
     _compute_quadratic_secants!(secant, y, spacing)
-
-    # 2. Fill slopes d[] (BC-dispatched: Left→forward, Right→backward)
     _fill_slopes!(d, secant, spacing, bc, x, y)
-
-    # 3. Compute quadratic coefficients a[]
     _compute_quadratic_coefficients!(a, d, secant, spacing)
 
     return nothing

--- a/src/quadratic/quadratic_solver.jl
+++ b/src/quadratic/quadratic_solver.jl
@@ -36,14 +36,14 @@ Compute secant slopes: s[i] = (y[i+1] - y[i]) * inv_h[i]
 
 # Arguments
 - `s::Vector{Tv}`: Output vector (length n-1, value-derived)
-- `y::AbstractVector{Tv}`: Values at grid points (length n)
+- `y::AbstractVector`: Values at grid points (length n)
 - `spacing::AbstractGridSpacing{Tg}`: Grid spacing (ScalarSpacing or VectorSpacing)
 
 # Type Parameters
 - `Tv`: Value type (unconstrained)
 - `Tg<:AbstractFloat`: Grid type
 """
-@inline function _compute_quadratic_secants!(s::AbstractVector{Tv}, y::AbstractVector{Tv}, spacing::AbstractGridSpacing{Tg}) where {Tv, Tg <: AbstractFloat}
+@inline function _compute_quadratic_secants!(s::AbstractVector, y::AbstractVector, spacing::AbstractGridSpacing)
     n = length(y) - 1
     @inbounds for i in 1:n
         s[i] = (y[i + 1] - y[i]) * _get_inv_h(spacing, i)  # Tv * Tg → Tv
@@ -69,7 +69,7 @@ d[i+1] = 2*s[i] - d[i]
 # Type Parameters
 - `Tv`: Value type (unconstrained)
 """
-@inline function _forward_recurrence!(d::AbstractVector{Tv}, s::AbstractVector{Tv}, d1::Tv) where {Tv}
+@inline function _forward_recurrence!(d::AbstractVector, s::AbstractVector, d1)
     d[1] = d1
     n = length(d)
     @inbounds for i in 1:(n - 1)
@@ -92,7 +92,7 @@ d[i] = 2*s[i] - d[i+1]
 # Type Parameters
 - `Tv`: Value type (unconstrained)
 """
-@inline function _backward_recurrence!(d::AbstractVector{Tv}, s::AbstractVector{Tv}, dn::Tv) where {Tv}
+@inline function _backward_recurrence!(d::AbstractVector, s::AbstractVector, dn)
     n = length(d)
     d[n] = dn
     @inbounds for i in (n - 1):-1:1
@@ -123,39 +123,39 @@ derivatives from data. For other BC types, they are ignored.
 # Left(Deriv1): d[1] given directly, forward recurrence
 # convert() is a no-op when types match (optimized away at compile time)
 @inline function _fill_slopes!(
-        d::AbstractVector{Tv}, s::AbstractVector{Tv}, spacing::AbstractGridSpacing{Tg},
-        bc::Left{<:Deriv1}, ::AbstractVector{Tg}, ::AbstractVector{Tv}
-    ) where {Tv, Tg <: AbstractFloat}
-    d1 = convert(Tv, bc.bc.val)
+        d::AbstractVector, s::AbstractVector, spacing::AbstractGridSpacing{Tg},
+        bc::Left{<:Deriv1}, ::AbstractVector{Tg}, ::AbstractVector
+    ) where {Tg}
+    d1 = convert(eltype(d), bc.bc.val)
     return _forward_recurrence!(d, s, d1)
 end
 
 # Left(Deriv2): d[1] = s[1] - (κ/2)*h[1], forward recurrence
 @inline function _fill_slopes!(
-        d::AbstractVector{Tv}, s::AbstractVector{Tv}, spacing::AbstractGridSpacing{Tg},
-        bc::Left{<:Deriv2}, ::AbstractVector{Tg}, ::AbstractVector{Tv}
-    ) where {Tv, Tg <: AbstractFloat}
-    κ = convert(Tv, bc.bc.val)
+        d::AbstractVector, s::AbstractVector, spacing::AbstractGridSpacing{Tg},
+        bc::Left{<:Deriv2}, ::AbstractVector{Tg}, ::AbstractVector
+    ) where {Tg}
+    κ = convert(eltype(d), bc.bc.val)
     d1 = s[1] - κ * (_get_h(spacing, 1) / 2)  # Tv - Tv*Tg → Tv (no /(Tv,Int) needed)
     return _forward_recurrence!(d, s, d1)
 end
 
 # Right(Deriv1): d[n] given directly, backward recurrence
 @inline function _fill_slopes!(
-        d::AbstractVector{Tv}, s::AbstractVector{Tv}, spacing::AbstractGridSpacing{Tg},
-        bc::Right{<:Deriv1}, ::AbstractVector{Tg}, ::AbstractVector{Tv}
-    ) where {Tv, Tg <: AbstractFloat}
-    dn = convert(Tv, bc.bc.val)
+        d::AbstractVector, s::AbstractVector, spacing::AbstractGridSpacing{Tg},
+        bc::Right{<:Deriv1}, ::AbstractVector{Tg}, ::AbstractVector
+    ) where {Tg}
+    dn = convert(eltype(d), bc.bc.val)
     return _backward_recurrence!(d, s, dn)
 end
 
 # Right(Deriv2): compute d[n] from curvature, backward recurrence
 # d[n] = s[n-1] + (κ/2)*h[n-1]  (derived from a[n-1] = κ/2)
 @inline function _fill_slopes!(
-        d::AbstractVector{Tv}, s::AbstractVector{Tv}, spacing::AbstractGridSpacing{Tg},
-        bc::Right{<:Deriv2}, ::AbstractVector{Tg}, ::AbstractVector{Tv}
-    ) where {Tv, Tg <: AbstractFloat}
-    κ = convert(Tv, bc.bc.val)
+        d::AbstractVector, s::AbstractVector, spacing::AbstractGridSpacing{Tg},
+        bc::Right{<:Deriv2}, ::AbstractVector{Tg}, ::AbstractVector
+    ) where {Tg}
+    κ = convert(eltype(d), bc.bc.val)
     n_intervals = length(s)
     dn = s[end] + κ * (_get_h(spacing, n_intervals) / 2)  # Tv + Tv*Tg → Tv (no /(Tv,Int) needed)
     return _backward_recurrence!(d, s, dn)
@@ -184,9 +184,9 @@ element-wise on real and imaginary parts.
 O(n) time, O(1) extra space (on-the-fly β computation).
 """
 @inline function _fill_slopes!(
-        d::AbstractVector{Tv}, s::AbstractVector{Tv}, spacing::AbstractGridSpacing{Tg},
-        ::MinCurvFit, ::AbstractVector{Tg}, ::AbstractVector{Tv}
-    ) where {Tv, Tg <: AbstractFloat}
+        d::AbstractVector, s::AbstractVector, spacing::AbstractGridSpacing{Tg},
+        ::MinCurvFit, ::AbstractVector{Tg}, ::AbstractVector
+    ) where {Tg}
     n = length(d)
     n_intervals = n - 1  # = length(s)
 
@@ -246,9 +246,9 @@ QuadraticFit (D=2), CubicFit (D=3), etc.
 For Complex y values, materialize_bc returns Deriv1{ComplexF64} naturally.
 """
 @inline function _fill_slopes!(
-        d::AbstractVector{Tv}, s::AbstractVector{Tv}, ::AbstractGridSpacing{Tg},
-        bc::Left{PolyFit{D}}, x::AbstractVector{Tg}, y::AbstractVector{Tv}
-    ) where {D, Tv, Tg <: AbstractFloat}
+        d::AbstractVector, s::AbstractVector, ::AbstractGridSpacing{Tg},
+        bc::Left{PolyFit{D}}, x::AbstractVector{Tg}, y::AbstractVector
+    ) where {D, Tg}
     # Materialize PolyFit{D} → Deriv1{Tv} using estimated derivative
     concrete_bc = materialize_bc(bc.bc, x, y, LeftSide())
     d1 = concrete_bc.val  # Already Tv type from polynomial fit on y values
@@ -264,9 +264,9 @@ Materializes PolyFit{D} to Deriv1{Tv} using `materialize_bc`, then uses the
 estimated derivative directly.
 """
 @inline function _fill_slopes!(
-        d::AbstractVector{Tv}, s::AbstractVector{Tv}, ::AbstractGridSpacing{Tg},
-        bc::Right{PolyFit{D}}, x::AbstractVector{Tg}, y::AbstractVector{Tv}
-    ) where {D, Tv, Tg <: AbstractFloat}
+        d::AbstractVector, s::AbstractVector, ::AbstractGridSpacing{Tg},
+        bc::Right{PolyFit{D}}, x::AbstractVector{Tg}, y::AbstractVector
+    ) where {D, Tg}
     # Materialize PolyFit{D} → Deriv1{Tv} using estimated derivative
     concrete_bc = materialize_bc(bc.bc, x, y, RightSide())
     dn = concrete_bc.val  # Already Tv type from polynomial fit on y values
@@ -292,7 +292,7 @@ Compute quadratic coefficients: a[i] = (s[i] - d[i]) * inv_h[i]
 - `Tv`: Value type (unconstrained)
 - `Tg<:AbstractFloat`: Grid type
 """
-@inline function _compute_quadratic_coefficients!(a::AbstractVector{Tv}, d::AbstractVector{Tv}, s::AbstractVector{Tv}, spacing::AbstractGridSpacing{Tg}) where {Tv, Tg <: AbstractFloat}
+@inline function _compute_quadratic_coefficients!(a::AbstractVector, d::AbstractVector, s::AbstractVector, spacing::AbstractGridSpacing{Tg}) where {Tg}
     @inbounds for i in eachindex(a)
         a[i] = (s[i] - d[i]) * _get_inv_h(spacing, i)  # (Tv - Tv) * Tg → Tv
     end
@@ -310,11 +310,11 @@ Fill pre-allocated coefficient arrays for quadratic spline.
 Uses AdaptiveArrayPools internally for temporary `secant` array.
 
 # Arguments (outputs first, then inputs)
-- `d::AbstractVector{Tv}`: Slope coefficients (length n, value-derived)
-- `a::AbstractVector{Tv}`: Quadratic coefficients (length n-1, value-derived)
+- `d::AbstractVector`: Slope coefficients (length n, value-derived)
+- `a::AbstractVector`: Quadratic coefficients (length n-1, value-derived)
 - `spacing::AbstractGridSpacing{Tg}`: Precomputed grid spacing
 - `x::AbstractVector{Tg}`: x-coordinates (length n)
-- `y::AbstractVector{Tv}`: y-values (length n)
+- `y::AbstractVector`: y-values (length n)
 - `bc::QuadraticBC`: Boundary condition (Left, Right, or MinCurvFit)
 
 # Type Parameters
@@ -322,16 +322,17 @@ Uses AdaptiveArrayPools internally for temporary `secant` array.
 - `Tv`: Value type (unconstrained)
 """
 @with_pool pool function _compute_quadratic_coeffs!(
-        d::AbstractVector{Tv},
-        a::AbstractVector{Tv},
+        d::AbstractVector,
+        a::AbstractVector,
         spacing::AbstractGridSpacing{Tg},
         x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
+        y::AbstractVector,
         bc::QuadraticBC
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg}
     nx = length(x)
 
-    secant = acquire!(pool, Tv, nx - 1) # secant slopes (Tv)
+    Tcoeff = eltype(d)
+    secant = acquire!(pool, Tcoeff, nx - 1)
 
     # 1. Compute secants using spacing
     _compute_quadratic_secants!(secant, y, spacing)
@@ -370,15 +371,16 @@ which stores precomputed coefficients.
 """
 function _compute_quadratic_coeffs(
         x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
+        y::AbstractVector,
         bc::QuadraticBC,
         spacing::AbstractGridSpacing{Tg}
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg}
     nx = length(x)
 
-    # Allocate arrays with appropriate types
-    d = Vector{Tv}(undef, nx)     # Slopes (value-derived)
-    a = Vector{Tv}(undef, nx - 1)   # Quadratic coefficients (value-derived)
+    # Allocate arrays — widened type when grid is duck-typed (e.g. Dual)
+    Tcoeff = _output_eltype(eltype(y), Tg)
+    d = Vector{Tcoeff}(undef, nx)
+    a = Vector{Tcoeff}(undef, nx - 1)
 
     # Fill using in-place version
     _compute_quadratic_coeffs!(d, a, spacing, x, y, bc)

--- a/src/quadratic/quadratic_solver.jl
+++ b/src/quadratic/quadratic_solver.jl
@@ -35,13 +35,9 @@ const QuadraticBC = Union{Left, Right, MinCurvFit}
 Compute secant slopes: s[i] = (y[i+1] - y[i]) * inv_h[i]
 
 # Arguments
-- `s::Vector{Tv}`: Output vector (length n-1, value-derived)
+- `s::AbstractVector`: Output secant vector (length n-1)
 - `y::AbstractVector`: Values at grid points (length n)
 - `spacing::AbstractGridSpacing{Tg}`: Grid spacing (ScalarSpacing or VectorSpacing)
-
-# Type Parameters
-- `Tv`: Value type (unconstrained)
-- `Tg`: Grid type
 """
 @inline function _compute_quadratic_secants!(s::AbstractVector, y::AbstractVector, spacing::AbstractGridSpacing)
     n = length(y) - 1
@@ -62,12 +58,9 @@ Fill slope array using forward recurrence from d[1].
 d[i+1] = 2*s[i] - d[i]
 
 # Arguments
-- `d::Vector{Tv}`: Output slope array (length n, value-derived)
-- `s::Vector{Tv}`: Secant slopes (length n-1, value-derived)
-- `d1::Tv`: Initial slope d[1]
-
-# Type Parameters
-- `Tv`: Value type (unconstrained)
+- `d::AbstractVector`: Output slope array (length n)
+- `s::AbstractVector`: Secant slopes (length n-1)
+- `d1`: Initial slope d[1]
 """
 @inline function _forward_recurrence!(d::AbstractVector, s::AbstractVector, d1)
     d[1] = d1
@@ -85,12 +78,9 @@ Fill slope array using backward recurrence from d[n].
 d[i] = 2*s[i] - d[i+1]
 
 # Arguments
-- `d::Vector{Tv}`: Output slope array (length n, value-derived)
-- `s::Vector{Tv}`: Secant slopes (length n-1, value-derived)
-- `dn::Tv`: Final slope d[n]
-
-# Type Parameters
-- `Tv`: Value type (unconstrained)
+- `d::AbstractVector`: Output slope array (length n)
+- `s::AbstractVector`: Secant slopes (length n-1)
+- `dn`: Final slope d[n]
 """
 @inline function _backward_recurrence!(d::AbstractVector, s::AbstractVector, dn)
     n = length(d)

--- a/src/quadratic/quadratic_solver.jl
+++ b/src/quadratic/quadratic_solver.jl
@@ -41,7 +41,7 @@ Compute secant slopes: s[i] = (y[i+1] - y[i]) * inv_h[i]
 
 # Type Parameters
 - `Tv`: Value type (unconstrained)
-- `Tg<:AbstractFloat`: Grid type
+- `Tg`: Grid type
 """
 @inline function _compute_quadratic_secants!(s::AbstractVector, y::AbstractVector, spacing::AbstractGridSpacing)
     n = length(y) - 1
@@ -118,7 +118,7 @@ derivatives from data. For other BC types, they are ignored.
 
 # Type Parameters
 - `Tv`: Value type for d, s (unconstrained)
-- `Tg<:AbstractFloat`: Grid type for spacing, x
+- `Tg`: Grid type for spacing, x
 """
 # Left(Deriv1): d[1] given directly, forward recurrence
 # convert() is a no-op when types match (optimized away at compile time)
@@ -290,7 +290,7 @@ Compute quadratic coefficients: a[i] = (s[i] - d[i]) * inv_h[i]
 
 # Type Parameters
 - `Tv`: Value type (unconstrained)
-- `Tg<:AbstractFloat`: Grid type
+- `Tg`: Grid type
 """
 @inline function _compute_quadratic_coefficients!(a::AbstractVector, d::AbstractVector, s::AbstractVector, spacing::AbstractGridSpacing{Tg}) where {Tg}
     @inbounds for i in eachindex(a)
@@ -318,7 +318,7 @@ Uses AdaptiveArrayPools internally for temporary `secant` array.
 - `bc::QuadraticBC`: Boundary condition (Left, Right, or MinCurvFit)
 
 # Type Parameters
-- `Tg<:AbstractFloat`: Grid type
+- `Tg`: Grid type
 - `Tv`: Value type (unconstrained)
 """
 @with_pool pool function _compute_quadratic_coeffs!(
@@ -357,7 +357,7 @@ Compute quadratic spline coefficients (allocating version).
 Returns only the arrays needed for evaluation: `d`, `a`.
 
 # Type Parameters
-- `Tg<:AbstractFloat`: Grid type for x
+- `Tg`: Grid type for x
 - `Tv`: Value type for y, d, a (unconstrained)
 
 # Returns

--- a/src/quadratic/quadratic_types.jl
+++ b/src/quadratic/quadratic_types.jl
@@ -10,7 +10,7 @@
 # from bc_types.jl (shared with cubic and other interpolators).
 
 """
-    QuadraticInterpolant{Tg,Tv,X,Y,S,E,P,BC}
+    QuadraticInterpolant{Tg,Tv,X,Y,S,E,P,BC,Tc}
 
 Lightweight callable interpolant for quadratic spline interpolation.
 Returned by `quadratic_interp(x, y)` (2-argument form).
@@ -24,13 +24,14 @@ Returned by `quadratic_interp(x, y)` (2-argument form).
 - `E<:AbstractExtrap`: Extrapolation mode type (compile-time specialized)
 - `P<:AbstractSearchPolicy`: Search policy type
 - `BC<:QuadraticBC`: Boundary condition type (retained for adjoint/matrix convenience)
+- `Tc`: Coefficient element type (`_output_eltype(Tv, Tg)` — may be Dual for duck grids)
 
 # Fields
 - `x::X`: x-coordinates (sorted)
 - `y::Y`: y-values
 - `spacing::S`: Precomputed grid spacing (avoids TwicePrecision overhead on Range grids)
-- `a::Vector{Tv}`: Quadratic coefficients (value-derived)
-- `d::Vector{Tv}`: Slope coefficients (value-derived)
+- `a::Vector{Tc}`: Quadratic coefficients
+- `d::Vector{Tc}`: Slope coefficients
 - `extrap::E`: Extrapolation mode (NoExtrap(), ExtendExtrap(), ClampExtrap(), or WrapExtrap())
 - `search_policy::P`: Default search policy for interval lookup
 - `bc::BC`: Boundary condition used during construction (retained for `Matrix(itp, xq)` convenience)
@@ -59,20 +60,20 @@ itp = quadratic_interp(x, y; search=LinearBinarySearch())  # explicit override
 val = itp(0.5; search=BinarySearch())  # per-call override
 ```
 """
-struct QuadraticInterpolant{Tg, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy, BC <: QuadraticBC, A <: AbstractVector, D <: AbstractVector} <: AbstractInterpolant1D{Tg, Tv}
+struct QuadraticInterpolant{Tg, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy, BC <: QuadraticBC, Tc} <: AbstractInterpolant1D{Tg, Tv}
     x::X
     y::Y
-    spacing::S       # Precomputed grid spacing (ScalarSpacing for Range, VectorSpacing for Vector)
-    a::A             # Quadratic coefficients (may be Dual when grid is duck-typed)
-    d::D             # Slope coefficients (may be Dual when grid is duck-typed)
-    extrap::E        # Extrapolation mode (compile-time specialized)
-    search_policy::P  # Default search policy (immutable, thread-safe)
-    bc::BC           # Boundary condition (retained for Matrix(itp, xq) convenience)
+    spacing::S          # Precomputed grid spacing (ScalarSpacing for Range, VectorSpacing for Vector)
+    a::Vector{Tc}       # Quadratic coefficients (Tc = _output_eltype(Tv, Tg))
+    d::Vector{Tc}       # Slope coefficients (Tc = _output_eltype(Tv, Tg))
+    extrap::E           # Extrapolation mode (compile-time specialized)
+    search_policy::P    # Default search policy (immutable, thread-safe)
+    bc::BC              # Boundary condition (retained for Matrix(itp, xq) convenience)
 
     # Inner constructor: parametric, only calls new (handles validation only)
-    function QuadraticInterpolant{Tg, Tv, X, Y, S, E, P, BC, A, D}(
-            x::AbstractVector{Tg}, y::AbstractVector{Tv}, spacing::S, a::A, d::D, ev::E, search::P, bc::BC
-        ) where {Tg, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy, BC <: QuadraticBC, A <: AbstractVector, D <: AbstractVector}
+    function QuadraticInterpolant{Tg, Tv, X, Y, S, E, P, BC, Tc}(
+            x::AbstractVector{Tg}, y::AbstractVector{Tv}, spacing::S, a::Vector{Tc}, d::Vector{Tc}, ev::E, search::P, bc::BC
+        ) where {Tg, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy, BC <: QuadraticBC, Tc}
         length(x) == length(y) || _throw_length_mismatch(length(x), length(y))
         length(x) >= 2 || _throw_grid_too_small(length(x))
         # Copy to ensure immutability: once constructed, the interpolant owns
@@ -80,7 +81,7 @@ struct QuadraticInterpolant{Tg, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector
         # copy() on immutable Range types is a no-op (zero allocation).
         # typeof() rebinds X/Y to the post-copy concrete type (e.g. SubArray → Vector).
         xc, yc = copy(x), copy(y)
-        return new{Tg, Tv, typeof(xc), typeof(yc), S, E, P, BC, A, D}(xc, yc, spacing, a, d, ev, search, bc)
+        return new{Tg, Tv, typeof(xc), typeof(yc), S, E, P, BC, Tc}(xc, yc, spacing, a, d, ev, search, bc)
     end
 end
 
@@ -95,15 +96,13 @@ end
         x::X,
         y::Y,
         spacing::S,
-        a::AbstractVector,
-        d::AbstractVector;
+        a::Vector{Tc},
+        d::Vector{Tc};
         bc::QuadraticBC = Left(QuadraticFit()),
         extrap::AbstractExtrap = NoExtrap(),
         search::P = AutoSearch()
-    ) where {Tg, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, S <: AbstractGridSpacing{Tg}, P <: AbstractSearchPolicy}
+    ) where {Tg, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, S <: AbstractGridSpacing{Tg}, P <: AbstractSearchPolicy, Tc}
     E = typeof(extrap)
     BC = typeof(bc)
-    A = typeof(a)
-    D = typeof(d)
-    return QuadraticInterpolant{Tg, Tv, X, Y, S, E, P, BC, A, D}(x, y, spacing, a, d, extrap, search, bc)
+    return QuadraticInterpolant{Tg, Tv, X, Y, S, E, P, BC, Tc}(x, y, spacing, a, d, extrap, search, bc)
 end

--- a/src/quadratic/quadratic_types.jl
+++ b/src/quadratic/quadratic_types.jl
@@ -16,7 +16,7 @@ Lightweight callable interpolant for quadratic spline interpolation.
 Returned by `quadratic_interp(x, y)` (2-argument form).
 
 # Type Parameters
-- `Tg<:AbstractFloat`: Grid type (Float32, Float64) for x-coordinates
+- `Tg`: Grid type (unconstrained) for x-coordinates
 - `Tv`: Value type (unconstrained)
 - `X<:AbstractVector{Tg}`: Type of x-coordinates
 - `Y<:AbstractVector{Tv}`: Type of y-values

--- a/src/quadratic/quadratic_types.jl
+++ b/src/quadratic/quadratic_types.jl
@@ -59,20 +59,20 @@ itp = quadratic_interp(x, y; search=LinearBinarySearch())  # explicit override
 val = itp(0.5; search=BinarySearch())  # per-call override
 ```
 """
-struct QuadraticInterpolant{Tg <: AbstractFloat, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy, BC <: QuadraticBC} <: AbstractInterpolant1D{Tg, Tv}
+struct QuadraticInterpolant{Tg, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy, BC <: QuadraticBC, A <: AbstractVector, D <: AbstractVector} <: AbstractInterpolant1D{Tg, Tv}
     x::X
     y::Y
     spacing::S       # Precomputed grid spacing (ScalarSpacing for Range, VectorSpacing for Vector)
-    a::Vector{Tv}   # Quadratic coefficients (value-derived)
-    d::Vector{Tv}   # Slope coefficients (value-derived)
+    a::A             # Quadratic coefficients (may be Dual when grid is duck-typed)
+    d::D             # Slope coefficients (may be Dual when grid is duck-typed)
     extrap::E        # Extrapolation mode (compile-time specialized)
     search_policy::P  # Default search policy (immutable, thread-safe)
     bc::BC           # Boundary condition (retained for Matrix(itp, xq) convenience)
 
     # Inner constructor: parametric, only calls new (handles validation only)
-    function QuadraticInterpolant{Tg, Tv, X, Y, S, E, P, BC}(
-            x::AbstractVector{Tg}, y::AbstractVector{Tv}, spacing::S, a::Vector{Tv}, d::Vector{Tv}, ev::E, search::P, bc::BC
-        ) where {Tg <: AbstractFloat, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy, BC <: QuadraticBC}
+    function QuadraticInterpolant{Tg, Tv, X, Y, S, E, P, BC, A, D}(
+            x::AbstractVector{Tg}, y::AbstractVector{Tv}, spacing::S, a::A, d::D, ev::E, search::P, bc::BC
+        ) where {Tg, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy, BC <: QuadraticBC, A <: AbstractVector, D <: AbstractVector}
         length(x) == length(y) || _throw_length_mismatch(length(x), length(y))
         length(x) >= 2 || _throw_grid_too_small(length(x))
         # Copy to ensure immutability: once constructed, the interpolant owns
@@ -80,7 +80,7 @@ struct QuadraticInterpolant{Tg <: AbstractFloat, Tv, X <: AbstractVector{Tg}, Y 
         # copy() on immutable Range types is a no-op (zero allocation).
         # typeof() rebinds X/Y to the post-copy concrete type (e.g. SubArray → Vector).
         xc, yc = copy(x), copy(y)
-        return new{Tg, Tv, typeof(xc), typeof(yc), S, E, P, BC}(xc, yc, spacing, a, d, ev, search, bc)
+        return new{Tg, Tv, typeof(xc), typeof(yc), S, E, P, BC, A, D}(xc, yc, spacing, a, d, ev, search, bc)
     end
 end
 
@@ -95,13 +95,15 @@ end
         x::X,
         y::Y,
         spacing::S,
-        a::Vector{Tv},
-        d::Vector{Tv};
+        a::AbstractVector,
+        d::AbstractVector;
         bc::QuadraticBC = Left(QuadraticFit()),
         extrap::AbstractExtrap = NoExtrap(),
         search::P = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, S <: AbstractGridSpacing{Tg}, P <: AbstractSearchPolicy}
+    ) where {Tg, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{Tv}, S <: AbstractGridSpacing{Tg}, P <: AbstractSearchPolicy}
     E = typeof(extrap)
     BC = typeof(bc)
-    return QuadraticInterpolant{Tg, Tv, X, Y, S, E, P, BC}(x, y, spacing, a, d, extrap, search, bc)
+    A = typeof(a)
+    D = typeof(d)
+    return QuadraticInterpolant{Tg, Tv, X, Y, S, E, P, BC, A, D}(x, y, spacing, a, d, extrap, search, bc)
 end

--- a/test/LocalPreferences.toml
+++ b/test/LocalPreferences.toml
@@ -1,2 +1,2 @@
 [AdaptiveArrayPools]
-runtime_check = true
+runtime_check = false

--- a/test/ext/runtests.jl
+++ b/test/ext/runtests.jl
@@ -24,6 +24,7 @@ include("test_autodiff_Enzyme.jl")
 include("test_autodiff_ForwardDiff.jl")
 include("test_linear_dual_grid.jl")   # Linear 1D grid-side Dual
 include("test_hermite_dual_grid.jl")  # Hermite family grid-side Dual
+include("test_constant_quadratic_dual_grid.jl")  # Constant+Quadratic grid-side Dual
 include("test_autodiff_Zygote.jl")
 include("test_autodiff_hetero.jl")
 include("test_hermite_rrule.jl")

--- a/test/ext/test_constant_quadratic_dual_grid.jl
+++ b/test/ext/test_constant_quadratic_dual_grid.jl
@@ -144,6 +144,37 @@ const FI = FastInterpolations
     # (coefficient precomputation per-axis) — deferred to follow-up PR with Cubic ND.
 
     # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           Extrapolation modes + edge cases with Dual grids             ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "Extrap modes: NoExtrap, ClampExtrap with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        x_dual = d .* x_base
+        # NoExtrap — endpoint queries should be in-domain (primal-based check)
+        v = quadratic_interp(x_dual, y_base, first(x_base); extrap=NoExtrap())
+        @test ForwardDiff.value(v) ≈ quadratic_interp(x_base, y_base, first(x_base))
+        # ClampExtrap — OOB query clamped to boundary
+        v_clamp = quadratic_interp(x_dual, y_base, -1.0; extrap=ClampExtrap())
+        @test isfinite(ForwardDiff.value(v_clamp))
+    end
+
+    @testset "Quadratic 2-point grid with Dual" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        x2 = d .* [1.0, 3.0]
+        y2 = [2.0, 6.0]
+        v = quadratic_interp(x2, y2, 2.0; bc=Left(Deriv1(0.0)), extrap=ExtendExtrap())
+        @test v isa ForwardDiff.Dual
+    end
+
+    @testset "Quadratic derivative with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        v1 = quadratic_interp(d .* x_base, y_base, xq_scalar; deriv=DerivOp(1), extrap=ExtendExtrap())
+        @test v1 isa ForwardDiff.Dual
+        v2 = quadratic_interp(d .* x_base, y_base, xq_scalar; deriv=DerivOp(2), extrap=ExtendExtrap())
+        @test v2 isa ForwardDiff.Dual
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
     # ║           Regression: Float path                                       ║
     # ╚═══════════════════════════════════════════════════════════════════════╝
 

--- a/test/ext/test_constant_quadratic_dual_grid.jl
+++ b/test/ext/test_constant_quadratic_dual_grid.jl
@@ -15,7 +15,7 @@ const FI = FastInterpolations
     y_base = sin.(x_base)
     xq_scalar = 2.5
     xq_vec = [0.5, 1.5, 2.5, 3.5, 4.5]
-    h_fd = 1e-7
+    h_fd = 1.0e-7
     fd_deriv(f) = (f(1.0 + h_fd) - f(1.0 - h_fd)) / (2h_fd)
 
     # ╔═══════════════════════════════════════════════════════════════════════╗
@@ -26,24 +26,24 @@ const FI = FastInterpolations
         # Constant interpolation returns y[idx] directly — no grid arithmetic.
         # Result is Float (y type), not Dual (grid type). This is correct:
         # ∂/∂(grid_param) of constant_interp = 0 almost everywhere.
-        f = t -> constant_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        f = t -> constant_interp(t .* x_base, y_base, xq_scalar; extrap = ExtendExtrap())
         v = f(ForwardDiff.Dual{:tag}(1.0, 1.0))
         # Constant kernel returns y[idx] which is Float — no grid partials propagate
-        @test ForwardDiff.value(v) ≈ constant_interp(x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        @test ForwardDiff.value(v) ≈ constant_interp(x_base, y_base, xq_scalar; extrap = ExtendExtrap())
     end
 
     @testset "constant_interp — interpolant with Dual grid constructs" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        itp = constant_interp(d .* x_base, y_base; extrap=ExtendExtrap())
+        itp = constant_interp(d .* x_base, y_base; extrap = ExtendExtrap())
         v = itp(xq_scalar)
-        itp_f = constant_interp(x_base, y_base; extrap=ExtendExtrap())
+        itp_f = constant_interp(x_base, y_base; extrap = ExtendExtrap())
         @test ForwardDiff.value(v) ≈ itp_f(xq_scalar)
     end
 
     @testset "constant_interp — vector oneshot with Dual grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        result = constant_interp(d .* x_base, y_base, xq_vec; extrap=ExtendExtrap())
-        ref = constant_interp(x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        result = constant_interp(d .* x_base, y_base, xq_vec; extrap = ExtendExtrap())
+        ref = constant_interp(x_base, y_base, xq_vec; extrap = ExtendExtrap())
         @test ForwardDiff.value.(result) ≈ ref
     end
 
@@ -51,13 +51,13 @@ const FI = FastInterpolations
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
         # Range{Dual} construction works; value may differ from Vector path
         # because DirectSearch index uses primal-based trunc (rounding differences)
-        v = constant_interp(d .* range(0.0, 5.0, 20), y_base, xq_scalar; extrap=ExtendExtrap())
+        v = constant_interp(d .* range(0.0, 5.0, 20), y_base, xq_scalar; extrap = ExtendExtrap())
         @test isfinite(ForwardDiff.value(v))
     end
 
     @testset "constant_interp — adjoint with Dual grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        adj = constant_adjoint(d .* x_base, xq_vec; extrap=ExtendExtrap())
+        adj = constant_adjoint(d .* x_base, xq_vec; extrap = ExtendExtrap())
         y_bar = randn(length(xq_vec))
         f_bar = adj(y_bar)
         @test length(f_bar) == length(x_base)
@@ -68,47 +68,47 @@ const FI = FastInterpolations
     # ╚═══════════════════════════════════════════════════════════════════════╝
 
     @testset "quadratic_interp — scalar oneshot with Dual grid" begin
-        f = t -> quadratic_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        f = t -> quadratic_interp(t .* x_base, y_base, xq_scalar; extrap = ExtendExtrap())
         v = f(ForwardDiff.Dual{:tag}(1.0, 1.0))
         @test v isa ForwardDiff.Dual
-        @test ForwardDiff.value(v) ≈ quadratic_interp(x_base, y_base, xq_scalar; extrap=ExtendExtrap())
-        @test isapprox(ForwardDiff.partials(v)[1], fd_deriv(f); atol=1e-5)
+        @test ForwardDiff.value(v) ≈ quadratic_interp(x_base, y_base, xq_scalar; extrap = ExtendExtrap())
+        @test isapprox(ForwardDiff.partials(v)[1], fd_deriv(f); atol = 1.0e-5)
     end
 
     @testset "quadratic_interp — ForwardDiff.derivative MWE" begin
         deriv = ForwardDiff.derivative(
-            t -> quadratic_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap()), 1.0
+            t -> quadratic_interp(t .* x_base, y_base, xq_scalar; extrap = ExtendExtrap()), 1.0
         )
-        fd = fd_deriv(t -> quadratic_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap()))
-        @test isapprox(deriv, fd; atol=1e-5)
+        fd = fd_deriv(t -> quadratic_interp(t .* x_base, y_base, xq_scalar; extrap = ExtendExtrap()))
+        @test isapprox(deriv, fd; atol = 1.0e-5)
     end
 
     @testset "quadratic_interp — interpolant with Dual grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        itp = quadratic_interp(d .* x_base, y_base; extrap=ExtendExtrap())
+        itp = quadratic_interp(d .* x_base, y_base; extrap = ExtendExtrap())
         v = itp(xq_scalar)
         @test v isa ForwardDiff.Dual
-        itp_f = quadratic_interp(x_base, y_base; extrap=ExtendExtrap())
+        itp_f = quadratic_interp(x_base, y_base; extrap = ExtendExtrap())
         @test ForwardDiff.value(v) ≈ itp_f(xq_scalar)
     end
 
     @testset "quadratic_interp — vector oneshot with Dual grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        result = quadratic_interp(d .* x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        result = quadratic_interp(d .* x_base, y_base, xq_vec; extrap = ExtendExtrap())
         @test eltype(result) <: ForwardDiff.Dual
-        ref = quadratic_interp(x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        ref = quadratic_interp(x_base, y_base, xq_vec; extrap = ExtendExtrap())
         @test ForwardDiff.value.(result) ≈ ref
     end
 
     @testset "quadratic_interp — Range{Dual} grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        v = quadratic_interp(d .* range(0.0, 5.0, 20), y_base, xq_scalar; extrap=ExtendExtrap())
+        v = quadratic_interp(d .* range(0.0, 5.0, 20), y_base, xq_scalar; extrap = ExtendExtrap())
         @test v isa ForwardDiff.Dual
     end
 
     @testset "quadratic_interp — adjoint with Dual grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        adj = quadratic_adjoint(d .* x_base, xq_vec; extrap=ExtendExtrap())
+        adj = quadratic_adjoint(d .* x_base, xq_vec; extrap = ExtendExtrap())
         y_bar = randn(length(xq_vec))
         f_bar = adj(y_bar)
         @test eltype(f_bar) <: ForwardDiff.Dual
@@ -118,7 +118,7 @@ const FI = FastInterpolations
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
         x_dual = d .* x_base
         for bc in [Left(QuadraticFit()), Right(Deriv2(0.0)), Left(Deriv1(0.0))]
-            v = quadratic_interp(x_dual, y_base, xq_scalar; bc=bc, extrap=ExtendExtrap())
+            v = quadratic_interp(x_dual, y_base, xq_scalar; bc = bc, extrap = ExtendExtrap())
             @test v isa ForwardDiff.Dual
         end
     end
@@ -134,7 +134,7 @@ const FI = FastInterpolations
         data = [sin(xi) * cos(yi) for xi in xv, yi in yv]
 
         # Constant ND: construction works, result matches Float (no grid arithmetic)
-        itp = constant_interp((d .* xv, d .* yv), data; extrap=ExtendExtrap())
+        itp = constant_interp((d .* xv, d .* yv), data; extrap = ExtendExtrap())
         v = itp((2.55, 3.55))
         itp_f = constant_interp((xv, yv), data)
         @test ForwardDiff.value(v) ≈ itp_f((2.55, 3.55))
@@ -151,10 +151,10 @@ const FI = FastInterpolations
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
         x_dual = d .* x_base
         # NoExtrap — endpoint queries should be in-domain (primal-based check)
-        v = quadratic_interp(x_dual, y_base, first(x_base); extrap=NoExtrap())
+        v = quadratic_interp(x_dual, y_base, first(x_base); extrap = NoExtrap())
         @test ForwardDiff.value(v) ≈ quadratic_interp(x_base, y_base, first(x_base))
         # ClampExtrap — OOB query clamped to boundary
-        v_clamp = quadratic_interp(x_dual, y_base, -1.0; extrap=ClampExtrap())
+        v_clamp = quadratic_interp(x_dual, y_base, -1.0; extrap = ClampExtrap())
         @test isfinite(ForwardDiff.value(v_clamp))
     end
 
@@ -162,15 +162,15 @@ const FI = FastInterpolations
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
         x2 = d .* [1.0, 3.0]
         y2 = [2.0, 6.0]
-        v = quadratic_interp(x2, y2, 2.0; bc=Left(Deriv1(0.0)), extrap=ExtendExtrap())
+        v = quadratic_interp(x2, y2, 2.0; bc = Left(Deriv1(0.0)), extrap = ExtendExtrap())
         @test v isa ForwardDiff.Dual
     end
 
     @testset "Quadratic derivative with Dual grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        v1 = quadratic_interp(d .* x_base, y_base, xq_scalar; deriv=DerivOp(1), extrap=ExtendExtrap())
+        v1 = quadratic_interp(d .* x_base, y_base, xq_scalar; deriv = DerivOp(1), extrap = ExtendExtrap())
         @test v1 isa ForwardDiff.Dual
-        v2 = quadratic_interp(d .* x_base, y_base, xq_scalar; deriv=DerivOp(2), extrap=ExtendExtrap())
+        v2 = quadratic_interp(d .* x_base, y_base, xq_scalar; deriv = DerivOp(2), extrap = ExtendExtrap())
         @test v2 isa ForwardDiff.Dual
     end
 

--- a/test/ext/test_constant_quadratic_dual_grid.jl
+++ b/test/ext/test_constant_quadratic_dual_grid.jl
@@ -1,0 +1,161 @@
+# ╔═══════════════════════════════════════════════════════════════════════════╗
+# ║     Constant + Quadratic — Dual Grid Tests (ForwardDiff)                  ║
+# ╚═══════════════════════════════════════════════════════════════════════════╝
+
+using Test
+using FastInterpolations
+using ForwardDiff
+using LinearAlgebra
+
+const FI = FastInterpolations
+
+@testset "Constant + Quadratic — Dual Grid" begin
+
+    x_base = collect(range(0.0, 5.0, 20))
+    y_base = sin.(x_base)
+    xq_scalar = 2.5
+    xq_vec = [0.5, 1.5, 2.5, 3.5, 4.5]
+    h_fd = 1e-7
+    fd_deriv(f) = (f(1.0 + h_fd) - f(1.0 - h_fd)) / (2h_fd)
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           constant_interp                                              ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "constant_interp — scalar oneshot with Dual grid" begin
+        # Constant interpolation returns y[idx] directly — no grid arithmetic.
+        # Result is Float (y type), not Dual (grid type). This is correct:
+        # ∂/∂(grid_param) of constant_interp = 0 almost everywhere.
+        f = t -> constant_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        v = f(ForwardDiff.Dual{:tag}(1.0, 1.0))
+        # Constant kernel returns y[idx] which is Float — no grid partials propagate
+        @test ForwardDiff.value(v) ≈ constant_interp(x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+    end
+
+    @testset "constant_interp — interpolant with Dual grid constructs" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        itp = constant_interp(d .* x_base, y_base; extrap=ExtendExtrap())
+        v = itp(xq_scalar)
+        itp_f = constant_interp(x_base, y_base; extrap=ExtendExtrap())
+        @test ForwardDiff.value(v) ≈ itp_f(xq_scalar)
+    end
+
+    @testset "constant_interp — vector oneshot with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        result = constant_interp(d .* x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        ref = constant_interp(x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        @test ForwardDiff.value.(result) ≈ ref
+    end
+
+    @testset "constant_interp — Range{Dual} grid (constructs)" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        # Range{Dual} construction works; value may differ from Vector path
+        # because DirectSearch index uses primal-based trunc (rounding differences)
+        v = constant_interp(d .* range(0.0, 5.0, 20), y_base, xq_scalar; extrap=ExtendExtrap())
+        @test isfinite(ForwardDiff.value(v))
+    end
+
+    @testset "constant_interp — adjoint with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        adj = constant_adjoint(d .* x_base, xq_vec; extrap=ExtendExtrap())
+        y_bar = randn(length(xq_vec))
+        f_bar = adj(y_bar)
+        @test length(f_bar) == length(x_base)
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           quadratic_interp                                             ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "quadratic_interp — scalar oneshot with Dual grid" begin
+        f = t -> quadratic_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        v = f(ForwardDiff.Dual{:tag}(1.0, 1.0))
+        @test v isa ForwardDiff.Dual
+        @test ForwardDiff.value(v) ≈ quadratic_interp(x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        @test isapprox(ForwardDiff.partials(v)[1], fd_deriv(f); atol=1e-5)
+    end
+
+    @testset "quadratic_interp — ForwardDiff.derivative MWE" begin
+        deriv = ForwardDiff.derivative(
+            t -> quadratic_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap()), 1.0
+        )
+        fd = fd_deriv(t -> quadratic_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap()))
+        @test isapprox(deriv, fd; atol=1e-5)
+    end
+
+    @testset "quadratic_interp — interpolant with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        itp = quadratic_interp(d .* x_base, y_base; extrap=ExtendExtrap())
+        v = itp(xq_scalar)
+        @test v isa ForwardDiff.Dual
+        itp_f = quadratic_interp(x_base, y_base; extrap=ExtendExtrap())
+        @test ForwardDiff.value(v) ≈ itp_f(xq_scalar)
+    end
+
+    @testset "quadratic_interp — vector oneshot with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        result = quadratic_interp(d .* x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        @test eltype(result) <: ForwardDiff.Dual
+        ref = quadratic_interp(x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        @test ForwardDiff.value.(result) ≈ ref
+    end
+
+    @testset "quadratic_interp — Range{Dual} grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        v = quadratic_interp(d .* range(0.0, 5.0, 20), y_base, xq_scalar; extrap=ExtendExtrap())
+        @test v isa ForwardDiff.Dual
+    end
+
+    @testset "quadratic_interp — adjoint with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        adj = quadratic_adjoint(d .* x_base, xq_vec; extrap=ExtendExtrap())
+        y_bar = randn(length(xq_vec))
+        f_bar = adj(y_bar)
+        @test eltype(f_bar) <: ForwardDiff.Dual
+    end
+
+    @testset "quadratic_interp — BC variants with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        x_dual = d .* x_base
+        for bc in [Left(QuadraticFit()), Right(Deriv2(0.0)), Left(Deriv1(0.0))]
+            v = quadratic_interp(x_dual, y_base, xq_scalar; bc=bc, extrap=ExtendExtrap())
+            @test v isa ForwardDiff.Dual
+        end
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           ND paths                                                     ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "constant_interp ND — Dual grid 2D" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        xv = collect(1.0:0.5:5.0)
+        yv = collect(2.0:0.5:6.0)
+        data = [sin(xi) * cos(yi) for xi in xv, yi in yv]
+
+        # Constant ND: construction works, result matches Float (no grid arithmetic)
+        itp = constant_interp((d .* xv, d .* yv), data; extrap=ExtendExtrap())
+        v = itp((2.55, 3.55))
+        itp_f = constant_interp((xv, yv), data)
+        @test ForwardDiff.value(v) ≈ itp_f((2.55, 3.55))
+    end
+
+    # Note: Quadratic ND with Dual grids requires deeper changes in quadratic_nd_build.jl
+    # (coefficient precomputation per-axis) — deferred to follow-up PR with Cubic ND.
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           Regression: Float path                                       ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "Regression: Float scalar path zero-alloc" begin
+        x = collect(range(0.0, 5.0, 50))
+        y = sin.(x)
+
+        itp_c = constant_interp(x, y)
+        itp_q = quadratic_interp(x, y)
+
+        itp_c(2.5); itp_q(2.5)
+        @test (@allocated itp_c(2.5)) <= ALLOC_THRESHOLD
+        @test (@allocated itp_q(2.5)) <= ALLOC_THRESHOLD
+    end
+end


### PR DESCRIPTION
Motivated by #81 — this PR opens **Constant** and **Quadratic** methods (1D + ND) to duck-typed grid element types, completing the "non-Cubic" duck-grid story. Follows the patterns from Linear (#116) and Hermite (#117) PRs.

## Summary

```julia
# Both methods now work with Dual grids
ForwardDiff.derivative(t -> constant_interp(t .* x, y, xq), 1.0)
ForwardDiff.derivative(t -> quadratic_interp(t .* x, y, xq), 1.0)
```

## What changed

**Constant** (trivial — kernel returns `y[idx]` directly, no grid arithmetic):
- Relax all `Tg <: AbstractFloat` constraints across 1D + ND
- Delete Real wrappers, `Tq_float` query pattern
- Adjoint: `_extract_primal` for domain checks, relaxed `_fixup_constant_anchor_state!`

**Quadratic** (local recurrence solver, no tridiagonal):

| Pattern | Change | Why |
|---|---|---|
| `QuadraticInterpolant` struct | `A <: AbstractVector, D <: AbstractVector` → single `Tc` (`Vector{Tc}`) | Clearer intent, coefficients are `_output_eltype(Tv, Tg)` |
| `_quadratic_kernel` | `a::Tv, d::Tv, y::Tv, dL::Td` → duck-friendly with `dL::Td` anchor | `a`/`d` may be Dual; `dL::Td` provides LLVM specialization anchor |
| `_compute_quadratic_secants!` | `s::AbstractVector{Tv}, y::AbstractVector{Tv}` → `s::AbstractVector, y::AbstractVector` | Secant buffer type differs from y |
| `_fill_slopes!` (8 overloads) | Decoupled `d`, `s`, `y` types; `convert(Tv, ...)` → `convert(eltype(d), ...)` | `Tv` no longer bound |
| `_compute_quadratic_coeffs` | `Vector{Tv}` → `Vector{_output_eltype(Tv, Tg)}` | Coefficients wider than y |
| `materialize_bc` | `Deriv1{Tv}(val)` → `Deriv1(val)` | `val` may be Dual from grid-data interaction |
| Real wrappers | 3 deleted from oneshot, 4 from oneshot_series, 1 from series constructor | `Dual <: Real` infinite recursion |

**Core shared** (used by Quadratic + Cubic):
- `polyfit_kernels.jl`: relax all `T <: AbstractFloat` in `NTuple` constraints (~12 sites)
- `bc_types.jl`: relax `materialize_bc` signature + return type

## Key design decisions

1. **Coefficient type parameter** — `QuadraticInterpolant` uses a single `Tc` param (`Vector{Tc}` for both `a` and `d`), where `Tc = _output_eltype(Tv, Tg)`. Coefficients are Dual when the grid is Dual, while y-values stay Float.

2. **`@with_pool` + promotion** — Cannot use `_promote_itp_inputs` inside `@with_pool` (128-byte allocation from SROA failure on the tuple return). Instead: `x = _to_float(x, _promote_grid_float(Tg, Tv))` for the pooled hot path (single value, type-stable through pool boundary).

3. **LLVM specialization anchors** — Kernel and eval signatures keep typed parameters (`dL::Td`, `a::AbstractVector{Tc}`, `y::AbstractVector{Tv}`) even though duck types are unconstrained. Fully untyped args cause SROA failure on Windows x86-64 LLVM when inlined inside `@with_pool`. Follows the same pattern as `_hermite_kernel_1d(... h::Tg, inv_h::Tg, dL::Tq)`.

4. **Constant returns Float, not Dual** — `constant_interp(dual_x, float_y, xq)` returns `Float64`, not `Dual`. This is correct: constant interpolation just picks `y[idx]` with no grid arithmetic. `∂/∂(grid_param) = 0` almost everywhere.

5. **Constant eval: `_to_grid_type` for Dual safety** — Replaced `Tg(xi_primal)` with `_to_grid_type(xi, Tg)` in constant eval paths (3 extrap overloads) and series scalar anchor build. The bare `Tg(...)` constructor fails for abstract Dual types; `_to_grid_type` delegates to ForwardDiffExt which returns the primal float.

## Performance

Zero allocation regression on Float paths — verified via existing allocation tests.

## Tests

**`test/ext/test_constant_quadratic_dual_grid.jl`** (26 tests):
- Both methods × scalar/vector oneshot, ForwardDiff.derivative MWE, FD cross-check
- Interpolant construction (Quadratic with multiple BC types)
- Adjoint construction + `adj(y_bar)`
- Range{Dual} grid
- NoExtrap + ClampExtrap extrap modes with Dual grid
- 2-point grid edge case
- DerivOp(1) and DerivOp(2) with Dual grid
- Constant ND 2D
- Float scalar path zero-alloc regression gate

## Scope

This PR opens **Constant + Quadratic** (1D + ND for Constant; 1D for Quadratic). Quadratic ND interpolant build (axis-by-axis precomputation) requires deeper changes — deferred with Cubic. Cubic method is a separate PR due to tridiagonal solver complexity.

**32 files changed, +569 −596 (net −27). ~200 lines are tests.**
