### PR TITLE
(feat): ND Dual Grid — duck-typed grid support for all ND paths

### DIFF
--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -46,7 +46,7 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
 Writes results into `output`. No heap allocation beyond spacings.
 """
 @with_pool pool function _constant_interp_nd_oneshot_batch!(
-        output::AbstractVector{Tv},
+        output::AbstractVector,
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         queries,

--- a/src/core/nd_adjoint_scatter.jl
+++ b/src/core/nd_adjoint_scatter.jl
@@ -39,7 +39,7 @@ For each axis d:
 - Cubic uses all 4 entries: `(w_fL, w_fR, w_dyL, w_dyR)`
 - Quadratic uses 3 entries: `(w_fL, w_fR, w_dfL, 0)` — 4th always zero
 """
-struct _NDAdjointAnchor{Tg <: AbstractFloat, N}
+struct _NDAdjointAnchor{Tg, N}
     indices::NTuple{N, Int}
     w0::NTuple{N, NTuple{4, Tg}}
     w1::NTuple{N, NTuple{4, Tg}}
@@ -183,7 +183,7 @@ function _bake_nd_anchors_generic(
         queries,
         extraps::Tuple{Vararg{AbstractExtrap, N}},
         weight_fn
-    ) where {N, Tg <: AbstractFloat}
+    ) where {N, Tg}
     nq = _query_length(queries)
     _query_validate(queries)
     _validate_nd_domain(grids, queries, extraps)

--- a/src/cubic/nd/cubic_nd_build.jl
+++ b/src/cubic/nd/cubic_nd_build.jl
@@ -36,7 +36,7 @@ This approach is truly N-D generic because:
 - Axis 3 (after): flattened indices for dims d+1 to N
 
 # Type Parameters
-- `Tg`: Grid type (AbstractFloat) for coordinates
+- `Tg`: Grid type (unconstrained) for coordinates
 - `Tv`: Value type for data (unconstrained)
 
 # Arguments
@@ -125,7 +125,7 @@ Uses the same reshape trick but when `shape_before > 1`, processes all "before"
 slices simultaneously using the batch solver from 2D implementation.
 
 # Type Parameters
-- `Tg`: Grid type (AbstractFloat) for coordinates
+- `Tg`: Grid type (unconstrained) for coordinates
 - `Tv`: Value type for data (unconstrained)
 
 # Performance Characteristics
@@ -490,7 +490,7 @@ Uses the **bit-encoding build-up algorithm**:
 - Higher-order partials are built stage-by-stage from lower-order ones
 
 # Type Parameters
-- `Tg`: Grid type (AbstractFloat) for coordinates
+- `Tg`: Grid type (unconstrained) for coordinates
 - `Tv`: Value type for data (unconstrained)
 
 # Algorithm
@@ -566,7 +566,7 @@ end
 Compute all partial derivatives for N-dimensional Hermite interpolation.
 
 # Type Parameters
-- `Tg`: Grid type (AbstractFloat) for coordinates
+- `Tg`: Grid type (unconstrained) for coordinates
 - `Tv`: Value type for data (unconstrained)
 
 # Arguments

--- a/src/cubic/nd/cubic_nd_build.jl
+++ b/src/cubic/nd/cubic_nd_build.jl
@@ -529,11 +529,11 @@ For d = 1 to N:
 - Uses batch SIMD optimization for d≥2 with ZeroCurvBC
 """
 function _compute_nd_partials!(
-        partials::AbstractArray{Tv, NP1},
+        partials::AbstractArray{Tz, NP1},
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
-    ) where {Tv, Tg, N, NP1}
+    ) where {Tz, Tv, Tg, N, NP1}
     # Validate dimensions (fast, no allocation)
     @boundscheck begin
         NP1 == N + 1 || throw(DimensionMismatch("partials must have N+1 dimensions"))
@@ -586,12 +586,14 @@ function _build_nd_coeffs(
     _validate_nd_bcs!(grids, bcs, data, Val(N))
 
     # Allocate partials array: (2^N, n₁, n₂, ..., nₙ)
+    # Tz widens Tv with Tg: when grid is Dual, derivatives = data × inv_h → Dual-typed.
+    Tz = _output_eltype(Tv, Tg)
     n_partials = 1 << N
     partials_shape = (n_partials, size(data)...)
-    partials = Array{Tv, N + 1}(undef, partials_shape)
+    partials = Array{Tz, N + 1}(undef, partials_shape)
 
     # Compute all partial derivatives
     _compute_nd_partials!(partials, grids, data, bcs)
 
-    return _NodalDerivativesND{Tv, N, N + 1}(partials)
+    return _NodalDerivativesND{Tz, N, N + 1}(partials)
 end

--- a/src/cubic/nd/cubic_nd_interpolant.jl
+++ b/src/cubic/nd/cubic_nd_interpolant.jl
@@ -34,7 +34,7 @@ Create an N-dimensional cubic Hermite interpolant from grid vectors and data arr
 - `CubicInterpolantND{Tg, Tv, N, ...}`: Callable interpolant object
 
 # Type Inference
-- Grid type `Tg`: Promoted from all grid element types (always AbstractFloat)
+- Grid type `Tg`: Promoted from all grid element types (supports duck types like ForwardDiff.Dual)
 - Value type `Tv`: Element type of data (unconstrained)
 
 # Examples

--- a/src/cubic/nd/cubic_nd_interpolant.jl
+++ b/src/cubic/nd/cubic_nd_interpolant.jl
@@ -137,9 +137,11 @@ function _build_nd_interpolant(
     # (via _resolve_extrap_nd in cubic_interp)
 
     # Construct the interpolant
+    # Tz = coefficient type: widens Tv with Tg (Dual grid → Dual coefficients).
+    Tz = eltype(nodal_derivs)
     NP1 = N + 1
     return CubicInterpolantND{
-        Tg, Tv, N, NP1,
+        Tg, Tz, N, NP1,
         typeof(grids), typeof(spacings), typeof(bcs_store),
         typeof(extraps_val), typeof(searches),
     }(grids, spacings, nodal_derivs, bcs_store, extraps_val, searches)

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -129,8 +129,10 @@ Zero-allocation after warmup (pool reuse).
     grids_p, data_p, bcs_p = _prepare_periodic_nd_pooled(pool, grids, data, bcs)
 
     # 2. Pool-allocate partials array (THE KEY: pool instead of heap)
+    # Tz widens Tv with Tg: when grid is Dual, derivatives = data × inv_h → Dual-typed.
+    Tz = _output_eltype(Tv, Tg)
     n_partials = 1 << N
-    partials = acquire!(pool, Tv, (n_partials, size(data_p)...))
+    partials = acquire!(pool, Tz, (n_partials, size(data_p)...))
 
     # 3. Compute all partial derivatives in-place
     #    (internally uses autocached 1D caches + nested @with_pool for temp buffers)
@@ -175,8 +177,9 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
 
     # Build phase (same as scalar, done once)
     grids_p, data_p, bcs_p = _prepare_periodic_nd_pooled(pool, grids, data, bcs)
+    Tz = _output_eltype(Tv, Tg)
     n_partials = 1 << N
-    partials = acquire!(pool, Tv, (n_partials, size(data_p)...))
+    partials = acquire!(pool, Tz, (n_partials, size(data_p)...))
     _compute_nd_partials!(partials, grids_p, data_p, bcs_p)
     spacings = _create_spacings_pooled(pool, grids_p)
 

--- a/src/hetero/hetero_adjoint.jl
+++ b/src/hetero/hetero_adjoint.jl
@@ -41,7 +41,7 @@ function _bake_hetero_nd_anchors(
         queries,
         extraps::Tuple{Vararg{AbstractExtrap, N}},
         methods::Tuple{Vararg{AbstractInterpMethod, N}}
-    ) where {N, Tg <: AbstractFloat}
+    ) where {N, Tg}
     return _bake_nd_anchors_generic(
         grids, spacings, queries, extraps,
         (d, t, h, inv_h, dL) -> _compute_hetero_anchor_weights(t, h, inv_h, dL, methods[d])
@@ -447,7 +447,7 @@ function hetero_adjoint(
     ) where {N}
     length(queries) == N || _throw_ndims_mismatch("query vectors", N, length(queries))
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     extraps = _resolve_extrap_nd(extrap, nothing, Val(N), Tg)
     return _build_hetero_nd_adjoint(grids_typed, queries, methods, extraps)
@@ -487,7 +487,7 @@ function hetero_adjoint(
     ) where {N}
     _query_check_ndims(queries, Val(N))
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     extraps = _resolve_extrap_nd(extrap, nothing, Val(N), Tg)
     return _build_hetero_nd_adjoint(grids_typed, queries, methods, extraps)
@@ -513,7 +513,7 @@ function _build_hetero_nd_adjoint(
         queries,
         methods::Tuple{Vararg{AbstractInterpMethod, N}},
         extraps::Tuple{Vararg{AbstractExtrap, N}}
-    ) where {N, Tg <: AbstractFloat}
+    ) where {N, Tg}
     # Reject Hermite family methods upfront with a clear message. Without this
     # guard, the scatter path below would fail deep in the per-axis weight
     # computation with an obscure MethodError. Single point of entry for both
@@ -584,21 +584,23 @@ function _build_hetero_nd_adjoint(
     end
 
     # Per-axis caches (cubic only)
+    # _effective_autocache: bypass cache pool for Dual grids (ephemeral, hit rate ≈ 0%)
+    ac = _effective_autocache(true, Tg)
     caches = map(methods, grids_ext, bcs) do method_d, grid_d, bp_d
         method_d isa CubicInterp || return nothing
         if _is_periodic_bc(bp_d)
-            _get_cubic_cache(grid_d, PeriodicBC())
+            _get_cubic_cache(grid_d, PeriodicBC(), ac)
         else
-            _get_cubic_cache(grid_d, bp_d)
+            _get_cubic_cache(grid_d, bp_d, ac)
         end
     end
 
     mixed_caches = map(methods, grids_ext, mixed_bcs) do method_d, grid_d, mbp_d
         method_d isa CubicInterp || return nothing
         if _is_periodic_bc(mbp_d)
-            _get_cubic_cache(grid_d, PeriodicBC())
+            _get_cubic_cache(grid_d, PeriodicBC(), ac)
         else
-            _get_cubic_cache(grid_d, mbp_d)
+            _get_cubic_cache(grid_d, mbp_d, ac)
         end
     end
 

--- a/src/hetero/hetero_adjoint_types.jl
+++ b/src/hetero/hetero_adjoint_types.jl
@@ -88,7 +88,7 @@ Constructed from grids, query points, and per-axis methods (query-baked, data-fr
 The same adjoint can be applied to any `ȳ` vector.
 
 # Type Parameters
-- `Tg`:  Grid float type (Float32 or Float64)
+- `Tg`:  Grid float type (unconstrained — supports duck types like ForwardDiff.Dual)
 - `N`:   Number of dimensions
 - `M`:   Per-axis methods tuple type
 - `G`:   Grid tuple type

--- a/src/hetero/hetero_adjoint_types.jl
+++ b/src/hetero/hetero_adjoint_types.jl
@@ -116,7 +116,7 @@ adj(f_bar, y_bar)               # in-place (zero-allocation)
 ```
 """
 struct HeteroAdjointND{
-        Tg <: AbstractFloat,
+        Tg,
         N,
         M <: Tuple{Vararg{AbstractInterpMethod, N}},
         G <: Tuple{Vararg{AbstractVector, N}},

--- a/src/hetero/hetero_build.jl
+++ b/src/hetero/hetero_build.jl
@@ -131,7 +131,7 @@ function _compute_nd_partials_hetero!(
         data::AbstractArray{<:Any, N},
         methods::Tuple{Vararg{AbstractInterpMethod, N}},
         sizes::NTuple{N, Int},
-    ) where {Tv, Tg <: AbstractFloat, N, NP1}
+    ) where {Tv, Tg, N, NP1}
     @boundscheck begin
         NP1 == N + 1 || throw(DimensionMismatch("partials must have N+1 dimensions"))
         n_partials = prod(sizes)
@@ -165,15 +165,17 @@ function _build_nd_coeffs_hetero(
         ::Type{Tv},
         data::AbstractArray{<:Any, N},
         methods::Tuple{Vararg{AbstractInterpMethod, N}},
-    ) where {Tg <: AbstractFloat, Tv, N}
+    ) where {Tg, Tv, N}
     sizes = map(_deriv_size, methods)
 
     # Single allocation: (prod(sizes), n₁, n₂, ..., nₙ)
+    # Tz widens Tv with Tg: when grid is Dual, derivatives = data × inv_h → Dual-typed.
+    Tz = _output_eltype(Tv, Tg)
     n_partials = prod(sizes)
-    partials = Array{Tv, N + 1}(undef, n_partials, size(data)...)
+    partials = Array{Tz, N + 1}(undef, n_partials, size(data)...)
 
-    # copyto! in _compute_nd_partials_hetero! handles data → Tv promotion
+    # copyto! in _compute_nd_partials_hetero! handles data → Tz promotion
     _compute_nd_partials_hetero!(partials, grids, data, methods, sizes)
 
-    return _HeteroPartials{Tv, N, N + 1}(partials)
+    return _HeteroPartials{Tz, N, N + 1}(partials)
 end

--- a/src/hetero/hetero_eval.jl
+++ b/src/hetero/hetero_eval.jl
@@ -353,8 +353,8 @@ end
         ops::NTuple{N, AbstractEvalOp},
     ) where {Tg, Tv, N, G, S, M, E, P}
     data, grids, methods, extraps, q_eval, searches, hints, windows = cell
-    # Tr promotes data eltype with query eltypes → Dual-safe pool buffers for AD.
-    Tr = _promote_query_eltype(Tv, q_eval)
+    # Tr promotes data eltype with grid + query eltypes → Dual-safe pool buffers for AD.
+    Tr = _output_eltype(Tv, Tg, typeof.(q_eval)...)
     return _collapse_dims(Tr, data, grids, methods, extraps, q_eval, ops, searches, hints, windows)
 end
 

--- a/src/hetero/hetero_eval.jl
+++ b/src/hetero/hetero_eval.jl
@@ -187,9 +187,10 @@ end
         hints,
     ) where {Tg, Tv, N, G, S, M, E, P}
     q_eval = _handle_all_extraps(query, itp.grids, itp.extraps)
-    # Tr promotes data eltype with query eltypes → Dual-safe pool buffers for AD.
-    # Recursive type fold specializes at compile time for each concrete query tuple.
-    Tr = _promote_query_eltype(Tv, q_eval)
+    # Tr promotes data eltype with grid + query eltypes → Dual-safe pool buffers for AD.
+    # Grid eltype included: when grid is Dual, 1D oneshot returns Dual-typed results
+    # that must fit into _collapse_dims intermediate buffers.
+    Tr = _output_eltype(Tv, Tg, typeof.(q_eval)...)
 
     # Persistent-path gate: use `_has_any_windowable_method` (strict superset of
     # `_has_any_local_method`) because `itp.spacings` is pre-computed at

--- a/src/hetero/hetero_interpolant.jl
+++ b/src/hetero/hetero_interpolant.jl
@@ -259,9 +259,9 @@ function _build_hetero_nd(
         _validate_nd_grids(grids, data)
     end
 
-    # 2. Promote grid type (Int → Float64)
+    # 2. Promote grid type (Int → Float64, Dual preserved via float())
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
 
     # 3. Convert grids to target type (preserving Range structure)
     grids_typed = _convert_grids_typed(grids, Tg)
@@ -312,7 +312,7 @@ function _build_hetero_precomputed(
         _validate_nd_grids(grids, data)
     end
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     Tv = _value_type(Tv_raw, Tg)
     bcs_periodic = map(_bc_for_periodic_check, methods)

--- a/src/hetero/hetero_nointerp.jl
+++ b/src/hetero/hetero_nointerp.jl
@@ -475,8 +475,7 @@ function _interp_nointerp_oneshot(
     # All-GridIdx edge case: pure table lookup (or zero if any deriv requested)
     if grids_r === ()
         if _any_nointerp_grididx_has_nonzero_deriv(query, method_tuple, deriv_t)
-            Tg = _promote_grid_eltype(grids)
-            Tg = Tg <: AbstractFloat ? Tg : Float64
+            Tg = float(_promote_grid_eltype(grids))
             return zero(_output_eltype(eltype(data), Tg))
         end
         return data_r[]
@@ -490,8 +489,7 @@ function _interp_nointerp_oneshot(
 
     # Check if any GridIdx axis has non-zero deriv → return zero (with promoted type)
     if _any_nointerp_grididx_has_nonzero_deriv(query, method_tuple, deriv_t)
-        Tg = _promote_grid_eltype(grids)
-        Tg = Tg <: AbstractFloat ? Tg : Float64
+        Tg = float(_promote_grid_eltype(grids))
         return zero(_output_eltype(eltype(data), Tg, typeof.(query_r)...))
     end
 

--- a/src/hetero/hetero_nointerp.jl
+++ b/src/hetero/hetero_nointerp.jl
@@ -374,7 +374,7 @@ positions, filters all per-axis tuples to Real-only axes, delegates to existing 
                 rsrc = ($(r_searches...),)
                 search_r = _resolve_search_nd(rsrc, Val($N_r), rq)
                 hint_r = hint === nothing ? nothing : ($([:(hint[$d]) for d in real_dims]...),)
-                Tr = _promote_query_eltype(eltype(d_sliced), q_eval)
+                Tr = _output_eltype(eltype(d_sliced), $Tg, typeof.(q_eval)...)
 
                 # Pre-search: mutates user hints (real-axis subset) to absolute indices.
                 idxs_r, _, _ = _search_all_intervals(q_eval, rg, rs, search_r, hint_r)
@@ -409,7 +409,7 @@ positions, filters all per-axis tuples to Real-only axes, delegates to existing 
             rsrc = ($(r_searches...),)
             search_r = _resolve_search_nd(rsrc, Val($N_r), rq)
             hint_r = hint === nothing ? nothing : ($([:(hint[$d]) for d in real_dims]...),)
-            Tr = _promote_query_eltype(eltype(d_sliced), q_eval)
+            Tr = _output_eltype(eltype(d_sliced), $Tg, typeof.(q_eval)...)
             full_windows_r = ($(r_full_windows...),)
             return _collapse_dims(Tr, d_sliced, rg, rm, re, q_eval, ro, search_r, hint_r, full_windows_r)
         end

--- a/src/hetero/hetero_oneshot.jl
+++ b/src/hetero/hetero_oneshot.jl
@@ -22,7 +22,7 @@
         searches::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
         hints = nothing,
-    ) where {Tg <: AbstractFloat, N}
+    ) where {Tg, N}
     # 0. Domain check + FillExtrap short-circuit
     _validate_nd_domain(grids, query, extraps_val)
     oob_result = _try_fill_oob(query, grids, extraps_val, ops, @inbounds first(data))
@@ -67,7 +67,7 @@ end
         searches::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
         hints = nothing,
-    ) where {Tg <: AbstractFloat, N}
+    ) where {Tg, N}
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
@@ -127,13 +127,15 @@ end
         ops::NTuple{N, AbstractEvalOp},
         hints = nothing,
         spacings::Union{Nothing, Tuple{Vararg{AbstractGridSpacing, N}}} = nothing,
-    ) where {Tg <: AbstractFloat, Tv, N}
+    ) where {Tg, Tv, N}
     _validate_nd_domain(grids, query, extraps_val)
     oob_result = _try_fill_oob(query, grids, extraps_val, ops, @inbounds first(data))
     oob_result !== nothing && return oob_result
     q_eval = _handle_all_extraps(query, grids, extraps_val)
-    # Tr promotes data eltype with query eltypes → Dual-safe pool buffers for AD.
-    Tr = _promote_query_eltype(Tv, q_eval)
+    # Tr promotes data eltype with grid + query eltypes → Dual-safe pool buffers for AD.
+    # Grid eltype included: when grid is Dual, 1D oneshot returns Dual-typed results
+    # that must fit into _collapse_dims intermediate buffers.
+    Tr = _output_eltype(Tv, Tg, typeof.(q_eval)...)
 
     # GridIdx safety gate: same reason as the persistent path — a GridIdx on a
     # windowable axis would be aliased to the wrong grid entry once the data
@@ -220,7 +222,7 @@ function _interp_nd_oneshot_dispatch(
         deriv, extrap, search, hints, coeffs,
     ) where {N}
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     _validate_nd_grids(grids_typed, data)
     Tv = _value_type(eltype(data), Tg)
@@ -288,7 +290,7 @@ end
         deriv, extrap, search, hints, coeffs,
     ) where {N}
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
     _validate_nd_grids(grids_typed, data)
     _query_check_ndims(queries, Val(N))
@@ -446,7 +448,7 @@ function interp(
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing,
     ) where {Tv, N}
     Tg = _promote_grid_eltype(grids)
-    Tg = Tg <: AbstractFloat ? Tg : Float64
+    Tg = float(Tg)
     Tq = _query_eltype(queries)
     Tr = _output_eltype(Tv, Tg, Tq)
     output = Vector{Tr}(undef, _query_length(queries))

--- a/src/hetero/hetero_oneshot.jl
+++ b/src/hetero/hetero_oneshot.jl
@@ -32,11 +32,12 @@
     bcs_periodic = map(_bc_for_periodic_check, methods)
     grids_p, data_p, _ = _prepare_periodic_nd_pooled(pool, grids, data, bcs_periodic)
 
-    # 2. Pool-allocate compact partials (promoted Tv, matching constructor path)
+    # 2. Pool-allocate compact partials (widened with Tg for Dual grid support)
     Tv = _value_type(eltype(data), Tg)
+    Tz = _output_eltype(Tv, Tg)
     sizes = map(_deriv_size, methods)
     n_partials = prod(sizes)
-    partials = acquire!(pool, Tv, (n_partials, size(data_p)...))
+    partials = acquire!(pool, Tz, (n_partials, size(data_p)...))
 
     # 3. Compute heterogeneous partials in-place (reuses build.jl core)
     _compute_nd_partials_hetero!(partials, grids_p, data_p, methods, sizes)
@@ -78,9 +79,10 @@ end
     grids_p, data_p, _ = _prepare_periodic_nd_pooled(pool, grids, data, bcs_periodic)
 
     Tv = _value_type(eltype(data), Tg)
+    Tz = _output_eltype(Tv, Tg)
     sizes = map(_deriv_size, methods)
     n_partials = prod(sizes)
-    partials = acquire!(pool, Tv, (n_partials, size(data_p)...))
+    partials = acquire!(pool, Tz, (n_partials, size(data_p)...))
     _compute_nd_partials_hetero!(partials, grids_p, data_p, methods, sizes)
     spacings = _create_spacings_pooled(pool, grids_p)
 

--- a/src/hetero/hetero_types.jl
+++ b/src/hetero/hetero_types.jl
@@ -47,7 +47,7 @@ itp((0.5, 0.3))
 ```
 """
 struct HeteroInterpolantND{
-        Tg <: AbstractFloat,
+        Tg,
         Tv,
         N,
         G <: Tuple{Vararg{AbstractVector, N}},

--- a/src/hetero/hetero_types.jl
+++ b/src/hetero/hetero_types.jl
@@ -7,7 +7,7 @@
 # - PreCompute: D = _HeteroPartials{Tv, N, N+1} — precomputed partials, O(1) eval
 #
 # Type Parameters Convention:
-# - Tg: Grid/coordinate type (AbstractFloat)
+# - Tg: Grid/coordinate type (unconstrained — supports duck types like ForwardDiff.Dual)
 # - Tv: Value type (unconstrained)
 # - N:  Number of dimensions
 
@@ -23,7 +23,7 @@ linear on axis 2) with two evaluation strategies:
 - **`PreCompute()`**: Precomputed partial derivatives with local kernel eval (O(1) per query)
 
 # Type Parameters
-- `Tg`: Grid/coordinate type (Float32 or Float64)
+- `Tg`: Grid/coordinate type (unconstrained — supports duck types like ForwardDiff.Dual)
 - `Tv`: Value type (unconstrained)
 - `N`: Number of dimensions
 - `G`: Tuple type for grids

--- a/src/quadratic/nd/quadratic_nd_build.jl
+++ b/src/quadratic/nd/quadratic_nd_build.jl
@@ -292,11 +292,11 @@ Uses the same bit-encoding build-up algorithm as cubic, but with quadratic
 recurrence for 1D differentiation instead of Thomas tridiagonal.
 """
 function _compute_nd_partials_quadratic!(
-        partials::AbstractArray{Tv, NP1},
+        partials::AbstractArray{Tz, NP1},
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
-    ) where {Tv, Tg, N, NP1}
+    ) where {Tz, Tv, Tg, N, NP1}
     # Validate dimensions
     @boundscheck begin
         NP1 == N + 1 || throw(DimensionMismatch("partials must have N+1 dimensions"))
@@ -336,12 +336,14 @@ function _build_nd_coeffs_quadratic(
         bcs::NTuple{N, AbstractBC}
     ) where {Tg, Tv, N}
     # Allocate partials array: (2^N, n₁, n₂, ..., nₙ)
+    # Tz widens Tv with Tg: when grid is Dual, derivatives = data × inv_h → Dual-typed.
+    Tz = _output_eltype(Tv, Tg)
     n_partials = 1 << N
     partials_shape = (n_partials, size(data)...)
-    partials = Array{Tv, N + 1}(undef, partials_shape)
+    partials = Array{Tz, N + 1}(undef, partials_shape)
 
     # Compute all partial derivatives
     _compute_nd_partials_quadratic!(partials, grids, data, bcs)
 
-    return _NodalDerivativesND{Tv, N, N + 1}(partials)
+    return _NodalDerivativesND{Tz, N, N + 1}(partials)
 end

--- a/src/quadratic/nd/quadratic_nd_interpolant.jl
+++ b/src/quadratic/nd/quadratic_nd_interpolant.jl
@@ -102,9 +102,11 @@ function _build_nd_quadratic_interpolant(
     # extraps_val already resolved to concrete types at API boundary
 
     # Construct the interpolant
+    # Tz = coefficient type: widens Tv with Tg (Dual grid → Dual coefficients).
+    Tz = eltype(nodal_derivs)
     NP1 = N + 1
     return QuadraticInterpolantND{
-        Tg, Tv, N, NP1,
+        Tg, Tz, N, NP1,
         typeof(grids), typeof(spacings), typeof(bcs_store),
         typeof(extraps_val), typeof(searches),
     }(grids, spacings, nodal_derivs, bcs_store, extraps_val, searches)

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -36,8 +36,10 @@ Zero-allocation after warmup (pool reuse).
     oob_result !== nothing && return oob_result
 
     # 1. Pool-allocate partials array (THE KEY: pool instead of heap)
+    # Tz widens Tv with Tg: when grid is Dual, derivatives = data × inv_h → Dual-typed.
+    Tz = _output_eltype(Tv, Tg)
     n_partials = 1 << N
-    partials = acquire!(pool, Tv, (n_partials, size(data)...))
+    partials = acquire!(pool, Tz, (n_partials, size(data)...))
 
     # 2. Compute all partial derivatives in-place
     _compute_nd_partials_quadratic!(partials, grids, data, bcs)
@@ -78,8 +80,9 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
     _validate_nd_domain(grids, queries, extraps_val)
 
     # Build phase (done once)
+    Tz = _output_eltype(Tv, Tg)
     n_partials = 1 << N
-    partials = acquire!(pool, Tv, (n_partials, size(data)...))
+    partials = acquire!(pool, Tz, (n_partials, size(data)...))
     _compute_nd_partials_quadratic!(partials, grids, data, bcs)
     spacings = _create_spacings_pooled(pool, grids)
 

--- a/src/quadratic/nd/quadratic_nd_types.jl
+++ b/src/quadratic/nd/quadratic_nd_types.jl
@@ -5,7 +5,7 @@
 # Generic N-dimensional type definitions for quadratic interpolation.
 #
 # Type Parameters Convention:
-# - Tg: Grid/coordinate type (AbstractFloat) - used for x/y/z coordinates, spacing
+# - Tg: Grid/coordinate type (unconstrained) - used for x/y/z coordinates, spacing
 # - Tv: Value type - used for data values, coefficients (can be Complex{Tg}, Dual, etc.)
 # - N:  Number of dimensions
 #

--- a/test/ext/runtests.jl
+++ b/test/ext/runtests.jl
@@ -27,6 +27,7 @@ include("test_hermite_dual_grid.jl")  # Hermite family grid-side Dual
 include("test_constant_quadratic_dual_grid.jl")  # Constant+Quadratic grid-side Dual
 include("test_cubic_dual_grid.jl")              # Cubic grid-side Dual
 include("test_series_dual_grid.jl")             # All methods × Series × Dual grid
+include("test_nd_dual_grid.jl")                 # ND (Cubic/Quadratic/Hetero) Dual grid
 include("test_autodiff_Zygote.jl")
 include("test_autodiff_hetero.jl")
 include("test_hermite_rrule.jl")

--- a/test/ext/test_nd_dual_grid.jl
+++ b/test/ext/test_nd_dual_grid.jl
@@ -388,6 +388,43 @@ end
     # ║  Regression: Float grid ND path unchanged                           ║
     # ╚═══════════════════════════════════════════════════════════════════════╝
 
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  Phase 3: HeteroInterpolantND (persistent callable)                 ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "HeteroInterpolantND OnTheFly — Dual grid construct + eval" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        itp = interp((d .* xv_base, d .* yv_base), data_2d;
+            method = (CubicInterp(), LinearInterp()), extrap = ExtendExtrap())
+        v = itp(q_2d)
+        itp_f = interp((xv_base, yv_base), data_2d;
+            method = (CubicInterp(), LinearInterp()), extrap = ExtendExtrap())
+        @test ForwardDiff.value(v) ≈ itp_f(q_2d)
+    end
+
+    @testset "HeteroInterpolantND OnTheFly — ForwardDiff.derivative" begin
+        f_interp = t -> begin
+            itp = interp((t .* xv_base, t .* yv_base), data_2d;
+                method = (CubicInterp(), LinearInterp()), extrap = ExtendExtrap())
+            itp(q_2d)
+        end
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    @testset "HeteroInterpolantND PreCompute — Dual grid construct + eval" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        itp = interp((d .* xv_base, d .* yv_base), data_2d;
+            method = (CubicInterp(), LinearInterp()), coeffs = PreCompute(),
+            extrap = ExtendExtrap())
+        v = itp(q_2d)
+        itp_f = interp((xv_base, yv_base), data_2d;
+            method = (CubicInterp(), LinearInterp()), coeffs = PreCompute(),
+            extrap = ExtendExtrap())
+        @test ForwardDiff.value(v) ≈ itp_f(q_2d)
+    end
+
     @testset "Float regression — Cubic ND OnTheFly still works" begin
         v = cubic_interp(
             (xv_base, yv_base), data_2d, q_2d;

--- a/test/ext/test_nd_dual_grid.jl
+++ b/test/ext/test_nd_dual_grid.jl
@@ -509,6 +509,76 @@ end
         @test ForwardDiff.value.(H) ≈ H_f
     end
 
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  Phase 4: Adjoint ND + Dual grid                                   ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "LinearAdjointND — Dual grid construct + apply" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        adj = linear_adjoint((d .* xv_base, d .* yv_base), q_2d; extrap = ExtendExtrap())
+        f_bar = adj(1.0)
+        @test f_bar isa Matrix
+        @test eltype(f_bar) <: ForwardDiff.Dual
+
+        # Primal should match Float-grid adjoint
+        adj_f = linear_adjoint((xv_base, yv_base), q_2d; extrap = ExtendExtrap())
+        f_bar_f = adj_f(1.0)
+        @test ForwardDiff.value.(f_bar) ≈ f_bar_f
+    end
+
+    @testset "LinearAdjointND — adjoint identity: dot(adj(1), data) = interp(data, q)" begin
+        # Adjoint identity: ⟨adj(y_bar), data⟩ = y_bar * interp(grids, data, q)
+        # Differentiating both sides w.r.t. t (grid scaling):
+        #   d/dt ⟨adj(t*x)(1), data⟩ = d/dt interp(t*x, data, q)
+        # LHS = AD through adjoint, RHS = AD through forward interp (Phase 1 validated)
+        f_adj = t -> begin
+            adj = linear_adjoint((t .* xv_base, t .* yv_base), q_2d; extrap = ExtendExtrap())
+            sum(adj(1.0) .* data_2d)
+        end
+        f_fwd = t -> linear_interp((t .* xv_base, t .* yv_base), data_2d, q_2d; extrap = ExtendExtrap())
+
+        ad_adj = ForwardDiff.derivative(f_adj, 1.0)
+        ad_fwd = ForwardDiff.derivative(f_fwd, 1.0)
+        fd_val = fd_deriv(f_fwd)
+
+        # Three-way cross-check: adjoint AD ≈ forward AD ≈ FD
+        @test ad_adj ≈ ad_fwd rtol = 1.0e-10
+        @test ad_adj ≈ fd_val rtol = 1.0e-5
+    end
+
+    @testset "CubicAdjointND — Dual grid construct + apply" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        adj = cubic_adjoint((d .* xv_base, d .* yv_base), q_2d; extrap = ExtendExtrap())
+        f_bar = adj(1.0)
+        @test f_bar isa Matrix
+        @test eltype(f_bar) <: ForwardDiff.Dual
+
+        adj_f = cubic_adjoint((xv_base, yv_base), q_2d; extrap = ExtendExtrap())
+        f_bar_f = adj_f(1.0)
+        @test ForwardDiff.value.(f_bar) ≈ f_bar_f
+    end
+
+    @testset "CubicAdjointND — adjoint identity: dot(adj(1), data) = interp(data, q)" begin
+        # Same three-way cross-check as Linear:
+        #   d/dt ⟨adj(t*x)(1), data⟩ = d/dt interp(t*x, data, q)
+        f_adj = t -> begin
+            adj = cubic_adjoint((t .* xv_base, t .* yv_base), q_2d; extrap = ExtendExtrap())
+            sum(adj(1.0) .* data_2d)
+        end
+        f_fwd = t -> cubic_interp(
+            (t .* xv_base, t .* yv_base), data_2d, q_2d;
+            coeffs = PreCompute(), extrap = ExtendExtrap(),
+        )
+
+        ad_adj = ForwardDiff.derivative(f_adj, 1.0)
+        ad_fwd = ForwardDiff.derivative(f_fwd, 1.0)
+        fd_val = fd_deriv(f_fwd)
+
+        # Three-way cross-check: adjoint AD ≈ forward AD ≈ FD
+        @test ad_adj ≈ ad_fwd rtol = 1.0e-10
+        @test ad_adj ≈ fd_val rtol = 1.0e-5
+    end
+
     @testset "Float regression — Cubic ND OnTheFly still works" begin
         v = cubic_interp(
             (xv_base, yv_base), data_2d, q_2d;

--- a/test/ext/test_nd_dual_grid.jl
+++ b/test/ext/test_nd_dual_grid.jl
@@ -1,0 +1,268 @@
+# ╔═══════════════════════════════════════════════════════════════════════════╗
+# ║          ND — ForwardDiff.Dual grid support (OnTheFly + PreCompute)       ║
+# ╚═══════════════════════════════════════════════════════════════════════════╝
+#
+# Tests for ND interpolation with ForwardDiff.Dual grid elements.
+# Phase 1: OnTheFly path (constraint lift in hetero_oneshot.jl)
+# Phase 2: PreCompute path (partials pipeline type widening)
+#
+# Run standalone:
+#     cc-julia-test-runner . ext/test_nd_dual_grid.jl
+
+using Test
+using FastInterpolations
+using ForwardDiff
+
+const FI = FastInterpolations
+
+# ── Shared test data ──────────────────────────────────────────────────────
+
+const xv_base = collect(range(0.0, 5.0, 15))
+const yv_base = collect(range(0.0, 4.0, 12))
+const data_2d = [sin(xi) * cos(yi) for xi in xv_base, yi in yv_base]
+const q_2d = (2.3, 1.7)
+const h_fd = 1.0e-7
+
+# FD helper: central difference for scalar t
+fd_deriv(f) = (f(1.0 + h_fd) - f(1.0 - h_fd)) / (2h_fd)
+
+# FD helper: central difference gradient for vector t
+function fd_gradient(f, t0::Vector{Float64})
+    g = similar(t0)
+    for i in eachindex(t0)
+        tp = copy(t0); tp[i] += h_fd
+        tm = copy(t0); tm[i] -= h_fd
+        g[i] = (f(tp) - f(tm)) / (2h_fd)
+    end
+    return g
+end
+
+@testset "ND Dual Grid" begin
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  Phase 1: OnTheFly — Homogeneous methods (coeffs=OnTheFly())        ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "Cubic ND OnTheFly — all-Dual grids" begin
+        f_interp = t -> cubic_interp(
+            (t .* xv_base, t .* yv_base), data_2d, q_2d;
+            coeffs = OnTheFly(), extrap = ExtendExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    @testset "Quadratic ND OnTheFly — all-Dual grids" begin
+        f_interp = t -> quadratic_interp(
+            (t .* xv_base, t .* yv_base), data_2d, q_2d;
+            coeffs = OnTheFly(), extrap = ExtendExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    @testset "Hetero (Cubic × Linear) OnTheFly — all-Dual grids" begin
+        f_interp = t -> interp(
+            (t .* xv_base, t .* yv_base), data_2d, q_2d;
+            method = (CubicInterp(), LinearInterp()),
+            extrap = ExtendExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    @testset "PCHIP ND OnTheFly — all-Dual grids" begin
+        f_interp = t -> interp(
+            (t .* xv_base, t .* yv_base), data_2d, q_2d;
+            method = PchipInterp(), extrap = ExtendExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    @testset "Cardinal ND OnTheFly — all-Dual grids" begin
+        f_interp = t -> interp(
+            (t .* xv_base, t .* yv_base), data_2d, q_2d;
+            method = CardinalInterp(), extrap = ExtendExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    @testset "Akima ND OnTheFly — all-Dual grids" begin
+        f_interp = t -> interp(
+            (t .* xv_base, t .* yv_base), data_2d, q_2d;
+            method = AkimaInterp(), extrap = ExtendExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  Phase 1: Hybrid grids — per-axis Dual                              ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "Cubic ND OnTheFly — axis-1 Dual only" begin
+        # Only axis-1 grid is Dual → partial wrt t should reflect axis-1 sensitivity
+        f_interp = t -> cubic_interp(
+            (t .* xv_base, yv_base), data_2d, q_2d;
+            coeffs = OnTheFly(), extrap = ExtendExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    @testset "Cubic ND OnTheFly — axis-2 Dual only" begin
+        f_interp = t -> cubic_interp(
+            (xv_base, t .* yv_base), data_2d, q_2d;
+            coeffs = OnTheFly(), extrap = ExtendExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    @testset "Cubic ND OnTheFly — per-axis ForwardDiff.gradient" begin
+        # Two-variable gradient: t = [t1, t2], grids = (t1*x, t2*y)
+        f_grad = t -> cubic_interp(
+            (t[1] .* xv_base, t[2] .* yv_base), data_2d, q_2d;
+            coeffs = OnTheFly(), extrap = ExtendExtrap(),
+        )
+        ad_grad = ForwardDiff.gradient(f_grad, [1.0, 1.0])
+        fd_grad = fd_gradient(f_grad, [1.0, 1.0])
+        @test ad_grad ≈ fd_grad rtol = 1.0e-5
+        # Verify both axes contribute (non-zero partials)
+        @test abs(ad_grad[1]) > 1.0e-10
+        @test abs(ad_grad[2]) > 1.0e-10
+    end
+
+    @testset "PCHIP ND OnTheFly — per-axis gradient" begin
+        f_grad = t -> interp(
+            (t[1] .* xv_base, t[2] .* yv_base), data_2d, q_2d;
+            method = PchipInterp(), extrap = ExtendExtrap(),
+        )
+        ad_grad = ForwardDiff.gradient(f_grad, [1.0, 1.0])
+        fd_grad = fd_gradient(f_grad, [1.0, 1.0])
+        @test ad_grad ≈ fd_grad rtol = 1.0e-5
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  Phase 1: Hybrid grids — Range{Dual} + Vector{Float}               ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "Cubic ND OnTheFly — Range{Dual} × Vector{Float}" begin
+        xr = range(0.0, 5.0, 15)
+        f_interp = t -> cubic_interp(
+            (t .* xr, yv_base), data_2d, q_2d;
+            coeffs = OnTheFly(), extrap = ExtendExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    @testset "PCHIP ND OnTheFly — Range{Dual} × Vector{Float}" begin
+        xr = range(0.0, 5.0, 15)
+        f_interp = t -> interp(
+            (t .* xr, yv_base), data_2d, q_2d;
+            method = PchipInterp(), extrap = ExtendExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    @testset "Hetero (Cubic × Linear) — Range{Dual} × Vector{Dual}" begin
+        xr = range(0.0, 5.0, 15)
+        f_interp = t -> interp(
+            (t .* xr, t .* yv_base), data_2d, q_2d;
+            method = (CubicInterp(), LinearInterp()),
+            extrap = ExtendExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  Phase 1: Primal correctness — Dual values match Float path         ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "Cubic ND OnTheFly — Dual primal matches Float" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        v_dual = cubic_interp(
+            (d .* xv_base, d .* yv_base), data_2d, q_2d;
+            coeffs = OnTheFly(), extrap = ExtendExtrap(),
+        )
+        v_float = cubic_interp(
+            (xv_base, yv_base), data_2d, q_2d;
+            coeffs = OnTheFly(), extrap = ExtendExtrap(),
+        )
+        @test ForwardDiff.value(v_dual) ≈ v_float
+    end
+
+    @testset "PCHIP ND — Dual primal matches Float" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        v_dual = interp(
+            (d .* xv_base, d .* yv_base), data_2d, q_2d;
+            method = PchipInterp(), extrap = ExtendExtrap(),
+        )
+        v_float = interp(
+            (xv_base, yv_base), data_2d, q_2d;
+            method = PchipInterp(), extrap = ExtendExtrap(),
+        )
+        @test ForwardDiff.value(v_dual) ≈ v_float
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  Phase 1: Batch queries                                             ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "Cubic ND OnTheFly batch — all-Dual primals match Float" begin
+        queries = [(2.3, 1.7), (1.5, 2.5), (3.1, 0.8)]
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        # Per-query scalar OnTheFly to verify primals
+        for q in queries
+            v_dual = cubic_interp(
+                (d .* xv_base, d .* yv_base), data_2d, q;
+                coeffs = OnTheFly(), extrap = ExtendExtrap(),
+            )
+            v_float = cubic_interp(
+                (xv_base, yv_base), data_2d, q;
+                coeffs = OnTheFly(), extrap = ExtendExtrap(),
+            )
+            @test ForwardDiff.value(v_dual) ≈ v_float
+        end
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  Regression: Float grid ND path unchanged                           ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "Float regression — Cubic ND OnTheFly still works" begin
+        v = cubic_interp(
+            (xv_base, yv_base), data_2d, q_2d;
+            coeffs = OnTheFly(), extrap = ExtendExtrap(),
+        )
+        @test v isa Float64
+        @test isfinite(v)
+    end
+
+    @testset "Float regression — interp() hetero still works" begin
+        v = interp(
+            (xv_base, yv_base), data_2d, q_2d;
+            method = (CubicInterp(), LinearInterp()),
+            extrap = ExtendExtrap(),
+        )
+        @test v isa Float64
+        @test isfinite(v)
+    end
+
+end

--- a/test/ext/test_nd_dual_grid.jl
+++ b/test/ext/test_nd_dual_grid.jl
@@ -394,18 +394,24 @@ end
 
     @testset "HeteroInterpolantND OnTheFly — Dual grid construct + eval" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        itp = interp((d .* xv_base, d .* yv_base), data_2d;
-            method = (CubicInterp(), LinearInterp()), extrap = ExtendExtrap())
+        itp = interp(
+            (d .* xv_base, d .* yv_base), data_2d;
+            method = (CubicInterp(), LinearInterp()), extrap = ExtendExtrap()
+        )
         v = itp(q_2d)
-        itp_f = interp((xv_base, yv_base), data_2d;
-            method = (CubicInterp(), LinearInterp()), extrap = ExtendExtrap())
+        itp_f = interp(
+            (xv_base, yv_base), data_2d;
+            method = (CubicInterp(), LinearInterp()), extrap = ExtendExtrap()
+        )
         @test ForwardDiff.value(v) ≈ itp_f(q_2d)
     end
 
     @testset "HeteroInterpolantND OnTheFly — ForwardDiff.derivative" begin
         f_interp = t -> begin
-            itp = interp((t .* xv_base, t .* yv_base), data_2d;
-                method = (CubicInterp(), LinearInterp()), extrap = ExtendExtrap())
+            itp = interp(
+                (t .* xv_base, t .* yv_base), data_2d;
+                method = (CubicInterp(), LinearInterp()), extrap = ExtendExtrap()
+            )
             itp(q_2d)
         end
         ad_val = ForwardDiff.derivative(f_interp, 1.0)
@@ -415,13 +421,17 @@ end
 
     @testset "HeteroInterpolantND PreCompute — Dual grid construct + eval" begin
         d = ForwardDiff.Dual{:tag}(1.0, 1.0)
-        itp = interp((d .* xv_base, d .* yv_base), data_2d;
+        itp = interp(
+            (d .* xv_base, d .* yv_base), data_2d;
             method = (CubicInterp(), LinearInterp()), coeffs = PreCompute(),
-            extrap = ExtendExtrap())
+            extrap = ExtendExtrap()
+        )
         v = itp(q_2d)
-        itp_f = interp((xv_base, yv_base), data_2d;
+        itp_f = interp(
+            (xv_base, yv_base), data_2d;
             method = (CubicInterp(), LinearInterp()), coeffs = PreCompute(),
-            extrap = ExtendExtrap())
+            extrap = ExtendExtrap()
+        )
         @test ForwardDiff.value(v) ≈ itp_f(q_2d)
     end
 
@@ -610,8 +620,10 @@ end
 
     @testset "HeteroAdjointND (Cubic × Linear) — adjoint identity" begin
         f_adj = t -> begin
-            adj = hetero_adjoint((t .* xv_base, t .* yv_base), q_2d;
-                methods = (CubicInterp(), LinearInterp()), extrap = ExtendExtrap())
+            adj = hetero_adjoint(
+                (t .* xv_base, t .* yv_base), q_2d;
+                methods = (CubicInterp(), LinearInterp()), extrap = ExtendExtrap()
+            )
             sum(adj(1.0) .* data_2d)
         end
         f_fwd = t -> interp(

--- a/test/ext/test_nd_dual_grid.jl
+++ b/test/ext/test_nd_dual_grid.jl
@@ -243,6 +243,148 @@ end
     end
 
     # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  Phase 2: PreCompute — Homogeneous one-shot                         ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "Cubic ND PreCompute — all-Dual grids" begin
+        f_interp = t -> cubic_interp(
+            (t .* xv_base, t .* yv_base), data_2d, q_2d;
+            coeffs = PreCompute(), extrap = ExtendExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    @testset "Quadratic ND PreCompute — all-Dual grids" begin
+        f_interp = t -> quadratic_interp(
+            (t .* xv_base, t .* yv_base), data_2d, q_2d;
+            coeffs = PreCompute(), extrap = ExtendExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    @testset "Cubic ND PreCompute — per-axis gradient" begin
+        f_grad = t -> cubic_interp(
+            (t[1] .* xv_base, t[2] .* yv_base), data_2d, q_2d;
+            coeffs = PreCompute(), extrap = ExtendExtrap(),
+        )
+        ad_grad = ForwardDiff.gradient(f_grad, [1.0, 1.0])
+        fd_grad = fd_gradient(f_grad, [1.0, 1.0])
+        @test ad_grad ≈ fd_grad rtol = 1.0e-5
+    end
+
+    @testset "Cubic ND PreCompute — axis-1 Dual only" begin
+        f_interp = t -> cubic_interp(
+            (t .* xv_base, yv_base), data_2d, q_2d;
+            coeffs = PreCompute(), extrap = ExtendExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  Phase 2: PreCompute — Heterogeneous one-shot                       ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "Hetero (Cubic × Linear) PreCompute — all-Dual grids" begin
+        f_interp = t -> interp(
+            (t .* xv_base, t .* yv_base), data_2d, q_2d;
+            method = (CubicInterp(), LinearInterp()),
+            coeffs = PreCompute(), extrap = ExtendExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    @testset "Hetero PreCompute batch — all-Dual grids" begin
+        queries = [(2.3, 1.7), (1.5, 2.5), (3.1, 0.8)]
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        result = interp(
+            (d .* xv_base, d .* yv_base), data_2d, queries;
+            method = (CubicInterp(), LinearInterp()),
+            extrap = ExtendExtrap(),
+        )
+        ref = interp(
+            (xv_base, yv_base), data_2d, queries;
+            method = (CubicInterp(), LinearInterp()),
+            extrap = ExtendExtrap(),
+        )
+        @test ForwardDiff.value.(result) ≈ ref
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  Phase 2: PreCompute — Interpolant (2-arg persistent callable)      ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "Cubic ND Interpolant — Dual grid construct + eval" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        itp = cubic_interp((d .* xv_base, d .* yv_base), data_2d; extrap = ExtendExtrap())
+        v = itp(q_2d)
+        itp_f = cubic_interp((xv_base, yv_base), data_2d; extrap = ExtendExtrap())
+        @test ForwardDiff.value(v) ≈ itp_f(q_2d)
+    end
+
+    @testset "Quadratic ND Interpolant — Dual grid construct + eval" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        itp = quadratic_interp((d .* xv_base, d .* yv_base), data_2d; extrap = ExtendExtrap())
+        v = itp(q_2d)
+        itp_f = quadratic_interp((xv_base, yv_base), data_2d; extrap = ExtendExtrap())
+        @test ForwardDiff.value(v) ≈ itp_f(q_2d)
+    end
+
+    @testset "Cubic ND Interpolant — ForwardDiff.derivative" begin
+        f_interp = t -> begin
+            itp = cubic_interp((t .* xv_base, t .* yv_base), data_2d; extrap = ExtendExtrap())
+            itp(q_2d)
+        end
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  Phase 2: PreCompute — Range{Dual} hybrid                          ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "Cubic ND PreCompute — Range{Dual} × Vector{Float}" begin
+        xr = range(0.0, 5.0, 15)
+        f_interp = t -> cubic_interp(
+            (t .* xr, yv_base), data_2d, q_2d;
+            coeffs = PreCompute(), extrap = ExtendExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  Phase 2: Float regression for PreCompute path                      ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "Float regression — Cubic ND PreCompute still works" begin
+        v = cubic_interp(
+            (xv_base, yv_base), data_2d, q_2d;
+            coeffs = PreCompute(), extrap = ExtendExtrap(),
+        )
+        @test v isa Float64
+        @test isfinite(v)
+    end
+
+    @testset "Float regression — Quadratic ND PreCompute still works" begin
+        v = quadratic_interp(
+            (xv_base, yv_base), data_2d, q_2d;
+            coeffs = PreCompute(), extrap = ExtendExtrap(),
+        )
+        @test v isa Float64
+        @test isfinite(v)
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
     # ║  Regression: Float grid ND path unchanged                           ║
     # ╚═══════════════════════════════════════════════════════════════════════╝
 

--- a/test/ext/test_nd_dual_grid.jl
+++ b/test/ext/test_nd_dual_grid.jl
@@ -579,6 +579,54 @@ end
         @test ad_adj ≈ fd_val rtol = 1.0e-5
     end
 
+    @testset "ConstantAdjointND — Dual grid construct + apply" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        adj = constant_adjoint((d .* xv_base, d .* yv_base), q_2d; extrap = ExtendExtrap())
+        f_bar = adj(1.0)
+        @test f_bar isa Matrix
+        @test eltype(f_bar) <: ForwardDiff.Dual
+
+        adj_f = constant_adjoint((xv_base, yv_base), q_2d; extrap = ExtendExtrap())
+        @test ForwardDiff.value.(f_bar) ≈ adj_f(1.0)
+    end
+
+    @testset "QuadraticAdjointND — adjoint identity: dot(adj(1), data) = interp(data, q)" begin
+        f_adj = t -> begin
+            adj = quadratic_adjoint((t .* xv_base, t .* yv_base), q_2d; extrap = ExtendExtrap())
+            sum(adj(1.0) .* data_2d)
+        end
+        f_fwd = t -> quadratic_interp(
+            (t .* xv_base, t .* yv_base), data_2d, q_2d;
+            coeffs = PreCompute(), extrap = ExtendExtrap(),
+        )
+
+        ad_adj = ForwardDiff.derivative(f_adj, 1.0)
+        ad_fwd = ForwardDiff.derivative(f_fwd, 1.0)
+        fd_val = fd_deriv(f_fwd)
+
+        @test ad_adj ≈ ad_fwd rtol = 1.0e-10
+        @test ad_adj ≈ fd_val rtol = 1.0e-5
+    end
+
+    @testset "HeteroAdjointND (Cubic × Linear) — adjoint identity" begin
+        f_adj = t -> begin
+            adj = hetero_adjoint((t .* xv_base, t .* yv_base), q_2d;
+                methods = (CubicInterp(), LinearInterp()), extrap = ExtendExtrap())
+            sum(adj(1.0) .* data_2d)
+        end
+        f_fwd = t -> interp(
+            (t .* xv_base, t .* yv_base), data_2d, q_2d;
+            method = (CubicInterp(), LinearInterp()), extrap = ExtendExtrap(),
+        )
+
+        ad_adj = ForwardDiff.derivative(f_adj, 1.0)
+        ad_fwd = ForwardDiff.derivative(f_fwd, 1.0)
+        fd_val = fd_deriv(f_fwd)
+
+        @test ad_adj ≈ ad_fwd rtol = 1.0e-10
+        @test ad_adj ≈ fd_val rtol = 1.0e-5
+    end
+
     @testset "Float regression — Cubic ND OnTheFly still works" begin
         v = cubic_interp(
             (xv_base, yv_base), data_2d, q_2d;

--- a/test/ext/test_nd_dual_grid.jl
+++ b/test/ext/test_nd_dual_grid.jl
@@ -425,6 +425,90 @@ end
         @test ForwardDiff.value(v) ≈ itp_f(q_2d)
     end
 
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  PeriodicBC × ND Dual grid                                         ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "Cubic ND PeriodicBC PreCompute — Dual grid" begin
+        xp = collect(range(0.0, 2π, 15))
+        yp = collect(range(0.0, 2π, 12))
+        data_p = [sin(xi) * cos(yi) for xi in xp, yi in yp]
+        f_interp = t -> cubic_interp(
+            (t .* xp, t .* yp), data_p, (1.5, 1.0);
+            coeffs = PreCompute(), bc = PeriodicBC(), extrap = WrapExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    @testset "Cubic ND PeriodicBC OnTheFly — Dual grid" begin
+        xp = collect(range(0.0, 2π, 15))
+        yp = collect(range(0.0, 2π, 12))
+        data_p = [sin(xi) * cos(yi) for xi in xp, yi in yp]
+        f_interp = t -> cubic_interp(
+            (t .* xp, t .* yp), data_p, (1.5, 1.0);
+            coeffs = OnTheFly(), bc = PeriodicBC(), extrap = WrapExtrap(),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-5
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  DerivOp on ND + Dual grid                                         ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "Cubic ND PreCompute DerivOp(1,0) — Dual grid" begin
+        f_interp = t -> cubic_interp(
+            (t .* xv_base, t .* yv_base), data_2d, q_2d;
+            coeffs = PreCompute(), extrap = ExtendExtrap(),
+            deriv = (DerivOp(1), DerivOp(0)),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-4
+    end
+
+    @testset "Cubic ND OnTheFly DerivOp(1,0) — Dual grid" begin
+        f_interp = t -> cubic_interp(
+            (t .* xv_base, t .* yv_base), data_2d, q_2d;
+            coeffs = OnTheFly(), extrap = ExtendExtrap(),
+            deriv = (DerivOp(1), DerivOp(0)),
+        )
+        ad_val = ForwardDiff.derivative(f_interp, 1.0)
+        fd_val = fd_deriv(f_interp)
+        @test ad_val ≈ fd_val rtol = 1.0e-4
+    end
+
+    # ╔═══════════════════════════════════════════════════════════════════════╗
+    # ║  Vector calculus (gradient/hessian) on Dual-grid interpolant        ║
+    # ╚═══════════════════════════════════════════════════════════════════════╝
+
+    @testset "gradient on Dual-grid CubicInterpolantND" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        itp = cubic_interp((d .* xv_base, d .* yv_base), data_2d; extrap = ExtendExtrap())
+        g = FI.gradient(itp, q_2d)
+        @test g isa Tuple{ForwardDiff.Dual, ForwardDiff.Dual}
+
+        # Cross-check: gradient primals match Float-grid gradient
+        itp_f = cubic_interp((xv_base, yv_base), data_2d; extrap = ExtendExtrap())
+        g_f = FI.gradient(itp_f, q_2d)
+        @test ForwardDiff.value(g[1]) ≈ g_f[1]
+        @test ForwardDiff.value(g[2]) ≈ g_f[2]
+    end
+
+    @testset "hessian on Dual-grid CubicInterpolantND" begin
+        d = ForwardDiff.Dual{:tag}(1.0, 1.0)
+        itp = cubic_interp((d .* xv_base, d .* yv_base), data_2d; extrap = ExtendExtrap())
+        H = FI.hessian(itp, q_2d)
+        @test H isa Matrix{<:ForwardDiff.Dual}
+
+        itp_f = cubic_interp((xv_base, yv_base), data_2d; extrap = ExtendExtrap())
+        H_f = FI.hessian(itp_f, q_2d)
+        @test ForwardDiff.value.(H) ≈ H_f
+    end
+
     @testset "Float regression — Cubic ND OnTheFly still works" begin
         v = cubic_interp(
             (xv_base, yv_base), data_2d, q_2d;


### PR DESCRIPTION
## Summary
Opens all ND interpolation paths to duck-typed grid elements like `ForwardDiff.Dual`.
Completes the grid-side AD story started by the 1D Dual grid PRs (#116–#119).

## Usage

```julia
# Grid-side sensitivity — ND gradient via ForwardDiff
ForwardDiff.gradient(t -> cubic_interp((t[1].*x, t[2].*y), data, q), [1.0, 1.0])

# Works with any method, any path
ForwardDiff.derivative(t -> interp((t.*x, t.*y), data, q; method=PchipInterp()), 1.0)

# Hybrid grids: Range{Dual} + Vector{Float}
ForwardDiff.derivative(t -> cubic_interp((t.*x_range, y_vec), data, q), 1.0)

# Adjoint identity: d/dt ⟨adj(t*x)(1), data⟩ = d/dt interp(t*x, data, q)
ForwardDiff.derivative(t -> sum(cubic_adjoint((t.*x, t.*y), q)(1.0) .* data), 1.0)
```

## What changed

### Phase 1 — OnTheFly constraint lift (7 edits, 1 file)

| Change | Why |
|---|---|
| `Tg <: AbstractFloat` → `Tg` on 3 dispatch functions | `Dual <: Real`, not `<: AbstractFloat` |
| `Tg <: AbstractFloat ? Tg : Float64` → `float(Tg)` on 3 helpers | `float(Dual) = Dual` (ForwardDiff defines this) |
| `Tr = _promote_query_eltype(Tv, q)` → `_output_eltype(Tv, Tg, ...)` | `_collapse_dims` buffer must hold Dual from 1D oneshot |

### Phase 2 — PreCompute partials pipeline (8 files)

| Change | Why |
|---|---|
| `Array{Tv, N+1}` → `Array{Tz, N+1}` where `Tz = _output_eltype(Tv, Tg)` | Derivatives = `data × inv_h(grid)` → Dual when grid is Dual |
| `acquire!(pool, Tv, ...)` → `acquire!(pool, Tz, ...)` | Same — pool buffers need Dual eltype |
| `_compute_nd_partials!(partials::Tv, data::Tv)` → `(partials::Tz, data::Tv)` | Decouple coefficient/data types |
| Interpolant struct `Tv` → `eltype(nodal_derivs)` | Match stored `_NodalDerivativesND{Tz}` |

### Phase 3 — HeteroInterpolantND persistent (5 files)

Same patterns as Phase 1–2 applied to `HeteroInterpolantND` struct, builders,
and eval paths (OnTheFly + PreCompute + @generated NoInterp).

### Phase 4–5 — Adjoint ND (3 files)

| Change | Why |
|---|---|
| `_NDAdjointAnchor{Tg <: AbstractFloat}` → `{Tg}` | Shared anchor struct blocked Dual |
| `_bake_nd_anchors_generic` constraint lift | Anchor baking dispatch |
| `HeteroAdjointND{Tg <: AbstractFloat}` → `{Tg}` | Struct definition |
| `_effective_autocache` added to `_get_cubic_cache` calls | Prevent infinite recursion in cache pool for Dual |

### Bug fix — Constant batch + _eval_at_cell Tr (2 files)

| Change | Why |
|---|---|
| `_constant_interp_nd_oneshot_batch!` output/data Tv decouple | Output `Vector{Dual}` ≠ data `Matrix{Float64}` |
| `_eval_at_cell` Tr widening | Same `_output_eltype` pattern as Phase 1 |

## Tests

**`test/ext/test_nd_dual_grid.jl`** — 66 tests:

| Category | Count | Coverage |
|----------|-------|---------|
| OnTheFly scalar | 10 | All methods × all-Dual / per-axis / Range hybrid |
| OnTheFly gradient | 2 | ForwardDiff.gradient multi-variable |
| PreCompute scalar | 4 | Cubic / Quadratic / hetero / Range hybrid |
| PreCompute batch | 1 | Hetero allocating batch |
| Interpolant (2-arg) | 3 | Cubic / Quadratic / Hetero persistent |
| PeriodicBC | 2 | PreCompute + OnTheFly |
| DerivOp | 2 | PreCompute + OnTheFly |
| gradient / hessian | 2 | Vector calculus on Dual-grid interpolant |
| Adjoint | 8 | Linear / Cubic / Quadratic / Constant / Hetero (three-way cross-check) |
| Primal match | 5 | Dual primals ≈ Float path |
| Float regression | 4 | Float path unchanged |

Adjoint tests use three-way cross-check (adjoint identity):
```
d/dt ⟨adj(t·x)(1), data⟩ = d/dt interp(t·x, data, q)
adjoint AD ≈ forward AD (rtol=1e-10) ≈ FD (rtol=1e-5)
```