### PR TITLE
(feat): Cubic — duck-typed grid support 

### DIFF
--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -121,8 +121,8 @@ end
 
 Build anchor for a query point. Required trait for AbstractSeriesInterpolant.
 """
-@inline function _make_anchor(sitp::ConstantSeriesInterpolant{Tg}, xq::Tg, searcher::P = DEFAULT_SEARCHER) where {Tg, P <: Searcher}
-    return _constant_anchor_query_impl(sitp.x, xq, _should_wrap(sitp), searcher)
+@inline function _make_anchor(sitp::ConstantSeriesInterpolant{Tg}, xq, searcher::P = DEFAULT_SEARCHER) where {Tg, P <: Searcher}
+    return _constant_anchor_query_impl(sitp.x, Tg(xq), _should_wrap(sitp), searcher)
 end
 
 """

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -290,7 +290,7 @@ function _prepare_periodic_nd(
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
-    ) where {Tg <: AbstractFloat, Tv, N}
+    ) where {Tg, Tv, N}
     # Fast path: no exclusive axes
     has_exclusive = false
     for d in 1:N
@@ -383,7 +383,7 @@ via `acquire!`, so they must NOT escape the enclosing `@with_pool` scope.
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
-    ) where {Tg <: AbstractFloat, Tv, N}
+    ) where {Tg, Tv, N}
     # Fast path: no exclusive axes
     has_exclusive = false
     for d in 1:N

--- a/src/core/series_matrix.jl
+++ b/src/core/series_matrix.jl
@@ -91,10 +91,11 @@ Both transposes are computed together on first scalar query.
 # Thread Safety
 Same RCU pattern as LazyTranspose.
 """
-mutable struct LazyTransposePair{Tv}
-    @atomic snapshot::Union{Nothing, Tuple{Matrix{Tv}, Matrix{Tv}}}
+mutable struct LazyTransposePair{Tv, Tz}
+    @atomic snapshot::Union{Nothing, Tuple{Matrix{Tv}, Matrix{Tz}}}
 
-    LazyTransposePair{Tv}() where {Tv} = new{Tv}(nothing)
+    LazyTransposePair{Tv, Tz}() where {Tv, Tz} = new{Tv, Tz}(nothing)
+    LazyTransposePair{Tv}() where {Tv} = new{Tv, Tv}(nothing)  # backward compat
 end
 
 """
@@ -118,13 +119,13 @@ Ensure point-contiguous transpose pair exists. Thread-safe via atomic RCU patter
 Tuple of transposed matrices (y_point, z_point), each (n_series × n_points).
 """
 @inline function _ensure_transpose_pair!(
-        ltp::LazyTransposePair{Tv},
+        ltp::LazyTransposePair{Tv, Tz},
         y::Matrix{Tv},
-        z::Matrix{Tv}
-    ) where {Tv}
+        z::Matrix{Tz}
+    ) where {Tv, Tz}
     # Fast path: check if already populated
     snap = @atomic :acquire ltp.snapshot
-    snap !== nothing && return snap::Tuple{Matrix{Tv}, Matrix{Tv}}
+    snap !== nothing && return snap::Tuple{Matrix{Tv}, Matrix{Tz}}
 
     # Slow path: compute both transposes
     y_point = permutedims(y)
@@ -155,10 +156,11 @@ All three transposes are computed together on first scalar query.
 # Thread Safety
 Same RCU pattern as LazyTranspose.
 """
-mutable struct LazyTransposeTriple{Tv}
-    @atomic snapshot::Union{Nothing, Tuple{Matrix{Tv}, Matrix{Tv}, Matrix{Tv}}}
+mutable struct LazyTransposeTriple{Tv, Tc}
+    @atomic snapshot::Union{Nothing, Tuple{Matrix{Tv}, Matrix{Tc}, Matrix{Tc}}}
 
-    LazyTransposeTriple{Tv}() where {Tv} = new{Tv}(nothing)
+    LazyTransposeTriple{Tv, Tc}() where {Tv, Tc} = new{Tv, Tc}(nothing)
+    LazyTransposeTriple{Tv}() where {Tv} = new{Tv, Tv}(nothing)  # backward compat
 end
 
 """
@@ -183,14 +185,14 @@ Ensure point-contiguous transpose triple exists. Thread-safe via atomic RCU patt
 Tuple of transposed matrices (y_point, a_point, d_point), each (n_series × n_points).
 """
 @inline function _ensure_transpose_triple!(
-        ltt::LazyTransposeTriple{Tv},
+        ltt::LazyTransposeTriple{Tv, Tc},
         y::Matrix{Tv},
-        a::Matrix{Tv},
-        d::Matrix{Tv}
-    ) where {Tv}
+        a::Matrix{Tc},
+        d::Matrix{Tc}
+    ) where {Tv, Tc}
     # Fast path: check if already populated
     snap = @atomic :acquire ltt.snapshot
-    snap !== nothing && return snap::Tuple{Matrix{Tv}, Matrix{Tv}, Matrix{Tv}}
+    snap !== nothing && return snap::Tuple{Matrix{Tv}, Matrix{Tc}, Matrix{Tc}}
 
     # Slow path: compute all three transposes
     y_point = permutedims(y)
@@ -223,7 +225,7 @@ end
 
 Pre-compute transpose pair before hot loops. Returns the holder for chaining.
 """
-function precompute_transpose!(ltp::LazyTransposePair{Tv}, y::Matrix{Tv}, z::Matrix{Tv}) where {Tv}
+function precompute_transpose!(ltp::LazyTransposePair{Tv, Tz}, y::Matrix{Tv}, z::Matrix{Tz}) where {Tv, Tz}
     _ensure_transpose_pair!(ltp, y, z)
     return ltp
 end
@@ -233,7 +235,7 @@ end
 
 Pre-compute transpose triple before hot loops. Returns the holder for chaining.
 """
-function precompute_transpose!(ltt::LazyTransposeTriple{Tv}, y::Matrix{Tv}, a::Matrix{Tv}, d::Matrix{Tv}) where {Tv}
+function precompute_transpose!(ltt::LazyTransposeTriple{Tv, Tc}, y::Matrix{Tv}, a::Matrix{Tc}, d::Matrix{Tc}) where {Tv, Tc}
     _ensure_transpose_triple!(ltt, y, a, d)
     return ltt
 end

--- a/src/core/thomas_lu_solver.jl
+++ b/src/core/thomas_lu_solver.jl
@@ -52,7 +52,7 @@ thomas = thomas_factorize!(dl, d, du)
 _ldiv_tridiagonal_nopiv!(b, thomas)
 ```
 """
-struct ThomasFactorization{T <: AbstractFloat, V <: AbstractVector{T}}
+struct ThomasFactorization{T, V <: AbstractVector{T}}
     dl::V     # Lower diagonal (L multipliers after factorization)
     du::V     # Upper diagonal (unchanged from input)
     inv_d::V  # Inverse of U diagonal (1/d[i])
@@ -105,7 +105,7 @@ thomas = thomas_factorize!(dl, d, du)
 """
 function thomas_factorize!(
         dl::V, d::V, du::V
-    ) where {T <: AbstractFloat, V <: AbstractVector{T}}
+    ) where {T, V <: AbstractVector{T}}
     n = length(d)
 
     @inbounds begin
@@ -162,7 +162,7 @@ Solves `Ax = b` in-place where `A = L*U` is the pre-computed factorization.
 @inline function _ldiv_tridiagonal_nopiv!(
         b::AbstractVector{Tv},
         thomas::ThomasFactorization{Tg, V},
-    ) where {Tg <: AbstractFloat, Tv, V <: AbstractVector{Tg}}
+    ) where {Tg, Tv, V <: AbstractVector{Tg}}
     dl = thomas.dl
     du = thomas.du
     inv_d = thomas.inv_d
@@ -205,7 +205,7 @@ correct transpose solve needed by the cubic adjoint operator.
 @inline function _ldiv_tridiagonal_transpose!(
         b::AbstractVector{Tv},
         thomas::ThomasFactorization{Tg, V},
-    ) where {Tg <: AbstractFloat, Tv, V <: AbstractVector{Tg}}
+    ) where {Tg, Tv, V <: AbstractVector{Tg}}
     dl = thomas.dl
     du = thomas.du
     inv_d = thomas.inv_d
@@ -263,7 +263,7 @@ z[n_batch, n_sys] where:
         z::AbstractMatrix{T},
         thomas::ThomasFactorization{T, V},
         ::Val{2},
-    ) where {T <: AbstractFloat, V <: AbstractVector{T}}
+    ) where {T, V <: AbstractVector{T}}
     dl = thomas.dl
     du = thomas.du
     inv_d = thomas.inv_d

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -343,6 +343,15 @@ ForwardDiff support is added via:
 """
 @inline _extract_primal(x) = x  # identity fallback; ForwardDiff ext specializes for Dual
 # GridIdx <: Real: _extract_primal(g::GridIdx) returns g (identity fallback).
+
+"""
+    _effective_autocache(autocache, Tg) -> Bool
+
+Disable autocache for non-AbstractFloat grid types (e.g. ForwardDiff.Dual).
+Dual grids are ephemeral (created fresh each AD call), so cache hit rate ≈ 0%.
+Resolves at specialization time — zero runtime cost on the Float hot path.
+"""
+@inline _effective_autocache(ac::Bool, ::Type{Tg}) where {Tg} = ac & (Tg <: AbstractFloat)
 # Arithmetic then auto-promotes GridIdx → g.val via promote_rule.
 
 """

--- a/src/cubic/cubic_adjoint.jl
+++ b/src/cubic/cubic_adjoint.jl
@@ -491,10 +491,10 @@ end
 
 function _build_cubic_adjoint_periodic(
         x::AbstractVector{Tg},
-        xq::AbstractVector{Tg},
+        xq::AbstractVector{Tq},
         bc::PeriodicBC,
         autocache::Bool
-    ) where {Tg}
+    ) where {Tg, Tq <: Real}
 
     # Extend exclusive → inclusive grid (grid-only, no y-data needed)
     x_ext = if bc isa PeriodicBC{:exclusive}

--- a/src/cubic/cubic_adjoint.jl
+++ b/src/cubic/cubic_adjoint.jl
@@ -96,7 +96,7 @@ Here `A` is the tridiagonal moment matrix, `R` the finite-difference RHS operato
 PolyFit stencil coefficients and periodic `q_transpose = A'^{-T}u` are computed on the
 fly at each `adj(ȳ)` call (O(D) and O(n) respectively, negligible vs overall pipeline).
 """
-struct CubicAdjoint{Tg <: AbstractFloat, C <: CubicSplineCache{Tg}, BC <: Union{BCPair, PeriodicBC}} <: AbstractAdjoint1D{Tg}
+struct CubicAdjoint{Tg, C <: CubicSplineCache{Tg}, BC <: Union{BCPair, PeriodicBC}} <: AbstractAdjoint1D{Tg}
     cache::C
     anchors::Vector{_CubicAnchoredQuery{Tg, Tg}}
     bc::BC
@@ -440,10 +440,12 @@ function cubic_adjoint(
         autocache::Bool = true,
         _extra...
     )
-    # Promote grid and query to AbstractFloat (handles Integer, Rational, etc.)
+    # Promote grid to float (handles Integer, Rational, duck-typed)
     Tg = _promote_grid_float(eltype(x), eltype(x_query))
     x_p = _to_float(x, Tg)
-    xq_p = _to_float(x_query, Tg)
+    # Query normalization: keep queries as plain Float when grid is duck-typed
+    Tq_float = Tg <: AbstractFloat ? Tg : float(eltype(x_query))
+    xq_p = _to_float(x_query, Tq_float)
 
     # Periodic path (Sherman-Morrison adjoint)
     if _is_periodic_bc(bc)
@@ -454,7 +456,7 @@ function cubic_adjoint(
     bc_pair = _normalize_bc(bc, Tg)
 
     # Get/build cache (reuses existing infrastructure + autocache)
-    cache = _get_cubic_cache(x_p, bc_pair, autocache)
+    cache = _get_cubic_cache(x_p, bc_pair, _effective_autocache(autocache, eltype(x_p)))
 
     # Build anchored queries with extrap-specific preprocessing
     wrap = extrap isa WrapExtrap
@@ -492,7 +494,7 @@ function _build_cubic_adjoint_periodic(
         xq::AbstractVector{Tg},
         bc::PeriodicBC,
         autocache::Bool
-    ) where {Tg <: AbstractFloat}
+    ) where {Tg}
 
     # Extend exclusive → inclusive grid (grid-only, no y-data needed)
     x_ext = if bc isa PeriodicBC{:exclusive}
@@ -508,7 +510,7 @@ function _build_cubic_adjoint_periodic(
     end
 
     # Get/build periodic cache (Thomas factorization + PeriodicData{q, period})
-    cache = _get_cubic_cache(x_ext, PeriodicBC(), autocache)
+    cache = _get_cubic_cache(x_ext, PeriodicBC(), _effective_autocache(autocache, Tg))
 
     # Build anchored queries with wrapping (queries outside domain → wrap to [x[1], x[end]))
     anchors = _anchor_query(cache.x, xq, Val(:cubic), true)
@@ -574,7 +576,7 @@ function _adjoint_periodic_solve!(
         cache::CubicSplineCache{Tg, X, F, PeriodicData{Tg}, S},
         q_t::AbstractVector,
         n::Int
-    ) where {Tv, Tg <: AbstractFloat, X, F, S <: AbstractGridSpacing{Tg}}
+    ) where {Tv, Tg, X, F, S <: AbstractGridSpacing{Tg}}
 
     # Transpose Thomas solve on z_bar[1:n]
     _ldiv_tridiagonal_transpose!(z_bar, cache.thomas)

--- a/src/cubic/cubic_anchor.jl
+++ b/src/cubic/cubic_anchor.jl
@@ -57,7 +57,7 @@ When `xq` is a `ForwardDiff.Dual`, the anchor preserves the Dual type
 in both `xq` and weight fields, enabling automatic differentiation through
 series interpolant evaluation.
 """
-struct _CubicAnchoredQuery{Tg,Tq <: Real}
+struct _CubicAnchoredQuery{Tg, Tq <: Real}
     idx::Int                   # interval index
     xq::Tq                     # query point (possibly wrapped), Float or Dual
     state::UInt8               # IN_DOMAIN / OOB_LEFT / OOB_RIGHT
@@ -204,7 +204,7 @@ in `xq` and weight fields, enabling automatic differentiation.
         ::Val{:cubic},
         wrap::Bool = false,
         searcher::P = DEFAULT_SEARCHER
-    ) where {Tg,Tq <: Real, P <: Searcher}
+    ) where {Tg, Tq <: Real, P <: Searcher}
     # Promote query for anchor: preserve Dual, promote Int/Rational to grid type
     # Cubic anchors store weight tuples with complex arithmetic that requires Float
     xq_promoted = _promote_for_anchor(xq, Tg)
@@ -323,7 +323,7 @@ while preserving the full Dual value for weight computation.
         xq::Tq,
         wrap::Bool,
         policy::P = DEFAULT_SEARCHER
-    ) where {Tg,Tq <: Real, P <: Searcher}
+    ) where {Tg, Tq <: Real, P <: Searcher}
     loc = _anchor_loc(x, xq, wrap, policy)
 
     # Compute geometry (cubic-internal concern)

--- a/src/cubic/cubic_anchor.jl
+++ b/src/cubic/cubic_anchor.jl
@@ -67,6 +67,14 @@ struct _CubicAnchoredQuery{Tg,Tq <: Real}
     w3::NTuple{2, Tq}           # (wzL, wzR) for third deriv - optimized
 end
 
+# Outer constructor: infer Tq from weight element type (not from input xq).
+# When grid is Dual, weights are Dual even if xq is Float64.
+# Widens xq to match weight type for struct consistency.
+@inline function _CubicAnchoredQuery(idx::Int, xq, state::UInt8, w0::NTuple{4, Tw}, w1::NTuple{4, Tw}, w2::NTuple{2, Tw}, w3::NTuple{2, Tw}, ::Type{Tg}) where {Tg, Tw}
+    xq_p = convert(Tw, xq)
+    return _CubicAnchoredQuery{Tg, Tw}(idx, xq_p, state, w0, w1, w2, w3)
+end
+
 # ========================================
 # Weight Computation
 # ========================================
@@ -241,11 +249,14 @@ function _anchor_query(
         wrap::Bool = false,
         searcher::P = _to_searcher(LinearBinarySearch())
     ) where {T, S <: Real, P <: Searcher}
+    isempty(xq) && return _CubicAnchoredQuery{T, T}[]
     searcher_resolved = _resolve_searcher_for_grid(x, searcher)
-    output = Vector{_CubicAnchoredQuery{T, T}}(undef, length(xq))
-
-    @inbounds for k in eachindex(xq)
-        output[k] = _anchor_query_impl(x, T(xq[k]), wrap, searcher_resolved)
+    # First anchor determines concrete element type (Tq may widen for duck-typed grids)
+    aq1 = _anchor_query_impl(x, _promote_for_anchor(xq[1], T), wrap, searcher_resolved)
+    output = Vector{typeof(aq1)}(undef, length(xq))
+    @inbounds output[1] = aq1
+    @inbounds for k in 2:length(xq)
+        output[k] = _anchor_query_impl(x, _promote_for_anchor(xq[k], T), wrap, searcher_resolved)
     end
     return output
 end
@@ -277,17 +288,16 @@ _fill_anchors!(buffer, x, xq, Val(:cubic))
 @inline function _fill_anchors!(
         buffer::AbstractVector{_CubicAnchoredQuery{Tg, Tq}},
         x::AbstractVector{Tg},
-        xq::AbstractVector{Tq},
+        xq::AbstractVector{S},
         ::Val{:cubic},
         wrap::Bool = false,
         searcher::P = _to_searcher(LinearBinarySearch())
-    ) where {Tg,Tq <: Real, P <: Searcher}
+    ) where {Tg, Tq <: Real, S <: Real, P <: Searcher}
     @assert length(buffer) >= length(xq) "Buffer too small: $(length(buffer)) < $(length(xq))"
     searcher_resolved = _resolve_searcher_for_grid(x, searcher)
 
-    # Use original xq[k] directly (no conversion) to preserve precision in weights
     @inbounds for k in eachindex(xq)
-        buffer[k] = _anchor_query_impl(x, xq[k], wrap, searcher_resolved)
+        buffer[k] = _anchor_query_impl(x, _promote_for_anchor(xq[k], Tg), wrap, searcher_resolved)
     end
     return buffer
 end
@@ -330,7 +340,7 @@ while preserving the full Dual value for weight computation.
     w2 = _compute_anchor_weights(EvalDeriv2(), h, inv_h, dL, dR)
     w3 = _compute_anchor_weights(EvalDeriv3(), h, inv_h, dL, dR)
 
-    return _CubicAnchoredQuery{Tg, typeof(loc.xq)}(loc.idx, loc.xq, loc.state, w0, w1, w2, w3)
+    return _CubicAnchoredQuery(loc.idx, loc.xq, loc.state, w0, w1, w2, w3, Tg)
 end
 
 # ========================================

--- a/src/cubic/cubic_anchor.jl
+++ b/src/cubic/cubic_anchor.jl
@@ -57,7 +57,7 @@ When `xq` is a `ForwardDiff.Dual`, the anchor preserves the Dual type
 in both `xq` and weight fields, enabling automatic differentiation through
 series interpolant evaluation.
 """
-struct _CubicAnchoredQuery{Tg <: AbstractFloat, Tq <: Real}
+struct _CubicAnchoredQuery{Tg,Tq <: Real}
     idx::Int                   # interval index
     xq::Tq                     # query point (possibly wrapped), Float or Dual
     state::UInt8               # IN_DOMAIN / OOB_LEFT / OOB_RIGHT
@@ -196,7 +196,7 @@ in `xq` and weight fields, enabling automatic differentiation.
         ::Val{:cubic},
         wrap::Bool = false,
         searcher::P = DEFAULT_SEARCHER
-    ) where {Tg <: AbstractFloat, Tq <: Real, P <: Searcher}
+    ) where {Tg,Tq <: Real, P <: Searcher}
     # Promote query for anchor: preserve Dual, promote Int/Rational to grid type
     # Cubic anchors store weight tuples with complex arithmetic that requires Float
     xq_promoted = _promote_for_anchor(xq, Tg)
@@ -240,7 +240,7 @@ function _anchor_query(
         ::Val{:cubic},
         wrap::Bool = false,
         searcher::P = _to_searcher(LinearBinarySearch())
-    ) where {T <: AbstractFloat, S <: Real, P <: Searcher}
+    ) where {T, S <: Real, P <: Searcher}
     searcher_resolved = _resolve_searcher_for_grid(x, searcher)
     output = Vector{_CubicAnchoredQuery{T, T}}(undef, length(xq))
 
@@ -281,7 +281,7 @@ _fill_anchors!(buffer, x, xq, Val(:cubic))
         ::Val{:cubic},
         wrap::Bool = false,
         searcher::P = _to_searcher(LinearBinarySearch())
-    ) where {Tg <: AbstractFloat, Tq <: Real, P <: Searcher}
+    ) where {Tg,Tq <: Real, P <: Searcher}
     @assert length(buffer) >= length(xq) "Buffer too small: $(length(buffer)) < $(length(xq))"
     searcher_resolved = _resolve_searcher_for_grid(x, searcher)
 
@@ -313,7 +313,7 @@ while preserving the full Dual value for weight computation.
         xq::Tq,
         wrap::Bool,
         policy::P = DEFAULT_SEARCHER
-    ) where {Tg <: AbstractFloat, Tq <: Real, P <: Searcher}
+    ) where {Tg,Tq <: Real, P <: Searcher}
     loc = _anchor_loc(x, xq, wrap, policy)
 
     # Compute geometry (cubic-internal concern)

--- a/src/cubic/cubic_cache.jl
+++ b/src/cubic/cubic_cache.jl
@@ -38,7 +38,7 @@ result1 = cubic_interp(cache, y1, [0.25, 0.75])
 result2 = cubic_interp(cache, y2, [0.25, 0.75])
 ```
 """
-function CubicSplineCache(x::AbstractVector{T}; bc::AbstractBC = CubicFit()) where {T <: AbstractFloat}
+function CubicSplineCache(x::AbstractVector{T}; bc::AbstractBC = CubicFit()) where {T}
     # Validate PolyFit{D} point requirements (e.g., CubicFit needs 4+ points)
     validate_polyfit_points(bc, length(x))
 

--- a/src/cubic/cubic_cache_pool.jl
+++ b/src/cubic/cubic_cache_pool.jl
@@ -682,3 +682,29 @@ end
 @inline function _get_periodic_cache_impl(x::AbstractVector{<:Real})
     return _get_periodic_cache_impl(_to_float(x, float(eltype(x))))
 end
+
+# ===============================================================
+# Duck-typed grid fallback (non-AbstractFloat, e.g. ForwardDiff.Dual)
+# ===============================================================
+# Dual grids bypass the pool entirely — build fresh each time.
+# _effective_autocache ensures autocache=false for these paths,
+# but we still need dispatch targets that accept non-AbstractFloat T.
+# Julia dispatches to the more specific T<:AbstractFloat methods first,
+# so these only fire for duck-typed grid elements (Dual, etc.).
+
+@inline function _get_cubic_cache(
+        x::AbstractVector,
+        bc::BCPair{L, R},
+        autocache::Bool
+    ) where {L <: PointBC, R <: PointBC}
+    bc_cache = _cache_bc_pair(bc, eltype(x))
+    return _build_derivative_bc_cache(x, bc_cache.left, bc_cache.right)
+end
+
+@inline function _get_cubic_cache(
+        x::AbstractVector,
+        bc::AbstractBC,
+        autocache::Bool
+    )
+    return CubicSplineCache(x; bc = bc)
+end

--- a/src/cubic/cubic_eval.jl
+++ b/src/cubic/cubic_eval.jl
@@ -13,11 +13,11 @@
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         spacing::AbstractGridSpacing{Tg},
-        z::AbstractVector{Tv},
+        z::AbstractVector,
         xq::Tq,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg,Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     idx, xL, xR = search_interval(searcher, x, spacing, xq)
 
     # Use original xq for arithmetic to preserve AD
@@ -42,10 +42,10 @@ end
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         spacing::AbstractGridSpacing{Tg},
-        z::AbstractVector{Tv},
+        z::AbstractVector,
         xq::Tq,
         op::O
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp}
+    ) where {Tg,Tv, Tq, O <: AbstractEvalOp}
     idx, xL, xR = _search_interval(x, spacing, xq)
 
     # Use original xq for arithmetic to preserve AD
@@ -70,12 +70,12 @@ end
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         spacing::AbstractGridSpacing{Tg},
-        z::AbstractVector{Tv},
+        z::AbstractVector,
         xq::Tq,
         period::Tg,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg,Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_wrapped = _wrap_to_domain(xq, first(x), first(x) + period)
     idx, xL, xR = search_interval(searcher, x, spacing, xq_wrapped)
 
@@ -114,12 +114,12 @@ end
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         spacing::AbstractGridSpacing{Tg},
-        z::AbstractVector{Tv},
+        z::AbstractVector,
         xq::Tq,
         extrap::AbstractExtrap,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg,Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     @boundscheck _check_domain(x, xq, extrap)
     idx, xL, xR = search_interval(searcher, x, spacing, xq)
     dL = xq - xL
@@ -138,12 +138,12 @@ end
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         spacing::AbstractGridSpacing{Tg},
-        z::AbstractVector{Tv},
+        z::AbstractVector,
         xq::Tq,
         extrap::_ClampOrFill,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg,Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_primal = _extract_primal(xq)
     xq_primal < first(x) && return _eval_extrapolation(op, first(y), extrap, xq)
     xq_primal > last(x) && return _eval_extrapolation(op, last(y), extrap, xq)
@@ -164,12 +164,12 @@ end
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         spacing::AbstractGridSpacing{Tg},
-        z::AbstractVector{Tv},
+        z::AbstractVector,
         xq::Tq,
         ::WrapExtrap,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg,Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_wrapped = _wrap_to_domain(xq, first(x), last(x))
     idx, xL, xR = search_interval(searcher, x, spacing, xq_wrapped)
     dL = xq_wrapped - xL
@@ -194,12 +194,12 @@ end
 @inline function _eval_with_bc(
         cache::CubicSplineCache{Tg, X, F, PeriodicData{Tg}, S},
         y::AbstractVector{Tv},
-        z::AbstractVector{Tv},
+        z::AbstractVector,
         xq::Tq,
         ::AbstractExtrap,  # extrapolation ignored for periodic
         op::O,
         searcher::P
-    ) where {Tg <: AbstractFloat, Tv, Tq, X, F, S <: AbstractGridSpacing{Tg}, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg,Tv, Tq, X, F, S <: AbstractGridSpacing{Tg}, O <: AbstractEvalOp, P <: Searcher}
     return _eval_cubic_at_point_periodic(cache.x, y, cache.spacing, z, xq, cache.bc_config.period, op, searcher)
 end
 
@@ -207,12 +207,12 @@ end
 @inline function _eval_with_bc(
         cache::CubicSplineCache{Tg, X, F, BCPair{L, R}, S},
         y::AbstractVector{Tv},
-        z::AbstractVector{Tv},
+        z::AbstractVector,
         xq::Tq,
         extrap::AbstractExtrap,
         op::O,
         searcher::P
-    ) where {Tg <: AbstractFloat, Tv, Tq, X, F, L <: PointBC, R <: PointBC, S <: AbstractGridSpacing{Tg}, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg,Tv, Tq, X, F, L <: PointBC, R <: PointBC, S <: AbstractGridSpacing{Tg}, O <: AbstractEvalOp, P <: Searcher}
     return _eval_cubic_at_point(cache.x, y, cache.spacing, z, xq, extrap, op, searcher)
 end
 
@@ -226,12 +226,12 @@ end
         output::AbstractVector,
         cache::CubicSplineCache{Tg, X, F, BC, S},
         y::AbstractVector{Tv},
-        z::AbstractVector{Tv},
+        z::AbstractVector,
         x_query::AbstractVector{<:Real},
         ev::E,
         op::O,
         searcher::P
-    ) where {Tg <: AbstractFloat, Tv, X, F, BC, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg,Tv, X, F, BC, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, O <: AbstractEvalOp, P <: Searcher}
     ev = _check_domain(cache.x, x_query, ev)
     return @inbounds for k in eachindex(x_query, output)
         output[k] = _eval_with_bc(cache, y, z, x_query[k], ev, op, searcher)
@@ -243,12 +243,12 @@ end
         output::AbstractVector,
         cache::CubicSplineCache{Tg, X, F, PeriodicData{Tg}, S},
         y::AbstractVector{Tv},
-        z::AbstractVector{Tv},
+        z::AbstractVector,
         x_query::AbstractVector{<:Real},
         ::AbstractExtrap,  # extrap ignored for periodic
         op::O,
         searcher::P
-    ) where {Tg <: AbstractFloat, Tv, X, F, S <: AbstractGridSpacing{Tg}, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg,Tv, X, F, S <: AbstractGridSpacing{Tg}, O <: AbstractEvalOp, P <: Searcher}
     x_min = first(cache.x)
     x_max = x_min + cache.bc_config.period
     qmin, qmax = minimum(x_query), maximum(x_query)
@@ -285,10 +285,11 @@ Uses task-local pool for workspace allocation.
         deriv::DerivOp = EvalValue(),
         search = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, X, F, BC, S <: AbstractGridSpacing{Tg}}
+    ) where {Tg,Tv, X, F, BC, S <: AbstractGridSpacing{Tg}}
     @assert length(y) == length(cache.x) "y length must match cache grid"
 
-    z = similar!(pool, y)
+    Tz = _output_eltype(Tv, eltype(cache.x))
+    z = acquire!(pool, Tz, length(y))
     _solve_system!(z, cache, y, cache.bc_config)
 
     searcher = _resolve_search(cache.x, x_query, search, hint)

--- a/src/cubic/cubic_eval.jl
+++ b/src/cubic/cubic_eval.jl
@@ -280,12 +280,12 @@ Uses task-local pool for workspace allocation.
 @inline @with_pool pool function cubic_interp_scalar(
         cache::CubicSplineCache{Tg, X, F, BC, S},
         y::AbstractVector{Tv},
-        x_query::Tg;
+        x_query::Tq;
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg, Tv, X, F, BC, S <: AbstractGridSpacing{Tg}}
+    ) where {Tg, Tv, Tq <: Real, X, F, BC, S <: AbstractGridSpacing{Tg}}
     @assert length(y) == length(cache.x) "y length must match cache grid"
 
     Tz = _output_eltype(Tv, eltype(cache.x))

--- a/src/cubic/cubic_eval.jl
+++ b/src/cubic/cubic_eval.jl
@@ -17,7 +17,7 @@
         xq::Tq,
         op::O,
         searcher::S
-    ) where {Tg,Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     idx, xL, xR = search_interval(searcher, x, spacing, xq)
 
     # Use original xq for arithmetic to preserve AD
@@ -45,7 +45,7 @@ end
         z::AbstractVector,
         xq::Tq,
         op::O
-    ) where {Tg,Tv, Tq, O <: AbstractEvalOp}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp}
     idx, xL, xR = _search_interval(x, spacing, xq)
 
     # Use original xq for arithmetic to preserve AD
@@ -75,7 +75,7 @@ end
         period::Tg,
         op::O,
         searcher::S
-    ) where {Tg,Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_wrapped = _wrap_to_domain(xq, first(x), first(x) + period)
     idx, xL, xR = search_interval(searcher, x, spacing, xq_wrapped)
 
@@ -119,7 +119,7 @@ end
         extrap::AbstractExtrap,
         op::O,
         searcher::S
-    ) where {Tg,Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     @boundscheck _check_domain(x, xq, extrap)
     idx, xL, xR = search_interval(searcher, x, spacing, xq)
     dL = xq - xL
@@ -143,7 +143,7 @@ end
         extrap::_ClampOrFill,
         op::O,
         searcher::S
-    ) where {Tg,Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_primal = _extract_primal(xq)
     xq_primal < first(x) && return _eval_extrapolation(op, first(y), extrap, xq)
     xq_primal > last(x) && return _eval_extrapolation(op, last(y), extrap, xq)
@@ -169,7 +169,7 @@ end
         ::WrapExtrap,
         op::O,
         searcher::S
-    ) where {Tg,Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_wrapped = _wrap_to_domain(xq, first(x), last(x))
     idx, xL, xR = search_interval(searcher, x, spacing, xq_wrapped)
     dL = xq_wrapped - xL
@@ -199,7 +199,7 @@ end
         ::AbstractExtrap,  # extrapolation ignored for periodic
         op::O,
         searcher::P
-    ) where {Tg,Tv, Tq, X, F, S <: AbstractGridSpacing{Tg}, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg, Tv, Tq, X, F, S <: AbstractGridSpacing{Tg}, O <: AbstractEvalOp, P <: Searcher}
     return _eval_cubic_at_point_periodic(cache.x, y, cache.spacing, z, xq, cache.bc_config.period, op, searcher)
 end
 
@@ -212,7 +212,7 @@ end
         extrap::AbstractExtrap,
         op::O,
         searcher::P
-    ) where {Tg,Tv, Tq, X, F, L <: PointBC, R <: PointBC, S <: AbstractGridSpacing{Tg}, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg, Tv, Tq, X, F, L <: PointBC, R <: PointBC, S <: AbstractGridSpacing{Tg}, O <: AbstractEvalOp, P <: Searcher}
     return _eval_cubic_at_point(cache.x, y, cache.spacing, z, xq, extrap, op, searcher)
 end
 
@@ -231,7 +231,7 @@ end
         ev::E,
         op::O,
         searcher::P
-    ) where {Tg,Tv, X, F, BC, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg, Tv, X, F, BC, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, O <: AbstractEvalOp, P <: Searcher}
     ev = _check_domain(cache.x, x_query, ev)
     return @inbounds for k in eachindex(x_query, output)
         output[k] = _eval_with_bc(cache, y, z, x_query[k], ev, op, searcher)
@@ -248,7 +248,7 @@ end
         ::AbstractExtrap,  # extrap ignored for periodic
         op::O,
         searcher::P
-    ) where {Tg,Tv, X, F, S <: AbstractGridSpacing{Tg}, O <: AbstractEvalOp, P <: Searcher}
+    ) where {Tg, Tv, X, F, S <: AbstractGridSpacing{Tg}, O <: AbstractEvalOp, P <: Searcher}
     x_min = first(cache.x)
     x_max = x_min + cache.bc_config.period
     qmin, qmax = minimum(x_query), maximum(x_query)
@@ -285,7 +285,7 @@ Uses task-local pool for workspace allocation.
         deriv::DerivOp = EvalValue(),
         search = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg,Tv, X, F, BC, S <: AbstractGridSpacing{Tg}}
+    ) where {Tg, Tv, X, F, BC, S <: AbstractGridSpacing{Tg}}
     @assert length(y) == length(cache.x) "y length must match cache grid"
 
     Tz = _output_eltype(Tv, eltype(cache.x))

--- a/src/cubic/cubic_interpolant.jl
+++ b/src/cubic/cubic_interpolant.jl
@@ -59,7 +59,7 @@ aq = _anchor_query(x, 0.35, Val(:cubic))
 itp(aq)  # Ultra-fast evaluation
 ```
 """
-@inline function (itp::CubicInterpolant{Tg, Tv})(aq::_CubicAnchoredQuery{Tg, Tq}; deriv::DerivOp = EvalValue()) where {Tg,Tv, Tq <: Real}
+@inline function (itp::CubicInterpolant{Tg, Tv})(aq::_CubicAnchoredQuery{Tg, Tq}; deriv::DerivOp = EvalValue()) where {Tg, Tv, Tq <: Real}
     # Fast path: inside domain (most common case)
     if aq.state == IN_DOMAIN
         return _eval_anchored_kernel(itp, aq, deriv)
@@ -82,7 +82,7 @@ Thin wrapper: delegates to shared `_cubic_eval_kernel(y, z, aq, op)` in cubic_an
 # ========================================
 
 # NoExtrap - throw DomainError with enriched bounds
-@inline function _eval_anchored_extrap(itp::CubicInterpolant{Tg, Tv}, aq::_CubicAnchoredQuery{Tg, Tq}, ::NoExtrap, ::AbstractEvalOp) where {Tg,Tv, Tq <: Real}
+@inline function _eval_anchored_extrap(itp::CubicInterpolant{Tg, Tv}, aq::_CubicAnchoredQuery{Tg, Tq}, ::NoExtrap, ::AbstractEvalOp) where {Tg, Tv, Tq <: Real}
     x_min, x_max = first(itp.cache.x), last(itp.cache.x)
     throw(DomainError(aq.xq, "query point outside domain [$x_min, $x_max]"))
 end
@@ -119,7 +119,7 @@ For extrap=NoExtrap(), throws DomainError on first out-of-domain anchor.
         itp::CubicInterpolant{Tg, Tv},
         aq::AbstractVector{<:_CubicAnchoredQuery{Tg}},
         op::AbstractEvalOp
-    ) where {Tg,Tv}
+    ) where {Tg, Tv}
     @inbounds for k in eachindex(aq, output)
         aq_k = aq[k]
         if aq_k.state == IN_DOMAIN
@@ -157,7 +157,7 @@ derivs = itp(aq_vec; deriv=DerivOp(1)) # First derivative
 function (itp::CubicInterpolant{Tg, Tv})(
         aq::AbstractVector{<:_CubicAnchoredQuery{Tg, Tq}};
         deriv::DerivOp = EvalValue()
-    ) where {Tg,Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     T_out = promote_type(Tv, Tq)  # Lossless: wider type to avoid precision loss from anchor
     output = Vector{T_out}(undef, length(aq))
     _eval_anchored_vector_loop!(output, itp, aq, deriv)
@@ -179,7 +179,7 @@ function (itp::CubicInterpolant{Tg, Tv})(
         output::AbstractVector{Tv},
         aq::AbstractVector{<:_CubicAnchoredQuery{Tg}};
         deriv::DerivOp = EvalValue()
-    ) where {Tg,Tv}
+    ) where {Tg, Tv}
     @assert length(output) == length(aq) "output length ($(length(output))) must match aq length ($(length(aq)))"
     _eval_anchored_vector_loop!(output, itp, aq, deriv)
     return output
@@ -236,7 +236,7 @@ so the pool memory can be safely reused after this function returns.
         bc::PeriodicBC,
         autocache::Bool,
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg,Tv}
+    ) where {Tg, Tv}
     x, y = _prepare_periodic(x, y, bc)
     _check_periodic_endpoints(bc, y)
     cache = _get_cubic_cache(x, PeriodicBC(), _effective_autocache(autocache, Tg))
@@ -314,7 +314,7 @@ val = itp(0.5)  # returns ComplexF64
         extrap::AbstractExtrap,
         autocache::Bool,
         search::P = AutoSearch()
-    ) where {Tg,Tv, P <: AbstractSearchPolicy}
+    ) where {Tg, Tv, P <: AbstractSearchPolicy}
     if _is_periodic_bc(bc)
         return _build_interpolant_periodic(x, y, bc, autocache, search)
     else
@@ -361,7 +361,7 @@ so the pool memory can be safely reused after this function returns.
         y::AbstractVector{Tv};
         extrap::AbstractExtrap = NoExtrap(),
         search::P = AutoSearch()
-    ) where {Tg,Tv, P <: AbstractSearchPolicy}
+    ) where {Tg, Tv, P <: AbstractSearchPolicy}
     Tz = _output_eltype(Tv, eltype(cache.x))
     tmp_z = acquire!(pool, Tz, length(y))
     _solve_system!(tmp_z, cache, y, cache.bc_config)

--- a/src/cubic/cubic_interpolant.jl
+++ b/src/cubic/cubic_interpolant.jl
@@ -59,7 +59,7 @@ aq = _anchor_query(x, 0.35, Val(:cubic))
 itp(aq)  # Ultra-fast evaluation
 ```
 """
-@inline function (itp::CubicInterpolant{Tg, Tv})(aq::_CubicAnchoredQuery{Tg, Tq}; deriv::DerivOp = EvalValue()) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+@inline function (itp::CubicInterpolant{Tg, Tv})(aq::_CubicAnchoredQuery{Tg, Tq}; deriv::DerivOp = EvalValue()) where {Tg,Tv, Tq <: Real}
     # Fast path: inside domain (most common case)
     if aq.state == IN_DOMAIN
         return _eval_anchored_kernel(itp, aq, deriv)
@@ -82,7 +82,7 @@ Thin wrapper: delegates to shared `_cubic_eval_kernel(y, z, aq, op)` in cubic_an
 # ========================================
 
 # NoExtrap - throw DomainError with enriched bounds
-@inline function _eval_anchored_extrap(itp::CubicInterpolant{Tg, Tv}, aq::_CubicAnchoredQuery{Tg, Tq}, ::NoExtrap, ::AbstractEvalOp) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+@inline function _eval_anchored_extrap(itp::CubicInterpolant{Tg, Tv}, aq::_CubicAnchoredQuery{Tg, Tq}, ::NoExtrap, ::AbstractEvalOp) where {Tg,Tv, Tq <: Real}
     x_min, x_max = first(itp.cache.x), last(itp.cache.x)
     throw(DomainError(aq.xq, "query point outside domain [$x_min, $x_max]"))
 end
@@ -119,7 +119,7 @@ For extrap=NoExtrap(), throws DomainError on first out-of-domain anchor.
         itp::CubicInterpolant{Tg, Tv},
         aq::AbstractVector{<:_CubicAnchoredQuery{Tg}},
         op::AbstractEvalOp
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg,Tv}
     @inbounds for k in eachindex(aq, output)
         aq_k = aq[k]
         if aq_k.state == IN_DOMAIN
@@ -157,7 +157,7 @@ derivs = itp(aq_vec; deriv=DerivOp(1)) # First derivative
 function (itp::CubicInterpolant{Tg, Tv})(
         aq::AbstractVector{<:_CubicAnchoredQuery{Tg, Tq}};
         deriv::DerivOp = EvalValue()
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg,Tv, Tq <: Real}
     T_out = promote_type(Tv, Tq)  # Lossless: wider type to avoid precision loss from anchor
     output = Vector{T_out}(undef, length(aq))
     _eval_anchored_vector_loop!(output, itp, aq, deriv)
@@ -179,7 +179,7 @@ function (itp::CubicInterpolant{Tg, Tv})(
         output::AbstractVector{Tv},
         aq::AbstractVector{<:_CubicAnchoredQuery{Tg}};
         deriv::DerivOp = EvalValue()
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg,Tv}
     @assert length(output) == length(aq) "output length ($(length(output))) must match aq length ($(length(aq)))"
     _eval_anchored_vector_loop!(output, itp, aq, deriv)
     return output
@@ -208,10 +208,11 @@ so the pool memory can be safely reused after this function returns.
         extrap::AbstractExtrap,
         autocache::Bool,
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv, L <: PointBC, R <: PointBC}
+    ) where {Tg, Tv, L <: PointBC, R <: PointBC}
     # Cache uses structural equivalent (PolyFit → Deriv1 via _cache_bc_pair internally)
-    cache = _get_cubic_cache(x, bc_pair, autocache)
-    tmp_z = similar!(pool, y)
+    cache = _get_cubic_cache(x, bc_pair, _effective_autocache(autocache, Tg))
+    Tz = _output_eltype(Tv, eltype(cache.x))
+    tmp_z = acquire!(pool, Tz, length(y))
     # Solve uses original BC for proper RHS materialization
     _solve_system!(tmp_z, cache, y, bc_pair)
     extrap_p = _promote_extrap(extrap, Tv)
@@ -235,11 +236,12 @@ so the pool memory can be safely reused after this function returns.
         bc::PeriodicBC,
         autocache::Bool,
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg,Tv}
     x, y = _prepare_periodic(x, y, bc)
     _check_periodic_endpoints(bc, y)
-    cache = _get_cubic_cache(x, PeriodicBC(), autocache)
-    tmp_z = similar!(pool, y)
+    cache = _get_cubic_cache(x, PeriodicBC(), _effective_autocache(autocache, Tg))
+    Tz = _output_eltype(eltype(y), eltype(cache.x))
+    tmp_z = acquire!(pool, Tz, length(y))
     _solve_system!(tmp_z, cache, y, cache.bc_config)
     bc_display = _with_resolved_period(bc, cache.bc_config.period)
     return CubicInterpolant(cache, y, tmp_z, bc_display, WrapExtrap(), search)
@@ -312,7 +314,7 @@ val = itp(0.5)  # returns ComplexF64
         extrap::AbstractExtrap,
         autocache::Bool,
         search::P = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv, P <: AbstractSearchPolicy}
+    ) where {Tg,Tv, P <: AbstractSearchPolicy}
     if _is_periodic_bc(bc)
         return _build_interpolant_periodic(x, y, bc, autocache, search)
     else
@@ -321,7 +323,7 @@ val = itp(0.5)  # returns ComplexF64
     end
 end
 
-# Hot path: x is AbstractFloat, Tv unconstrained
+# Unified entry: handles all grid types including duck-typed (Dual).
 function cubic_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv};
@@ -329,8 +331,7 @@ function cubic_interp(
         extrap::AbstractExtrap = NoExtrap(),
         autocache::Bool = true,
         search::P = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv, P <: AbstractSearchPolicy}
-    # Auto-promote x/y types (zero allocation if already compatible)
+    ) where {Tg, Tv, P <: AbstractSearchPolicy}
     x_p, y_p = _promote_itp_inputs(x, y)
     bc_promoted = _promote_bc(bc, eltype(y_p))
     return _cubic_interp_impl(x_p, y_p, bc_promoted, extrap, autocache, search)
@@ -360,8 +361,9 @@ so the pool memory can be safely reused after this function returns.
         y::AbstractVector{Tv};
         extrap::AbstractExtrap = NoExtrap(),
         search::P = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv, P <: AbstractSearchPolicy}
-    tmp_z = similar!(pool, y)
+    ) where {Tg,Tv, P <: AbstractSearchPolicy}
+    Tz = _output_eltype(Tv, eltype(cache.x))
+    tmp_z = acquire!(pool, Tz, length(y))
     _solve_system!(tmp_z, cache, y, cache.bc_config)
 
     if cache.bc_config isa PeriodicData
@@ -374,16 +376,6 @@ so the pool memory can be safely reused after this function returns.
     return CubicInterpolant(cache, y, tmp_z, cache.bc_config, extrap_p, search)
 end
 
-# Generic Real wrapper for 2-argument form (handles Integer grids, etc.)
-function cubic_interp(
-        x::AbstractVector{TX},
-        y::AbstractVector{TY};
-        bc::AbstractBC = CubicFit(),
-        extrap::AbstractExtrap = NoExtrap(),
-        autocache::Bool = true,
-        search::P = AutoSearch()
-    ) where {TX <: Real, TY, P <: AbstractSearchPolicy}
-    x_p, y_p = _promote_itp_inputs(x, y)
-    bc_promoted = _promote_bc(bc, eltype(y_p))
-    return _cubic_interp_impl(x_p, y_p, bc_promoted, extrap, autocache, search)
-end
+
+# Note: Real wrapper (TX <: Real) removed — unified entry above handles
+# all grid types including ForwardDiff.Dual via _promote_itp_inputs.

--- a/src/cubic/cubic_kernels.jl
+++ b/src/cubic/cubic_kernels.jl
@@ -18,9 +18,10 @@
 Evaluate cubic spline value using moment (z) formulation.
 
 # Type Parameters
-- `Tg<:AbstractFloat`: Grid type for h, inv_h (always real)
+- `Tg`: Grid type for h, inv_h (AbstractFloat or duck-typed, e.g. ForwardDiff.Dual)
+- `Tz`: Coefficient type for zL, zR (= `_output_eltype(Tv, Tg)` — Dual when grid is Dual)
+- `Tv`: Value type for yL, yR (unconstrained, typically Float)
 - `Td<:Real`: Offset type for dL, dR (can be Tg or ForwardDiff.Dual for AD)
-- `Tv`: Value type for zL, zR, yL, yR (unconstrained)
 
 # Formula
     S(x) = zL*(dR³)/(6h) + zR*(dL³)/(6h)
@@ -35,9 +36,9 @@ for FMA (Fused Multiply-Add) hardware instructions, reducing total FP operations
 """
 @inline function _cubic_kernel(
         ::EvalValue,
-        zL, zR, yL, yR,
+        zL::Tz, zR::Tz, yL::Tv, yR::Tv,
         h::Tg, inv_h::Tg, dL::Td, dR::Td
-    ) where {Tg, Td <: Real}
+    ) where {Tg, Tz, Tv, Td <: Real}
     # Native (ARM64) instruction breakdown:
     div6 = inv(Tg(6))                                   # (const-folded)
     # inv_h passed as parameter (fdiv eliminated)
@@ -60,9 +61,10 @@ end
 Evaluate first derivative of cubic spline.
 
 # Type Parameters
-- `Tg<:AbstractFloat`: Grid type for h, inv_h (always real)
+- `Tg`: Grid type for h, inv_h (AbstractFloat or duck-typed, e.g. ForwardDiff.Dual)
+- `Tz`: Coefficient type for zL, zR (= `_output_eltype(Tv, Tg)` — Dual when grid is Dual)
+- `Tv`: Value type for yL, yR (unconstrained, typically Float)
 - `Td<:Real`: Offset type for dL, dR (can be Tg or ForwardDiff.Dual for AD)
-- `Tv`: Value type for zL, zR, yL, yR (unconstrained)
 
 Formula:
     S'(x) = (-zL*dR² + zR*dL²)/(2h)
@@ -71,9 +73,9 @@ Formula:
 """
 @inline function _cubic_kernel(
         ::EvalDeriv1,
-        zL, zR, yL, yR,
+        zL::Tz, zR::Tz, yL::Tv, yR::Tv,
         h::Tg, inv_h::Tg, dL::Td, dR::Td
-    ) where {Tg, Td <: Real}
+    ) where {Tg, Tz, Tv, Td <: Real}
     # inv_h passed as parameter (fdiv eliminated)
 
     inv_2h = inv_h * inv(Tg(2))
@@ -99,18 +101,19 @@ Evaluate second derivative of cubic spline.
 This is simply a linear interpolation of the z (moment) values.
 
 # Type Parameters
-- `Tg<:AbstractFloat`: Grid type for h, inv_h (always real)
+- `Tg`: Grid type for h, inv_h (AbstractFloat or duck-typed, e.g. ForwardDiff.Dual)
+- `Tz`: Coefficient type for zL, zR (= `_output_eltype(Tv, Tg)` — Dual when grid is Dual)
+- `Tv`: Value type for yL, yR (unconstrained, typically Float)
 - `Td<:Real`: Offset type for dL, dR (can be Tg or ForwardDiff.Dual for AD)
-- `Tv`: Value type for zL, zR, yL, yR (unconstrained)
 
 Formula:
     S''(x) = (zL*dR + zR*dL) / h
 """
 @inline function _cubic_kernel(
         ::EvalDeriv2,
-        zL, zR, _, _,
+        zL::Tz, zR::Tz, _, _,
         ::Tg, inv_h::Tg, dL::Td, dR::Td
-    ) where {Tg, Td <: Real}
+    ) where {Tg, Tz, Td <: Real}
     return muladd(zL, dR, zR * dL) * inv_h
 end
 
@@ -120,9 +123,10 @@ end
 Third derivative of cubic spline (constant within each interval).
 
 # Type Parameters
-- `Tg<:AbstractFloat`: Grid type for h, inv_h (always real)
+- `Tg`: Grid type for h, inv_h (AbstractFloat or duck-typed, e.g. ForwardDiff.Dual)
+- `Tz`: Coefficient type for zL, zR (= `_output_eltype(Tv, Tg)` — Dual when grid is Dual)
+- `Tv`: Value type for yL, yR (unconstrained, typically Float)
 - `Td<:Real`: Offset type for dL, dR (can be Tg or ForwardDiff.Dual for AD)
-- `Tv`: Value type for zL, zR, yL, yR (unconstrained)
 
 # Formula
     S'''(x) = (zR - zL) / h
@@ -139,9 +143,9 @@ Third derivative (constant, independent of x within interval):
 """
 @inline function _cubic_kernel(
         ::EvalDeriv3,
-        zL, zR, _, _,
+        zL::Tz, zR::Tz, _, _,
         ::Tg, inv_h::Tg, ::Td, ::Td
-    ) where {Tg, Td <: Real}
+    ) where {Tg, Tz, Td <: Real}
     return (zR - zL) * inv_h
 end
 
@@ -153,8 +157,8 @@ Julia dispatch ensures `DerivOp{0..3}` methods (more specific) are selected firs
 """
 @inline function _cubic_kernel(
         ::DerivOp{N},
-        zL, _, _, _,
+        zL::Tz, _, _, _,
         ::Tg, ::Tg, ::Td, ::Td
-    ) where {N, Tg, Td <: Real}
+    ) where {N, Tg, Tz, Td <: Real}
     return 0 * zL
 end

--- a/src/cubic/cubic_kernels.jl
+++ b/src/cubic/cubic_kernels.jl
@@ -35,9 +35,9 @@ for FMA (Fused Multiply-Add) hardware instructions, reducing total FP operations
 """
 @inline function _cubic_kernel(
         ::EvalValue,
-        zL::Tv, zR::Tv, yL::Tv, yR::Tv,
+        zL, zR, yL, yR,
         h::Tg, inv_h::Tg, dL::Td, dR::Td
-    ) where {Tg <: AbstractFloat, Tv, Td <: Real}
+    ) where {Tg, Td <: Real}
     # Native (ARM64) instruction breakdown:
     div6 = inv(Tg(6))                                   # (const-folded)
     # inv_h passed as parameter (fdiv eliminated)
@@ -71,9 +71,9 @@ Formula:
 """
 @inline function _cubic_kernel(
         ::EvalDeriv1,
-        zL::Tv, zR::Tv, yL::Tv, yR::Tv,
+        zL, zR, yL, yR,
         h::Tg, inv_h::Tg, dL::Td, dR::Td
-    ) where {Tg <: AbstractFloat, Tv, Td <: Real}
+    ) where {Tg, Td <: Real}
     # inv_h passed as parameter (fdiv eliminated)
 
     inv_2h = inv_h * inv(Tg(2))
@@ -108,9 +108,9 @@ Formula:
 """
 @inline function _cubic_kernel(
         ::EvalDeriv2,
-        zL::Tv, zR::Tv, ::Tv, ::Tv,
+        zL, zR, _, _,
         ::Tg, inv_h::Tg, dL::Td, dR::Td
-    ) where {Tg <: AbstractFloat, Tv, Td <: Real}
+    ) where {Tg, Td <: Real}
     return muladd(zL, dR, zR * dL) * inv_h
 end
 
@@ -139,9 +139,9 @@ Third derivative (constant, independent of x within interval):
 """
 @inline function _cubic_kernel(
         ::EvalDeriv3,
-        zL::Tv, zR::Tv, ::Tv, ::Tv,
+        zL, zR, _, _,
         ::Tg, inv_h::Tg, ::Td, ::Td
-    ) where {Tg <: AbstractFloat, Tv, Td <: Real}
+    ) where {Tg, Td <: Real}
     return (zR - zL) * inv_h
 end
 
@@ -153,8 +153,8 @@ Julia dispatch ensures `DerivOp{0..3}` methods (more specific) are selected firs
 """
 @inline function _cubic_kernel(
         ::DerivOp{N},
-        zL::Tv, ::Tv, ::Tv, ::Tv,
+        zL, _, _, _,
         ::Tg, ::Tg, ::Td, ::Td
-    ) where {N, Tg <: AbstractFloat, Tv, Td <: Real}
+    ) where {N, Tg, Td <: Real}
     return 0 * zL
 end

--- a/src/cubic/cubic_oneshot.jl
+++ b/src/cubic/cubic_oneshot.jl
@@ -36,7 +36,7 @@ Thread-safe: workspaces allocated from task-local pool.
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg,Tv, X, F, BC}
+    ) where {Tg, Tv, X, F, BC}
     @assert length(y) == length(cache.x) "y length must match cache grid"
     @assert length(output) == length(x_query) "output length must match x_query"
 
@@ -110,7 +110,7 @@ AD-compatible: xq is unconstrained to support ForwardDiff.Dual types.
         autocache::Bool,
         op::O,
         searcher::S
-    ) where {Tg,Tv, Tq <: Real, L <: PointBC, R <: PointBC, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq <: Real, L <: PointBC, R <: PointBC, O <: AbstractEvalOp, S <: Searcher}
     # Cache uses structural equivalent (PolyFit → Deriv1 via _cache_bc_pair internally)
     cache = _get_cubic_cache(x, bc, _effective_autocache(autocache, Tg))
     Tz = _output_eltype(Tv, eltype(cache.x))
@@ -135,7 +135,7 @@ manages their lifetime. Follows the `_create_spacing_pooled(pool, ...)` pattern.
         y::AbstractVector{Tv},
         bc::PeriodicBC,
         autocache::Bool
-    ) where {Tg,Tv}
+    ) where {Tg, Tv}
     @assert length(x) == length(y) "x and y must have the same length"
 
     # ── Extend exclusive → inclusive (pool-based, zero-alloc after warmup) ──
@@ -214,7 +214,7 @@ Pool-based exclusive extension: zero-alloc after warmup.
         autocache::Bool,
         op::O,
         searcher::S
-    ) where {Tg,Tv, Tq <: Real, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, Tv, Tq <: Real, O <: AbstractEvalOp, S <: Searcher}
     cache, y_p, z = _cubic_periodic_solve!(pool, x, y, bc, autocache)
 
     _check_domain(cache.x, xq, WrapExtrap())
@@ -261,7 +261,7 @@ end
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg,Tv, X, F, BC}
+    ) where {Tg, Tv, X, F, BC}
     @assert length(output) >= 1 "output must have at least 1 element"
     output[1] = cubic_interp_scalar(cache, y, x_query; extrap = extrap, deriv = deriv, search = search)
     return output
@@ -315,7 +315,7 @@ function cubic_interp(
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg,Tv}
+    ) where {Tg, Tv}
     output = Vector{Tv}(undef, length(x_query))
     cubic_interp!(output, cache, y, x_query; extrap = extrap, deriv = deriv, search = search)
     return output
@@ -369,7 +369,7 @@ end
 cubic_interp(
     cache::CubicSplineCache{Tg}, y::AbstractVector{Tv},
     x_query::Tg; extrap::AbstractExtrap = NoExtrap(), deriv::DerivOp = EvalValue(), search::AbstractSearchPolicy = AutoSearch(), hint::Union{Nothing, Base.RefValue{Int}} = nothing
-) where {Tg,Tv} =
+) where {Tg, Tv} =
     cubic_interp_scalar(cache, y, x_query; extrap = extrap, deriv = deriv, search = search, hint = hint)
 
 # Primary scalar method - AD-compatible
@@ -394,7 +394,6 @@ function cubic_interp(
     bc_pair = _normalize_bc(bc, first(y))
     return _cubic_interp_bcpair_scalar(x, y, xq, bc_pair, extrap, autocache, deriv, searcher)
 end
-
 
 
 # Note: Real wrappers (Tg <: Real) removed — duck-typed Tg dispatch handles

--- a/src/cubic/cubic_oneshot.jl
+++ b/src/cubic/cubic_oneshot.jl
@@ -36,7 +36,7 @@ Thread-safe: workspaces allocated from task-local pool.
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv, X, F, BC}
+    ) where {Tg,Tv, X, F, BC}
     @assert length(y) == length(cache.x) "y length must match cache grid"
     @assert length(output) == length(x_query) "output length must match x_query"
 
@@ -69,22 +69,23 @@ Type-Free design: handles both concrete (Deriv1{T}) and lazy (PolyFit{D}) types.
 - Solve uses original BC for proper RHS materialization (PolyFit materializes via compute_rhs!)
 """
 @inline @with_pool pool function _cubic_interp_bcpair!(
-        output::AbstractVector{Tv},
+        output::AbstractVector,
         x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg},
+        y::AbstractVector,
+        x_query::AbstractVector{<:Real},
         bc::BCPair{L, R},
         extrap::AbstractExtrap,
         autocache::Bool,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, L <: PointBC, R <: PointBC, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, L <: PointBC, R <: PointBC, O <: AbstractEvalOp, S <: Searcher}
     @assert length(y) == length(x) "y length must match x"
     @assert length(output) == length(x_query) "output length must match x_query"
 
     # Cache uses structural equivalent (PolyFit → Deriv1 via _cache_bc_pair internally)
-    cache = _get_cubic_cache(x, bc, autocache)
-    z = similar!(pool, y)
+    cache = _get_cubic_cache(x, bc, _effective_autocache(autocache, Tg))
+    Tz = _output_eltype(eltype(y), eltype(cache.x))
+    z = acquire!(pool, Tz, length(y))
     # Solve uses original BC for proper RHS materialization
     _solve_system!(z, cache, y, bc)
 
@@ -109,10 +110,11 @@ AD-compatible: xq is unconstrained to support ForwardDiff.Dual types.
         autocache::Bool,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real, L <: PointBC, R <: PointBC, O <: AbstractEvalOp, S <: Searcher}
-    tmp_z = similar!(pool, y)
+    ) where {Tg,Tv, Tq <: Real, L <: PointBC, R <: PointBC, O <: AbstractEvalOp, S <: Searcher}
     # Cache uses structural equivalent (PolyFit → Deriv1 via _cache_bc_pair internally)
-    cache = _get_cubic_cache(x, bc, autocache)
+    cache = _get_cubic_cache(x, bc, _effective_autocache(autocache, Tg))
+    Tz = _output_eltype(Tv, eltype(cache.x))
+    tmp_z = acquire!(pool, Tz, length(y))
     # Solve uses original BC for proper RHS materialization
     _solve_system!(tmp_z, cache, y, bc)
 
@@ -133,7 +135,7 @@ manages their lifetime. Follows the `_create_spacing_pooled(pool, ...)` pattern.
         y::AbstractVector{Tv},
         bc::PeriodicBC,
         autocache::Bool
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg,Tv}
     @assert length(x) == length(y) "x and y must have the same length"
 
     # ── Extend exclusive → inclusive (pool-based, zero-alloc after warmup) ──
@@ -167,8 +169,9 @@ manages their lifetime. Follows the `_create_spacing_pooled(pool, ...)` pattern.
 
     # ── Solve periodic tridiagonal system ──
     _check_periodic_endpoints(bc, y_p)
-    cache = _get_cubic_cache(x_p, PeriodicBC(), autocache)
-    z = acquire!(pool, Tv, length(y_p))
+    cache = _get_cubic_cache(x_p, PeriodicBC(), _effective_autocache(autocache, Tg))
+    Tz = _output_eltype(Tv, eltype(cache.x))
+    z = acquire!(pool, Tz, length(y_p))
     _solve_system!(z, cache, y_p, cache.bc_config)
 
     return cache, y_p, z
@@ -180,15 +183,15 @@ Thread-safe: uses _get_cubic_cache + @with_pool pattern.
 Pool-based exclusive extension: zero-alloc after warmup.
 """
 @inline @with_pool pool function _cubic_interp_periodic!(
-        output::AbstractVector{Tv},
+        output::AbstractVector,
         x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg},
+        y::AbstractVector,
+        x_query::AbstractVector{<:Real},
         bc::PeriodicBC,
         autocache::Bool,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg, O <: AbstractEvalOp, S <: Searcher}
     @assert length(output) == length(x_query) "output length must match x_query"
 
     cache, y_p, z = _cubic_periodic_solve!(pool, x, y, bc, autocache)
@@ -211,7 +214,7 @@ Pool-based exclusive extension: zero-alloc after warmup.
         autocache::Bool,
         op::O,
         searcher::S
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real, O <: AbstractEvalOp, S <: Searcher}
+    ) where {Tg,Tv, Tq <: Real, O <: AbstractEvalOp, S <: Searcher}
     cache, y_p, z = _cubic_periodic_solve!(pool, x, y, bc, autocache)
 
     _check_domain(cache.x, xq, WrapExtrap())
@@ -224,18 +227,19 @@ end
 In-place cubic spline interpolation with optional automatic caching.
 """
 @inline function cubic_interp!(
-        output::AbstractVector{Tv},
+        output::AbstractVector,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg};
+        x_query::AbstractVector{<:Real};
         bc::AbstractBC = CubicFit(),
         extrap::AbstractExtrap = NoExtrap(),
         autocache::Bool = true,
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv}
-    x = _to_float(x, Tg)
-    x_query = _to_float(x_query, Tg)
+    ) where {Tg, Tv}
+    x = _to_float(x, _promote_grid_float(Tg, Tv))
+    Tq_float = eltype(x) <: AbstractFloat ? eltype(x) : float(eltype(x_query))
+    x_query = _to_float(x_query, Tq_float)
     searcher = _resolve_search(x, x_query, search, nothing)
     # Periodic BC
     if _is_periodic_bc(bc)
@@ -257,23 +261,23 @@ end
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv, X, F, BC}
+    ) where {Tg,Tv, X, F, BC}
     @assert length(output) >= 1 "output must have at least 1 element"
     output[1] = cubic_interp_scalar(cache, y, x_query; extrap = extrap, deriv = deriv, search = search)
     return output
 end
 
 @inline function cubic_interp!(
-        output::AbstractVector{Tv},
+        output::AbstractVector,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::Tg;
+        x_query::Real;
         bc::AbstractBC = CubicFit(),
         extrap::AbstractExtrap = NoExtrap(),
         autocache::Bool = true,
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     @assert length(output) >= 1 "output must have at least 1 element"
     output[1] = cubic_interp(x, y, x_query; bc, extrap, autocache, deriv, search)
     return output
@@ -311,7 +315,7 @@ function cubic_interp(
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg,Tv}
     output = Vector{Tv}(undef, length(x_query))
     cubic_interp!(output, cache, y, x_query; extrap = extrap, deriv = deriv, search = search)
     return output
@@ -347,14 +351,16 @@ vals = cubic_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_windo
 function cubic_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg};
+        x_query::AbstractVector{<:Real};
         bc::AbstractBC = CubicFit(),
         extrap::AbstractExtrap = NoExtrap(),
         autocache::Bool = true,
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv}
-    output = Vector{Tv}(undef, length(x_query))
+    ) where {Tg, Tv}
+    Tq = eltype(x_query)
+    Tr = _output_eltype(Tv, Tg, Tq)
+    output = Vector{Tr}(undef, length(x_query))
     cubic_interp!(output, x, y, x_query; bc, extrap, autocache, deriv, search)
     return output
 end
@@ -363,7 +369,7 @@ end
 cubic_interp(
     cache::CubicSplineCache{Tg}, y::AbstractVector{Tv},
     x_query::Tg; extrap::AbstractExtrap = NoExtrap(), deriv::DerivOp = EvalValue(), search::AbstractSearchPolicy = AutoSearch(), hint::Union{Nothing, Base.RefValue{Int}} = nothing
-) where {Tg <: AbstractFloat, Tv} =
+) where {Tg,Tv} =
     cubic_interp_scalar(cache, y, x_query; extrap = extrap, deriv = deriv, search = search, hint = hint)
 
 # Primary scalar method - AD-compatible
@@ -378,8 +384,8 @@ function cubic_interp(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
-    x = _to_float(x, Tg)
+    ) where {Tg, Tv, Tq <: Real}
+    x = _to_float(x, _promote_grid_float(Tg, Tv))
     searcher = _resolve_search(x, xq, search, hint)
     if _is_periodic_bc(bc)
         return _cubic_interp_periodic_scalar(x, y, xq, bc, autocache, deriv, searcher)
@@ -390,68 +396,7 @@ function cubic_interp(
 end
 
 
-# ╔═══════════════════════════════════════════════════════════════════════════╗
-# ║                     GENERIC WRAPPERS - CONVENIENCE                        ║
-# ║              Auto-promote Real types to Float (type conversion)           ║
-# ╚═══════════════════════════════════════════════════════════════════════════╝
-# Note: CubicInterpolant callable methods and 2-arg form are in cubic_interpolant.jl
-# POLICY: Tg is computed from x/y ONLY, not from x_query
 
-# Allocating - vector query
-function cubic_interp(
-        x::AbstractVector{Tg}, y::AbstractVector{Tv}, x_query::AbstractVector{Tq}; kwargs...
-    ) where {Tg <: Real, Tv, Tq <: Real}
-    x_typed, y_typed, xq_typed = _promote_itp_inputs(x, y, x_query)
-    return cubic_interp(x_typed, y_typed, xq_typed; kwargs...)
-end
-
-# Allocating - scalar query wrapper
-# Preserves original xq type for AD support (Dual types flow through)
-function cubic_interp(
-        x::AbstractVector{Tg}, y::AbstractVector{Tv}, xq::Tq; kwargs...
-    ) where {Tg <: Real, Tv, Tq <: Real}
-    x_typed, y_typed = _promote_itp_inputs(x, y)
-    # Pass xq directly to preserve Dual type for AD
-    return cubic_interp(x_typed, y_typed, xq; kwargs...)
-end
-
-# In-place - vector query
-function cubic_interp!(
-        output::AbstractVector,
-        x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        x_query::AbstractVector{Tq};
-        kwargs...
-    ) where {Tg <: Real, Tv, Tq <: Real}
-    @assert length(y) == length(x) "x and y must have same length"
-    @assert length(output) == length(x_query) "output must match x_query length"
-
-    x_typed, y_typed, xq_typed = _promote_itp_inputs(x, y, x_query)
-    Tg_float = eltype(x_typed)
-    Tv_float = eltype(y_typed)
-
-    # Validate output can hold result type
-    Tout = eltype(output)
-    if promote_type(Tout, Tv_float) !== Tout
-        throw(
-            ArgumentError(
-                "output eltype $Tout cannot hold interpolation result type $Tv_float. " *
-                    "Use Vector{$Tv_float} or a wider type (e.g., Vector{Complex{$Tg_float}} for complex y-values)."
-            )
-        )
-    end
-
-    return cubic_interp!(output, x_typed, y_typed, xq_typed; kwargs...)
-end
-
-# In-place - scalar query
-function cubic_interp!(
-        output::AbstractVector, x::AbstractVector{Tg}, y::AbstractVector{Tv}, x_query::Tq; kwargs...
-    ) where {Tg <: Real, Tv, Tq <: Real}
-    @assert length(output) >= 1 "output must have at least 1 element"
-
-    x_typed, y_typed = _promote_itp_inputs(x, y)
-    Tg_float = eltype(x_typed)
-    output[1] = cubic_interp(x_typed, y_typed, Tg_float(x_query); kwargs...)
-    return output
-end
+# Note: Real wrappers (Tg <: Real) removed — duck-typed Tg dispatch handles
+# all grid types including ForwardDiff.Dual. See _to_float + _promote_grid_float
+# for type promotion inside @with_pool paths.

--- a/src/cubic/cubic_oneshot.jl
+++ b/src/cubic/cubic_oneshot.jl
@@ -29,18 +29,19 @@ Thread-safe: workspaces allocated from task-local pool.
 - `search::AbstractSearchPolicy=AutoSearch()`: Search algorithm for interval finding
 """
 @inline @with_pool pool function cubic_interp!(
-        output::AbstractVector{Tv},
+        output::AbstractVector,
         cache::CubicSplineCache{Tg, X, F, BC},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg};
+        x_query::AbstractVector{Tq};
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg, Tv, X, F, BC}
+    ) where {Tg, Tv, Tq <: Real, X, F, BC}
     @assert length(y) == length(cache.x) "y length must match cache grid"
     @assert length(output) == length(x_query) "output length must match x_query"
 
-    z = similar!(pool, y)
+    Tz = _output_eltype(Tv, eltype(cache.x))
+    z = acquire!(pool, Tz, length(y))
     _solve_system!(z, cache, y, cache.bc_config)
 
     searcher = _resolve_search(cache.x, x_query, search, nothing)
@@ -311,12 +312,13 @@ vals = cubic_interp(cache, y, sorted_queries; search=LinearBinarySearch(linear_w
 function cubic_interp(
         cache::CubicSplineCache{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tg};
+        x_query::AbstractVector{Tq};
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg, Tv}
-    output = Vector{Tv}(undef, length(x_query))
+    ) where {Tg, Tv, Tq <: Real}
+    Tr = _output_eltype(Tv, eltype(cache.x), Tq)
+    output = Vector{Tr}(undef, length(x_query))
     cubic_interp!(output, cache, y, x_query; extrap = extrap, deriv = deriv, search = search)
     return output
 end
@@ -368,8 +370,8 @@ end
 # Scalar query - zero allocation
 cubic_interp(
     cache::CubicSplineCache{Tg}, y::AbstractVector{Tv},
-    x_query::Tg; extrap::AbstractExtrap = NoExtrap(), deriv::DerivOp = EvalValue(), search::AbstractSearchPolicy = AutoSearch(), hint::Union{Nothing, Base.RefValue{Int}} = nothing
-) where {Tg, Tv} =
+    x_query::Tq; extrap::AbstractExtrap = NoExtrap(), deriv::DerivOp = EvalValue(), search::AbstractSearchPolicy = AutoSearch(), hint::Union{Nothing, Base.RefValue{Int}} = nothing
+) where {Tg, Tv, Tq <: Real} =
     cubic_interp_scalar(cache, y, x_query; extrap = extrap, deriv = deriv, search = search, hint = hint)
 
 # Primary scalar method - AD-compatible

--- a/src/cubic/cubic_oneshot_series.jl
+++ b/src/cubic/cubic_oneshot_series.jl
@@ -25,8 +25,8 @@
         autocache::Bool,
         op::AbstractEvalOp,
         searcher
-    ) where {Tg <: AbstractFloat}
-    cache = _get_cubic_cache(x, bc, autocache)
+    ) where {Tg}
+    cache = _get_cubic_cache(x, bc, _effective_autocache(autocache, Tg))
     aq = _anchor_query(cache.x, xq, Val(:cubic), extrap isa WrapExtrap, searcher)
     vecs = _series_vectors(s)
     Tv_out = _value_type(_series_eltype(s), Tg)
@@ -53,7 +53,7 @@ end
         op::AbstractEvalOp,
         autocache::Bool,
         searcher
-    ) where {Tg <: AbstractFloat}
+    ) where {Tg}
     vecs = _series_vectors(s)
     n = length(x)
     Tv_out = _value_type(_series_eltype(s), Tg)
@@ -105,7 +105,7 @@ end
         op::AbstractEvalOp,
         autocache::Bool,
         search::AbstractSearchPolicy
-    ) where {Tg <: AbstractFloat, Tq <: Real}
+    ) where {Tg,Tq <: Real}
     vecs = _series_vectors(s)
     n = length(x)
     K = n_series(s)
@@ -179,9 +179,9 @@ Build cache once → anchor once → solve+eval per y-vector with z-buffer reuse
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tq <: Real}
+    ) where {Tg,Tq <: Real}
     _validate_series_lengths(s, length(x))
-    x = _to_float(x, Tg)
+    x = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
     _is_periodic_bc(bc) || _check_domain(x, xq, extrap)
     K = n_series(s)
     output = Vector{_series_output_type(_value_type(_series_eltype(s), Tg), Tq)}(undef, K)
@@ -208,10 +208,10 @@ end
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tq <: Real}
+    ) where {Tg,Tq <: Real}
     _validate_series_lengths(s, length(x))
     length(output) == n_series(s) || _throw_series_dim_mismatch(length(output), n_series(s))
-    x = _to_float(x, Tg)
+    x = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
     _is_periodic_bc(bc) || _check_domain(x, xq, extrap)
     searcher = _resolve_search(x, xq, search, hint)
     if _is_periodic_bc(bc)
@@ -239,9 +239,9 @@ end
         autocache::Bool = true,
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tq <: Real}
+    ) where {Tg,Tq <: Real}
     _validate_series_lengths(s, length(x))
-    x = _to_float(x, Tg)
+    x = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
     K = n_series(s)
     _validate_series_outputs(outputs, K, length(xqs))
     vecs = _series_vectors(s)
@@ -257,7 +257,7 @@ end
     extrap_eff = _check_domain(x, xqs, extrap)
 
     bc_pair = _normalize_bc(bc, _series_eltype(s))
-    cache = _get_cubic_cache(x, bc_pair, autocache)
+    cache = _get_cubic_cache(x, bc_pair, _effective_autocache(autocache, Tg))
 
     # Pre-compute anchors once (search Q times, not K×Q)
     aq_vec = acquire!(pool, _CubicAnchoredQuery{Tg, Tq}, length(xqs))
@@ -289,7 +289,7 @@ function cubic_interp(
         autocache::Bool = true,
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tq <: Real}
+    ) where {Tg,Tq <: Real}
     K = n_series(s)
     Tv = _series_output_type(_value_type(_series_eltype(s), Tg), Tq)
     outputs = [Vector{Tv}(undef, length(xqs)) for _ in 1:K]
@@ -297,44 +297,6 @@ function cubic_interp(
     return outputs
 end
 
-# ╔═══════════════════════════════════════════════════════════════════════════╗
-# ║                     REAL TYPE PROMOTION WRAPPERS                         ║
-# ╚═══════════════════════════════════════════════════════════════════════════╝
 
-@inline function cubic_interp(
-        x::AbstractVector{Tg}, s::Series, xq::Tq; bc::AbstractBC = CubicFit(), kwargs...
-    ) where {Tg <: Real, Tq <: Real}
-    Tg_float = _promote_grid_float(Tg, _series_eltype(s))
-    return cubic_interp(_to_float(x, Tg_float), s, xq; bc = _promote_bc(bc, Tg_float), kwargs...)
-end
-
-@inline function cubic_interp!(
-        output::AbstractVector, x::AbstractVector{Tg}, s::Series, xq::Tq;
-        bc::AbstractBC = CubicFit(), kwargs...
-    ) where {Tg <: Real, Tq <: Real}
-    Tg_float = _promote_grid_float(Tg, _series_eltype(s))
-    return cubic_interp!(output, _to_float(x, Tg_float), s, xq; bc = _promote_bc(bc, Tg_float), kwargs...)
-end
-
-function cubic_interp!(
-        outputs::AbstractVector{<:AbstractVector},
-        x::AbstractVector{Tg}, s::Series, xqs::AbstractVector{Tq};
-        bc::AbstractBC = CubicFit(), kwargs...
-    ) where {Tg <: Real, Tq <: Real}
-    Tg_float = _promote_grid_float(Tg, _series_eltype(s))
-    return cubic_interp!(
-        outputs, _to_float(x, Tg_float), s, xqs;
-        bc = _promote_bc(bc, Tg_float), kwargs...
-    )
-end
-
-function cubic_interp(
-        x::AbstractVector{Tg}, s::Series, xqs::AbstractVector{Tq};
-        bc::AbstractBC = CubicFit(), kwargs...
-    ) where {Tg <: Real, Tq <: Real}
-    Tg_float = _promote_grid_float(Tg, _series_eltype(s))
-    return cubic_interp(
-        _to_float(x, Tg_float), s, xqs;
-        bc = _promote_bc(bc, Tg_float), kwargs...
-    )
-end
+# Note: Real wrappers (Tg <: Real) removed — typed methods above handle
+# all grid types including ForwardDiff.Dual via _to_float + _promote_grid_float.

--- a/src/cubic/cubic_oneshot_series.jl
+++ b/src/cubic/cubic_oneshot_series.jl
@@ -30,8 +30,9 @@
     aq = _anchor_query(cache.x, xq, Val(:cubic), extrap isa WrapExtrap, searcher)
     vecs = _series_vectors(s)
     Tv_out = _value_type(_series_eltype(s), Tg)
+    Tz = _output_eltype(_series_eltype(s), eltype(cache.x))
     n = length(first(vecs))
-    z = acquire!(pool, Tv_out, n)
+    z = acquire!(pool, Tz, n)
     y_buf = acquire!(pool, Tv_out, n)
     @inbounds for k in eachindex(output)
         copyto!(y_buf, 1, vecs[k], 1, n)
@@ -120,7 +121,9 @@ end
     n_p = length(y_p_first)
 
     # Pre-compute anchors on the extended (inclusive) grid — once for all series
-    aq_vec = acquire!(pool, _CubicAnchoredQuery{Tg, Tq}, length(xqs))
+    # Tq widens when grid is Dual: promote_type(Float64, Dual) = Dual
+    Tq_w = promote_type(Tq, eltype(cache.x))
+    aq_vec = acquire!(pool, _CubicAnchoredQuery{eltype(cache.x), Tq_w}, length(xqs))
     searcher = _resolve_search(cache.x, xqs, search, nothing)
     _fill_anchors!(aq_vec, cache.x, xqs, Val(:cubic), true, searcher)
 
@@ -184,7 +187,8 @@ Build cache once → anchor once → solve+eval per y-vector with z-buffer reuse
     x = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
     _is_periodic_bc(bc) || _check_domain(x, xq, extrap)
     K = n_series(s)
-    output = Vector{_series_output_type(_value_type(_series_eltype(s), Tg), Tq)}(undef, K)
+    Tg_actual = eltype(x)
+    output = Vector{_series_output_type(_output_eltype(_series_eltype(s), Tg_actual), Tq)}(undef, K)
     searcher = _resolve_search(x, xq, search, hint)
     if _is_periodic_bc(bc)
         _cubic_oneshot_series_periodic!(output, x, s, xq, bc, deriv, autocache, searcher)
@@ -260,11 +264,13 @@ end
     cache = _get_cubic_cache(x, bc_pair, _effective_autocache(autocache, Tg))
 
     # Pre-compute anchors once (search Q times, not K×Q)
-    aq_vec = acquire!(pool, _CubicAnchoredQuery{Tg, Tq}, length(xqs))
+    Tq_w = promote_type(Tq, eltype(cache.x))
+    aq_vec = acquire!(pool, _CubicAnchoredQuery{eltype(cache.x), Tq_w}, length(xqs))
     searcher = _resolve_search(cache.x, xqs, search, nothing)
     _fill_anchors!(aq_vec, cache.x, xqs, Val(:cubic), extrap_eff isa WrapExtrap, searcher)
 
-    z = acquire!(pool, Tv_out, n)
+    Tz = _output_eltype(_series_eltype(s), eltype(cache.x))
+    z = acquire!(pool, Tz, n)
     y_buf = acquire!(pool, Tv_out, n)
 
     # Solve z for series k, then eval at all query points before moving to k+1.

--- a/src/cubic/cubic_oneshot_series.jl
+++ b/src/cubic/cubic_oneshot_series.jl
@@ -297,7 +297,8 @@ function cubic_interp(
         search::AbstractSearchPolicy = AutoSearch()
     ) where {Tg,Tq <: Real}
     K = n_series(s)
-    Tv = _series_output_type(_value_type(_series_eltype(s), Tg), Tq)
+    Tg_float = _promote_grid_float(Tg, _series_eltype(s))
+    Tv = _series_output_type(_output_eltype(_series_eltype(s), Tg_float), Tq)
     outputs = [Vector{Tv}(undef, length(xqs)) for _ in 1:K]
     cubic_interp!(outputs, x, s, xqs; bc, extrap, autocache, deriv, search)
     return outputs

--- a/src/cubic/cubic_oneshot_series.jl
+++ b/src/cubic/cubic_oneshot_series.jl
@@ -106,7 +106,7 @@ end
         op::AbstractEvalOp,
         autocache::Bool,
         search::AbstractSearchPolicy
-    ) where {Tg,Tq <: Real}
+    ) where {Tg, Tq <: Real}
     vecs = _series_vectors(s)
     n = length(x)
     K = n_series(s)
@@ -182,7 +182,7 @@ Build cache once → anchor once → solve+eval per y-vector with z-buffer reuse
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg,Tq <: Real}
+    ) where {Tg, Tq <: Real}
     _validate_series_lengths(s, length(x))
     x = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
     _is_periodic_bc(bc) || _check_domain(x, xq, extrap)
@@ -212,7 +212,7 @@ end
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg,Tq <: Real}
+    ) where {Tg, Tq <: Real}
     _validate_series_lengths(s, length(x))
     length(output) == n_series(s) || _throw_series_dim_mismatch(length(output), n_series(s))
     x = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
@@ -243,7 +243,7 @@ end
         autocache::Bool = true,
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg,Tq <: Real}
+    ) where {Tg, Tq <: Real}
     _validate_series_lengths(s, length(x))
     x = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
     K = n_series(s)
@@ -295,7 +295,7 @@ function cubic_interp(
         autocache::Bool = true,
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg,Tq <: Real}
+    ) where {Tg, Tq <: Real}
     K = n_series(s)
     Tg_float = _promote_grid_float(Tg, _series_eltype(s))
     Tv = _series_output_type(_output_eltype(_series_eltype(s), Tg_float), Tq)

--- a/src/cubic/cubic_series_interp.jl
+++ b/src/cubic/cubic_series_interp.jl
@@ -84,11 +84,12 @@ mutable struct CubicSeriesInterpolant{
         B,
         E <: AbstractExtrap,
         P <: AbstractSearchPolicy,
+        Tz,
     } <: AbstractSeriesInterpolant{Tg, Tv}
     const cache::C                    # Shared cache with LU factorization
     const bc_for_solve::B             # BC config for solving
     const y::Matrix{Tv}               # Series-contiguous y (n_points × n_series)
-    const z::Matrix{Tv}               # Series-contiguous z (n_points × n_series)
+    const z::Matrix{Tz}               # Series-contiguous z: Tz = _output_eltype(Tv, Tg)
     const _transpose::LazyTransposePair{Tv}  # Lazy point-contiguous layout (shared infra)
     const extrap::E                   # Extrapolation mode (compile-time specialized)
     const search_policy::P            # Default search policy (immutable, thread-safe)
@@ -97,12 +98,13 @@ mutable struct CubicSeriesInterpolant{
             cache::C,
             bc_for_solve::B,
             y::Matrix{Tv},
-            z::Matrix{Tv},
+            z::Matrix,
             extrap::E,
             search::P = AutoSearch()
         ) where {Tg, Tv, C <: CubicSplineCache{Tg}, B, E <: AbstractExtrap, P <: AbstractSearchPolicy}
+        Tz = eltype(z)
         # y/z are NOT copied here — factory function provides owned matrices.
-        return new{Tg, Tv, C, B, E, P}(
+        return new{Tg, Tv, C, B, E, P, Tz}(
             cache, bc_for_solve, y, z,
             LazyTransposePair{Tv}(),
             extrap, search
@@ -498,11 +500,11 @@ end
 Solve cubic spline systems for all series using shared LU factorization.
 """
 @with_pool pool function _solve_series_coefficients!(
-        z_mat::Matrix{Tv},
+        z_mat::Matrix{Tz},
         y_mat::Matrix{Tv},
         cache::CubicSplineCache{Tg},
         bc_for_solve
-    ) where {Tg, Tv}
+    ) where {Tz, Tv, Tg}
     n_series_count = size(y_mat, 2)
 
     # Solve each series column
@@ -528,13 +530,13 @@ Groups series by BC type for cache efficiency.
 - `autocache`: Whether to use cache pool
 """
 @with_pool pool function _solve_series_with_bc_array!(
-        z_mat::Matrix{Tv},
+        z_mat::Matrix{Tz},
         y_mat::Matrix{Tv},
         x::AbstractVector{Tg},
         bc_cache_array::AbstractVector{<:BCPair},
         bc_solve_array::AbstractVector{<:BCPair},
         autocache::Bool
-    ) where {Tg, Tv}
+    ) where {Tz, Tv, Tg}
     n_series = size(y_mat, 2)
 
     # Group series by BC type for cache reuse (using Tg-typed BCs for matrix structure)
@@ -643,7 +645,9 @@ function cubic_interp(
     end
 
     # Build z matrix by solving tridiagonal systems
-    z_mat = Matrix{Tv_out}(undef, n_pts, n_ser)
+    # z coefficients mix y (Tv_out) with grid spacing (Tg) → Dual when grid is Dual
+    Tz = _output_eltype(Tv_out, Tg)
+    z_mat = Matrix{Tz}(undef, n_pts, n_ser)
 
     if bc isa AbstractVector
         # Per-series BC array: Tg-typed for cache matrix, Tv-typed for RHS
@@ -703,8 +707,9 @@ function _build_series_periodic(
     # Get periodic cache
     cache = _get_cubic_cache(x, PeriodicBC(), _effective_autocache(autocache, eltype(x)))
 
-    # Build z matrix
-    z_mat = Matrix{Tv}(undef, n_pts, n_series_count)
+    # Build z matrix (Dual when grid is Dual)
+    Tz = _output_eltype(Tv, eltype(cache.x))
+    z_mat = Matrix{Tz}(undef, n_pts, n_series_count)
     _solve_series_coefficients!(z_mat, y_mat, cache, cache.bc_config)
 
     # Periodic BC always uses wrap extrapolation
@@ -858,9 +863,9 @@ Builds anchors from original `xq` (preserving precision in weights) for scalar/v
         end
     end
 
-    # Build anchors - pool handles both Tq===Tg and mixed-type cases
-    # Each unique type combination gets its own pool slot
-    aq_vec = acquire!(pool, _CubicAnchoredQuery{Tg, Tq}, n_query)
+    # Build anchors — Tq widens via promote_type (Float32 on Float64 grid → Float64)
+    Tq_w = promote_type(Tq, Tg)
+    aq_vec = acquire!(pool, _CubicAnchoredQuery{Tg, Tq_w}, n_query)
     searcher = _resolve_search(sitp.cache.x, xq, search, hint)
     _fill_anchors!(aq_vec, sitp.cache.x, xq, Val(:cubic), _should_wrap(sitp), searcher)
 

--- a/src/cubic/cubic_series_interp.jl
+++ b/src/cubic/cubic_series_interp.jl
@@ -805,7 +805,7 @@ function (sitp::CubicSeriesInterpolant{Tg, Tv})(
     ) where {Tg, Tv, Tq <: Real}
     n_query = length(xq)
     n_ser = n_series(sitp)
-    T_out = _series_output_type(Tv, Tq)
+    T_out = _series_output_type(_output_eltype(Tv, Tg), Tq)
 
     # Explicit Vector{Vector{T_out}} for type stability on Julia LTS
     outputs = Vector{Vector{T_out}}(undef, n_ser)
@@ -953,9 +953,9 @@ Internal: Evaluate a single series for vector of query points.
 Uses argument-passing pattern for optimal performance (avoids struct field access in loop).
 """
 @inline function _eval_series_vector!(
-        out::AbstractVector{Tv},
+        out::AbstractVector,
         y::Matrix{Tv},
-        z::Matrix{Tv},
+        z::Matrix{Tz},
         n_pts::Int,
         x_min::Tg,
         x_max::Tg,
@@ -963,7 +963,7 @@ Uses argument-passing pattern for optimal performance (avoids struct field acces
         aq_vec::AbstractVector{<:_CubicAnchoredQuery{Tg}},
         extrap::AbstractExtrap,
         op::AbstractEvalOp
-    ) where {Tg, Tv}
+    ) where {Tg, Tv, Tz}
     @inbounds for j in eachindex(out, aq_vec)
         out[j] = _eval_series_with_extrap(y, z, n_pts, x_min, x_max, k, aq_vec[j], extrap, op)
     end
@@ -976,7 +976,7 @@ Takes matrices as arguments for optimal performance.
 """
 @inline function _eval_series_with_extrap(
         y::Matrix{Tv},
-        z::Matrix{Tv},
+        z::Matrix{Tz},
         n_pts::Int,
         x_min::Tg,
         x_max::Tg,
@@ -984,7 +984,7 @@ Takes matrices as arguments for optimal performance.
         aq::_CubicAnchoredQuery{Tg},
         extrap::AbstractExtrap,
         op::AbstractEvalOp
-    ) where {Tg, Tv}
+    ) where {Tg, Tv, Tz}
     # Inside domain: normal evaluation
     if aq.state == IN_DOMAIN
         return _eval_series_anchored(y, z, k, aq, op)
@@ -1011,11 +1011,11 @@ Dispatches on concrete EvalOp for optimal performance:
 # EvalValue: Full 4-term evaluation
 @inline function _eval_series_anchored(
         y::Matrix{Tv},
-        z::Matrix{Tv},
+        z::Matrix{Tz},
         k::Int,
         aq::_CubicAnchoredQuery{Tg},
         ::EvalValue
-    ) where {Tg, Tv}
+    ) where {Tg, Tv, Tz}
     idx = aq.idx
     wyL, wyR, wzL, wzR = aq.w0
     @inbounds begin
@@ -1030,11 +1030,11 @@ end
 # EvalDeriv1: Full 4-term evaluation
 @inline function _eval_series_anchored(
         y::Matrix{Tv},
-        z::Matrix{Tv},
+        z::Matrix{Tz},
         k::Int,
         aq::_CubicAnchoredQuery{Tg},
         ::EvalDeriv1
-    ) where {Tg, Tv}
+    ) where {Tg, Tv, Tz}
     idx = aq.idx
     wyL, wyR, wzL, wzR = aq.w1
     @inbounds begin
@@ -1049,11 +1049,11 @@ end
 # EvalDeriv2: Optimized 2-term evaluation (no y-loads)
 @inline function _eval_series_anchored(
         y::Matrix{Tv},
-        z::Matrix{Tv},
+        z::Matrix{Tz},
         k::Int,
         aq::_CubicAnchoredQuery{Tg},
         ::EvalDeriv2
-    ) where {Tg, Tv}
+    ) where {Tg, Tv, Tz}
     idx = aq.idx
     wzL, wzR = aq.w2
     @inbounds begin
@@ -1065,11 +1065,11 @@ end
 
 @inline function _eval_series_anchored(
         y::Matrix{Tv},
-        z::Matrix{Tv},
+        z::Matrix{Tz},
         k::Int,
         aq::_CubicAnchoredQuery{Tg},
         ::DerivOp{N}
-    ) where {Tg, Tv, N}
+    ) where {Tg, Tv, Tz, N}
     @inbounds yL = y[aq.idx, k]
     return 0 * yL
 end
@@ -1077,11 +1077,11 @@ end
 # EvalDeriv3: Optimized 2-term evaluation (no y-loads)
 @inline function _eval_series_anchored(
         y::Matrix{Tv},
-        z::Matrix{Tv},
+        z::Matrix{Tz},
         k::Int,
         aq::_CubicAnchoredQuery{Tg},
         ::EvalDeriv3
-    ) where {Tg, Tv}
+    ) where {Tg, Tv, Tz}
     idx = aq.idx
     wzL, wzR = aq.w3
     @inbounds begin

--- a/src/cubic/cubic_series_interp.jl
+++ b/src/cubic/cubic_series_interp.jl
@@ -78,7 +78,7 @@ cannot be reassigned while allowing heap allocation. This pattern provides:
 Benchmarks show ~15% regression when using plain `struct` instead.
 """
 mutable struct CubicSeriesInterpolant{
-        Tg <: AbstractFloat,
+        Tg,
         Tv,
         C <: CubicSplineCache{Tg},
         B,
@@ -100,7 +100,7 @@ mutable struct CubicSeriesInterpolant{
             z::Matrix{Tv},
             extrap::E,
             search::P = AutoSearch()
-        ) where {Tg <: AbstractFloat, Tv, C <: CubicSplineCache{Tg}, B, E <: AbstractExtrap, P <: AbstractSearchPolicy}
+        ) where {Tg, Tv, C <: CubicSplineCache{Tg}, B, E <: AbstractExtrap, P <: AbstractSearchPolicy}
         # y/z are NOT copied here — factory function provides owned matrices.
         return new{Tg, Tv, C, B, E, P}(
             cache, bc_for_solve, y, z,
@@ -162,7 +162,7 @@ When `aq` has Dual type weights (from Dual query), the output will have promoted
         sitp::CubicSeriesInterpolant{Tg, Tv},
         aq::_CubicAnchoredQuery{Tg, Tq},
         op::AbstractEvalOp
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     y_point, z_point = _ensure_point_layout!(sitp)
     n_pts = n_points(sitp)
     x_min, x_max = Tg(first(sitp.cache.x)), Tg(last(sitp.cache.x))
@@ -216,7 +216,7 @@ Dispatches on concrete EvalOp for optimal performance:
         z_point::Matrix{Tv},
         aq::_CubicAnchoredQuery{Tg, Tq},
         ::EvalValue
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     idx = aq.idx
     idx1 = idx + 1
     wyL, wyR, wzL, wzR = aq.w0
@@ -238,7 +238,7 @@ end
         z_point::Matrix{Tv},
         aq::_CubicAnchoredQuery{Tg, Tq},
         ::EvalDeriv1
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     idx = aq.idx
     idx1 = idx + 1
     wyL, wyR, wzL, wzR = aq.w1
@@ -260,7 +260,7 @@ end
         z_point::Matrix{Tv},
         aq::_CubicAnchoredQuery{Tg, Tq},
         ::EvalDeriv2
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     idx = aq.idx
     idx1 = idx + 1
     wzL, wzR = aq.w2
@@ -280,7 +280,7 @@ end
         z_point::Matrix{Tv},
         aq::_CubicAnchoredQuery{Tg, Tq},
         ::EvalDeriv3
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     idx = aq.idx
     idx1 = idx + 1
     wzL, wzR = aq.w3
@@ -299,7 +299,7 @@ end
         z_point::Matrix{Tv},
         aq::_CubicAnchoredQuery{Tg, Tq},
         ::DerivOp{N}
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real, N}
+    ) where {Tg, Tv, Tq <: Real, N}
     z = 0 * (@inbounds y_point[1, aq.idx])
     @inbounds @simd for k in axes(out, 1)
         out[k] = z
@@ -322,7 +322,7 @@ SIMD evaluation with extrapolation handling for multi-series.
         aq::_CubicAnchoredQuery{Tg, Tq},
         extrap::AbstractExtrap,
         op::AbstractEvalOp
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     # Inside domain: normal evaluation
     if aq.state == IN_DOMAIN
         return _eval_series_point!(out, y_point, z_point, aq, op)
@@ -344,7 +344,7 @@ end
         ::NoExtrap,
         ::AbstractEvalOp,
         ::UInt8
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     _throw_extrap_domain_error(aq.xq, x_min, x_max)
 end
 
@@ -360,7 +360,7 @@ end
         extrap::_ClampOrFill,
         op::AbstractEvalOp,
         side::UInt8
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     return _fill_constant_extrap_simd!(out, y_point, side, n_pts, op, extrap)
 end
 
@@ -376,7 +376,7 @@ end
         ::ExtendExtrap,
         ::EvalValue,
         side::UInt8
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     idx = side == OOB_LEFT ? 1 : (n_pts - 1)
     idx1 = idx + 1
     wyL, wyR, wzL, wzR = aq.w0
@@ -403,7 +403,7 @@ end
         ::ExtendExtrap,
         ::EvalDeriv1,
         side::UInt8
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     idx = side == OOB_LEFT ? 1 : (n_pts - 1)
     idx1 = idx + 1
     wyL, wyR, wzL, wzR = aq.w1
@@ -430,7 +430,7 @@ end
         ::ExtendExtrap,
         ::EvalDeriv2,
         side::UInt8
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     idx = side == OOB_LEFT ? 1 : (n_pts - 1)
     idx1 = idx + 1
     wzL, wzR = aq.w2
@@ -455,7 +455,7 @@ end
         ::ExtendExtrap,
         ::EvalDeriv3,
         side::UInt8
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     idx = side == OOB_LEFT ? 1 : (n_pts - 1)
     idx1 = idx + 1
     wzL, wzR = aq.w3
@@ -480,7 +480,7 @@ end
         ::ExtendExtrap,
         ::DerivOp{N},
         ::UInt8
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real, N}
+    ) where {Tg, Tv, Tq <: Real, N}
     z = 0 * first(y_point)
     @inbounds @simd for k in axes(out, 1)
         out[k] = z
@@ -502,7 +502,7 @@ Solve cubic spline systems for all series using shared LU factorization.
         y_mat::Matrix{Tv},
         cache::CubicSplineCache{Tg},
         bc_for_solve
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     n_series_count = size(y_mat, 2)
 
     # Solve each series column
@@ -534,7 +534,7 @@ Groups series by BC type for cache efficiency.
         bc_cache_array::AbstractVector{<:BCPair},
         bc_solve_array::AbstractVector{<:BCPair},
         autocache::Bool
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     n_series = size(y_mat, 2)
 
     # Group series by BC type for cache reuse (using Tg-typed BCs for matrix structure)
@@ -550,7 +550,7 @@ Groups series by BC type for cache efficiency.
             push!(type_groups[bc_type][2], k)
         else
             # New BC type → get cache from pool
-            cache = _get_cubic_cache(x, bc, autocache)
+            cache = _get_cubic_cache(x, bc, _effective_autocache(autocache, eltype(x)))
             type_groups[bc_type] = (cache, [k])
         end
     end
@@ -618,7 +618,7 @@ function cubic_interp(
         autocache::Bool = true,
         precompute_transpose::Bool = false,
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat}
+    ) where {Tg}
     # Type promotion: widen grid if y's float base is wider than Tg
     Tv = _series_eltype(s)
     Tg_new = _promote_grid_float(Tg, Tv)
@@ -651,12 +651,12 @@ function cubic_interp(
         bc_solve_array = _normalize_bc_array(bc, Tv_out, n_ser)
         _solve_series_with_bc_array!(z_mat, y_mat, x, bc_cache_array, bc_solve_array, autocache)
         bc_representative = bc_cache_array[1]
-        cache = _get_cubic_cache(x, bc_representative, autocache)
+        cache = _get_cubic_cache(x, bc_representative, _effective_autocache(autocache, eltype(x)))
     else
         # Uniform BC: Tg-typed for cache matrix, Tv-typed for RHS
         bc_for_cache = _normalize_bc(bc, Tg)
         bc_for_solve = _normalize_bc(bc, first(y_mat))
-        cache = _get_cubic_cache(x, bc_for_cache, autocache)
+        cache = _get_cubic_cache(x, bc_for_cache, _effective_autocache(autocache, eltype(x)))
         _solve_series_coefficients!(z_mat, y_mat, cache, bc_for_solve)
         bc_representative = bc_for_cache
     end
@@ -672,21 +672,9 @@ function cubic_interp(
 end
 
 # Real grid promotion (Int, etc.) → convert to float and delegate
-function cubic_interp(
-        x::AbstractVector{Tg},
-        s::Series;
-        bc::Union{AbstractBC, AbstractVector{<:AbstractBC}} = CubicFit(),
-        extrap::AbstractExtrap = NoExtrap(),
-        autocache::Bool = true,
-        precompute_transpose::Bool = false,
-        search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: Real}
-    Tg_float = _promote_grid_float(Tg, _series_eltype(s))
-    return cubic_interp(
-        _to_float(x, Tg_float), s;
-        bc = _promote_bc(bc, Tg_float), extrap, autocache, precompute_transpose, search
-    )
-end
+
+# Note: Real wrapper (Tg <: Real) removed — typed method above handles
+# all grid types including ForwardDiff.Dual via _to_float + _promote_grid_float.
 
 """
 Internal helper for periodic BC multi-interpolant construction.
@@ -700,7 +688,7 @@ function _build_series_periodic(
         autocache::Bool,
         precompute_transpose::Bool,
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     # Extend data for exclusive endpoint
     x, y_mat = _prepare_periodic(x, y_mat, bc)
     n_pts = size(y_mat, 1)
@@ -713,7 +701,7 @@ function _build_series_periodic(
     end
 
     # Get periodic cache
-    cache = _get_cubic_cache(x, PeriodicBC(), autocache)
+    cache = _get_cubic_cache(x, PeriodicBC(), _effective_autocache(autocache, eltype(x)))
 
     # Build z matrix
     z_mat = Matrix{Tv}(undef, n_pts, n_series_count)
@@ -749,7 +737,7 @@ function (sitp::CubicSeriesInterpolant{Tg, Tv})(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     # Promote for anchor: Int→Float, Int-backed Dual→Float-backed Dual (no-op for Float/Float-backed Dual)
     xq_promoted = _promote_for_anchor(xq, Tg)
     T_out = _series_output_type(Tv, typeof(xq_promoted))
@@ -776,7 +764,7 @@ function (sitp::CubicSeriesInterpolant{Tg, Tv})(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     _validate_scalar_output(output, n_series(sitp))
 
     # Promote for anchor: Int→Float, Int-backed Dual→Float-backed Dual
@@ -809,7 +797,7 @@ function (sitp::CubicSeriesInterpolant{Tg, Tv})(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     n_query = length(xq)
     n_ser = n_series(sitp)
     T_out = _series_output_type(Tv, Tq)
@@ -848,7 +836,7 @@ Builds anchors from original `xq` (preserving precision in weights) for scalar/v
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tq <: Real}
     n_query = length(xq)
     n_ser = n_series(sitp)
 
@@ -895,7 +883,7 @@ Builds anchors from original `xq` (preserving precision in weights) for scalar/v
 end
 
 """
-    (sitp::CubicSeriesInterpolant)(outputs, aq_vec::AbstractVector{<:_CubicAnchoredQuery{Tg,Tq}}; deriv=EvalValue()) where {Tg<:AbstractFloat, Tq<:Real}
+    (sitp::CubicSeriesInterpolant)(outputs, aq_vec::AbstractVector{<:_CubicAnchoredQuery{Tg,Tq}}; deriv=EvalValue()) where {Tg, Tq<:Real}
 
 Evaluate multi-Y interpolant with pre-built anchors (TRUE zero-allocation).
 
@@ -919,7 +907,7 @@ function (sitp::CubicSeriesInterpolant{Tg, Tv})(
         outputs::AbstractVector{<:AbstractVector{Tv}},
         aq_vec::AbstractVector{<:_CubicAnchoredQuery{Tg}};
         deriv::DerivOp = EvalValue()
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     n_query = length(aq_vec)
     n_ser = n_series(sitp)
 
@@ -970,7 +958,7 @@ Uses argument-passing pattern for optimal performance (avoids struct field acces
         aq_vec::AbstractVector{<:_CubicAnchoredQuery{Tg}},
         extrap::AbstractExtrap,
         op::AbstractEvalOp
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     @inbounds for j in eachindex(out, aq_vec)
         out[j] = _eval_series_with_extrap(y, z, n_pts, x_min, x_max, k, aq_vec[j], extrap, op)
     end
@@ -991,7 +979,7 @@ Takes matrices as arguments for optimal performance.
         aq::_CubicAnchoredQuery{Tg},
         extrap::AbstractExtrap,
         op::AbstractEvalOp
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     # Inside domain: normal evaluation
     if aq.state == IN_DOMAIN
         return _eval_series_anchored(y, z, k, aq, op)
@@ -1022,7 +1010,7 @@ Dispatches on concrete EvalOp for optimal performance:
         k::Int,
         aq::_CubicAnchoredQuery{Tg},
         ::EvalValue
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     idx = aq.idx
     wyL, wyR, wzL, wzR = aq.w0
     @inbounds begin
@@ -1041,7 +1029,7 @@ end
         k::Int,
         aq::_CubicAnchoredQuery{Tg},
         ::EvalDeriv1
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     idx = aq.idx
     wyL, wyR, wzL, wzR = aq.w1
     @inbounds begin
@@ -1060,7 +1048,7 @@ end
         k::Int,
         aq::_CubicAnchoredQuery{Tg},
         ::EvalDeriv2
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     idx = aq.idx
     wzL, wzR = aq.w2
     @inbounds begin
@@ -1076,7 +1064,7 @@ end
         k::Int,
         aq::_CubicAnchoredQuery{Tg},
         ::DerivOp{N}
-    ) where {Tg <: AbstractFloat, Tv, N}
+    ) where {Tg, Tv, N}
     @inbounds yL = y[aq.idx, k]
     return 0 * yL
 end
@@ -1088,7 +1076,7 @@ end
         k::Int,
         aq::_CubicAnchoredQuery{Tg},
         ::EvalDeriv3
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg, Tv}
     idx = aq.idx
     wzL, wzR = aq.w3
     @inbounds begin

--- a/src/cubic/cubic_series_interp.jl
+++ b/src/cubic/cubic_series_interp.jl
@@ -90,7 +90,7 @@ mutable struct CubicSeriesInterpolant{
     const bc_for_solve::B             # BC config for solving
     const y::Matrix{Tv}               # Series-contiguous y (n_points × n_series)
     const z::Matrix{Tz}               # Series-contiguous z: Tz = _output_eltype(Tv, Tg)
-    const _transpose::LazyTransposePair{Tv}  # Lazy point-contiguous layout (shared infra)
+    const _transpose::LazyTransposePair{Tv, Tz}  # Lazy point-contiguous layout
     const extrap::E                   # Extrapolation mode (compile-time specialized)
     const search_policy::P            # Default search policy (immutable, thread-safe)
 
@@ -106,7 +106,7 @@ mutable struct CubicSeriesInterpolant{
         # y/z are NOT copied here — factory function provides owned matrices.
         return new{Tg, Tv, C, B, E, P, Tz}(
             cache, bc_for_solve, y, z,
-            LazyTransposePair{Tv}(),
+            LazyTransposePair{Tv, Tz}(),
             extrap, search
         )
     end
@@ -215,10 +215,10 @@ Dispatches on concrete EvalOp for optimal performance:
 @inline function _eval_series_point!(
         out::AbstractVector,
         y_point::Matrix{Tv},
-        z_point::Matrix{Tv},
+        z_point::Matrix{Tz},
         aq::_CubicAnchoredQuery{Tg, Tq},
         ::EvalValue
-    ) where {Tg, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tz, Tq <: Real}
     idx = aq.idx
     idx1 = idx + 1
     wyL, wyR, wzL, wzR = aq.w0
@@ -237,10 +237,10 @@ end
 @inline function _eval_series_point!(
         out::AbstractVector,
         y_point::Matrix{Tv},
-        z_point::Matrix{Tv},
+        z_point::Matrix{Tz},
         aq::_CubicAnchoredQuery{Tg, Tq},
         ::EvalDeriv1
-    ) where {Tg, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tz, Tq <: Real}
     idx = aq.idx
     idx1 = idx + 1
     wyL, wyR, wzL, wzR = aq.w1
@@ -259,10 +259,10 @@ end
 @inline function _eval_series_point!(
         out::AbstractVector,
         y_point::Matrix{Tv},
-        z_point::Matrix{Tv},
+        z_point::Matrix{Tz},
         aq::_CubicAnchoredQuery{Tg, Tq},
         ::EvalDeriv2
-    ) where {Tg, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tz, Tq <: Real}
     idx = aq.idx
     idx1 = idx + 1
     wzL, wzR = aq.w2
@@ -279,10 +279,10 @@ end
 @inline function _eval_series_point!(
         out::AbstractVector,
         y_point::Matrix{Tv},
-        z_point::Matrix{Tv},
+        z_point::Matrix{Tz},
         aq::_CubicAnchoredQuery{Tg, Tq},
         ::EvalDeriv3
-    ) where {Tg, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tz, Tq <: Real}
     idx = aq.idx
     idx1 = idx + 1
     wzL, wzR = aq.w3
@@ -298,10 +298,10 @@ end
 @inline function _eval_series_point!(
         out::AbstractVector,
         y_point::Matrix{Tv},
-        z_point::Matrix{Tv},
+        z_point::Matrix{Tz},
         aq::_CubicAnchoredQuery{Tg, Tq},
         ::DerivOp{N}
-    ) where {Tg, Tv, Tq <: Real, N}
+    ) where {Tg, Tv, Tz, Tq <: Real, N}
     z = 0 * (@inbounds y_point[1, aq.idx])
     @inbounds @simd for k in axes(out, 1)
         out[k] = z
@@ -317,14 +317,14 @@ SIMD evaluation with extrapolation handling for multi-series.
 @inline function _eval_series_point_with_extrap!(
         out::AbstractVector,
         y_point::Matrix{Tv},
-        z_point::Matrix{Tv},
+        z_point::Matrix{Tz},
         n_pts::Int,
         x_min::Tg,
         x_max::Tg,
         aq::_CubicAnchoredQuery{Tg, Tq},
         extrap::AbstractExtrap,
         op::AbstractEvalOp
-    ) where {Tg, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tz, Tq <: Real}
     # Inside domain: normal evaluation
     if aq.state == IN_DOMAIN
         return _eval_series_point!(out, y_point, z_point, aq, op)
@@ -370,7 +370,7 @@ end
 @inline function _eval_series_point_extrap!(
         out::AbstractVector,
         y_point::Matrix{Tv},
-        z_point::Matrix{Tv},
+        z_point::Matrix{Tz},
         n_pts::Int,
         ::Tg,
         ::Tg,
@@ -378,7 +378,7 @@ end
         ::ExtendExtrap,
         ::EvalValue,
         side::UInt8
-    ) where {Tg, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tz, Tq <: Real}
     idx = side == OOB_LEFT ? 1 : (n_pts - 1)
     idx1 = idx + 1
     wyL, wyR, wzL, wzR = aq.w0
@@ -397,7 +397,7 @@ end
 @inline function _eval_series_point_extrap!(
         out::AbstractVector,
         y_point::Matrix{Tv},
-        z_point::Matrix{Tv},
+        z_point::Matrix{Tz},
         n_pts::Int,
         ::Tg,
         ::Tg,
@@ -405,7 +405,7 @@ end
         ::ExtendExtrap,
         ::EvalDeriv1,
         side::UInt8
-    ) where {Tg, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tz, Tq <: Real}
     idx = side == OOB_LEFT ? 1 : (n_pts - 1)
     idx1 = idx + 1
     wyL, wyR, wzL, wzR = aq.w1
@@ -424,7 +424,7 @@ end
 @inline function _eval_series_point_extrap!(
         out::AbstractVector,
         y_point::Matrix{Tv},
-        z_point::Matrix{Tv},
+        z_point::Matrix{Tz},
         n_pts::Int,
         ::Tg,
         ::Tg,
@@ -432,7 +432,7 @@ end
         ::ExtendExtrap,
         ::EvalDeriv2,
         side::UInt8
-    ) where {Tg, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tz, Tq <: Real}
     idx = side == OOB_LEFT ? 1 : (n_pts - 1)
     idx1 = idx + 1
     wzL, wzR = aq.w2
@@ -449,7 +449,7 @@ end
 @inline function _eval_series_point_extrap!(
         out::AbstractVector,
         y_point::Matrix{Tv},
-        z_point::Matrix{Tv},
+        z_point::Matrix{Tz},
         n_pts::Int,
         ::Tg,
         ::Tg,
@@ -457,7 +457,7 @@ end
         ::ExtendExtrap,
         ::EvalDeriv3,
         side::UInt8
-    ) where {Tg, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tz, Tq <: Real}
     idx = side == OOB_LEFT ? 1 : (n_pts - 1)
     idx1 = idx + 1
     wzL, wzR = aq.w3
@@ -745,7 +745,7 @@ function (sitp::CubicSeriesInterpolant{Tg, Tv})(
     ) where {Tg, Tv, Tq <: Real}
     # Promote for anchor: Int→Float, Int-backed Dual→Float-backed Dual (no-op for Float/Float-backed Dual)
     xq_promoted = _promote_for_anchor(xq, Tg)
-    T_out = _series_output_type(Tv, typeof(xq_promoted))
+    T_out = _series_output_type(_output_eltype(Tv, Tg), typeof(xq_promoted))
     output = Vector{T_out}(undef, n_series(sitp))
 
     # Build anchor preserving Dual type in xq

--- a/src/cubic/cubic_solver.jl
+++ b/src/cubic/cubic_solver.jl
@@ -222,12 +222,13 @@ end
 # ----------------------------------------
 # All helpers now accept x parameter for consistency; existing BCs ignore it.
 # CubicFit (PolyFit{3}) uses x to compute endpoint derivatives from data.
-# Tg = grid type (x, spacing), Tv = value type (y, d, bc.val)
+# Tg = grid type (x, spacing). d (RHS buffer) may have wider eltype than y
+# when grid is duck-typed (e.g. Dual): d = _output_eltype(Tv, Tg).
 
 # First element - Deriv2: d[1] = bc.val (second derivative value)
 @inline function _compute_rhs_first!(
         d::AbstractVector, bc::Deriv2, ::AbstractVector, ::AbstractVector{Tg}, ::AbstractGridSpacing{Tg}
-    ) where {Tg,Tv}
+    ) where {Tg}
     d[1] = convert(eltype(d), bc.val)
     return nothing
 end
@@ -235,7 +236,7 @@ end
 # First element - Deriv1: d[1] = 6[(y₂-y₁)/h₁ - S'(x₁)]
 @inline function _compute_rhs_first!(
         d::AbstractVector, bc::Deriv1, y::AbstractVector, ::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
-    ) where {Tg,Tv}
+    ) where {Tg}
     d[1] = 6 * ((y[2] - y[1]) * _get_inv_h(spacing, 1) - convert(eltype(d), bc.val))
     return nothing
 end
@@ -243,7 +244,7 @@ end
 # Last element - Deriv2: d[end] = bc.val (second derivative value)
 @inline function _compute_rhs_last!(
         d::AbstractVector, bc::Deriv2, ::AbstractVector, ::AbstractVector{Tg}, ::AbstractGridSpacing{Tg}
-    ) where {Tg,Tv}
+    ) where {Tg}
     d[end] = convert(eltype(d), bc.val)
     return nothing
 end
@@ -251,7 +252,7 @@ end
 # Last element - Deriv1: d[end] = 6[S'(x_end) - (y_end - y_{end-1}) / h_end]
 @inline function _compute_rhs_last!(
         d::AbstractVector, bc::Deriv1, y::AbstractVector, ::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
-    ) where {Tg,Tv}
+    ) where {Tg}
     n = length(y) - 1
     d[end] = 6 * (convert(eltype(d), bc.val) - (y[end] - y[end - 1]) * _get_inv_h(spacing, n))
     return nothing
@@ -260,7 +261,7 @@ end
 # First element - Deriv3: d[1] = h[1] * bc.val (from -z[1] + z[2] = h[1] * val)
 @inline function _compute_rhs_first!(
         d::AbstractVector, bc::Deriv3, ::AbstractVector, ::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
-    ) where {Tg,Tv}
+    ) where {Tg}
     d[1] = _get_h(spacing, 1) * convert(eltype(d), bc.val)
     return nothing
 end
@@ -268,7 +269,7 @@ end
 # Last element - Deriv3: d[end] = h[n] * bc.val (from -z[n] + z[n+1] = h[n] * val)
 @inline function _compute_rhs_last!(
         d::AbstractVector, bc::Deriv3, ::AbstractVector, ::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
-    ) where {Tg,Tv}
+    ) where {Tg}
     n = length(d) - 1
     d[end] = _get_h(spacing, n) * convert(eltype(d), bc.val)
     return nothing
@@ -278,7 +279,7 @@ end
 # Supports all polynomial degrees: LinearFit (D=1), QuadraticFit (D=2), CubicFit (D=3), etc.
 @inline function _compute_rhs_first!(
         d::AbstractVector, bc::PolyFit{D}, y::AbstractVector, x::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
-    ) where {D, Tg,Tv}
+    ) where {D, Tg}
     # Materialize PolyFit{D} → Deriv1 using estimated derivative
     concrete_bc = materialize_bc(bc, x, y, LeftSide())
     # Delegate to existing Deriv1 code path
@@ -289,7 +290,7 @@ end
 # Last element - Generic PolyFit{D}: materialize to Deriv1, then delegate
 @inline function _compute_rhs_last!(
         d::AbstractVector, bc::PolyFit{D}, y::AbstractVector, x::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
-    ) where {D, Tg,Tv}
+    ) where {D, Tg}
     # Materialize PolyFit{D} → Deriv1 using estimated derivative
     concrete_bc = materialize_bc(bc, x, y, RightSide())
     # Delegate to existing Deriv1 code path
@@ -426,16 +427,15 @@ Thread-safe: workspaces allocated from task-local pool.
 Tg = grid type, Tv = value type (can be Complex)
 """
 @inline @with_pool pool function _solve_system!(
-        out_z::AbstractVector,
+        out_z::AbstractVector{Tz},
         cache::CubicSplineCache{Tg, X, F, PeriodicData{Tg}, S},
         y::AbstractVector,
         ::PeriodicData{Tg}  # Unused, for API consistency with BCPair version
-    ) where {Tg, X, F, S <: AbstractGridSpacing{Tg}}
+    ) where {Tz, Tg, X, F, S <: AbstractGridSpacing{Tg}}
     n = length(y) - 1
 
     # Periodic workspaces need n elements (NOT length(y)!)
     # Use pool allocation for zero-allocation hot path
-    Tz = eltype(out_z)
     y_temp = acquire!(pool, Tz, n)
 
     _solve_cubic_system_periodic!(out_z, y_temp, cache, y)

--- a/src/cubic/cubic_solver.jl
+++ b/src/cubic/cubic_solver.jl
@@ -15,7 +15,7 @@
 # First row - Deriv2 (second derivative specified): z[1] = bc.val
 @inline function _set_first_row!(
         d_diag::AbstractVector{Tg}, du::AbstractVector{Tg}, ::Deriv2, ::AbstractGridSpacing{Tg}
-    ) where {Tg <: AbstractFloat}
+    ) where {Tg}
     d_diag[1] = one(Tg)
     du[1] = zero(Tg)
     return nothing
@@ -24,7 +24,7 @@ end
 # First row - Deriv1 (first derivative specified): 2h₁z₁ + h₁z₂ = 6[(y₂-y₁)/h₁ - S'(x₁)]
 @inline function _set_first_row!(
         d_diag::AbstractVector{Tg}, du::AbstractVector{Tg}, ::Deriv1, spacing::AbstractGridSpacing{Tg}
-    ) where {Tg <: AbstractFloat}
+    ) where {Tg}
     h1 = _get_h(spacing, 1)
     d_diag[1] = 2 * h1
     du[1] = h1
@@ -34,7 +34,7 @@ end
 # Last row - Deriv2 (second derivative specified): matrix row enforces z[end] = bc.val
 @inline function _set_last_row!(
         dl::AbstractVector{Tg}, d_diag::AbstractVector{Tg}, ::Deriv2, ::AbstractGridSpacing{Tg}
-    ) where {Tg <: AbstractFloat}
+    ) where {Tg}
     dl[end] = zero(Tg)
     d_diag[end] = one(Tg)
     return nothing
@@ -43,7 +43,7 @@ end
 # Last row - Deriv1 (first derivative specified): hₙzₙ + 2hₙzₙ₊₁ = 6[S'(xₙ₊₁) - (yₙ₊₁-yₙ)/hₙ]
 @inline function _set_last_row!(
         dl::AbstractVector{Tg}, d_diag::AbstractVector{Tg}, ::Deriv1, spacing::AbstractGridSpacing{Tg}
-    ) where {Tg <: AbstractFloat}
+    ) where {Tg}
     # For the last row, we need h[n] which is the last spacing value
     # The number of spacing values is length(dl) for dl (n elements)
     n = length(dl)
@@ -57,7 +57,7 @@ end
 # Rearranged: -z[1] + z[2] = h[1] * val
 @inline function _set_first_row!(
         d_diag::AbstractVector{Tg}, du::AbstractVector{Tg}, ::Deriv3, ::AbstractGridSpacing{Tg}
-    ) where {Tg <: AbstractFloat}
+    ) where {Tg}
     d_diag[1] = -one(Tg)
     du[1] = one(Tg)
     return nothing
@@ -67,7 +67,7 @@ end
 # Rearranged: -z[n] + z[n+1] = h[n] * val
 @inline function _set_last_row!(
         dl::AbstractVector{Tg}, d_diag::AbstractVector{Tg}, ::Deriv3, ::AbstractGridSpacing{Tg}
-    ) where {Tg <: AbstractFloat}
+    ) where {Tg}
     dl[end] = -one(Tg)
     d_diag[end] = one(Tg)
     return nothing
@@ -77,7 +77,7 @@ end
 # The derivative value is computed from data in RHS, not specified by user
 @inline function _set_first_row!(
         d_diag::AbstractVector{Tg}, du::AbstractVector{Tg}, ::PolyFit{D}, spacing::AbstractGridSpacing{Tg}
-    ) where {D, Tg <: AbstractFloat}
+    ) where {D, Tg}
     h1 = _get_h(spacing, 1)
     d_diag[1] = 2 * h1
     du[1] = h1
@@ -87,7 +87,7 @@ end
 # Last row - PolyFit{D} (auto-estimated first derivative): same matrix structure as Deriv1
 @inline function _set_last_row!(
         dl::AbstractVector{Tg}, d_diag::AbstractVector{Tg}, ::PolyFit{D}, spacing::AbstractGridSpacing{Tg}
-    ) where {D, Tg <: AbstractFloat}
+    ) where {D, Tg}
     n = length(dl)
     h_n = _get_h(spacing, n)
     dl[end] = h_n
@@ -100,7 +100,7 @@ end
 # ========================================
 
 "Build cache for periodic cubic spline using Sherman-Morrison formula."
-function _build_periodic_cache(x::AbstractVector{T}) where {T <: AbstractFloat}
+function _build_periodic_cache(x::AbstractVector{T}) where {T}
     n = length(x) - 1  # Number of intervals
 
     n >= 3 || throw(ArgumentError("Periodic spline requires at least 4 points"))
@@ -167,7 +167,7 @@ function _build_derivative_bc_cache(
         x::AbstractVector{T},
         left_bc::L,
         right_bc::R
-    ) where {T <: AbstractFloat, L <: PointBC, R <: PointBC}
+    ) where {T, L <: PointBC, R <: PointBC}
     n = length(x) - 1
 
     # Validate PolyFit requirements: PolyFit{D} requires D+1 points
@@ -226,59 +226,59 @@ end
 
 # First element - Deriv2: d[1] = bc.val (second derivative value)
 @inline function _compute_rhs_first!(
-        d::AbstractVector{Tv}, bc::Deriv2, ::AbstractVector{Tv}, ::AbstractVector{Tg}, ::AbstractGridSpacing{Tg}
-    ) where {Tg <: AbstractFloat, Tv}
-    d[1] = convert(Tv, bc.val)
+        d::AbstractVector, bc::Deriv2, ::AbstractVector, ::AbstractVector{Tg}, ::AbstractGridSpacing{Tg}
+    ) where {Tg,Tv}
+    d[1] = convert(eltype(d), bc.val)
     return nothing
 end
 
 # First element - Deriv1: d[1] = 6[(y₂-y₁)/h₁ - S'(x₁)]
 @inline function _compute_rhs_first!(
-        d::AbstractVector{Tv}, bc::Deriv1, y::AbstractVector{Tv}, ::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
-    ) where {Tg <: AbstractFloat, Tv}
-    d[1] = 6 * ((y[2] - y[1]) * _get_inv_h(spacing, 1) - convert(Tv, bc.val))
+        d::AbstractVector, bc::Deriv1, y::AbstractVector, ::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
+    ) where {Tg,Tv}
+    d[1] = 6 * ((y[2] - y[1]) * _get_inv_h(spacing, 1) - convert(eltype(d), bc.val))
     return nothing
 end
 
 # Last element - Deriv2: d[end] = bc.val (second derivative value)
 @inline function _compute_rhs_last!(
-        d::AbstractVector{Tv}, bc::Deriv2, ::AbstractVector{Tv}, ::AbstractVector{Tg}, ::AbstractGridSpacing{Tg}
-    ) where {Tg <: AbstractFloat, Tv}
-    d[end] = convert(Tv, bc.val)
+        d::AbstractVector, bc::Deriv2, ::AbstractVector, ::AbstractVector{Tg}, ::AbstractGridSpacing{Tg}
+    ) where {Tg,Tv}
+    d[end] = convert(eltype(d), bc.val)
     return nothing
 end
 
 # Last element - Deriv1: d[end] = 6[S'(x_end) - (y_end - y_{end-1}) / h_end]
 @inline function _compute_rhs_last!(
-        d::AbstractVector{Tv}, bc::Deriv1, y::AbstractVector{Tv}, ::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
-    ) where {Tg <: AbstractFloat, Tv}
+        d::AbstractVector, bc::Deriv1, y::AbstractVector, ::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
+    ) where {Tg,Tv}
     n = length(y) - 1
-    d[end] = 6 * (convert(Tv, bc.val) - (y[end] - y[end - 1]) * _get_inv_h(spacing, n))
+    d[end] = 6 * (convert(eltype(d), bc.val) - (y[end] - y[end - 1]) * _get_inv_h(spacing, n))
     return nothing
 end
 
 # First element - Deriv3: d[1] = h[1] * bc.val (from -z[1] + z[2] = h[1] * val)
 @inline function _compute_rhs_first!(
-        d::AbstractVector{Tv}, bc::Deriv3, ::AbstractVector{Tv}, ::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
-    ) where {Tg <: AbstractFloat, Tv}
-    d[1] = _get_h(spacing, 1) * convert(Tv, bc.val)
+        d::AbstractVector, bc::Deriv3, ::AbstractVector, ::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
+    ) where {Tg,Tv}
+    d[1] = _get_h(spacing, 1) * convert(eltype(d), bc.val)
     return nothing
 end
 
 # Last element - Deriv3: d[end] = h[n] * bc.val (from -z[n] + z[n+1] = h[n] * val)
 @inline function _compute_rhs_last!(
-        d::AbstractVector{Tv}, bc::Deriv3, ::AbstractVector{Tv}, ::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
-    ) where {Tg <: AbstractFloat, Tv}
+        d::AbstractVector, bc::Deriv3, ::AbstractVector, ::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
+    ) where {Tg,Tv}
     n = length(d) - 1
-    d[end] = _get_h(spacing, n) * convert(Tv, bc.val)
+    d[end] = _get_h(spacing, n) * convert(eltype(d), bc.val)
     return nothing
 end
 
 # First element - Generic PolyFit{D}: materialize to Deriv1, then delegate
 # Supports all polynomial degrees: LinearFit (D=1), QuadraticFit (D=2), CubicFit (D=3), etc.
 @inline function _compute_rhs_first!(
-        d::AbstractVector{Tv}, bc::PolyFit{D}, y::AbstractVector{Tv}, x::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
-    ) where {D, Tg <: AbstractFloat, Tv}
+        d::AbstractVector, bc::PolyFit{D}, y::AbstractVector, x::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
+    ) where {D, Tg,Tv}
     # Materialize PolyFit{D} → Deriv1 using estimated derivative
     concrete_bc = materialize_bc(bc, x, y, LeftSide())
     # Delegate to existing Deriv1 code path
@@ -288,8 +288,8 @@ end
 
 # Last element - Generic PolyFit{D}: materialize to Deriv1, then delegate
 @inline function _compute_rhs_last!(
-        d::AbstractVector{Tv}, bc::PolyFit{D}, y::AbstractVector{Tv}, x::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
-    ) where {D, Tg <: AbstractFloat, Tv}
+        d::AbstractVector, bc::PolyFit{D}, y::AbstractVector, x::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}
+    ) where {D, Tg,Tv}
     # Materialize PolyFit{D} → Deriv1 using estimated derivative
     concrete_bc = materialize_bc(bc, x, y, RightSide())
     # Delegate to existing Deriv1 code path
@@ -308,9 +308,9 @@ Type-Free design: BCPair{L,R} where L, R are PointBC subtypes (Deriv1{Tv}, PolyF
 Tg = grid type (x, spacing), Tv = value type (y, d)
 """
 @inline function compute_rhs!(
-        d::AbstractVector{Tv}, y::AbstractVector{Tv}, x::AbstractVector{Tg},
+        d::AbstractVector, y::AbstractVector, x::AbstractVector{Tg},
         spacing::AbstractGridSpacing{Tg}, bc_config::BCPair{L, R}
-    ) where {Tg <: AbstractFloat, Tv, L <: PointBC, R <: PointBC}
+    ) where {Tg, L <: PointBC, R <: PointBC}
     n = length(y) - 1
     _compute_rhs_first!(d, bc_config.left, y, x, spacing)
     # Use spacing accessors
@@ -326,7 +326,7 @@ end
 # ----------------------------------------
 
 "Compute RHS vector d for periodic cubic spline system in-place."
-@inline function compute_rhs_periodic!(d::AbstractVector{Tv}, y::AbstractVector{Tv}, spacing::AbstractGridSpacing{Tg}) where {Tg <: AbstractFloat, Tv}
+@inline function compute_rhs_periodic!(d::AbstractVector, y::AbstractVector, spacing::AbstractGridSpacing{Tg}) where {Tg}
     n = length(y) - 1
 
     # Use spacing accessors
@@ -349,11 +349,11 @@ end
 
 "Solve periodic cyclic tridiagonal system using Sherman-Morrison formula."
 @inline function _solve_cubic_system_periodic!(
-        z_workspace::AbstractVector{Tv},
-        y_temp::AbstractVector{Tv},
+        z_workspace::AbstractVector,
+        y_temp::AbstractVector,
         cache::CubicSplineCache{Tg, X, F, PeriodicData{Tg}, S},
-        y::AbstractVector{Tv}
-    ) where {Tg <: AbstractFloat, Tv, X, F, S <: AbstractGridSpacing{Tg}}
+        y::AbstractVector
+    ) where {Tg, X, F, S <: AbstractGridSpacing{Tg}}
     n = length(y) - 1
 
     compute_rhs_periodic!(y_temp, y, cache.spacing)
@@ -410,11 +410,11 @@ Type-Free design:
 - Tg = grid type, Tv = value type (can be Complex)
 """
 @inline function _solve_system!(
-        out_z::AbstractVector{Tv},
+        out_z::AbstractVector,
         cache::CubicSplineCache{Tg, X, F, BCPair{CL, CR}, S},
-        y::AbstractVector{Tv},
+        y::AbstractVector,
         bc_pair::BCPair{L, R}
-    ) where {Tg <: AbstractFloat, Tv, X, F, CL <: PointBC, CR <: PointBC, L <: PointBC, R <: PointBC, S <: AbstractGridSpacing{Tg}}
+    ) where {Tg, X, F, CL <: PointBC, CR <: PointBC, L <: PointBC, R <: PointBC, S <: AbstractGridSpacing{Tg}}
     compute_rhs!(out_z, y, cache.x, cache.spacing, bc_pair)
     _ldiv_tridiagonal_nopiv!(out_z, cache.thomas)
     return out_z
@@ -426,16 +426,17 @@ Thread-safe: workspaces allocated from task-local pool.
 Tg = grid type, Tv = value type (can be Complex)
 """
 @inline @with_pool pool function _solve_system!(
-        out_z::AbstractVector{Tv},
+        out_z::AbstractVector,
         cache::CubicSplineCache{Tg, X, F, PeriodicData{Tg}, S},
-        y::AbstractVector{Tv},
+        y::AbstractVector,
         ::PeriodicData{Tg}  # Unused, for API consistency with BCPair version
-    ) where {Tg <: AbstractFloat, Tv, X, F, S <: AbstractGridSpacing{Tg}}
+    ) where {Tg, X, F, S <: AbstractGridSpacing{Tg}}
     n = length(y) - 1
 
     # Periodic workspaces need n elements (NOT length(y)!)
     # Use pool allocation for zero-allocation hot path
-    y_temp = acquire!(pool, Tv, n)
+    Tz = eltype(out_z)
+    y_temp = acquire!(pool, Tz, n)
 
     _solve_cubic_system_periodic!(out_z, y_temp, cache, y)
     return out_z

--- a/src/cubic/cubic_types.jl
+++ b/src/cubic/cubic_types.jl
@@ -36,7 +36,7 @@ end
 Cache structure for cubic spline interpolation with reusable Thomas factorization.
 
 # Type Parameters
-- `T`: Float type (Float32 or Float64)
+- `T`: Grid element type (Float32, Float64, or duck-typed e.g. ForwardDiff.Dual)
 - `X`: Grid type (Vector{T} or AbstractRange{T})
 - `F`: Factorization type (ThomasFactorization{T,V})
 - `BC`: Boundary condition data type (BCPair{L,R} for derivative BC, PeriodicData{T} for periodic)
@@ -106,17 +106,18 @@ Lightweight callable interpolant for broadcast fusion optimization.
 Returned by `cubic_interp(x, y)` (2-argument form).
 
 # Type Parameters
-- `Tg<:AbstractFloat`: Grid type (Float32 or Float64) for x-coordinates
+- `Tg`: Grid element type (Float32, Float64, or duck-typed e.g. ForwardDiff.Dual)
 - `Tv`: Value type (unconstrained)
 - `C`: CubicSplineCache type (preserves grid type info for O(1) vs O(log n) lookup)
 - `E`: Extrapolation mode type (compile-time specialized)
 - `P`: Search policy type (AutoSearch, BinarySearch, LinearBinarySearch, etc.)
 - `BC`: Boundary condition type (BCPair or PeriodicBC)
+- `Tz`: Element type of z coefficients (`= _output_eltype(Tv, Tg)` — Dual when grid is Dual)
 
 # Fields
 - `cache::C`: Pre-computed CubicSplineCache (LU factorization)
 - `y::Vector{Tv}`: y-values (function values at grid points)
-- `z::Vector{Tv}`: Pre-computed second derivative coefficients (solves system once!)
+- `z::Vector{Tz}`: Pre-computed second derivative coefficients (solves system once!)
 - `bc::BC`: Boundary condition used for this interpolant
 - `extrap::E`: Extrapolation mode (compile-time specialized via type parameter)
 - `search_policy::P`: Default search policy for interval lookup

--- a/src/cubic/cubic_types.jl
+++ b/src/cubic/cubic_types.jl
@@ -25,7 +25,7 @@ where q = A'^{-1} * u is pre-computed and reused for different y vectors.
 Workspaces for the periodic solver are allocated from task-local pools via `@with_pool`,
 not stored in this struct. This eliminates shared mutable state.
 """
-struct PeriodicData{T <: AbstractFloat}
+struct PeriodicData{T}
     q::Vector{T}  # Pre-computed A'^{-1} * u
     period::T     # x[end] - x[1]
 end
@@ -73,7 +73,7 @@ to ~4 cycles (fmul) — a 2.5× speedup in the inner loop.
 - `bc=ZeroCurvBC()`: Zero-curvature spline with z[1] = z[n+1] = 0
 - `bc=PeriodicBC()`: Periodic spline with C2 continuity at boundaries
 """
-struct CubicSplineCache{T <: AbstractFloat, X <: AbstractVector{T}, F, BC, S <: AbstractGridSpacing{T}}
+struct CubicSplineCache{T, X <: AbstractVector{T}, F, BC, S <: AbstractGridSpacing{T}}
     x::X
     spacing::S
     thomas::F
@@ -83,7 +83,7 @@ struct CubicSplineCache{T <: AbstractFloat, X <: AbstractVector{T}, F, BC, S <: 
     # copy() on immutable Range types is a no-op (zero allocation).
     function CubicSplineCache{T, X, F, BC, S}(
             x::AbstractVector{T}, spacing::S, thomas::F, bc_config::BC
-        ) where {T <: AbstractFloat, X <: AbstractVector{T}, F, BC, S <: AbstractGridSpacing{T}}
+        ) where {T, X <: AbstractVector{T}, F, BC, S <: AbstractGridSpacing{T}}
         # copy() for mutation safety; typeof() rebinds X after copy (SubArray → Vector).
         xc = copy(x)
         return new{T, typeof(xc), F, BC, S}(xc, spacing, thomas, bc_config)
@@ -93,7 +93,7 @@ end
 # Outer constructor: infers type parameters for convenience.
 @inline function CubicSplineCache(
         x::X, spacing::S, thomas::F, bc_config::BC
-    ) where {T <: AbstractFloat, X <: AbstractVector{T}, F, BC, S <: AbstractGridSpacing{T}}
+    ) where {T, X <: AbstractVector{T}, F, BC, S <: AbstractGridSpacing{T}}
     return CubicSplineCache{T, X, F, BC, S}(x, spacing, thomas, bc_config)
 end
 
@@ -146,28 +146,25 @@ val = itp(0.5)  # returns ComplexF64
 - Broadcast operations are perfectly fused (no intermediate arrays)
 - Extrapolation mode uses type-parametrized dispatch for zero overhead
 """
-struct CubicInterpolant{Tg <: AbstractFloat, Tv, C <: CubicSplineCache{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy, BC <: CubicBC} <: AbstractInterpolant1D{Tg, Tv}
+struct CubicInterpolant{Tg, Tv, C <: CubicSplineCache{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy, BC <: CubicBC, Tz} <: AbstractInterpolant1D{Tg, Tv}
     cache::C
     y::Vector{Tv}
-    z::Vector{Tv}  # Pre-computed second derivative coefficients (value type)
+    z::Vector{Tz}  # Second derivative coefficients: Tz = _output_eltype(Tv, Tg)
     bc::BC  # Boundary condition used for this interpolant
     extrap::E  # Extrapolation mode (compile-time specialized via type parameter)
     search_policy::P  # Default search policy (immutable, thread-safe)
     function CubicInterpolant(
             cache::C,
             y::AbstractVector{Tv},
-            z::AbstractVector{Tv},
+            z::AbstractVector,
             bc::BC,
             extrap::E,
             search::P = AutoSearch()
-        ) where {Tg <: AbstractFloat, Tv, C <: CubicSplineCache{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy, BC <: CubicBC}
+        ) where {Tg, Tv, C <: CubicSplineCache{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy, BC <: CubicBC}
         length(cache.x) == length(y) || _throw_length_mismatch(length(cache.x), length(y))
         length(cache.x) == length(z) || _throw_length_mismatch(length(cache.x), length(z), "grid", "z")
-        # Always copy to ensure immutability: once constructed, the interpolant
-        # owns its data and always returns identical results for the same query.
-        # Without copying, external modifications to y or cache reuse could
-        # silently corrupt results.
-        return new{Tg, Tv, C, E, P, BC}(cache, Vector{Tv}(y), Vector{Tv}(z), bc, extrap, search)
+        Tz = eltype(z)
+        return new{Tg, Tv, C, E, P, BC, Tz}(cache, Vector{Tv}(y), Vector{Tz}(z), bc, extrap, search)
     end
 end
 

--- a/src/cubic/nd/cubic_nd_adjoint.jl
+++ b/src/cubic/nd/cubic_nd_adjoint.jl
@@ -295,7 +295,7 @@ so each branch dispatches on a concrete cache type — no Union boxing.
         mixed_bcs,
         grids::NTuple{N, AbstractVector{Tg}},
         grid_size::NTuple{N, Int}
-    ) where {Tv, Tg,N}
+    ) where {Tv, Tg, N}
     # Process axes in reverse order: d=N, N-1, ..., 1
     for d in N:-1:1
         bit_d = 1 << (d - 1)

--- a/src/cubic/nd/cubic_nd_adjoint.jl
+++ b/src/cubic/nd/cubic_nd_adjoint.jl
@@ -137,7 +137,7 @@ function _bake_nd_anchors(
         spacings::NTuple{N, AbstractGridSpacing{Tg}},
         queries,
         extraps::Tuple{Vararg{AbstractExtrap, N}}
-    ) where {N, Tg <: AbstractFloat}
+    ) where {N, Tg}
     return _bake_nd_anchors_generic(
         grids, spacings, queries, extraps,
         (d, t, h, inv_h, dL) -> _compute_nd_anchor_weights(t, h, inv_h)
@@ -295,7 +295,7 @@ so each branch dispatches on a concrete cache type — no Union boxing.
         mixed_bcs,
         grids::NTuple{N, AbstractVector{Tg}},
         grid_size::NTuple{N, Int}
-    ) where {Tv, Tg <: AbstractFloat, N}
+    ) where {Tv, Tg,N}
     # Process axes in reverse order: d=N, N-1, ..., 1
     for d in N:-1:1
         bit_d = 1 << (d - 1)
@@ -443,7 +443,7 @@ function cubic_adjoint(
     ) where {N}
     length(queries) == N || _throw_ndims_mismatch("query vectors", N, length(queries))
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     bcs = _resolve_bcs_nd(bc, Val(N))
     extraps = _resolve_extrap_nd(extrap, bcs, Val(N), Tg)
@@ -491,7 +491,7 @@ function cubic_adjoint(
     ) where {N}
     _query_check_ndims(queries, Val(N))
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     bcs = _resolve_bcs_nd(bc, Val(N))
     extraps = _resolve_extrap_nd(extrap, bcs, Val(N), Tg)
@@ -520,7 +520,7 @@ function _build_nd_adjoint(
         bcs::NTuple{N, AbstractBC},
         extraps::Tuple{Vararg{AbstractExtrap, N}},
         autocache::Bool
-    ) where {N, Tg <: AbstractFloat}
+    ) where {N, Tg}
     # Validate: PolyFit BCs have enough grid points (periodic axes skip this)
     _validate_polyfit_bcs(grids, bcs, Val(N))
 
@@ -545,9 +545,9 @@ function _build_nd_adjoint(
 
     caches = map(grids_ext, norm_bcs) do grid_d, bp_d
         if _is_periodic_bc(bp_d)
-            _get_cubic_cache(grid_d, PeriodicBC(), autocache)
+            _get_cubic_cache(grid_d, PeriodicBC(), _effective_autocache(autocache, Tg))
         else
-            _get_cubic_cache(grid_d, bp_d, autocache)
+            _get_cubic_cache(grid_d, bp_d, _effective_autocache(autocache, Tg))
         end
     end
 
@@ -565,9 +565,9 @@ function _build_nd_adjoint(
 
     mixed_caches = map(grids_ext, mixed_bcs) do grid_d, mbp_d
         if _is_periodic_bc(mbp_d)
-            _get_cubic_cache(grid_d, PeriodicBC(), autocache)
+            _get_cubic_cache(grid_d, PeriodicBC(), _effective_autocache(autocache, Tg))
         else
-            _get_cubic_cache(grid_d, mbp_d, autocache)
+            _get_cubic_cache(grid_d, mbp_d, _effective_autocache(autocache, Tg))
         end
     end
 

--- a/src/cubic/nd/cubic_nd_adjoint_types.jl
+++ b/src/cubic/nd/cubic_nd_adjoint_types.jl
@@ -72,7 +72,7 @@ adj = cubic_adjoint((x, y), (xq, yq); bc=(PeriodicBC(), CubicFit()))
 ```
 """
 struct CubicAdjointND{
-        Tg <: AbstractFloat,
+        Tg,
         N,
         S <: NTuple{N, AbstractGridSpacing{Tg}},
         C <: NTuple{N, CubicSplineCache{Tg}},

--- a/src/cubic/nd/cubic_nd_build.jl
+++ b/src/cubic/nd/cubic_nd_build.jl
@@ -60,7 +60,7 @@ For a 4D array f(x₁,x₂,x₃,x₄) with shape (10, 20, 30, 40), computing ∂
         grid::AbstractVector{Tg},
         bc::AbstractBC,
         d::Int
-    ) where {Tv, Tg,N}
+    ) where {Tv, Tg, N}
     @boundscheck begin
         1 ≤ d ≤ N || throw(ArgumentError("dimension d=$d out of range 1:$N"))
         size(out) == size(data) || throw(DimensionMismatch("out and data must have same size"))
@@ -143,7 +143,7 @@ slices simultaneously using the batch solver from 2D implementation.
         grid::AbstractVector{Tg},
         bc::AbstractBC,
         d::Int
-    ) where {Tv, Tg,N}
+    ) where {Tv, Tg, N}
     @boundscheck begin
         1 ≤ d ≤ N || throw(ArgumentError("dimension d=$d out of range 1:$N"))
         size(out) == size(data) || throw(DimensionMismatch("out and data must have same size"))
@@ -370,7 +370,7 @@ end
     grids::NTuple{N, AbstractVector{Tg}},
     data::AbstractArray{Tv, N},
     ::Val{N}
-) where {Tv, Tg,N} = _validate_nd_partials_dims!(partials, grids, data, Val(1), Val(N))
+) where {Tv, Tg, N} = _validate_nd_partials_dims!(partials, grids, data, Val(1), Val(N))
 
 @inline function _validate_nd_partials_dims!(
         partials::AbstractArray,
@@ -378,7 +378,7 @@ end
         data::AbstractArray{Tv, N},
         ::Val{D},
         ::Val{N}
-    ) where {Tv, Tg,D, N}
+    ) where {Tv, Tg, D, N}
     size(partials, D + 1) == size(data, D) || throw(
         DimensionMismatch(
             "partials dim $(D + 1) must match data dim $D"
@@ -400,7 +400,7 @@ end
     bcs::NTuple{N, AbstractBC},
     data::AbstractArray{Tv, N},
     ::Val{N}
-) where {Tv, Tg,N} = _validate_nd_bcs!(grids, bcs, data, Val(1), Val(N))
+) where {Tv, Tg, N} = _validate_nd_bcs!(grids, bcs, data, Val(1), Val(N))
 
 @inline function _validate_nd_bcs!(
         grids::NTuple{N, AbstractVector{Tg}},
@@ -408,7 +408,7 @@ end
         data::AbstractArray{Tv, N},
         ::Val{D},
         ::Val{N}
-    ) where {Tv, Tg,D, N}
+    ) where {Tv, Tg, D, N}
     # Only validate inclusive PeriodicBC: for exclusive, the endpoint is not yet present
     # in the data (it is added by _prepare_periodic_nd/_prepare_periodic_nd_pooled after
     # this validation).  Checking data[1] ≈ data[end] on unextended exclusive data would
@@ -456,7 +456,7 @@ end
     grids::NTuple{N, AbstractVector{Tg}},
     bcs::NTuple{N, AbstractBC},
     ::Val{N}
-) where {Tv, Tg,N, NP1} = _build_nd_partials_dim!(partials, grids, bcs, Val(1), Val(N))
+) where {Tv, Tg, N, NP1} = _build_nd_partials_dim!(partials, grids, bcs, Val(1), Val(N))
 
 @inline function _build_nd_partials_dim!(
         partials::AbstractArray{Tv, NP1},
@@ -464,7 +464,7 @@ end
         bcs::NTuple{N, AbstractBC},
         ::Val{D},
         ::Val{N}
-    ) where {Tv, Tg,D, N, NP1}
+    ) where {Tv, Tg, D, N, NP1}
     bit_d = 1 << (D - 1)
     @inbounds for p_src in 1:bit_d
         p_dst = p_src + bit_d
@@ -533,7 +533,7 @@ function _compute_nd_partials!(
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
-    ) where {Tv, Tg,N, NP1}
+    ) where {Tv, Tg, N, NP1}
     # Validate dimensions (fast, no allocation)
     @boundscheck begin
         NP1 == N + 1 || throw(DimensionMismatch("partials must have N+1 dimensions"))
@@ -581,7 +581,7 @@ function _build_nd_coeffs(
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
-    ) where {Tg,Tv, N}
+    ) where {Tg, Tv, N}
     # Validate periodic BCs and PolyFit requirements (runs once at construction time)
     _validate_nd_bcs!(grids, bcs, data, Val(N))
 

--- a/src/cubic/nd/cubic_nd_build.jl
+++ b/src/cubic/nd/cubic_nd_build.jl
@@ -60,7 +60,7 @@ For a 4D array f(x₁,x₂,x₃,x₄) with shape (10, 20, 30, 40), computing ∂
         grid::AbstractVector{Tg},
         bc::AbstractBC,
         d::Int
-    ) where {Tv, Tg <: AbstractFloat, N}
+    ) where {Tv, Tg,N}
     @boundscheck begin
         1 ≤ d ≤ N || throw(ArgumentError("dimension d=$d out of range 1:$N"))
         size(out) == size(data) || throw(DimensionMismatch("out and data must have same size"))
@@ -143,7 +143,7 @@ slices simultaneously using the batch solver from 2D implementation.
         grid::AbstractVector{Tg},
         bc::AbstractBC,
         d::Int
-    ) where {Tv, Tg <: AbstractFloat, N}
+    ) where {Tv, Tg,N}
     @boundscheck begin
         1 ≤ d ≤ N || throw(ArgumentError("dimension d=$d out of range 1:$N"))
         size(out) == size(data) || throw(DimensionMismatch("out and data must have same size"))
@@ -177,7 +177,7 @@ slices simultaneously using the batch solver from 2D implementation.
     if can_batch
         # Batch SIMD path: use 2D batch solver along axis 2
         # Cache construction: _get_cubic_cache internally uses _cache_pointbc (duck-safe).
-        cache = _get_cubic_cache(grid, bc, true)
+        cache = _get_cubic_cache(grid, bc, _effective_autocache(true, eltype(grid)))
         actual_bc = cache.bc_config isa PeriodicData ? cache.bc_config : _normalize_bc(bc, first(data_3d))
 
         # Acquire workspace for moments matrix
@@ -242,7 +242,7 @@ the index expressions into the method body at specialization time.
         data::AbstractArray{Tv, N},
         ::Val{D},
         ::Type{Tg}
-    ) where {Tv, N, D, Tg <: AbstractFloat}
+    ) where {Tv, N, D, Tg}
     # Symbolic loop variables: i1, i2, ..., iN
     idx_vars = [Symbol("i", d) for d in 1:N]
 
@@ -370,7 +370,7 @@ end
     grids::NTuple{N, AbstractVector{Tg}},
     data::AbstractArray{Tv, N},
     ::Val{N}
-) where {Tv, Tg <: AbstractFloat, N} = _validate_nd_partials_dims!(partials, grids, data, Val(1), Val(N))
+) where {Tv, Tg,N} = _validate_nd_partials_dims!(partials, grids, data, Val(1), Val(N))
 
 @inline function _validate_nd_partials_dims!(
         partials::AbstractArray,
@@ -378,7 +378,7 @@ end
         data::AbstractArray{Tv, N},
         ::Val{D},
         ::Val{N}
-    ) where {Tv, Tg <: AbstractFloat, D, N}
+    ) where {Tv, Tg,D, N}
     size(partials, D + 1) == size(data, D) || throw(
         DimensionMismatch(
             "partials dim $(D + 1) must match data dim $D"
@@ -400,7 +400,7 @@ end
     bcs::NTuple{N, AbstractBC},
     data::AbstractArray{Tv, N},
     ::Val{N}
-) where {Tv, Tg <: AbstractFloat, N} = _validate_nd_bcs!(grids, bcs, data, Val(1), Val(N))
+) where {Tv, Tg,N} = _validate_nd_bcs!(grids, bcs, data, Val(1), Val(N))
 
 @inline function _validate_nd_bcs!(
         grids::NTuple{N, AbstractVector{Tg}},
@@ -408,7 +408,7 @@ end
         data::AbstractArray{Tv, N},
         ::Val{D},
         ::Val{N}
-    ) where {Tv, Tg <: AbstractFloat, D, N}
+    ) where {Tv, Tg,D, N}
     # Only validate inclusive PeriodicBC: for exclusive, the endpoint is not yet present
     # in the data (it is added by _prepare_periodic_nd/_prepare_periodic_nd_pooled after
     # this validation).  Checking data[1] ≈ data[end] on unextended exclusive data would
@@ -456,7 +456,7 @@ end
     grids::NTuple{N, AbstractVector{Tg}},
     bcs::NTuple{N, AbstractBC},
     ::Val{N}
-) where {Tv, Tg <: AbstractFloat, N, NP1} = _build_nd_partials_dim!(partials, grids, bcs, Val(1), Val(N))
+) where {Tv, Tg,N, NP1} = _build_nd_partials_dim!(partials, grids, bcs, Val(1), Val(N))
 
 @inline function _build_nd_partials_dim!(
         partials::AbstractArray{Tv, NP1},
@@ -464,7 +464,7 @@ end
         bcs::NTuple{N, AbstractBC},
         ::Val{D},
         ::Val{N}
-    ) where {Tv, Tg <: AbstractFloat, D, N, NP1}
+    ) where {Tv, Tg,D, N, NP1}
     bit_d = 1 << (D - 1)
     @inbounds for p_src in 1:bit_d
         p_dst = p_src + bit_d
@@ -533,7 +533,7 @@ function _compute_nd_partials!(
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
-    ) where {Tv, Tg <: AbstractFloat, N, NP1}
+    ) where {Tv, Tg,N, NP1}
     # Validate dimensions (fast, no allocation)
     @boundscheck begin
         NP1 == N + 1 || throw(DimensionMismatch("partials must have N+1 dimensions"))
@@ -581,7 +581,7 @@ function _build_nd_coeffs(
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
-    ) where {Tg <: AbstractFloat, Tv, N}
+    ) where {Tg,Tv, N}
     # Validate periodic BCs and PolyFit requirements (runs once at construction time)
     _validate_nd_bcs!(grids, bcs, data, Val(N))
 

--- a/src/cubic/nd/cubic_nd_interpolant.jl
+++ b/src/cubic/nd/cubic_nd_interpolant.jl
@@ -67,7 +67,7 @@ function cubic_interp(
     ) where {N, Tv_raw}
     # Zero-allocation type promotion (uses @generated function)
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64  # Ensure AbstractFloat
+    Tg = float(Tg)
 
     # Zero-allocation grid conversion (uses @generated function)
     grids_typed = _convert_grids_typed(grids, Tg)
@@ -110,7 +110,7 @@ function _build_nd_interpolant(
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
         searches::NTuple{N, AbstractSearchPolicy},
         ::PreCompute
-    ) where {Tg <: AbstractFloat, Tv, N}
+    ) where {Tg, Tv, N}
     # Extend grids/data for exclusive periodic axes (build-time only)
     # After this, all periodic axes have inclusive-form data.
     grids, data, bcs = _prepare_periodic_nd(grids, data, bcs)

--- a/src/cubic/nd/cubic_nd_math.jl
+++ b/src/cubic/nd/cubic_nd_math.jl
@@ -281,7 +281,7 @@ function _apply_derivative_bc!(dydx::AbstractVector{Tv}, bc::BCPair, args...) wh
     return nothing
 end
 
-function _apply_derivative_bc!(dydx::AbstractVector{Tv}, bc::PeriodicData{Tg}, args...) where {Tv, Tg <: AbstractFloat}
+function _apply_derivative_bc!(dydx::AbstractVector{Tv}, bc::PeriodicData{Tg}, args...) where {Tv, Tg}
     # Enforce periodic: dydx[1] == dydx[end]
     avg = inv(Tg(2)) * (dydx[1] + dydx[end])
     @inbounds dydx[1] = avg
@@ -310,13 +310,13 @@ Differentiate 1D vector using cubic splines. BC type determines the method:
 @with_pool pool function _deriv_1d!(
         deriv::AbstractVector{Tv}, values::AbstractVector{Tv},
         grid::AbstractVector{Tg}, bc::AbstractBC
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg,Tv}
     n = length(values)
     # Cache construction: _get_cubic_cache internally uses _cache_pointbc (duck-safe,
     # converts BC to structural form with zero(Tg) — no convert(Tg, bc.val) needed).
     # Computation: normalize BC values to Tv via value-based _normalize_bc.
     bc_compute = _is_periodic_bc(bc) ? PeriodicBC() : _normalize_bc(bc, first(values))
-    cache = _get_cubic_cache(grid, bc, true)
+    cache = _get_cubic_cache(grid, bc, _effective_autocache(true, Tg))
     actual_bc = cache.bc_config isa PeriodicData ? cache.bc_config : bc_compute
     m = acquire!(pool, Tv, n)
     _solve_system!(m, cache, values, actual_bc)
@@ -328,7 +328,7 @@ end
 @with_pool pool function _deriv_1d!(
         deriv::AbstractVector{Tv}, values::AbstractVector{Tv},
         grid::AbstractVector{Tg}, ::CubicFit
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg,Tv}
     n = length(values)
     @assert n >= 4 "Need at least 4 points for CubicFit"
 
@@ -339,7 +339,7 @@ end
     bc = BCPair(Deriv1(deriv_left), Deriv1(deriv_right))
     # Cache uses grid type Tg for matrix structure
     bc_cache = BCPair(Deriv1(zero(Tg)), Deriv1(zero(Tg)))
-    cache = _get_cubic_cache(grid, bc_cache, true)
+    cache = _get_cubic_cache(grid, bc_cache, _effective_autocache(true, Tg))
     m = acquire!(pool, Tv, n)
     _solve_system!(m, cache, values, bc)
     _moments_to_derivatives_1d!(deriv, m, values, cache.spacing)
@@ -381,7 +381,7 @@ This enables @simd vectorization over the contiguous dimension.
 @inline function _ldiv_along_dim_vectorized!(
         z::AbstractMatrix{Tv},
         thomas::ThomasFactorization{Tg, V}
-    ) where {Tv, Tg <: AbstractFloat, V <: AbstractVector{Tg}}
+    ) where {Tv, Tg,V <: AbstractVector{Tg}}
     dl = thomas.dl
     du = thomas.du
     inv_d = thomas.inv_d
@@ -448,7 +448,7 @@ function solve_along_dim!(
         data::AbstractMatrix{Tv},
         bc::BCPair,
         dim::Val{D}
-    ) where {Tv, Tg <: AbstractFloat, X, F, BC_cache, S <: AbstractGridSpacing{Tg}, D}
+    ) where {Tv, Tg,X, F, BC_cache, S <: AbstractGridSpacing{Tg}, D}
     # Step 1: Compute RHS for all systems
     # Note: bc can have different value type than cache.bc_config (e.g., ComplexF64 vs Float64)
     compute_rhs_along_dim!(out_z, data, cache.x, cache.spacing, bc, dim)
@@ -485,7 +485,7 @@ function compute_rhs_along_dim!(
         spacing::AbstractGridSpacing{Tg},
         bc::BCPair,
         ::Val{2}
-    ) where {Tv, Tg <: AbstractFloat}
+    ) where {Tv, Tg}
     n_batch = size(data, 1)
     @inbounds for i in 1:n_batch
         compute_rhs!(view(D, i, :), view(data, i, :), x, spacing, bc)
@@ -519,7 +519,7 @@ function moments_to_derivatives_along_dim!(
         spacing::AbstractGridSpacing{Tg},
         bc,
         ::Val{2}
-    ) where {Tv, Tg <: AbstractFloat}
+    ) where {Tv, Tg}
     n_batch = size(data, 1)
     @inbounds for i in 1:n_batch
         _moments_to_derivatives_1d!(
@@ -570,7 +570,7 @@ Use `compute_rhs!` in a loop for axis 1, or use `Val(2)` for batch computation.
         spacing::AbstractGridSpacing{Tg},
         bc::BCPair,
         ::Val{1}
-    ) where {Tv, Tg <: AbstractFloat}
+    ) where {Tv, Tg}
     throw(
         ArgumentError(
             "Batch RHS computation along axis 1 (Val(1)) is not supported.\n" *

--- a/src/cubic/nd/cubic_nd_math.jl
+++ b/src/cubic/nd/cubic_nd_math.jl
@@ -318,7 +318,8 @@ Differentiate 1D vector using cubic splines. BC type determines the method:
     bc_compute = _is_periodic_bc(bc) ? PeriodicBC() : _normalize_bc(bc, first(values))
     cache = _get_cubic_cache(grid, bc, _effective_autocache(true, Tg))
     actual_bc = cache.bc_config isa PeriodicData ? cache.bc_config : bc_compute
-    m = acquire!(pool, Tv, n)
+    Tz = _output_eltype(Tv, eltype(cache.x))
+    m = acquire!(pool, Tz, n)
     _solve_system!(m, cache, values, actual_bc)
     _moments_to_derivatives_1d!(deriv, m, values, cache.spacing)
     _apply_derivative_bc!(deriv, actual_bc)
@@ -340,7 +341,8 @@ end
     # Cache uses grid type Tg for matrix structure
     bc_cache = BCPair(Deriv1(zero(Tg)), Deriv1(zero(Tg)))
     cache = _get_cubic_cache(grid, bc_cache, _effective_autocache(true, Tg))
-    m = acquire!(pool, Tv, n)
+    Tz = _output_eltype(Tv, eltype(cache.x))
+    m = acquire!(pool, Tz, n)
     _solve_system!(m, cache, values, bc)
     _moments_to_derivatives_1d!(deriv, m, values, cache.spacing)
     _apply_derivative_bc!(deriv, bc)

--- a/src/cubic/nd/cubic_nd_math.jl
+++ b/src/cubic/nd/cubic_nd_math.jl
@@ -310,7 +310,7 @@ Differentiate 1D vector using cubic splines. BC type determines the method:
 @with_pool pool function _deriv_1d!(
         deriv::AbstractVector{Tv}, values::AbstractVector{Tv},
         grid::AbstractVector{Tg}, bc::AbstractBC
-    ) where {Tg,Tv}
+    ) where {Tg, Tv}
     n = length(values)
     # Cache construction: _get_cubic_cache internally uses _cache_pointbc (duck-safe,
     # converts BC to structural form with zero(Tg) — no convert(Tg, bc.val) needed).
@@ -329,7 +329,7 @@ end
 @with_pool pool function _deriv_1d!(
         deriv::AbstractVector{Tv}, values::AbstractVector{Tv},
         grid::AbstractVector{Tg}, ::CubicFit
-    ) where {Tg,Tv}
+    ) where {Tg, Tv}
     n = length(values)
     @assert n >= 4 "Need at least 4 points for CubicFit"
 
@@ -383,7 +383,7 @@ This enables @simd vectorization over the contiguous dimension.
 @inline function _ldiv_along_dim_vectorized!(
         z::AbstractMatrix{Tv},
         thomas::ThomasFactorization{Tg, V}
-    ) where {Tv, Tg,V <: AbstractVector{Tg}}
+    ) where {Tv, Tg, V <: AbstractVector{Tg}}
     dl = thomas.dl
     du = thomas.du
     inv_d = thomas.inv_d
@@ -450,7 +450,7 @@ function solve_along_dim!(
         data::AbstractMatrix{Tv},
         bc::BCPair,
         dim::Val{D}
-    ) where {Tv, Tg,X, F, BC_cache, S <: AbstractGridSpacing{Tg}, D}
+    ) where {Tv, Tg, X, F, BC_cache, S <: AbstractGridSpacing{Tg}, D}
     # Step 1: Compute RHS for all systems
     # Note: bc can have different value type than cache.bc_config (e.g., ComplexF64 vs Float64)
     compute_rhs_along_dim!(out_z, data, cache.x, cache.spacing, bc, dim)

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -38,7 +38,7 @@ function cubic_interp(
     ) where {Tv, N}
     # Type promotion + validation (same as constructor path)
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     _validate_nd_grids(grids_typed, data)
     Tr = _output_eltype(Tv, Tg, typeof.(query)...)
@@ -81,7 +81,7 @@ function cubic_interp(
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     Tq = _query_eltype(queries)
     Tr = _output_eltype(Tv, Tg, Tq)
     output = Vector{Tr}(undef, _query_length(queries))
@@ -119,7 +119,7 @@ Zero-allocation after warmup (pool reuse).
         searches::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
         hints = nothing
-    ) where {Tg <: AbstractFloat, Tv, N}
+    ) where {Tg,Tv, N}
     # 0. NoExtrap domain check must precede FillExtrap short-circuit
     _validate_nd_domain(grids, query, extraps_val)
     oob_result = _try_fill_oob(query, grids, extraps_val, ops, @inbounds first(data))
@@ -167,7 +167,7 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
         searches::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
         hints = nothing
-    ) where {Tg <: AbstractFloat, Tv, N}
+    ) where {Tg,Tv, N}
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
@@ -227,7 +227,7 @@ function cubic_interp!(
     ) where {Tv, N}
     _query_check_ndims(queries, Val(N))
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     _validate_nd_grids(grids_typed, data)
 

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -119,7 +119,7 @@ Zero-allocation after warmup (pool reuse).
         searches::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
         hints = nothing
-    ) where {Tg,Tv, N}
+    ) where {Tg, Tv, N}
     # 0. NoExtrap domain check must precede FillExtrap short-circuit
     _validate_nd_domain(grids, query, extraps_val)
     oob_result = _try_fill_oob(query, grids, extraps_val, ops, @inbounds first(data))
@@ -167,7 +167,7 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
         searches::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
         hints = nothing
-    ) where {Tg,Tv, N}
+    ) where {Tg, Tv, N}
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)

--- a/src/cubic/nd/cubic_nd_types.jl
+++ b/src/cubic/nd/cubic_nd_types.jl
@@ -78,7 +78,7 @@ itp((1.0, 0.5, 0.3))                  # Evaluate at (1.0, 0.5, 0.3)
 ```
 """
 struct CubicInterpolantND{
-        Tg <: AbstractFloat,
+        Tg,
         Tv,
         N,
         NP1,

--- a/src/quadratic/quadratic_anchor.jl
+++ b/src/quadratic/quadratic_anchor.jl
@@ -56,6 +56,13 @@ struct _QuadraticAnchoredQuery{Tg, Tq <: Real}
     dL::Tq                     # offset from interval start, Float or Dual
 end
 
+# Outer constructor: infer Tq from dL type (not from input xq).
+# When grid is Dual, dL = xq - xL is Dual even if xq is Float64.
+@inline function _QuadraticAnchoredQuery(idx::Int, xq, state::UInt8, dL::Td, ::Type{Tg}) where {Tg, Td}
+    xq_p = convert(Td, xq)
+    return _QuadraticAnchoredQuery{Tg, Td}(idx, xq_p, state, dL)
+end
+
 # ========================================
 # Anchor Construction
 # ========================================
@@ -210,7 +217,7 @@ while preserving the full Dual value for `dL` computation.
     # Compute dL: offset from interval start (preserves Dual type)
     dL = loc.xq - loc.xL
 
-    return _QuadraticAnchoredQuery{Tg, typeof(loc.xq)}(loc.idx, loc.xq, loc.state, dL)
+    return _QuadraticAnchoredQuery(loc.idx, loc.xq, loc.state, dL, Tg)
 end
 
 # ========================================

--- a/src/quadratic/quadratic_oneshot_series.jl
+++ b/src/quadratic/quadratic_oneshot_series.jl
@@ -32,9 +32,11 @@
     searcher = _resolve_search(x, xq, search, hint)
     aq = _anchor_query(x, xq, Val(:quadratic), extrap isa WrapExtrap, searcher)
     Tv_out = _value_type(_series_eltype(s), Tg)
-    output = Vector{_series_output_type(Tv_out, Tq)}(undef, K)
-    d = acquire!(pool, Tv_out, nx)
-    a = acquire!(pool, Tv_out, nx - 1)
+    Tg_actual = eltype(x)
+    Tcoeff = _output_eltype(_series_eltype(s), Tg_actual)
+    output = Vector{_series_output_type(Tcoeff, Tq)}(undef, K)
+    d = acquire!(pool, Tcoeff, nx)
+    a = acquire!(pool, Tcoeff, nx - 1)
     y_buf = acquire!(pool, Tv_out, nx)
     @inbounds for k in 1:K
         copyto!(y_buf, 1, vecs[k], 1, nx)
@@ -68,8 +70,10 @@ end
     searcher = _resolve_search(x, xq, search, hint)
     aq = _anchor_query(x, xq, Val(:quadratic), extrap isa WrapExtrap, searcher)
     Tv_out = _value_type(_series_eltype(s), Tg)
-    d = acquire!(pool, Tv_out, nx)
-    a = acquire!(pool, Tv_out, nx - 1)
+    Tg_actual = eltype(x)
+    Tcoeff = _output_eltype(_series_eltype(s), Tg_actual)
+    d = acquire!(pool, Tcoeff, nx)
+    a = acquire!(pool, Tcoeff, nx - 1)
     y_buf = acquire!(pool, Tv_out, nx)
     @inbounds for k in eachindex(output)
         copyto!(y_buf, 1, vecs[k], 1, nx)
@@ -106,14 +110,17 @@ end
     vecs = _series_vectors(s)
     spacing = _create_spacing_pooled(pool, x)
     Tv_out = _value_type(_series_eltype(s), Tg)
+    Tg_actual = eltype(x)
+    Tcoeff = _output_eltype(_series_eltype(s), Tg_actual)
 
     # Pre-compute anchors once (search Q times, not K×Q)
-    aq_vec = acquire!(pool, _QuadraticAnchoredQuery{Tg, Tq}, length(xqs))
+    Tq_w = promote_type(Tq, Tg_actual)
+    aq_vec = acquire!(pool, _QuadraticAnchoredQuery{Tg_actual, Tq_w}, length(xqs))
     searcher = _resolve_search(x, xqs, search, nothing)
     _fill_anchors!(aq_vec, x, xqs, Val(:quadratic), extrap_eff isa WrapExtrap, searcher)
 
-    d = acquire!(pool, Tv_out, nx)
-    a = acquire!(pool, Tv_out, nx - 1)
+    d = acquire!(pool, Tcoeff, nx)
+    a = acquire!(pool, Tcoeff, nx - 1)
     y_buf = acquire!(pool, Tv_out, nx)
     @inbounds for k in 1:K
         copyto!(y_buf, 1, vecs[k], 1, nx)
@@ -136,7 +143,8 @@ function quadratic_interp(
         search::AbstractSearchPolicy = AutoSearch()
     ) where {Tg, Tq <: Real}
     K = n_series(s)
-    Tv_out = _series_output_type(_value_type(_series_eltype(s), Tg), Tq)
+    Tg_float = _promote_grid_float(Tg, _series_eltype(s))
+    Tv_out = _series_output_type(_output_eltype(_series_eltype(s), Tg_float), Tq)
     outputs = [Vector{Tv_out}(undef, length(xqs)) for _ in 1:K]
     quadratic_interp!(outputs, x, s, xqs; bc, extrap, deriv, search)
     return outputs

--- a/src/quadratic/quadratic_series_interp.jl
+++ b/src/quadratic/quadratic_series_interp.jl
@@ -76,31 +76,28 @@ sitp_complex = quadratic_interp(x, y_complex)
 This type uses `mutable struct` with all `const` fields (Julia 1.8+) instead of
 plain `struct` for performance reasons. See CubicSeriesInterpolant for details.
 """
-mutable struct QuadraticSeriesInterpolant{Tg, Tv, E <: AbstractExtrap, P <: AbstractSearchPolicy, X <: AbstractVector{Tg}, S <: AbstractGridSpacing{Tg}} <: AbstractSeriesInterpolant{Tg, Tv}
-    const x::X                                # Grid points (Range or Vector)
-    const y::Matrix{Tv}                       # Series-contiguous y (n_points × n_series)
-    const a::Matrix{Tv}                       # Series-contiguous a (n_points × n_series)
-    const d::Matrix{Tv}                       # Series-contiguous d (n_points × n_series)
-    const spacing::S                          # Precomputed grid spacing (ScalarSpacing for Range, VectorSpacing for Vector)
-    const _transpose::LazyTransposeTriple{Tv} # Lazy point-contiguous layout
-    const extrap::E                           # Extrapolation mode (compile-time specialized)
-    const search_policy::P                    # Default search policy
+mutable struct QuadraticSeriesInterpolant{Tg, Tv, E <: AbstractExtrap, P <: AbstractSearchPolicy, X <: AbstractVector{Tg}, S <: AbstractGridSpacing{Tg}, Tc} <: AbstractSeriesInterpolant{Tg, Tv}
+    const x::X                                 # Grid points (Range or Vector)
+    const y::Matrix{Tv}                        # Series-contiguous y (n_points × n_series)
+    const a::Matrix{Tc}                        # Series-contiguous a: Tc = _output_eltype(Tv, Tg)
+    const d::Matrix{Tc}                        # Series-contiguous d: Tc = _output_eltype(Tv, Tg)
+    const spacing::S                           # Precomputed grid spacing
+    const _transpose::LazyTransposeTriple{Tv, Tc} # Lazy point-contiguous layout
+    const extrap::E                            # Extrapolation mode (compile-time specialized)
+    const search_policy::P                     # Default search policy
 
     function QuadraticSeriesInterpolant(
             x::AbstractVector{Tg},
             y::Matrix{Tv},
-            a::Matrix{Tv},
-            d::Matrix{Tv},
+            a::Matrix,
+            d::Matrix,
             spacing::S,
             extrap::E,
             search::P = AutoSearch()
         ) where {Tg, Tv, S <: AbstractGridSpacing{Tg}, E <: AbstractExtrap, P <: AbstractSearchPolicy}
-        # _to_float(copy(x), Tg): Range → _CachedRange (O(1) search + no TwicePrecision overhead);
-        # Vector → defensive copy. copy() on Range is identity (zero alloc).
-        # typeof(xc) rebinds X after conversion (view → Vector, TwicePrecision → _CachedRange).
-        # y/a/d are NOT copied here — factory function provides owned matrices.
+        Tc = eltype(a)
         xc = _to_float(copy(x), Tg)
-        return new{Tg, Tv, E, P, typeof(xc), S}(xc, y, a, d, spacing, LazyTransposeTriple{Tv}(), extrap, search)
+        return new{Tg, Tv, E, P, typeof(xc), S, Tc}(xc, y, a, d, spacing, LazyTransposeTriple{Tv, Tc}(), extrap, search)
     end
 end
 
@@ -190,15 +187,15 @@ SIMD kernel for evaluating all series at a single anchor point with extrapolatio
 @inline function _eval_quadratic_series_point_with_extrap!(
         output::AbstractVector,
         y_point::Matrix{Tv},
-        a_point::Matrix{Tv},
-        d_point::Matrix{Tv},
+        a_point::Matrix{Tc},
+        d_point::Matrix{Tc},
         n_pts::Int,
         x_min::Tg,
         x_max::Tg,
         aq::_QuadraticAnchoredQuery{Tg, Tq},
         extrap::NoExtrap,
         op::AbstractEvalOp
-    ) where {Tg, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tc, Tq <: Real}
     if aq.state != IN_DOMAIN
         _throw_extrap_domain_error(aq.xq, x_min, x_max)
     end
@@ -208,15 +205,15 @@ end
 @inline function _eval_quadratic_series_point_with_extrap!(
         output::AbstractVector,
         y_point::Matrix{Tv},
-        a_point::Matrix{Tv},
-        d_point::Matrix{Tv},
+        a_point::Matrix{Tc},
+        d_point::Matrix{Tc},
         n_pts::Int,
         x_min::Tg,
         x_max::Tg,
         aq::_QuadraticAnchoredQuery{Tg, Tq},
         extrap::_ClampOrFill,
         op::AbstractEvalOp
-    ) where {Tg, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tc, Tq <: Real}
     return if aq.state != IN_DOMAIN  # outside domain
         _fill_constant_extrap_simd!(output, y_point, aq.state, n_pts, op, extrap)
     else
@@ -227,15 +224,15 @@ end
 @inline function _eval_quadratic_series_point_with_extrap!(
         output::AbstractVector,
         y_point::Matrix{Tv},
-        a_point::Matrix{Tv},
-        d_point::Matrix{Tv},
+        a_point::Matrix{Tc},
+        d_point::Matrix{Tc},
         n_pts::Int,
         x_min::Tg,
         x_max::Tg,
         aq::_QuadraticAnchoredQuery{Tg, Tq},
         extrap::AbstractExtrap,  # ExtendExtrap, WrapExtrap, or anything else
         op::AbstractEvalOp
-    ) where {Tg, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tc, Tq <: Real}
     return _eval_quadratic_series_point_kernel!(output, y_point, a_point, d_point, aq, op)
 end
 
@@ -255,11 +252,11 @@ When `aq.dL` is a ForwardDiff.Dual, the output will also be Dual.
 @inline function _eval_quadratic_series_point_kernel!(
         output::AbstractVector,
         y_point::Matrix{Tv},
-        a_point::Matrix{Tv},
-        d_point::Matrix{Tv},
+        a_point::Matrix{Tc},
+        d_point::Matrix{Tc},
         aq::_QuadraticAnchoredQuery{Tg, Tq},
         op::EvalValue
-    ) where {Tg, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tc, Tq <: Real}
     idx = aq.idx
     dL = aq.dL
 
@@ -276,11 +273,11 @@ end
 @inline function _eval_quadratic_series_point_kernel!(
         output::AbstractVector,
         y_point::Matrix{Tv},
-        a_point::Matrix{Tv},
-        d_point::Matrix{Tv},
+        a_point::Matrix{Tc},
+        d_point::Matrix{Tc},
         aq::_QuadraticAnchoredQuery{Tg, Tq},
         op::EvalDeriv1
-    ) where {Tg, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tc, Tq <: Real}
     idx = aq.idx
     dL = aq.dL
 
@@ -296,11 +293,11 @@ end
 @inline function _eval_quadratic_series_point_kernel!(
         output::AbstractVector,
         y_point::Matrix{Tv},
-        a_point::Matrix{Tv},
-        d_point::Matrix{Tv},
+        a_point::Matrix{Tc},
+        d_point::Matrix{Tc},
         aq::_QuadraticAnchoredQuery{Tg, Tq},
         op::EvalDeriv2
-    ) where {Tg, Tv, Tq <: Real}
+    ) where {Tg, Tv, Tc, Tq <: Real}
     idx = aq.idx
 
     @inbounds @simd for k in eachindex(output)
@@ -314,11 +311,11 @@ end
 @inline function _eval_quadratic_series_point_kernel!(
         output::AbstractVector,
         y_point::Matrix{Tv},
-        a_point::Matrix{Tv},
-        d_point::Matrix{Tv},
+        a_point::Matrix{Tc},
+        d_point::Matrix{Tc},
         aq::_QuadraticAnchoredQuery{Tg, Tq},
         op::DerivOp{N}
-    ) where {Tg, Tv, Tq <: Real, N}
+    ) where {Tg, Tv, Tc, Tq <: Real, N}
     z = 0 * (@inbounds y_point[first(eachindex(output)), aq.idx])
     @inbounds @simd for k in eachindex(output)
         output[k] = z
@@ -375,9 +372,10 @@ function quadratic_interp(
     Tv_out = _value_type(Tv, Tg)
     y_mat, n_ser = _build_series_mat(s, n_pts, Tv_out)
 
-    # Allocate coefficient matrices
-    a_mat = Matrix{Tv_out}(undef, n_pts, n_ser)
-    d_mat = Matrix{Tv_out}(undef, n_pts, n_ser)
+    # Allocate coefficient matrices (Dual when grid is Dual)
+    Tc = _output_eltype(Tv_out, eltype(x))
+    a_mat = Matrix{Tc}(undef, n_pts, n_ser)
+    d_mat = Matrix{Tc}(undef, n_pts, n_ser)
 
     # Compute spacing once — shared across all series
     spacing = _create_spacing(x)
@@ -427,7 +425,7 @@ function (sitp::QuadraticSeriesInterpolant{Tg, Tv, P})(
     ) where {Tg, Tv, P, Tq <: Real}
     # Promote for anchor: Int→Float, Int-backed Dual→Float-backed Dual (no-op for Float/Float-backed Dual)
     xq_promoted = _promote_for_anchor(xq, Tg)
-    T_out = _series_output_type(Tv, typeof(xq_promoted))
+    T_out = _series_output_type(_output_eltype(Tv, Tg), typeof(xq_promoted))
     aq = _make_anchor(sitp, xq_promoted, _resolve_search(sitp.x, xq, search, hint))
 
     output = Vector{T_out}(undef, n_series(sitp))

--- a/src/quadratic/quadratic_series_interp.jl
+++ b/src/quadratic/quadratic_series_interp.jl
@@ -479,7 +479,7 @@ function (sitp::QuadraticSeriesInterpolant{Tg, Tv, P})(
     ) where {Tg, Tv, P, Tq <: Real}
     n_query = length(xq)
     n_ser = n_series(sitp)
-    T_out = _series_output_type(Tv, Tq)
+    T_out = _series_output_type(_output_eltype(Tv, Tg), Tq)
 
     # Explicit Vector{Vector{T_out}} for type stability on Julia LTS
     outputs = Vector{Vector{T_out}}(undef, n_ser)
@@ -568,8 +568,8 @@ Takes `dL` as a parameter to allow caller to compute with original xq precision.
 """
 @inline function _eval_single_quadratic_with_extrap(
         y::AbstractVector{Tv},
-        a::AbstractVector{Tv},
-        d::AbstractVector{Tv},
+        a::AbstractVector{Tc},
+        d::AbstractVector{Tc},
         n_pts::Int,
         x_min::Tg,
         x_max::Tg,
@@ -577,7 +577,7 @@ Takes `dL` as a parameter to allow caller to compute with original xq precision.
         dL::Tq,  # Passed by caller for precision control
         extrap::NoExtrap,
         op::AbstractEvalOp
-    ) where {Tg, Tv, Taq <: Real, Tq <: Real}
+    ) where {Tg, Tv, Tc, Taq <: Real, Tq <: Real}
     if aq.state != IN_DOMAIN
         _throw_extrap_domain_error(aq.xq, x_min, x_max)
     end
@@ -586,8 +586,8 @@ end
 
 @inline function _eval_single_quadratic_with_extrap(
         y::AbstractVector{Tv},
-        a::AbstractVector{Tv},
-        d::AbstractVector{Tv},
+        a::AbstractVector{Tc},
+        d::AbstractVector{Tc},
         n_pts::Int,
         x_min::Tg,
         x_max::Tg,
@@ -595,7 +595,7 @@ end
         dL::Tq,
         extrap::_ClampOrFill,
         op::EvalValue
-    ) where {Tg, Tv, Taq <: Real, Tq <: Real}
+    ) where {Tg, Tv, Tc, Taq <: Real, Tq <: Real}
     if aq.state != IN_DOMAIN  # outside domain
         y_bnd = @inbounds y[_boundary_point_index(aq.state, n_pts)]
         return _eval_extrapolation(op, y_bnd, extrap, aq.xq)
@@ -606,8 +606,8 @@ end
 
 @inline function _eval_single_quadratic_with_extrap(
         y::AbstractVector{Tv},
-        a::AbstractVector{Tv},
-        d::AbstractVector{Tv},
+        a::AbstractVector{Tc},
+        d::AbstractVector{Tc},
         n_pts::Int,
         x_min::Tg,
         x_max::Tg,
@@ -615,7 +615,7 @@ end
         dL::Tq,
         extrap::_ClampOrFill,
         op::Union{EvalDeriv1, EvalDeriv2, EvalDeriv3}
-    ) where {Tg, Tv, Taq <: Real, Tq <: Real}
+    ) where {Tg, Tv, Tc, Taq <: Real, Tq <: Real}
     if aq.state != IN_DOMAIN  # outside domain
         return _eval_extrapolation(op, first(y), extrap, aq.xq)
     else
@@ -635,14 +635,14 @@ end
         ::Tq,
         ::_ClampOrFill,
         ::DerivOp{N}
-    ) where {Tg, Tv, Taq <: Real, Tq <: Real, N}
+    ) where {Tg, Tv, Tc, Taq <: Real, Tq <: Real, N}
     return 0 * first(y)
 end
 
 @inline function _eval_single_quadratic_with_extrap(
         y::AbstractVector{Tv},
-        a::AbstractVector{Tv},
-        d::AbstractVector{Tv},
+        a::AbstractVector{Tc},
+        d::AbstractVector{Tc},
         n_pts::Int,
         x_min::Tg,
         x_max::Tg,
@@ -650,7 +650,7 @@ end
         dL::Tq,
         extrap::AbstractExtrap,  # ExtendExtrap, WrapExtrap, etc.
         op::AbstractEvalOp
-    ) where {Tg, Tv, Taq <: Real, Tq <: Real}
+    ) where {Tg, Tv, Tc, Taq <: Real, Tq <: Real}
     return _quadratic_kernel(op, a[aq.idx], d[aq.idx], y[aq.idx], dL)
 end
 

--- a/test/ext/runtests.jl
+++ b/test/ext/runtests.jl
@@ -26,6 +26,7 @@ include("test_linear_dual_grid.jl")   # Linear 1D grid-side Dual
 include("test_hermite_dual_grid.jl")  # Hermite family grid-side Dual
 include("test_constant_quadratic_dual_grid.jl")  # Constant+Quadratic grid-side Dual
 include("test_cubic_dual_grid.jl")              # Cubic grid-side Dual
+include("test_series_dual_grid.jl")             # All methods × Series × Dual grid
 include("test_autodiff_Zygote.jl")
 include("test_autodiff_hetero.jl")
 include("test_hermite_rrule.jl")

--- a/test/ext/runtests.jl
+++ b/test/ext/runtests.jl
@@ -25,6 +25,7 @@ include("test_autodiff_ForwardDiff.jl")
 include("test_linear_dual_grid.jl")   # Linear 1D grid-side Dual
 include("test_hermite_dual_grid.jl")  # Hermite family grid-side Dual
 include("test_constant_quadratic_dual_grid.jl")  # Constant+Quadratic grid-side Dual
+include("test_cubic_dual_grid.jl")              # Cubic grid-side Dual
 include("test_autodiff_Zygote.jl")
 include("test_autodiff_hetero.jl")
 include("test_hermite_rrule.jl")

--- a/test/ext/test_cubic_dual_grid.jl
+++ b/test/ext/test_cubic_dual_grid.jl
@@ -153,17 +153,43 @@ const FI = FastInterpolations
     end
 
     # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           In-place vector API with Dual grid                             ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "cubic_interp! — in-place with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        xd = d .* x_base
+        # Allocating version works (output type inferred)
+        result = cubic_interp(xd, y_base, xq_vec; extrap=ExtendExtrap())
+        ref = cubic_interp(x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        @test ForwardDiff.value.(result) ≈ ref
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           Series with Dual grid                                          ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    # NOTE: Cubic Series + Dual grid and Cubic ND + Dual grid require deeper
+    # changes in the anchor/tensor-product infrastructure (_promote_for_anchor,
+    # vector anchor T(xq[k]) conversion). Deferred to a follow-up PR.
+    # The constraint relaxation in cubic_oneshot_series.jl and cubic_nd_*.jl
+    # is still correct — it enables the Float hot path to coexist with
+    # future Dual support without regressions.
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
     # ║           Float path — zero-alloc regression gate                        ║
     # ╚═══════════════════════════════════════════════════════════════════════╝
 
     @testset "cubic Float scalar — zero-alloc regression" begin
-        x_f = collect(range(0.0, 5.0, 100))
-        y_f = sin.(x_f)
-        # Warmup
-        cubic_interp(x_f, y_f, 2.5)
-        cubic_interp(x_f, y_f, 2.5)
-        allocs = @allocated cubic_interp(x_f, y_f, 2.5)
-        @test allocs <= ALLOC_THRESHOLD
+        function _cubic_alloc_test()
+            x_f = collect(range(0.0, 5.0, 100))
+            y_f = sin.(x_f)
+            cubic_interp(x_f, y_f, 2.5)
+            cubic_interp(x_f, y_f, 2.5)
+            return @allocated cubic_interp(x_f, y_f, 2.5)
+        end
+        _cubic_alloc_test()  # warmup
+        @test _cubic_alloc_test() <= ALLOC_THRESHOLD
     end
 
 end

--- a/test/ext/test_cubic_dual_grid.jl
+++ b/test/ext/test_cubic_dual_grid.jl
@@ -1,0 +1,169 @@
+# ╔═══════════════════════════════════════════════════════════════════════════╗
+# ║           Cubic — Dual Grid Tests (ForwardDiff)                            ║
+# ╚═══════════════════════════════════════════════════════════════════════════╝
+
+using Test
+using FastInterpolations
+using ForwardDiff
+using LinearAlgebra
+
+const FI = FastInterpolations
+
+@testset "Cubic — Dual Grid" begin
+
+    x_base = collect(range(0.0, 5.0, 20))
+    y_base = sin.(x_base)
+    xq_scalar = 2.5
+    xq_vec = [0.5, 1.5, 2.5, 3.5, 4.5]
+    h_fd = 1.0e-7
+    fd_deriv(f) = (f(1.0 + h_fd) - f(1.0 - h_fd)) / (2h_fd)
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           Scalar Oneshot — ForwardDiff.derivative MWE                    ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "cubic scalar oneshot — ForwardDiff.derivative + FD cross-check" begin
+        f_interp = t -> cubic_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol=1e-5
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           Vector Oneshot                                                 ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "cubic vector oneshot — Dual grid primals match Float path" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        result = cubic_interp(d .* x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        ref = cubic_interp(x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        @test ForwardDiff.value.(result) ≈ ref
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           Interpolant (2-arg form)                                       ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "cubic interpolant — Dual grid constructs + callable" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        itp = cubic_interp(d .* x_base, y_base; extrap=ExtendExtrap())
+        v = itp(xq_scalar)
+        itp_f = cubic_interp(x_base, y_base; extrap=ExtendExtrap())
+        @test ForwardDiff.value(v) ≈ itp_f(xq_scalar)
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           BC types                                                       ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "cubic BC types with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        xd = d .* x_base
+
+        for (name, bc) in [
+            ("CubicFit",    CubicFit()),
+            ("ZeroCurvBC",  ZeroCurvBC()),
+            ("ZeroSlopeBC", ZeroSlopeBC()),
+            ("Deriv1(0)",   Deriv1(0.0)),
+            ("Deriv2(0)",   Deriv2(0.0)),
+            ("Deriv3(0)",   Deriv3(0.0)),
+        ]
+            @testset "$name" begin
+                v = cubic_interp(xd, y_base, xq_scalar; bc, extrap=ExtendExtrap())
+                @test isfinite(ForwardDiff.value(v))
+                ref = cubic_interp(x_base, y_base, xq_scalar; bc, extrap=ExtendExtrap())
+                @test ForwardDiff.value(v) ≈ ref
+            end
+        end
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           PeriodicBC                                                     ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "cubic PeriodicBC with Dual grid" begin
+        x_per = collect(range(0.0, 2π, 33))
+        y_per = sin.(x_per)
+        y_per[end] = y_per[1]  # periodic endpoint
+        xq_per = 1.5
+
+        f_per = t -> cubic_interp(t .* x_per, y_per, xq_per; bc=PeriodicBC())
+        ad_val = ForwardDiff.derivative(f_per, 1.0)
+        fd_val = fd_deriv(f_per)
+        @test ad_val ≈ fd_val rtol=1e-5
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           DerivOp with Dual grid                                         ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "cubic DerivOp(1) and DerivOp(2) with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        xd = d .* x_base
+
+        for n in 1:2
+            @testset "DerivOp($n)" begin
+                v = cubic_interp(xd, y_base, xq_scalar; extrap=ExtendExtrap(), deriv=DerivOp(n))
+                ref = cubic_interp(x_base, y_base, xq_scalar; extrap=ExtendExtrap(), deriv=DerivOp(n))
+                @test ForwardDiff.value(v) ≈ ref
+            end
+        end
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           Extrap modes                                                   ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "cubic ClampExtrap + NoExtrap with Dual grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        xd = d .* x_base
+
+        # ClampExtrap
+        v = cubic_interp(xd, y_base, xq_scalar; extrap=ClampExtrap())
+        @test isfinite(ForwardDiff.value(v))
+
+        # NoExtrap in-domain
+        v2 = cubic_interp(xd, y_base, xq_scalar; extrap=NoExtrap())
+        @test isfinite(ForwardDiff.value(v2))
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           Range{Dual} grid                                               ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "cubic Range{Dual} grid" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        x_range = d .* range(0.0, 5.0, 20)
+        v = cubic_interp(collect(x_range), y_base, xq_scalar; extrap=ExtendExtrap())
+        ref = cubic_interp(x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        @test ForwardDiff.value(v) ≈ ref
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           Adjoint with Dual grid                                         ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "cubic adjoint — Dual grid constructs" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        adj = cubic_adjoint(d .* x_base, xq_vec; extrap=ExtendExtrap())
+        y_bar = ones(length(xq_vec))
+        result = adj(y_bar)
+        @test length(result) == length(x_base)
+        @test all(isfinite, result)
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║           Float path — zero-alloc regression gate                        ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "cubic Float scalar — zero-alloc regression" begin
+        x_f = collect(range(0.0, 5.0, 100))
+        y_f = sin.(x_f)
+        # Warmup
+        cubic_interp(x_f, y_f, 2.5)
+        cubic_interp(x_f, y_f, 2.5)
+        allocs = @allocated cubic_interp(x_f, y_f, 2.5)
+        @test allocs <= ALLOC_THRESHOLD
+    end
+
+end

--- a/test/ext/test_cubic_dual_grid.jl
+++ b/test/ext/test_cubic_dual_grid.jl
@@ -169,12 +169,21 @@ const FI = FastInterpolations
     # ║           Series with Dual grid                                          ║
     # ╚═══════════════════════════════════════════════════════════════════════╝
 
-    # NOTE: Cubic Series + Dual grid and Cubic ND + Dual grid require deeper
-    # changes in the anchor/tensor-product infrastructure (_promote_for_anchor,
-    # vector anchor T(xq[k]) conversion). Deferred to a follow-up PR.
-    # The constraint relaxation in cubic_oneshot_series.jl and cubic_nd_*.jl
-    # is still correct — it enables the Float hot path to coexist with
-    # future Dual support without regressions.
+    @testset "cubic Series — Dual grid scalar" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        xd = d .* x_base
+        y1 = sin.(x_base)
+        y2 = cos.(x_base)
+
+        vals = cubic_interp(xd, Series(y1, y2), xq_scalar; extrap=ExtendExtrap())
+        ref1 = cubic_interp(xd, y1, xq_scalar; extrap=ExtendExtrap())
+        ref2 = cubic_interp(xd, y2, xq_scalar; extrap=ExtendExtrap())
+        @test vals[1] ≈ ref1
+        @test vals[2] ≈ ref2
+    end
+
+    # NOTE: Series interpolant (2-arg form) with Dual grid needs LazyTransposePair
+    # to support Tz≠Tv. Deferred — scalar/vector oneshot Series paths work.
 
     # ╔═══════════════════════════════════════════════════════════════════════╗
     # ║           Float path — zero-alloc regression gate                        ║

--- a/test/ext/test_cubic_dual_grid.jl
+++ b/test/ext/test_cubic_dual_grid.jl
@@ -23,10 +23,10 @@ const FI = FastInterpolations
     # ╚═══════════════════════════════════════════════════════════════════════╝
 
     @testset "cubic scalar oneshot — ForwardDiff.derivative + FD cross-check" begin
-        f_interp = t -> cubic_interp(t .* x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        f_interp = t -> cubic_interp(t .* x_base, y_base, xq_scalar; extrap = ExtendExtrap())
         ad_val = ForwardDiff.derivative(f_interp, 1.0)
         fd_val = fd_deriv(f_interp)
-        @test ad_val ≈ fd_val rtol=1e-5
+        @test ad_val ≈ fd_val rtol = 1.0e-5
     end
 
     # ╔═══════════════════════════════════════════════════════════════════════╗
@@ -35,8 +35,8 @@ const FI = FastInterpolations
 
     @testset "cubic vector oneshot — Dual grid primals match Float path" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        result = cubic_interp(d .* x_base, y_base, xq_vec; extrap=ExtendExtrap())
-        ref = cubic_interp(x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        result = cubic_interp(d .* x_base, y_base, xq_vec; extrap = ExtendExtrap())
+        ref = cubic_interp(x_base, y_base, xq_vec; extrap = ExtendExtrap())
         @test ForwardDiff.value.(result) ≈ ref
     end
 
@@ -46,9 +46,9 @@ const FI = FastInterpolations
 
     @testset "cubic interpolant — Dual grid constructs + callable" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        itp = cubic_interp(d .* x_base, y_base; extrap=ExtendExtrap())
+        itp = cubic_interp(d .* x_base, y_base; extrap = ExtendExtrap())
         v = itp(xq_scalar)
-        itp_f = cubic_interp(x_base, y_base; extrap=ExtendExtrap())
+        itp_f = cubic_interp(x_base, y_base; extrap = ExtendExtrap())
         @test ForwardDiff.value(v) ≈ itp_f(xq_scalar)
     end
 
@@ -61,17 +61,17 @@ const FI = FastInterpolations
         xd = d .* x_base
 
         for (name, bc) in [
-            ("CubicFit",    CubicFit()),
-            ("ZeroCurvBC",  ZeroCurvBC()),
-            ("ZeroSlopeBC", ZeroSlopeBC()),
-            ("Deriv1(0)",   Deriv1(0.0)),
-            ("Deriv2(0)",   Deriv2(0.0)),
-            ("Deriv3(0)",   Deriv3(0.0)),
-        ]
+                ("CubicFit", CubicFit()),
+                ("ZeroCurvBC", ZeroCurvBC()),
+                ("ZeroSlopeBC", ZeroSlopeBC()),
+                ("Deriv1(0)", Deriv1(0.0)),
+                ("Deriv2(0)", Deriv2(0.0)),
+                ("Deriv3(0)", Deriv3(0.0)),
+            ]
             @testset "$name" begin
-                v = cubic_interp(xd, y_base, xq_scalar; bc, extrap=ExtendExtrap())
+                v = cubic_interp(xd, y_base, xq_scalar; bc, extrap = ExtendExtrap())
                 @test isfinite(ForwardDiff.value(v))
-                ref = cubic_interp(x_base, y_base, xq_scalar; bc, extrap=ExtendExtrap())
+                ref = cubic_interp(x_base, y_base, xq_scalar; bc, extrap = ExtendExtrap())
                 @test ForwardDiff.value(v) ≈ ref
             end
         end
@@ -87,10 +87,10 @@ const FI = FastInterpolations
         y_per[end] = y_per[1]  # periodic endpoint
         xq_per = 1.5
 
-        f_per = t -> cubic_interp(t .* x_per, y_per, xq_per; bc=PeriodicBC())
+        f_per = t -> cubic_interp(t .* x_per, y_per, xq_per; bc = PeriodicBC())
         ad_val = ForwardDiff.derivative(f_per, 1.0)
         fd_val = fd_deriv(f_per)
-        @test ad_val ≈ fd_val rtol=1e-5
+        @test ad_val ≈ fd_val rtol = 1.0e-5
     end
 
     # ╔═══════════════════════════════════════════════════════════════════════╗
@@ -103,8 +103,8 @@ const FI = FastInterpolations
 
         for n in 1:2
             @testset "DerivOp($n)" begin
-                v = cubic_interp(xd, y_base, xq_scalar; extrap=ExtendExtrap(), deriv=DerivOp(n))
-                ref = cubic_interp(x_base, y_base, xq_scalar; extrap=ExtendExtrap(), deriv=DerivOp(n))
+                v = cubic_interp(xd, y_base, xq_scalar; extrap = ExtendExtrap(), deriv = DerivOp(n))
+                ref = cubic_interp(x_base, y_base, xq_scalar; extrap = ExtendExtrap(), deriv = DerivOp(n))
                 @test ForwardDiff.value(v) ≈ ref
             end
         end
@@ -119,11 +119,11 @@ const FI = FastInterpolations
         xd = d .* x_base
 
         # ClampExtrap
-        v = cubic_interp(xd, y_base, xq_scalar; extrap=ClampExtrap())
+        v = cubic_interp(xd, y_base, xq_scalar; extrap = ClampExtrap())
         @test isfinite(ForwardDiff.value(v))
 
         # NoExtrap in-domain
-        v2 = cubic_interp(xd, y_base, xq_scalar; extrap=NoExtrap())
+        v2 = cubic_interp(xd, y_base, xq_scalar; extrap = NoExtrap())
         @test isfinite(ForwardDiff.value(v2))
     end
 
@@ -134,8 +134,8 @@ const FI = FastInterpolations
     @testset "cubic Range{Dual} grid" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
         x_range = d .* range(0.0, 5.0, 20)
-        v = cubic_interp(collect(x_range), y_base, xq_scalar; extrap=ExtendExtrap())
-        ref = cubic_interp(x_base, y_base, xq_scalar; extrap=ExtendExtrap())
+        v = cubic_interp(collect(x_range), y_base, xq_scalar; extrap = ExtendExtrap())
+        ref = cubic_interp(x_base, y_base, xq_scalar; extrap = ExtendExtrap())
         @test ForwardDiff.value(v) ≈ ref
     end
 
@@ -145,7 +145,7 @@ const FI = FastInterpolations
 
     @testset "cubic adjoint — Dual grid constructs" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        adj = cubic_adjoint(d .* x_base, xq_vec; extrap=ExtendExtrap())
+        adj = cubic_adjoint(d .* x_base, xq_vec; extrap = ExtendExtrap())
         y_bar = ones(length(xq_vec))
         result = adj(y_bar)
         @test length(result) == length(x_base)
@@ -160,8 +160,8 @@ const FI = FastInterpolations
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
         xd = d .* x_base
         # Allocating version works (output type inferred)
-        result = cubic_interp(xd, y_base, xq_vec; extrap=ExtendExtrap())
-        ref = cubic_interp(x_base, y_base, xq_vec; extrap=ExtendExtrap())
+        result = cubic_interp(xd, y_base, xq_vec; extrap = ExtendExtrap())
+        ref = cubic_interp(x_base, y_base, xq_vec; extrap = ExtendExtrap())
         @test ForwardDiff.value.(result) ≈ ref
     end
 
@@ -175,9 +175,9 @@ const FI = FastInterpolations
         y1 = sin.(x_base)
         y2 = cos.(x_base)
 
-        vals = cubic_interp(xd, Series(y1, y2), xq_scalar; extrap=ExtendExtrap())
-        ref1 = cubic_interp(xd, y1, xq_scalar; extrap=ExtendExtrap())
-        ref2 = cubic_interp(xd, y2, xq_scalar; extrap=ExtendExtrap())
+        vals = cubic_interp(xd, Series(y1, y2), xq_scalar; extrap = ExtendExtrap())
+        ref1 = cubic_interp(xd, y1, xq_scalar; extrap = ExtendExtrap())
+        ref2 = cubic_interp(xd, y2, xq_scalar; extrap = ExtendExtrap())
         @test vals[1] ≈ ref1
         @test vals[2] ≈ ref2
     end

--- a/test/ext/test_cubic_dual_grid.jl
+++ b/test/ext/test_cubic_dual_grid.jl
@@ -152,6 +152,29 @@ const FI = FastInterpolations
         @test all(isfinite, result)
     end
 
+    @testset "cubic adjoint — Dual grid + PeriodicBC" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        x_per = collect(range(0.0, 2π, 33))
+        y_per = sin.(x_per); y_per[end] = y_per[1]
+        adj = cubic_adjoint(d .* x_per, [1.0, 2.0]; bc = PeriodicBC())
+        result = adj(ones(2))
+        @test length(result) == length(x_per)
+        @test all(isfinite, result)
+    end
+
+    @testset "cubic cache-based eval — Dual grid + Float query" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        cache = CubicSplineCache(d .* x_base)
+        # Scalar
+        v = cubic_interp(cache, y_base, xq_scalar)
+        ref = cubic_interp(x_base, y_base, xq_scalar)
+        @test ForwardDiff.value(v) ≈ ref
+        # Vector
+        vv = cubic_interp(cache, y_base, xq_vec)
+        refv = cubic_interp(x_base, y_base, xq_vec)
+        @test ForwardDiff.value.(vv) ≈ refv
+    end
+
     # ╔═══════════════════════════════════════════════════════════════════════╗
     # ║           In-place vector API with Dual grid                             ║
     # ╚═══════════════════════════════════════════════════════════════════════╝
@@ -182,8 +205,7 @@ const FI = FastInterpolations
         @test vals[2] ≈ ref2
     end
 
-    # NOTE: Series interpolant (2-arg form) with Dual grid needs LazyTransposePair
-    # to support Tz≠Tv. Deferred — scalar/vector oneshot Series paths work.
+    # Series interpolant (2-arg form) with Dual grid: covered in test_series_dual_grid.jl
 
     # ╔═══════════════════════════════════════════════════════════════════════╗
     # ║           Float path — zero-alloc regression gate                        ║

--- a/test/ext/test_series_dual_grid.jl
+++ b/test/ext/test_series_dual_grid.jl
@@ -34,35 +34,35 @@ using ForwardDiff
     # ╚═══════════════════════════════════════════════════════════════════════╝
 
     @testset "constant" begin
-        ref_s = constant_interp(x_vec, s, xq; extrap=ExtendExtrap())
-        ref_v = constant_interp(x_vec, s, xq_vec; extrap=ExtendExtrap())
+        ref_s = constant_interp(x_vec, s, xq; extrap = ExtendExtrap())
+        ref_v = constant_interp(x_vec, s, xq_vec; extrap = ExtendExtrap())
 
         @testset "Vector grid — scalar query" begin
-            vals = constant_interp(xd_vec, s, xq; extrap=ExtendExtrap())
+            vals = constant_interp(xd_vec, s, xq; extrap = ExtendExtrap())
             @test check_primals(vals, ref_s)
         end
         @testset "Vector grid — vector query" begin
-            vals = constant_interp(xd_vec, s, xq_vec; extrap=ExtendExtrap())
+            vals = constant_interp(xd_vec, s, xq_vec; extrap = ExtendExtrap())
             @test check_primals(vals[1], ref_v[1])
         end
         @testset "Vector grid — in-place scalar" begin
             output = Vector{Any}(undef, 2)
-            constant_interp!(output, xd_vec, s, xq; extrap=ExtendExtrap())
+            constant_interp!(output, xd_vec, s, xq; extrap = ExtendExtrap())
             @test check_primals(output, ref_s)
         end
         @testset "Range grid — scalar query" begin
             # Range broadcasting (d .* range) has ULP differences vs d .* collect(range).
             # Constant is discontinuous (nearest-neighbor) so ULP boundary shift may pick
             # adjacent y-value. Check result is a valid y-value (within atol of some y[k]).
-            vals = constant_interp(xd_range_vec, s, xq; extrap=ExtendExtrap())
-            @test any(v -> isapprox(ForwardDiff.value(vals[1]), v; atol=1e-14), y1)
-            @test any(v -> isapprox(ForwardDiff.value(vals[2]), v; atol=1e-14), y2)
+            vals = constant_interp(xd_range_vec, s, xq; extrap = ExtendExtrap())
+            @test any(v -> isapprox(ForwardDiff.value(vals[1]), v; atol = 1.0e-14), y1)
+            @test any(v -> isapprox(ForwardDiff.value(vals[2]), v; atol = 1.0e-14), y2)
         end
         @testset "Range grid — vector query" begin
-            vals = constant_interp(xd_range_vec, s, xq_vec; extrap=ExtendExtrap())
+            vals = constant_interp(xd_range_vec, s, xq_vec; extrap = ExtendExtrap())
             # Each result element must be a valid y-value
-            @test all(r -> any(v -> isapprox(ForwardDiff.value(r), v; atol=1e-14), y1), vals[1])
-            @test all(r -> any(v -> isapprox(ForwardDiff.value(r), v; atol=1e-14), y2), vals[2])
+            @test all(r -> any(v -> isapprox(ForwardDiff.value(r), v; atol = 1.0e-14), y1), vals[1])
+            @test all(r -> any(v -> isapprox(ForwardDiff.value(r), v; atol = 1.0e-14), y2), vals[2])
         end
     end
 
@@ -71,28 +71,28 @@ using ForwardDiff
     # ╚═══════════════════════════════════════════════════════════════════════╝
 
     @testset "linear" begin
-        ref_s = linear_interp(x_vec, s, xq; extrap=ExtendExtrap())
-        ref_v = linear_interp(x_vec, s, xq_vec; extrap=ExtendExtrap())
+        ref_s = linear_interp(x_vec, s, xq; extrap = ExtendExtrap())
+        ref_v = linear_interp(x_vec, s, xq_vec; extrap = ExtendExtrap())
 
         @testset "Vector grid — scalar query" begin
-            vals = linear_interp(xd_vec, s, xq; extrap=ExtendExtrap())
+            vals = linear_interp(xd_vec, s, xq; extrap = ExtendExtrap())
             @test check_primals(vals, ref_s)
         end
         @testset "Vector grid — vector query" begin
-            vals = linear_interp(xd_vec, s, xq_vec; extrap=ExtendExtrap())
+            vals = linear_interp(xd_vec, s, xq_vec; extrap = ExtendExtrap())
             @test check_primals(vals[1], ref_v[1])
         end
         @testset "Vector grid — in-place scalar" begin
             output = Vector{Any}(undef, 2)
-            linear_interp!(output, xd_vec, s, xq; extrap=ExtendExtrap())
+            linear_interp!(output, xd_vec, s, xq; extrap = ExtendExtrap())
             @test check_primals(output, ref_s)
         end
         @testset "Range grid — scalar query" begin
-            vals = linear_interp(xd_range_vec, s, xq; extrap=ExtendExtrap())
+            vals = linear_interp(xd_range_vec, s, xq; extrap = ExtendExtrap())
             @test check_primals(vals, ref_s)
         end
         @testset "Range grid — vector query" begin
-            vals = linear_interp(xd_range_vec, s, xq_vec; extrap=ExtendExtrap())
+            vals = linear_interp(xd_range_vec, s, xq_vec; extrap = ExtendExtrap())
             @test check_primals(vals[1], ref_v[1])
         end
     end
@@ -102,28 +102,28 @@ using ForwardDiff
     # ╚═══════════════════════════════════════════════════════════════════════╝
 
     @testset "quadratic" begin
-        ref_s = quadratic_interp(x_vec, s, xq; extrap=ExtendExtrap())
-        ref_v = quadratic_interp(x_vec, s, xq_vec; extrap=ExtendExtrap())
+        ref_s = quadratic_interp(x_vec, s, xq; extrap = ExtendExtrap())
+        ref_v = quadratic_interp(x_vec, s, xq_vec; extrap = ExtendExtrap())
 
         @testset "Vector grid — scalar query" begin
-            vals = quadratic_interp(xd_vec, s, xq; extrap=ExtendExtrap())
+            vals = quadratic_interp(xd_vec, s, xq; extrap = ExtendExtrap())
             @test check_primals(vals, ref_s)
         end
         @testset "Vector grid — vector query" begin
-            vals = quadratic_interp(xd_vec, s, xq_vec; extrap=ExtendExtrap())
+            vals = quadratic_interp(xd_vec, s, xq_vec; extrap = ExtendExtrap())
             @test check_primals(vals[1], ref_v[1])
         end
         @testset "Vector grid — in-place scalar" begin
             output = Vector{Any}(undef, 2)
-            quadratic_interp!(output, xd_vec, s, xq; extrap=ExtendExtrap())
+            quadratic_interp!(output, xd_vec, s, xq; extrap = ExtendExtrap())
             @test check_primals(output, ref_s)
         end
         @testset "Range grid — scalar query" begin
-            vals = quadratic_interp(xd_range_vec, s, xq; extrap=ExtendExtrap())
+            vals = quadratic_interp(xd_range_vec, s, xq; extrap = ExtendExtrap())
             @test check_primals(vals, ref_s)
         end
         @testset "Range grid — vector query" begin
-            vals = quadratic_interp(xd_range_vec, s, xq_vec; extrap=ExtendExtrap())
+            vals = quadratic_interp(xd_range_vec, s, xq_vec; extrap = ExtendExtrap())
             @test check_primals(vals[1], ref_v[1])
         end
     end
@@ -133,29 +133,29 @@ using ForwardDiff
     # ╚═══════════════════════════════════════════════════════════════════════╝
 
     @testset "cubic" begin
-        ref_s = cubic_interp(x_vec, s, xq; extrap=ExtendExtrap())
-        ref_v = cubic_interp(x_vec, s, xq_vec; extrap=ExtendExtrap())
+        ref_s = cubic_interp(x_vec, s, xq; extrap = ExtendExtrap())
+        ref_v = cubic_interp(x_vec, s, xq_vec; extrap = ExtendExtrap())
 
         @testset "Vector grid — scalar query" begin
-            vals = cubic_interp(xd_vec, s, xq; extrap=ExtendExtrap())
+            vals = cubic_interp(xd_vec, s, xq; extrap = ExtendExtrap())
             @test check_primals(vals, ref_s)
         end
         @testset "Vector grid — vector query" begin
-            vals = cubic_interp(xd_vec, s, xq_vec; extrap=ExtendExtrap())
+            vals = cubic_interp(xd_vec, s, xq_vec; extrap = ExtendExtrap())
             @test check_primals(vals[1], ref_v[1])
         end
         @testset "Vector grid — in-place scalar" begin
             Tout = ForwardDiff.Dual{:tag, Float64, 1}
             output = Vector{Tout}(undef, 2)
-            cubic_interp!(output, xd_vec, s, xq; extrap=ExtendExtrap())
+            cubic_interp!(output, xd_vec, s, xq; extrap = ExtendExtrap())
             @test check_primals(output, ref_s)
         end
         @testset "Range grid — scalar query" begin
-            vals = cubic_interp(xd_range_vec, s, xq; extrap=ExtendExtrap())
+            vals = cubic_interp(xd_range_vec, s, xq; extrap = ExtendExtrap())
             @test check_primals(vals, ref_s)
         end
         @testset "Range grid — vector query" begin
-            vals = cubic_interp(xd_range_vec, s, xq_vec; extrap=ExtendExtrap())
+            vals = cubic_interp(xd_range_vec, s, xq_vec; extrap = ExtendExtrap())
             @test check_primals(vals[1], ref_v[1])
         end
     end
@@ -166,31 +166,31 @@ using ForwardDiff
     # ╚═══════════════════════════════════════════════════════════════════════╝
 
     @testset "constant Series interpolant — Dual grid" begin
-        sitp = constant_interp(xd_vec, s; extrap=ExtendExtrap())
+        sitp = constant_interp(xd_vec, s; extrap = ExtendExtrap())
         vals = sitp(xq)
-        sitp_f = constant_interp(x_vec, s; extrap=ExtendExtrap())
+        sitp_f = constant_interp(x_vec, s; extrap = ExtendExtrap())
         @test check_primals(vals, sitp_f(xq))
     end
 
     @testset "linear Series interpolant — Dual grid" begin
-        sitp = linear_interp(xd_vec, s; extrap=ExtendExtrap())
+        sitp = linear_interp(xd_vec, s; extrap = ExtendExtrap())
         vals = sitp(xq)
-        sitp_f = linear_interp(x_vec, s; extrap=ExtendExtrap())
+        sitp_f = linear_interp(x_vec, s; extrap = ExtendExtrap())
         @test check_primals(vals, sitp_f(xq))
     end
 
     @testset "quadratic Series interpolant — Dual grid" begin
-        sitp = quadratic_interp(xd_vec, s; extrap=ExtendExtrap())
+        sitp = quadratic_interp(xd_vec, s; extrap = ExtendExtrap())
         vals = sitp(xq)
-        sitp_f = quadratic_interp(x_vec, s; extrap=ExtendExtrap())
+        sitp_f = quadratic_interp(x_vec, s; extrap = ExtendExtrap())
         @test check_primals(vals, sitp_f(xq))
         @test any(!iszero, ForwardDiff.partials.(vals))
     end
 
     @testset "cubic Series interpolant — Dual grid" begin
-        sitp = cubic_interp(xd_vec, s; extrap=ExtendExtrap())
+        sitp = cubic_interp(xd_vec, s; extrap = ExtendExtrap())
         vals = sitp(xq)
-        sitp_f = cubic_interp(x_vec, s; extrap=ExtendExtrap())
+        sitp_f = cubic_interp(x_vec, s; extrap = ExtendExtrap())
         @test check_primals(vals, sitp_f(xq))
 
         # Verify partials are nonzero — grid sensitivity actually propagates

--- a/test/ext/test_series_dual_grid.jl
+++ b/test/ext/test_series_dual_grid.jl
@@ -46,7 +46,8 @@ using ForwardDiff
             @test check_primals(vals[1], ref_v[1])
         end
         @testset "Vector grid — in-place scalar" begin
-            output = Vector{Any}(undef, 2)
+            probe = constant_interp(xd_vec, s, xq; extrap = ExtendExtrap())
+            output = similar(probe)
             constant_interp!(output, xd_vec, s, xq; extrap = ExtendExtrap())
             @test check_primals(output, ref_s)
         end
@@ -83,7 +84,8 @@ using ForwardDiff
             @test check_primals(vals[1], ref_v[1])
         end
         @testset "Vector grid — in-place scalar" begin
-            output = Vector{Any}(undef, 2)
+            probe = linear_interp(xd_vec, s, xq; extrap = ExtendExtrap())
+            output = similar(probe)
             linear_interp!(output, xd_vec, s, xq; extrap = ExtendExtrap())
             @test check_primals(output, ref_s)
         end
@@ -114,7 +116,8 @@ using ForwardDiff
             @test check_primals(vals[1], ref_v[1])
         end
         @testset "Vector grid — in-place scalar" begin
-            output = Vector{Any}(undef, 2)
+            probe = quadratic_interp(xd_vec, s, xq; extrap = ExtendExtrap())
+            output = similar(probe)
             quadratic_interp!(output, xd_vec, s, xq; extrap = ExtendExtrap())
             @test check_primals(output, ref_s)
         end

--- a/test/ext/test_series_dual_grid.jl
+++ b/test/ext/test_series_dual_grid.jl
@@ -165,36 +165,66 @@ using ForwardDiff
     # ║  Tests LazyTranspose/Pair/Triple with Tz ≠ Tv                          ║
     # ╚═══════════════════════════════════════════════════════════════════════╝
 
-    @testset "constant Series interpolant — Dual grid" begin
+    # ── Interpolant: scalar query ──────────────────────────────────────
+
+    @testset "constant interpolant — scalar" begin
         sitp = constant_interp(xd_vec, s; extrap = ExtendExtrap())
-        vals = sitp(xq)
         sitp_f = constant_interp(x_vec, s; extrap = ExtendExtrap())
-        @test check_primals(vals, sitp_f(xq))
+        @test check_primals(sitp(xq), sitp_f(xq))
     end
 
-    @testset "linear Series interpolant — Dual grid" begin
+    @testset "linear interpolant — scalar" begin
         sitp = linear_interp(xd_vec, s; extrap = ExtendExtrap())
-        vals = sitp(xq)
         sitp_f = linear_interp(x_vec, s; extrap = ExtendExtrap())
-        @test check_primals(vals, sitp_f(xq))
+        @test check_primals(sitp(xq), sitp_f(xq))
     end
 
-    @testset "quadratic Series interpolant — Dual grid" begin
+    @testset "quadratic interpolant — scalar" begin
         sitp = quadratic_interp(xd_vec, s; extrap = ExtendExtrap())
-        vals = sitp(xq)
         sitp_f = quadratic_interp(x_vec, s; extrap = ExtendExtrap())
-        @test check_primals(vals, sitp_f(xq))
-        @test any(!iszero, ForwardDiff.partials.(vals))
+        @test check_primals(sitp(xq), sitp_f(xq))
+        @test any(!iszero, ForwardDiff.partials.(sitp(xq)))
     end
 
-    @testset "cubic Series interpolant — Dual grid" begin
+    @testset "cubic interpolant — scalar" begin
         sitp = cubic_interp(xd_vec, s; extrap = ExtendExtrap())
-        vals = sitp(xq)
         sitp_f = cubic_interp(x_vec, s; extrap = ExtendExtrap())
-        @test check_primals(vals, sitp_f(xq))
+        @test check_primals(sitp(xq), sitp_f(xq))
+        @test any(!iszero, ForwardDiff.partials.(sitp(xq)))
+    end
 
-        # Verify partials are nonzero — grid sensitivity actually propagates
-        @test any(!iszero, ForwardDiff.partials.(vals))
+    # ── Interpolant: vector query (out-of-place) ─────────────────────
+
+    @testset "constant interpolant — vector query" begin
+        sitp = constant_interp(xd_vec, s; extrap = ExtendExtrap())
+        sitp_f = constant_interp(x_vec, s; extrap = ExtendExtrap())
+        vals = sitp(xq_vec)
+        ref = sitp_f(xq_vec)
+        @test check_primals(vals[1], ref[1])
+    end
+
+    @testset "linear interpolant — vector query" begin
+        sitp = linear_interp(xd_vec, s; extrap = ExtendExtrap())
+        sitp_f = linear_interp(x_vec, s; extrap = ExtendExtrap())
+        vals = sitp(xq_vec)
+        ref = sitp_f(xq_vec)
+        @test check_primals(vals[1], ref[1])
+    end
+
+    @testset "quadratic interpolant — vector query" begin
+        sitp = quadratic_interp(xd_vec, s; extrap = ExtendExtrap())
+        sitp_f = quadratic_interp(x_vec, s; extrap = ExtendExtrap())
+        vals = sitp(xq_vec)
+        ref = sitp_f(xq_vec)
+        @test check_primals(vals[1], ref[1])
+    end
+
+    @testset "cubic interpolant — vector query" begin
+        sitp = cubic_interp(xd_vec, s; extrap = ExtendExtrap())
+        sitp_f = cubic_interp(x_vec, s; extrap = ExtendExtrap())
+        vals = sitp(xq_vec)
+        ref = sitp_f(xq_vec)
+        @test check_primals(vals[1], ref[1])
     end
 
 end

--- a/test/ext/test_series_dual_grid.jl
+++ b/test/ext/test_series_dual_grid.jl
@@ -1,0 +1,157 @@
+# ╔═══════════════════════════════════════════════════════════════════════════╗
+# ║     All Methods × Series × Dual Grid — Comprehensive Coverage             ║
+# ╚═══════════════════════════════════════════════════════════════════════════╝
+#
+# Cross-cutting test: ensures every method's Series oneshot path works with
+# Dual grids across all combinations:
+#   Grid type: Vector{Dual}, Range{Dual} (collected to Vector)
+#   Query mode: scalar, vector, in-place scalar
+#
+# NOTE: PCHIP/Cardinal/Akima do not have Series API — excluded.
+
+using Test
+using FastInterpolations
+using ForwardDiff
+
+@testset "Series × Dual Grid — all methods" begin
+
+    x_vec = collect(range(0.0, 5.0, 20))
+    x_range = range(0.0, 5.0, 20)
+    y1 = sin.(x_vec)
+    y2 = cos.(x_vec)
+    d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+    xd_vec = d .* x_vec
+    xd_range_vec = collect(d .* x_range)  # Range{Dual} → Vector{Dual}
+    xq = 2.5
+    xq_vec = [1.0, 2.5, 4.0]
+    s = Series(y1, y2)
+
+    # Helper: check primals match Float reference
+    check_primals(dual_vals, float_vals) = ForwardDiff.value.(dual_vals) ≈ float_vals
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  CONSTANT                                                              ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "constant" begin
+        ref_s = constant_interp(x_vec, s, xq; extrap=ExtendExtrap())
+        ref_v = constant_interp(x_vec, s, xq_vec; extrap=ExtendExtrap())
+
+        @testset "Vector grid — scalar query" begin
+            vals = constant_interp(xd_vec, s, xq; extrap=ExtendExtrap())
+            @test check_primals(vals, ref_s)
+        end
+        @testset "Vector grid — vector query" begin
+            vals = constant_interp(xd_vec, s, xq_vec; extrap=ExtendExtrap())
+            @test check_primals(vals[1], ref_v[1])
+        end
+        @testset "Vector grid — in-place scalar" begin
+            output = Vector{Any}(undef, 2)
+            constant_interp!(output, xd_vec, s, xq; extrap=ExtendExtrap())
+            @test check_primals(output, ref_s)
+        end
+        @testset "Range grid — scalar query" begin
+            # Range broadcasting (d .* range) has ULP differences vs d .* collect(range).
+            # Constant is discontinuous (nearest-neighbor) so ULP boundary shift may pick
+            # adjacent y-value. Check result is a valid y-value (within atol of some y[k]).
+            vals = constant_interp(xd_range_vec, s, xq; extrap=ExtendExtrap())
+            @test any(v -> isapprox(ForwardDiff.value(vals[1]), v; atol=1e-14), y1)
+            @test any(v -> isapprox(ForwardDiff.value(vals[2]), v; atol=1e-14), y2)
+        end
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  LINEAR                                                                ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "linear" begin
+        ref_s = linear_interp(x_vec, s, xq; extrap=ExtendExtrap())
+        ref_v = linear_interp(x_vec, s, xq_vec; extrap=ExtendExtrap())
+
+        @testset "Vector grid — scalar query" begin
+            vals = linear_interp(xd_vec, s, xq; extrap=ExtendExtrap())
+            @test check_primals(vals, ref_s)
+        end
+        @testset "Vector grid — vector query" begin
+            vals = linear_interp(xd_vec, s, xq_vec; extrap=ExtendExtrap())
+            @test check_primals(vals[1], ref_v[1])
+        end
+        @testset "Vector grid — in-place scalar" begin
+            output = Vector{Any}(undef, 2)
+            linear_interp!(output, xd_vec, s, xq; extrap=ExtendExtrap())
+            @test check_primals(output, ref_s)
+        end
+        @testset "Range grid — scalar query" begin
+            vals = linear_interp(xd_range_vec, s, xq; extrap=ExtendExtrap())
+            @test check_primals(vals, ref_s)
+        end
+        @testset "Range grid — vector query" begin
+            vals = linear_interp(xd_range_vec, s, xq_vec; extrap=ExtendExtrap())
+            @test check_primals(vals[1], ref_v[1])
+        end
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  QUADRATIC                                                             ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "quadratic" begin
+        ref_s = quadratic_interp(x_vec, s, xq; extrap=ExtendExtrap())
+        ref_v = quadratic_interp(x_vec, s, xq_vec; extrap=ExtendExtrap())
+
+        @testset "Vector grid — scalar query" begin
+            vals = quadratic_interp(xd_vec, s, xq; extrap=ExtendExtrap())
+            @test check_primals(vals, ref_s)
+        end
+        @testset "Vector grid — vector query" begin
+            vals = quadratic_interp(xd_vec, s, xq_vec; extrap=ExtendExtrap())
+            @test check_primals(vals[1], ref_v[1])
+        end
+        @testset "Vector grid — in-place scalar" begin
+            output = Vector{Any}(undef, 2)
+            quadratic_interp!(output, xd_vec, s, xq; extrap=ExtendExtrap())
+            @test check_primals(output, ref_s)
+        end
+        @testset "Range grid — scalar query" begin
+            vals = quadratic_interp(xd_range_vec, s, xq; extrap=ExtendExtrap())
+            @test check_primals(vals, ref_s)
+        end
+        @testset "Range grid — vector query" begin
+            vals = quadratic_interp(xd_range_vec, s, xq_vec; extrap=ExtendExtrap())
+            @test check_primals(vals[1], ref_v[1])
+        end
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  CUBIC                                                                 ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "cubic" begin
+        ref_s = cubic_interp(x_vec, s, xq; extrap=ExtendExtrap())
+        ref_v = cubic_interp(x_vec, s, xq_vec; extrap=ExtendExtrap())
+
+        @testset "Vector grid — scalar query" begin
+            vals = cubic_interp(xd_vec, s, xq; extrap=ExtendExtrap())
+            @test check_primals(vals, ref_s)
+        end
+        @testset "Vector grid — vector query" begin
+            vals = cubic_interp(xd_vec, s, xq_vec; extrap=ExtendExtrap())
+            @test check_primals(vals[1], ref_v[1])
+        end
+        @testset "Vector grid — in-place scalar" begin
+            Tout = ForwardDiff.Dual{:tag, Float64, 1}
+            output = Vector{Tout}(undef, 2)
+            cubic_interp!(output, xd_vec, s, xq; extrap=ExtendExtrap())
+            @test check_primals(output, ref_s)
+        end
+        @testset "Range grid — scalar query" begin
+            vals = cubic_interp(xd_range_vec, s, xq; extrap=ExtendExtrap())
+            @test check_primals(vals, ref_s)
+        end
+        @testset "Range grid — vector query" begin
+            vals = cubic_interp(xd_range_vec, s, xq_vec; extrap=ExtendExtrap())
+            @test check_primals(vals[1], ref_v[1])
+        end
+    end
+
+end

--- a/test/ext/test_series_dual_grid.jl
+++ b/test/ext/test_series_dual_grid.jl
@@ -58,6 +58,12 @@ using ForwardDiff
             @test any(v -> isapprox(ForwardDiff.value(vals[1]), v; atol=1e-14), y1)
             @test any(v -> isapprox(ForwardDiff.value(vals[2]), v; atol=1e-14), y2)
         end
+        @testset "Range grid — vector query" begin
+            vals = constant_interp(xd_range_vec, s, xq_vec; extrap=ExtendExtrap())
+            # Each result element must be a valid y-value
+            @test all(r -> any(v -> isapprox(ForwardDiff.value(r), v; atol=1e-14), y1), vals[1])
+            @test all(r -> any(v -> isapprox(ForwardDiff.value(r), v; atol=1e-14), y2), vals[2])
+        end
     end
 
     # ╔═══════════════════════════════════════════════════════════════════════╗
@@ -152,6 +158,43 @@ using ForwardDiff
             vals = cubic_interp(xd_range_vec, s, xq_vec; extrap=ExtendExtrap())
             @test check_primals(vals[1], ref_v[1])
         end
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  SERIES INTERPOLANT (2-arg, persistent) with Dual grid                 ║
+    # ║  Tests LazyTranspose/Pair/Triple with Tz ≠ Tv                          ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "constant Series interpolant — Dual grid" begin
+        sitp = constant_interp(xd_vec, s; extrap=ExtendExtrap())
+        vals = sitp(xq)
+        sitp_f = constant_interp(x_vec, s; extrap=ExtendExtrap())
+        @test check_primals(vals, sitp_f(xq))
+    end
+
+    @testset "linear Series interpolant — Dual grid" begin
+        sitp = linear_interp(xd_vec, s; extrap=ExtendExtrap())
+        vals = sitp(xq)
+        sitp_f = linear_interp(x_vec, s; extrap=ExtendExtrap())
+        @test check_primals(vals, sitp_f(xq))
+    end
+
+    @testset "quadratic Series interpolant — Dual grid" begin
+        sitp = quadratic_interp(xd_vec, s; extrap=ExtendExtrap())
+        vals = sitp(xq)
+        sitp_f = quadratic_interp(x_vec, s; extrap=ExtendExtrap())
+        @test check_primals(vals, sitp_f(xq))
+        @test any(!iszero, ForwardDiff.partials.(vals))
+    end
+
+    @testset "cubic Series interpolant — Dual grid" begin
+        sitp = cubic_interp(xd_vec, s; extrap=ExtendExtrap())
+        vals = sitp(xq)
+        sitp_f = cubic_interp(x_vec, s; extrap=ExtendExtrap())
+        @test check_primals(vals, sitp_f(xq))
+
+        # Verify partials are nonzero — grid sensitivity actually propagates
+        @test any(!iszero, ForwardDiff.partials.(vals))
     end
 
 end

--- a/test/test_quadratic_anchor.jl
+++ b/test/test_quadratic_anchor.jl
@@ -167,17 +167,15 @@ using FastInterpolations
     @testset "type preservation Real types" begin
         x = collect(range(0.0, 1.0, 11))
 
-        # Int query type is preserved (for AD compatibility)
+        # Int/Rational queries are widened to match dL type (grid arithmetic promotes)
+        # This is consistent with Linear anchor behavior
         aq_int = FastInterpolations._anchor_query(x, 0, Val(:quadratic))
-        @test aq_int.xq isa Int
-        @test aq_int.xq == 0
-        @test aq_int isa FastInterpolations._QuadraticAnchoredQuery{Float64, Int}
+        @test aq_int.xq ≈ 0.0
+        @test aq_int isa FastInterpolations._QuadraticAnchoredQuery{Float64, Float64}
 
-        # Rational query type is preserved (for AD compatibility)
         aq_rat = FastInterpolations._anchor_query(x, 1 // 2, Val(:quadratic))
-        @test aq_rat.xq isa Rational
-        @test aq_rat.xq == 1 // 2
-        @test aq_rat isa FastInterpolations._QuadraticAnchoredQuery{Float64, Rational{Int}}
+        @test aq_rat.xq ≈ 0.5
+        @test aq_rat isa FastInterpolations._QuadraticAnchoredQuery{Float64, Float64}
     end
 
     # ========================================


### PR DESCRIPTION
## Summary
Completes the grid-side AD story for #81 by opening Cubic (1D + Series) to duck-typed grid elements like `ForwardDiff.Dual`. Also fixes latent bugs in Quadratic/Constant anchor and Series infrastructure discovered during this work.
Note that `ND Dual grid` scope is deffered.

## Usage

```julia
# Grid-side sensitivity — the primary use case
ForwardDiff.derivative(t -> cubic_interp(t .* x, y, xq), 1.0)
ForwardDiff.derivative(t -> cubic_interp(t .* x, Series(y1, y2), xq), 1.0)

# All BC types work
ForwardDiff.derivative(t -> cubic_interp(t .* x, y, xq; bc=PeriodicBC()), 1.0)
ForwardDiff.derivative(t -> cubic_interp(t .* x, y, xq; bc=Deriv1(0.0)), 1.0)
```

## What changed

### Cubic 1D (~180 constraint sites, 22 files)

| Change | Why |
|---|---|
| `Tg <: AbstractFloat` → `Tg` across all structs/eval/solver/kernels | `Dual <: Real`, not `<: AbstractFloat` |
| Delete 9 `Tg <: Real` wrappers | `Dual <: Real` → infinite recursion |
| `_effective_autocache(ac, Tg)` helper (13 call sites) | Cache pool bypass — Dual grids are ephemeral, hit rate ≈ 0% |
| z buffer: `similar!(pool, y)` → `acquire!(pool, _output_eltype(Tv, Tg), n)` | RHS = y × inv_h(Dual) → Dual-typed coefficients |
| `CubicInterpolant{..., Tz}`, `CubicSeriesInterpolant{..., Tz}` | z coefficients differ from y when grid is Dual |
| Kernel: `zL::Tz, zR::Tz, yL::Tv, yR::Tv` (decoupled) | z=Dual, y=Float coexist |
| Thomas solver: `ThomasFactorization{T}` (no constraint) | Dual LU factors via pure arithmetic |

### Anchor Tq inference (cross-method fix)

Discovered that Quadratic and Cubic anchor structs inferred `Tq` from **input query type** instead of **computed value type**. When grid is Dual, weights/dL are Dual but `Tq` was set to Float64 → type mismatch.

| Method | Fix |
|---|---|
| **Cubic** | New outer constructor: infer `Tq = eltype(w0)`, widen `xq` |
| **Quadratic** | New outer constructor: infer `Tq = typeof(dL)`, widen `xq` |
| `_fill_anchors!` | Decouple buffer Tq from query type (`S` param, like Linear) |

### Series × Dual grid (cross-method fix)

TDD test matrix found Quadratic and Cubic Series failing at 3 layers:

1. **Coefficient buffers**: `acquire!(pool, Tv, n)` → `acquire!(pool, _output_eltype(Tv, Tg), n)`
2. **LazyTransposePair/Triple**: `{Tv}` → `{Tv, Tz}` / `{Tv, Tc}` for decoupled coefficient types
3. **Callable output**: `Vector{Tv}` → `Vector{_output_eltype(Tv, Tg)}` (following Linear's pattern)

### Cache pool — NO changes

Pool stays `AbstractFloat`-only. `_effective_autocache` disables caching at call sites for Dual grids. Two fallback `_get_cubic_cache` overloads route to direct build.

## Tests

**`test/ext/test_cubic_dual_grid.jl`** (27 tests):
- ForwardDiff.derivative + FD cross-check, all BC types, PeriodicBC
- Interpolant, adjoint, DerivOp(1/2), ClampExtrap, Range{Dual}
- Series scalar, Float zero-alloc regression

**`test/ext/test_series_dual_grid.jl`** (25 tests):
- 4 methods × {Vector scalar, Vector vector, in-place, Range scalar, Range vector}
- Series interpolant (2-arg) for Constant/Linear/Quadratic/Cubic
- Partials nonzero check (grid sensitivity propagates)

## Scope

**30 files changed, +878 −505 (net +373). ~400 lines are tests.**

### Deferred (ND Dual grid — separate PR)

Two independent blockers affect ND Dual grid across methods:

**1. OnTheFly path** (`hetero_oneshot.jl`): `_interp_nd_oneshot_onthefly` has `Tg <: AbstractFloat`
- Affects: Quadratic ND, PCHIP/Akima/Cardinal ND, Cubic ND (OnTheFly mode)
- Constant/Linear ND already work (self-contained eval, no hetero dispatch)

**2. PreCompute path** (partials pipeline): `partials = Array{Tv, N+1}` too narrow for Dual
- Affects: Cubic ND PreCompute (`_build_nd_partials_dim!`, `_moments_to_derivatives_1d!`)
- Affects: Quadratic ND PreCompute (`_build_nd_partials_dim_quadratic!`)
- Root cause: all intermediate partials arrays allocate with `Tv` (data type) but per-axis differentiation produces `_output_eltype(Tv, Tg)` (Dual when grid is Dual)

**Prep work done in this PR**: `periodic.jl` `_prepare_periodic_nd_pooled` relaxed, `cubic_nd_math.jl` moment buffers widened, all ND constraint sites already relaxed (Float regression passes)

**Note**: 1D PeriodicBC with Dual grid works fully — the ND blocker is the partials pipeline, not the periodic solver itself.
