### PR TITLE
(feat): Unified Searcher Path — Per-Axis Adaptive ND Search

### DIFF
--- a/src/constant/nd/constant_nd_eval.jl
+++ b/src/constant/nd/constant_nd_eval.jl
@@ -20,7 +20,7 @@
     ops = _resolve_deriv_nd(deriv, Val(N))
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
-    mono = ntuple(_ -> true, Val(N))
+    mono = _scalar_mono(hint, Val(N))
     return _eval_constant_nd(itp, resolved, ops, policies, hints, mono)
 end
 

--- a/src/constant/nd/constant_nd_eval.jl
+++ b/src/constant/nd/constant_nd_eval.jl
@@ -18,8 +18,10 @@
     ) where {Tg, Tv, N}
     resolved = map(_resolve_grididx, query, itp.grids)
     ops = _resolve_deriv_nd(deriv, Val(N))
-    search_tuple = _resolve_search_nd(search, Val(N), resolved)
-    return _eval_constant_nd(itp, resolved, ops, search_tuple, hint)
+    policies = _resolve_search_nd(search, Val(N))
+    hints = _ensure_hint_nd(hint, Val(N))
+    mono = ntuple(_ -> true, Val(N))
+    return _eval_constant_nd(itp, resolved, ops, policies, hints, mono)
 end
 
 # In-place batch evaluation (SoA + AoS) is handled by the unified
@@ -51,8 +53,9 @@ For constant interpolation:
         itp::ConstantInterpolantND{Tg, Tv, N},
         query::Tuple{Vararg{Real, N}},
         ops::NTuple{N, AbstractEvalOp},
-        search_tuple::NTuple{N, AbstractSearchPolicy},
-        hints = nothing
+        policies::NTuple{N, AbstractSearchPolicy},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
+        mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
     _validate_nd_domain(itp.grids, query, itp.extraps)
     oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
@@ -60,7 +63,7 @@ For constant interpolation:
     if _has_any_derivative(ops, Val(N))
         return 0 * first(itp.data)
     end
-    cell = _locate_cell(itp, query, search_tuple, hints)
+    cell = _locate_cell(itp, query, policies, hints, mono)
     return _eval_at_cell(itp, cell, ops)
 end
 
@@ -69,8 +72,9 @@ end
         itp::ConstantInterpolantND{Tg, Tv, 2},
         query::Tuple{Vararg{Real, 2}},
         ops::NTuple{2, AbstractEvalOp},
-        search_tuple::NTuple{2, AbstractSearchPolicy},
-        hints = nothing
+        policies::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
+        hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
+        mono::Tuple{Bool, Bool},
     ) where {Tg, Tv}
     _validate_nd_domain(itp.grids, query, itp.extraps)
     oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
@@ -79,7 +83,7 @@ end
     if !(op_x isa EvalValue) || !(op_y isa EvalValue)
         return 0 * first(itp.data)
     end
-    cell = _locate_cell(itp, query, search_tuple, hints)
+    cell = _locate_cell(itp, query, policies, hints, mono)
     return _eval_at_cell(itp, cell, ops)
 end
 
@@ -91,11 +95,12 @@ end
 @inline function _locate_cell(
         itp::ConstantInterpolantND{Tg, Tv, N},
         query::Tuple{Vararg{Real, N}},
-        search_tuple::NTuple{N, AbstractSearchPolicy},
-        hints = nothing
+        policies::NTuple{N, AbstractSearchPolicy},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
+        mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
     q_eval = _handle_all_extraps(query, itp.grids, itp.extraps)
-    indices, Ls, _ = _search_all_intervals(q_eval, itp.grids, itp.spacings, search_tuple, hints)
+    indices, Ls, _ = _search_all_intervals(q_eval, itp.grids, itp.spacings, policies, hints, mono)
     return (itp.data, itp.spacings, itp.sides, indices, q_eval, Ls)
 end
 
@@ -103,11 +108,12 @@ end
 @inline function _locate_cell(
         itp::ConstantInterpolantND{Tg, Tv, 2},
         query::Tuple{Vararg{Real, 2}},
-        search_tuple::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
-        hints = nothing
+        policies::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
+        hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
+        mono::Tuple{Bool, Bool},
     ) where {Tg, Tv}
     x_eval, y_eval, ix, iy, xL, yL = _locate_cell_2d_preamble(
-        query, itp.grids, itp.spacings, itp.extraps, search_tuple, hints
+        query, itp.grids, itp.spacings, itp.extraps, policies, hints, mono
     )
 
     return (itp.data, itp.spacings, itp.sides, (ix, iy), (x_eval, y_eval), (xL, yL))

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -52,8 +52,9 @@ Writes results into `output`. No heap allocation beyond spacings.
         queries,
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
         side_vals::Tuple{Vararg{AbstractSide, N}},
-        searches::NTuple{N, AbstractSearchPolicy},
-        hints = nothing
+        policies::NTuple{N, AbstractSearchPolicy},
+        hints,  # Nothing or NTuple{N, Ref{Int}}
+        mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
@@ -67,7 +68,7 @@ Writes results into `output`. No heap allocation beyond spacings.
             output[k] = oob_val; continue
         end
         q_eval = _handle_all_extraps(query_k, grids, extraps_val)
-        indices, Ls, _ = _search_all_intervals(q_eval, grids, spacings, searches, hints)
+        indices, Ls, _ = _search_all_intervals(q_eval, grids, spacings, policies, hints, mono)
         output[k] = _constant_nd_kernel(data, spacings, side_vals, indices, q_eval, Ls)
     end
     return output
@@ -84,11 +85,12 @@ function _constant_interp_nd_oneshot_batch(
         queries,
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
         side_vals::Tuple{Vararg{AbstractSide, N}},
-        searches::NTuple{N, AbstractSearchPolicy},
-        hints = nothing
+        policies::NTuple{N, AbstractSearchPolicy},
+        hints,  # Nothing or NTuple{N, Ref{Int}}
+        mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
     output = Vector{Tv}(undef, _query_length(queries))
-    return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, extraps_val, side_vals, searches, hints)
+    return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, extraps_val, side_vals, policies, hints, mono)
 end
 
 # ========================================
@@ -100,11 +102,11 @@ end
 
 # Function barrier: forces Julia to runtime-dispatch on the concrete
 # searches tuple type before entering the @with_pool boundary.
-function _constant_nd_batch_dispatch!(output, grids, data, queries, extraps, sides, searches, hints)
-    return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, extraps, sides, searches, hints)
+function _constant_nd_batch_dispatch!(output, grids, data, queries, extraps, sides, policies, hints, mono)
+    return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, extraps, sides, policies, hints, mono)
 end
-function _constant_nd_batch_dispatch(grids, data, queries, extraps, sides, searches, hints)
-    return _constant_interp_nd_oneshot_batch(grids, data, queries, extraps, sides, searches, hints)
+function _constant_nd_batch_dispatch(grids, data, queries, extraps, sides, policies, hints, mono)
+    return _constant_interp_nd_oneshot_batch(grids, data, queries, extraps, sides, policies, hints, mono)
 end
 
 # ========================================
@@ -169,11 +171,12 @@ function constant_interp(
     _validate_nd_grids(grids_typed, data)
 
     sides = _resolve_side_nd(side, Val(N))
-    searches = _resolve_search_nd_uniform(search, Val(N), queries, hint)
+    policies = _resolve_search_nd(search, Val(N))
+    mono = _check_mono_nd(policies, queries)
 
     extraps_val = _resolve_extrap_nd(extrap, nothing, Val(N), Tv)
     return _constant_nd_batch_dispatch(
-        grids_typed, data, queries, extraps_val, sides, searches, hint
+        grids_typed, data, queries, extraps_val, sides, policies, hint, mono
     )::Vector{Tv}
 end
 
@@ -209,10 +212,11 @@ function constant_interp!(
     _validate_nd_grids(grids_typed, data)
 
     sides = _resolve_side_nd(side, Val(N))
-    searches = _resolve_search_nd_uniform(search, Val(N), queries, hint)
+    policies = _resolve_search_nd(search, Val(N))
+    mono = _check_mono_nd(policies, queries)
 
     extraps_val = _resolve_extrap_nd(extrap, nothing, Val(N), Tv)
     return _constant_nd_batch_dispatch!(
-        output, grids_typed, data, queries, extraps_val, sides, searches, hint
+        output, grids_typed, data, queries, extraps_val, sides, policies, hint, mono
     )
 end

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -106,8 +106,9 @@ end
         itp::AbstractInterpolantND{Tg, Tv, N},
         queries,
         ops::NTuple{N, AbstractEvalOp},
-        search::Tuple{Vararg{AbstractSearchPolicy, N}},
-        hints = nothing
+        policies::Tuple{Vararg{AbstractSearchPolicy, N}},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
+        mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
     zref = _zero_ref(itp)
     @inbounds for k in 1:_query_length(queries)
@@ -117,7 +118,7 @@ end
             output[k] = oob_val
             continue
         end
-        cell = _locate_cell(itp, query_k, search, hints)
+        cell = _locate_cell(itp, query_k, policies, hints, mono)
         output[k] = _eval_at_cell(itp, cell, ops)
     end
     return output
@@ -172,12 +173,14 @@ function (itp::AbstractInterpolantND{Tg, Tv, N})(
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
     _validate_nd_domain(itp.grids, queries, itp.extraps)
-    search_tuple = _resolve_search_nd(search, Val(N), queries, hint)
+    policies = _resolve_search_nd(search, Val(N))
+    hints = _ensure_hint_nd(hint, Val(N))
+    mono = _check_mono_nd(policies, queries)
     if _deriv_zero_fill(itp, ops, Val(N))
         fill!(output, zero(eltype(output)))
         return output
     end
-    _interp_nd_batch!(output, itp, queries, ops, search_tuple, hint)
+    _interp_nd_batch!(output, itp, queries, ops, policies, hints, mono)
     return output
 end
 

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -606,6 +606,11 @@ are forbidden.
 @inline _check_axis_mono(::AutoSearch, q) = _is_likely_monotone(q)
 @inline _check_axis_mono(::AbstractSearchPolicy, _) = true  # explicit policies: flag unused
 
+# AoS per-axis helper: dispatches on policy type (concrete per-element via map).
+@inline _check_axis_mono_aos(::AutoSearch, d, queries, vn) =
+    _is_axis_likely_monotone(queries, d, vn)
+@inline _check_axis_mono_aos(::AbstractSearchPolicy, _, __, ___) = true
+
 """
     _check_mono_nd(policies, queries) -> NTuple{N, Bool}
 
@@ -621,9 +626,25 @@ policies always return `true` (the flag is ignored by `_search_axis_adaptive`).
 ) where {N} =
     map(_check_axis_mono, policies, queries)
 
-# Non-SoA queries (AoS, scalar tuples, etc.): can't check per-axis monotonicity.
-# Default to false (Binary/LB{0}) — conservative, avoids LB{8} walk overhead on
-# unknown query order. Future: extract first K points for per-axis mono check.
+# AoS queries (Vector of point-like elements: Tuple, SVector, etc.):
+# per-axis monotonicity via protocol-based _query_extract (no allocation).
+# Wraps queries + Val(N) in _AoSMonoChecker to avoid closure capture in map.
+struct _AoSMonoChecker{Q, VN}
+    queries::Q
+    vn::VN
+end
+@inline (c::_AoSMonoChecker)(p, d) = _check_axis_mono_aos(p, d, c.queries, c.vn)
+
+@inline function _check_mono_nd(
+    policies::Tuple{Vararg{AbstractSearchPolicy, N}},
+    queries::AbstractVector
+) where {N}
+    checker = _AoSMonoChecker(queries, Val(N))
+    map(checker, policies, ntuple(identity, Val(N)))
+end
+
+# Non-SoA queries (scalar tuples, etc.): can't check per-axis monotonicity.
+# Default to false (Binary) — conservative, avoids LB{8} walk overhead.
 @inline _check_mono_nd(
     policies::Tuple{Vararg{AbstractSearchPolicy, N}},
     queries

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -701,7 +701,16 @@ end
     return (map(_getidx, results), map(_getL, results), map(_getR, results))
 end
 
-# Nothing hint → delegate to existing 4-arg (zero overhead)
+# Nothing hint + mono → delegate to 4-arg (zero Ref alloc)
+@inline function _search_all_intervals(
+        q_evals::Tuple{Vararg{Real, N}}, grids::Tuple{Vararg{AbstractVector, N}},
+        spacings::Tuple{Vararg{AbstractGridSpacing, N}}, searches::Tuple{Vararg{AbstractSearchPolicy, N}},
+        ::Nothing, ::NTuple{N, Bool},
+    ) where {N}
+    return _search_all_intervals(q_evals, grids, spacings, searches)
+end
+
+# Nothing hint (no mono) → delegate to 4-arg (zero Ref alloc)
 @inline function _search_all_intervals(
         q_evals::Tuple{Vararg{Real, N}}, grids::Tuple{Vararg{AbstractVector, N}},
         spacings::Tuple{Vararg{AbstractGridSpacing, N}}, searches::Tuple{Vararg{AbstractSearchPolicy, N}},

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -699,41 +699,7 @@ end
 # Extracts query, handles extrapolation, and performs interval search.
 # Returns raw (x_eval, y_eval, ix, iy, xL, yL) for type-specific post-processing.
 
-"""
-    _locate_cell_2d_preamble(query, grids, spacings, extraps, search, hints)
-
-Shared preamble for all N=2 `_locate_cell` specializations.
-Destructures 2D query, applies per-axis extrapolation, and performs interval search.
-
-Returns `(x_eval, y_eval, ix, iy, xL, yL)` — the 6 raw values that each
-interpolant type then post-processes into its kernel-specific cell tuple.
-"""
-@inline function _locate_cell_2d_preamble(
-        query::Tuple{Vararg{Real, 2}},
-        grids, spacings, extraps,
-        search::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
-        hints
-    )
-    xq, yq = query
-    grid_x, grid_y = grids
-    spacing_x, spacing_y = spacings
-    extrap_x, extrap_y = extraps
-    search_x, search_y = search
-
-    x_eval = _handle_axis_extrap(xq, grid_x, extrap_x)
-    y_eval = _handle_axis_extrap(yq, grid_y, extrap_y)
-
-    hint_x = _get_axis_hint(hints, 1)
-    hint_y = _get_axis_hint(hints, 2)
-    searcher_x = _resolve_search(grid_x, x_eval, search_x, hint_x)
-    searcher_y = _resolve_search(grid_y, y_eval, search_y, hint_y)
-    ix, xL, _ = search_interval(searcher_x, grid_x, spacing_x, x_eval)
-    iy, yL, _ = search_interval(searcher_y, grid_y, spacing_y, y_eval)
-
-    return (x_eval, y_eval, ix, iy, xL, yL)
-end
-
-# Mono-flag overload: per-axis adaptive search inside function barrier
+# N=2 preamble: per-axis adaptive search inside function barrier
 @inline function _locate_cell_2d_preamble(
         query::Tuple{Vararg{Real, 2}},
         grids, spacings, extraps,

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -579,15 +579,6 @@ end
 # ----------------------------------------
 
 """
-    _get_axis_hint(hints, d) -> Nothing or Base.RefValue{Int}
-
-Extract per-axis hint from a hint tuple or Nothing.
-Used by N=2 specializations that destructure manually.
-"""
-@inline _get_axis_hint(::Nothing, d) = nothing
-@inline _get_axis_hint(hints::Tuple, d) = @inbounds hints[d]
-
-"""
     _ensure_hint_nd(hint, Val(N)) -> NTuple{N, Base.RefValue{Int}}
 
 Create persistent hint tuple for ND evaluation. User-provided hints pass
@@ -646,10 +637,8 @@ policies always return `true` (the flag is ignored by `_search_axis_adaptive`).
 # is resolved by Julia's union-splitting INSIDE the barrier — the concrete
 # return type (Int, Tg, Tg) never escapes as Union.
 #
-# mono=true → LB{8} with persistent hint (walk + locality)
-# mono=false → Binary+RefHint DIRECTLY (bypass _to_searcher auto-upgrade to avoid
-#   LB{8} overhead on random queries; auto-created hints from _ensure_hint_nd would
-#   otherwise trigger the _to_searcher(Binary, hint) → LB{8} auto-upgrade path)
+# mono=true  → LB{8} with persistent hint (walk + locality)
+# mono=false → Binary+RefHint (pure binary search + hint write-back, no walk overhead)
 
 # Range grid: always DirectSearch O(1) regardless of policy/mono
 @inline function _search_axis_adaptive(q, grid::AbstractRange, spacing, ::AbstractSearchPolicy, hint, _)
@@ -667,7 +656,7 @@ end
 @inline function _search_axis_adaptive(q, grid::AbstractVector, spacing, ::AutoSearch, hint, is_mono)
     searcher = is_mono ?
         _to_searcher(LinearBinarySearch(), hint) :
-        Searcher{BinarySearch, RefHint}(RefHint(hint))
+        _to_searcher(BinarySearch(), hint)
     return @inbounds search_interval(searcher, grid, spacing, q)
 end
 

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -609,13 +609,17 @@ end
     map(checker, policies, ntuple(identity, Val(N)))
 end
 
-# Non-SoA queries (scalar tuples, etc.): can't check per-axis monotonicity.
-# Default to false (Binary) — conservative, avoids LB{8} walk overhead.
-@inline _check_mono_nd(
+# Generic queries (custom protocol containers): per-axis monotonicity via
+# _is_axis_likely_monotone (same protocol-based check as AoS).
+# Covers any container implementing _query_length/_query_extract.
+@inline function _check_mono_nd(
     policies::Tuple{Vararg{AbstractSearchPolicy, N}},
     queries
-) where {N} =
-    ntuple(_false_flag, Val(N))
+) where {N}
+    _query_length(queries) < 8 && return ntuple(_false_flag, Val(N))
+    checker = _AoSMonoChecker(queries, Val(N))
+    map(checker, policies, ntuple(identity, Val(N)))
+end
 
 # ----------------------------------------
 # Per-axis adaptive search (function barrier)

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -601,6 +601,10 @@ are forbidden.
 @inline _true_flag(_) = true
 @inline _false_flag(_) = false
 
+# Scalar mono flag: hint provided → assume locality (LB), no hint → stateless (Binary)
+@inline _scalar_mono(::Nothing, ::Val{N}) where {N} = ntuple(_false_flag, Val(N))
+@inline _scalar_mono(::NTuple{N, Base.RefValue{Int}}, ::Val{N}) where {N} = ntuple(_true_flag, Val(N))
+
 # ----------------------------------------
 # Monotonicity Flags (batch-level, once per call)
 # ----------------------------------------
@@ -647,14 +651,28 @@ policies always return `true` (the flag is ignored by `_search_axis_adaptive`).
 #   LB{8} overhead on random queries; auto-created hints from _ensure_hint_nd would
 #   otherwise trigger the _to_searcher(Binary, hint) → LB{8} auto-upgrade path)
 
-@inline function _search_axis_adaptive(q, grid, spacing, ::AutoSearch, hint, is_mono)
+# Range grid: always DirectSearch O(1) regardless of policy/mono
+@inline function _search_axis_adaptive(q, grid::AbstractRange, spacing, ::AbstractSearchPolicy, hint, _)
+    searcher = _to_searcher(DirectSearch(), hint)
+    return @inbounds search_interval(searcher, grid, spacing, q)
+end
+
+# Disambiguate: Range + AutoSearch (AbstractRange <: AbstractVector, AutoSearch <: AbstractSearchPolicy)
+@inline function _search_axis_adaptive(q, grid::AbstractRange, spacing, ::AutoSearch, hint, _)
+    searcher = _to_searcher(DirectSearch(), hint)
+    return @inbounds search_interval(searcher, grid, spacing, q)
+end
+
+# Vector grid + AutoSearch: per-axis adaptive
+@inline function _search_axis_adaptive(q, grid::AbstractVector, spacing, ::AutoSearch, hint, is_mono)
     searcher = is_mono ?
         _to_searcher(LinearBinarySearch(), hint) :
         Searcher{BinarySearch, RefHint}(RefHint(hint))
     return @inbounds search_interval(searcher, grid, spacing, q)
 end
 
-@inline function _search_axis_adaptive(q, grid, spacing, policy::AbstractSearchPolicy, hint, _)
+# Vector grid + explicit policy
+@inline function _search_axis_adaptive(q, grid::AbstractVector, spacing, policy::AbstractSearchPolicy, hint, _)
     searcher = _to_searcher(policy, hint)
     return @inbounds search_interval(searcher, grid, spacing, q)
 end

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -358,8 +358,8 @@ end
 @inline _autosearch_to_lb(p::AbstractSearchPolicy) = p
 @inline _autosearch_to_binary(::AutoSearch) = BinarySearch()
 @inline _autosearch_to_binary(p::AbstractSearchPolicy) = p
-@inline _check_axis_monotone(::AutoSearch, q) = _is_likely_monotone(q)
-@inline _check_axis_monotone(::AbstractSearchPolicy, _) = true
+# _check_axis_mono is defined below (line ~606) — shared by both
+# _resolve_search_nd_uniform (oneshot) and _check_mono_nd (persistent batch).
 
 # SoA Real vectors + no hint → all-or-nothing adaptive resolution.
 @inline function _resolve_search_nd_uniform(
@@ -368,7 +368,7 @@ end
         ::Nothing
     ) where {N}
     tuple = _resolve_search_nd(s, Val(N))  # broadcast only, no resolution
-    all_mono = all(map(_check_axis_monotone, tuple, queries))
+    all_mono = all(map(_check_axis_mono, tuple, queries))
     return all_mono ? map(_autosearch_to_lb, tuple) : map(_autosearch_to_binary, tuple)
 end
 
@@ -555,12 +555,13 @@ Uses map over named helpers so each axis receives its concrete type directly,
 avoiding ntuple-closure boxing on heterogeneous tuple inputs.
 """
 
-# Named helpers for map-based search — each receives concrete types per axis.
+# Named helpers for oneshot map-based search — each receives concrete types per axis.
 # search_interval returns (idx, L, R) with the same concrete element type regardless
 # of spacing type (ScalarSpacing or VectorSpacing), so results is homogeneous.
-@inline _search_axis(q, grid, spacing, search) =
+# Persistent batch paths use _search_axis_adaptive instead (Bool-flag, no Union boxing).
+@inline _search_axis_oneshot(q, grid, spacing, search) =
     @inbounds search_interval(_resolve_search(grid, q, search, nothing), grid, spacing, q)
-@inline _search_axis_hint(q, grid, spacing, search, hint) =
+@inline _search_axis_oneshot_hint(q, grid, spacing, search, hint) =
     @inbounds search_interval(_resolve_search(grid, q, search, hint), grid, spacing, q)
 @inline _getidx(r) = r[1]
 @inline _getL(r) = r[2]
@@ -570,7 +571,7 @@ avoiding ntuple-closure boxing on heterogeneous tuple inputs.
         q_evals::Tuple{Vararg{Real, N}}, grids::Tuple{Vararg{AbstractVector, N}},
         spacings::Tuple{Vararg{AbstractGridSpacing, N}}, searches::Tuple{Vararg{AbstractSearchPolicy, N}}
     ) where {N}
-    results = map(_search_axis, q_evals, grids, spacings, searches)
+    results = map(_search_axis_oneshot, q_evals, grids, spacings, searches)
     return (map(_getidx, results), map(_getL, results), map(_getR, results))
 end
 
@@ -609,7 +610,7 @@ are forbidden.
 # AoS per-axis helper: dispatches on policy type (concrete per-element via map).
 @inline _check_axis_mono_aos(::AutoSearch, d, queries, vn) =
     _is_axis_likely_monotone(queries, d, vn)
-@inline _check_axis_mono_aos(::AbstractSearchPolicy, _, __, ___) = true
+@inline _check_axis_mono_aos(::AbstractSearchPolicy, _d, _queries, _vn) = true
 
 """
     _check_mono_nd(policies, queries) -> NTuple{N, Bool}
@@ -715,7 +716,7 @@ end
         spacings::Tuple{Vararg{AbstractGridSpacing, N}}, searches::Tuple{Vararg{AbstractSearchPolicy, N}},
         hints::Tuple{Vararg{Base.RefValue{Int}, N}}
     ) where {N}
-    results = map(_search_axis_hint, q_evals, grids, spacings, searches, hints)
+    results = map(_search_axis_oneshot_hint, q_evals, grids, spacings, searches, hints)
     return (map(_getidx, results), map(_getL, results), map(_getR, results))
 end
 

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -353,41 +353,6 @@ end
 # Return type is Union{ConcreteA, ConcreteB} — a 2-way Union of concrete tuple
 # types that Julia union-splits at the function barrier.
 
-# Named helpers for map — avoid closure capture.
-@inline _autosearch_to_lb(::AutoSearch) = LinearBinarySearch()
-@inline _autosearch_to_lb(p::AbstractSearchPolicy) = p
-@inline _autosearch_to_binary(::AutoSearch) = BinarySearch()
-@inline _autosearch_to_binary(p::AbstractSearchPolicy) = p
-# _check_axis_mono is defined below (line ~606) — shared by both
-# _resolve_search_nd_uniform (oneshot) and _check_mono_nd (persistent batch).
-
-# SoA Real vectors + no hint → all-or-nothing adaptive resolution.
-@inline function _resolve_search_nd_uniform(
-        s, ::Val{N},
-        queries::Tuple{Vararg{AbstractVector{<:Real}, N}},
-        ::Nothing
-    ) where {N}
-    tuple = _resolve_search_nd(s, Val(N))  # broadcast only, no resolution
-    all_mono = all(map(_check_axis_mono, tuple, queries))
-    return all_mono ? map(_autosearch_to_lb, tuple) : map(_autosearch_to_binary, tuple)
-end
-
-# Generic queries + no hint → protocol-based all-or-nothing adaptive resolution.
-# Fallback for non-SoA queries — SoA has a more specific method above (line ~365).
-@inline function _resolve_search_nd_uniform(s, vn::Val{N}, queries, ::Nothing) where {N}
-    tuple = _resolve_search_nd(s, vn)
-    any(p -> p isa AutoSearch, tuple) || return tuple
-    all_mono = all(
-        ntuple(Val(N)) do d
-            p = tuple[d]
-            !isa(p, AutoSearch) || _is_axis_likely_monotone(queries, d, vn)
-        end
-    )
-    return all_mono ? map(_autosearch_to_lb, tuple) : map(_autosearch_to_binary, tuple)
-end
-
-# Hinted → standard 3-arg type-based (already concrete, no monotonicity check).
-@inline _resolve_search_nd_uniform(s, vn, queries, hints) = _resolve_search_nd(s, vn, queries)
 
 # ========================================
 # Boundary Condition Resolution

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -582,8 +582,14 @@ are forbidden.
 
 Check per-axis monotonicity for AutoSearch axes.  Returns `NTuple{N, Bool}`,
 a concrete tuple type that avoids the `Union{BinarySearch, LinearBinarySearch}`
-boxing that per-axis policy resolution would produce.  Explicit (non-AutoSearch)
-policies always return `true` (the flag is ignored by `_search_axis_adaptive`).
+boxing that per-axis policy resolution would produce.
+
+For explicit (non-AutoSearch) policies, the returned flag is ignored by
+`_search_axis_adaptive`; callers should not rely on it having any particular
+value.  Short queries (< 8 elements) return all-false as a conservative
+fallback.  The mono flags are only effective when hints are present —
+without hints, `_search_all_intervals` delegates to the stateless 4-arg
+path regardless of mono values.
 """
 # SoA queries: per-axis monotonicity check (each query vector checked independently)
 @inline _check_mono_nd(
@@ -670,7 +676,10 @@ end
     return (map(_getidx, results), map(_getL, results), map(_getR, results))
 end
 
-# Nothing hint + mono → delegate to 4-arg (zero Ref alloc)
+# Nothing hint + mono → delegate to stateless 4-arg (zero Ref alloc).
+# mono is accepted but ignored: without hints, no LB walk benefit → Binary always.
+# Callers (oneshot batch with hint=nothing) compute mono for API uniformity;
+# the cost is negligible (one-time _check_mono_nd vs nq search_interval calls).
 @inline function _search_all_intervals(
         q_evals::Tuple{Vararg{Real, N}}, grids::Tuple{Vararg{AbstractVector, N}},
         spacings::Tuple{Vararg{AbstractGridSpacing, N}}, searches::Tuple{Vararg{AbstractSearchPolicy, N}},

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -587,6 +587,91 @@ Used by N=2 specializations that destructure manually.
 @inline _get_axis_hint(::Nothing, d) = nothing
 @inline _get_axis_hint(hints::Tuple, d) = @inbounds hints[d]
 
+"""
+    _ensure_hint_nd(hint, Val(N)) -> NTuple{N, Base.RefValue{Int}}
+
+Create persistent hint tuple for ND evaluation. User-provided hints pass
+through; `nothing` creates N fresh `Ref(1)` objects. Must be a named function
+(not a lambda) because callers include `@generated` bodies where closures
+are forbidden.
+"""
+@inline _ensure_hint_nd(hint::NTuple{N, Base.RefValue{Int}}, ::Val{N}) where {N} = hint
+@inline _ensure_hint_nd(::Nothing, ::Val{N}) where {N} = ntuple(_ref1, Val(N))
+@inline _ref1(_) = Ref(1)
+@inline _true_flag(_) = true
+@inline _false_flag(_) = false
+
+# ----------------------------------------
+# Monotonicity Flags (batch-level, once per call)
+# ----------------------------------------
+# Pre-compute per-axis monotonicity as NTuple{N, Bool} — concrete, zero-alloc.
+# Used by _search_axis_adaptive to select LB vs Binary inside a function barrier,
+# avoiding Union boxing from materializing a Tuple{Union{Binary,LB},...} policy tuple.
+
+@inline _check_axis_mono(::AutoSearch, q) = _is_likely_monotone(q)
+@inline _check_axis_mono(::AbstractSearchPolicy, _) = true  # explicit policies: flag unused
+
+"""
+    _check_mono_nd(policies, queries) -> NTuple{N, Bool}
+
+Check per-axis monotonicity for AutoSearch axes.  Returns `NTuple{N, Bool}`,
+a concrete tuple type that avoids the `Union{BinarySearch, LinearBinarySearch}`
+boxing that per-axis policy resolution would produce.  Explicit (non-AutoSearch)
+policies always return `true` (the flag is ignored by `_search_axis_adaptive`).
+"""
+# SoA queries: per-axis monotonicity check (each query vector checked independently)
+@inline _check_mono_nd(
+    policies::Tuple{Vararg{AbstractSearchPolicy, N}},
+    queries::Tuple{Vararg{AbstractVector, N}}
+) where {N} =
+    map(_check_axis_mono, policies, queries)
+
+# Non-SoA queries (AoS, scalar tuples, etc.): can't check per-axis monotonicity.
+# Default to false (Binary/LB{0}) — conservative, avoids LB{8} walk overhead on
+# unknown query order. Future: extract first K points for per-axis mono check.
+@inline _check_mono_nd(
+    policies::Tuple{Vararg{AbstractSearchPolicy, N}},
+    queries
+) where {N} =
+    ntuple(_false_flag, Val(N))
+
+# ----------------------------------------
+# Per-axis adaptive search (function barrier)
+# ----------------------------------------
+# Creates Searcher per-axis inside a function barrier. The Union{LB{8}, Binary+RefHint}
+# is resolved by Julia's union-splitting INSIDE the barrier — the concrete
+# return type (Int, Tg, Tg) never escapes as Union.
+#
+# mono=true → LB{8} with persistent hint (walk + locality)
+# mono=false → Binary+RefHint DIRECTLY (bypass _to_searcher auto-upgrade to avoid
+#   LB{8} overhead on random queries; auto-created hints from _ensure_hint_nd would
+#   otherwise trigger the _to_searcher(Binary, hint) → LB{8} auto-upgrade path)
+
+@inline function _search_axis_adaptive(q, grid, spacing, ::AutoSearch, hint, is_mono)
+    searcher = is_mono ?
+        _to_searcher(LinearBinarySearch(), hint) :
+        Searcher{BinarySearch, RefHint}(RefHint(hint))
+    return @inbounds search_interval(searcher, grid, spacing, q)
+end
+
+@inline function _search_axis_adaptive(q, grid, spacing, policy::AbstractSearchPolicy, hint, _)
+    searcher = _to_searcher(policy, hint)
+    return @inbounds search_interval(searcher, grid, spacing, q)
+end
+
+# Mono-flag overload of _search_all_intervals: per-axis adaptive, zero boxing
+@inline function _search_all_intervals(
+        q_evals::Tuple{Vararg{Real, N}},
+        grids::Tuple{Vararg{AbstractVector, N}},
+        spacings::Tuple{Vararg{AbstractGridSpacing, N}},
+        policies::Tuple{Vararg{AbstractSearchPolicy, N}},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
+        mono::NTuple{N, Bool},
+    ) where {N}
+    results = map(_search_axis_adaptive, q_evals, grids, spacings, policies, hints, mono)
+    return (map(_getidx, results), map(_getL, results), map(_getR, results))
+end
+
 # Nothing hint → delegate to existing 4-arg (zero overhead)
 @inline function _search_all_intervals(
         q_evals::Tuple{Vararg{Real, N}}, grids::Tuple{Vararg{AbstractVector, N}},
@@ -644,6 +729,30 @@ interpolant type then post-processes into its kernel-specific cell tuple.
     searcher_y = _resolve_search(grid_y, y_eval, search_y, hint_y)
     ix, xL, _ = search_interval(searcher_x, grid_x, spacing_x, x_eval)
     iy, yL, _ = search_interval(searcher_y, grid_y, spacing_y, y_eval)
+
+    return (x_eval, y_eval, ix, iy, xL, yL)
+end
+
+# Mono-flag overload: per-axis adaptive search inside function barrier
+@inline function _locate_cell_2d_preamble(
+        query::Tuple{Vararg{Real, 2}},
+        grids, spacings, extraps,
+        policies::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
+        hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
+        mono::Tuple{Bool, Bool},
+    )
+    xq, yq = query
+    grid_x, grid_y = grids
+    spacing_x, spacing_y = spacings
+    extrap_x, extrap_y = extraps
+    policy_x, policy_y = policies
+    hint_x, hint_y = hints
+    mono_x, mono_y = mono
+
+    x_eval = _handle_axis_extrap(xq, grid_x, extrap_x)
+    y_eval = _handle_axis_extrap(yq, grid_y, extrap_y)
+    ix, xL, _ = _search_axis_adaptive(x_eval, grid_x, spacing_x, policy_x, hint_x, mono_x)
+    iy, yL, _ = _search_axis_adaptive(y_eval, grid_y, spacing_y, policy_y, hint_y, mono_y)
 
     return (x_eval, y_eval, ix, iy, xL, yL)
 end

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -316,23 +316,20 @@ end
     ) where {N, K}
     nq = _query_length(queries)
     nq < K && return false
+    # Single-pass direction tracking (same algorithm as _is_likely_monotone).
+    state = 0
     @inbounds begin
-        v1 = _query_extract(queries, 1)[d]
-        v2 = _query_extract(queries, 2)[d]
-        ascending = v2 >= v1
-        prev = v2
-        if ascending
-            for i in 3:K
-                curr = _query_extract(queries, i)[d]
-                curr < prev && return false
-                prev = curr
+        prev = _query_extract(queries, 1)[d]
+        for i in 2:K
+            curr = _query_extract(queries, i)[d]
+            diff = curr - prev
+            s = (diff > 0) - (diff < 0)
+            if state == 0
+                state = s
+            else
+                diff * state < 0 && return false
             end
-        else
-            for i in 3:K
-                curr = _query_extract(queries, i)[d]
-                curr > prev && return false
-                prev = curr
-            end
+            prev = curr
         end
     end
     return true

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -602,23 +602,23 @@ end
 @inline (c::_AoSMonoChecker)(p, d) = _check_axis_mono_aos(p, d, c.queries, c.vn)
 
 @inline function _check_mono_nd(
-    policies::Tuple{Vararg{AbstractSearchPolicy, N}},
-    queries::AbstractVector
-) where {N}
+        policies::Tuple{Vararg{AbstractSearchPolicy, N}},
+        queries::AbstractVector
+    ) where {N}
     checker = _AoSMonoChecker(queries, Val(N))
-    map(checker, policies, ntuple(identity, Val(N)))
+    return map(checker, policies, ntuple(identity, Val(N)))
 end
 
 # Generic queries (custom protocol containers): per-axis monotonicity via
 # _is_axis_likely_monotone (same protocol-based check as AoS).
 # Covers any container implementing _query_length/_query_extract.
 @inline function _check_mono_nd(
-    policies::Tuple{Vararg{AbstractSearchPolicy, N}},
-    queries
-) where {N}
+        policies::Tuple{Vararg{AbstractSearchPolicy, N}},
+        queries
+    ) where {N}
     _query_length(queries) < 8 && return ntuple(_false_flag, Val(N))
     checker = _AoSMonoChecker(queries, Val(N))
-    map(checker, policies, ntuple(identity, Val(N)))
+    return map(checker, policies, ntuple(identity, Val(N)))
 end
 
 # ----------------------------------------

--- a/src/core/query_protocol.jl
+++ b/src/core/query_protocol.jl
@@ -142,7 +142,9 @@ end
     return nothing
 end
 
-# Generic queries: per-query per-axis scalar check
+# Generic queries (AoS, etc.): per-query per-axis scalar check.
+# Uses map over (grids, extraps, axes) to avoid runtime-Int indexing of
+# heterogeneous grid tuples — prevents Union boxing on mixed-grid combos.
 function _validate_nd_domain(
         grids::NTuple{N, AbstractVector},
         queries,
@@ -150,11 +152,12 @@ function _validate_nd_domain(
     ) where {N}
     any(e -> e isa NoExtrap, extraps) || return nothing
     nq = _query_length(queries)
+    axes = ntuple(identity, Val(N))
     for q in 1:nq
         query_q = _extract_query_point(queries, q, Val(N))
-        for d in 1:N
-            extraps[d] isa NoExtrap || continue
-            _check_domain(grids[d], query_q[d], NoExtrap())
+        map(grids, extraps, axes) do grid, extrap, d
+            extrap isa NoExtrap && _check_domain(grid, query_q[d], NoExtrap())
+            nothing
         end
     end
     return nothing

--- a/src/core/search.jl
+++ b/src/core/search.jl
@@ -285,8 +285,13 @@ end
 # strategy, so we skip adaptive resolution and defer to the 2-arg form —
 # AutoSearch+vector already resolves to LinearBinarySearch there, which is correct
 # because hinted callers expect walk-based locality.
+# Explicit policy (non-Auto) + any hint → policy unchanged.
 @inline _resolve_search_policy(search, xq, hint) = _resolve_search_policy(search, xq)
 
+# AutoSearch + hint present → caller wants locality, resolve to LB regardless of query type.
+@inline _resolve_search_policy(::AutoSearch, xq, ::Base.RefValue{Int}) = LinearBinarySearch()
+
+# AutoSearch + no hint + vector → adaptive per prefix monotonicity check.
 @inline function _resolve_search_policy(::AutoSearch, xq::AbstractVector{<:Real}, ::Nothing)
     return _is_likely_monotone(xq) ? LinearBinarySearch() : BinarySearch()
 end
@@ -396,7 +401,7 @@ Creates a new RefHint for stateful policies, ensuring thread safety.
 # When hint=Ref{Int}, stateful policies use the external Ref for persistence.
 
 @inline _to_searcher(::BinarySearch, ::Nothing) = Searcher{BinarySearch, NoHint}(NoHint())
-@inline _to_searcher(::BinarySearch, hint::Base.RefValue{Int}) = _to_searcher(LinearBinarySearch(), hint)  # auto-upgrade to default LinearBinarySearch
+@inline _to_searcher(::BinarySearch, hint::Base.RefValue{Int}) = Searcher{BinarySearch, RefHint}(RefHint(hint))  # Binary + hint write-back (respects explicit policy choice)
 @inline _to_searcher(::LinearSearch, ::Nothing) = Searcher{LinearSearch, RefHint}(RefHint())
 @inline _to_searcher(::LinearSearch, hint::Base.RefValue{Int}) = Searcher{LinearSearch, RefHint}(RefHint(hint))
 @inline _to_searcher(::LinearBinarySearch{MAX}, ::Nothing) where {MAX} = Searcher{LinearBinarySearch{MAX}, RefHint}(RefHint())
@@ -849,6 +854,18 @@ end
     _search_binary(x, xq)
 @inline _search_interval_real(::Searcher{BinarySearch, NoHint}, x::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}, xq::Real) where {Tg} =
     _search_binary(x, spacing, xq)
+
+# BinarySearch + RefHint (pure binary + hint write-back, zero search overhead)
+@inline function _search_interval_real(p::Searcher{BinarySearch, RefHint}, x::AbstractVector, xq::Real)
+    idx, xL, xR = _search_binary(x, xq)
+    p.hint.idx[] = idx
+    return idx, xL, xR
+end
+@inline function _search_interval_real(p::Searcher{BinarySearch, RefHint}, x::AbstractVector{Tg}, spacing::AbstractGridSpacing{Tg}, xq::Real) where {Tg}
+    idx, xL, xR = _search_binary(x, spacing, xq)
+    p.hint.idx[] = idx
+    return idx, xL, xR
+end
 
 # LinearSearch + RefHint
 @inline _search_interval_real(p::Searcher{LinearSearch, RefHint}, x::AbstractVector, xq::Real) =

--- a/src/core/search.jl
+++ b/src/core/search.jl
@@ -232,16 +232,18 @@ False positive rate: 1/K! ≈ 2.5e-5 for K=8 (random data appearing sorted in fi
 @inline function _is_likely_monotone(xq::AbstractVector{<:Real}, ::Val{K} = Val(8)) where {K}
     n = length(xq)
     n < K && return false
-    @inbounds begin
-        ascending = xq[2] >= xq[1]
-        if ascending
-            for i in 2:K
-                xq[i] < xq[i - 1] && return false
-            end
+    # Single-pass direction tracking: state ∈ {-1, 0, 1}.
+    # state=0 (undecided) adopts the first non-zero diff's sign.
+    # Any diff that opposes state → not monotone.
+    # Equal consecutive values (diff=0) are always compatible.
+    state = 0
+    @inbounds for i in 2:K
+        diff = xq[i] - xq[i - 1]
+        s = (diff > 0) - (diff < 0)
+        if state == 0
+            state = s
         else
-            for i in 2:K
-                xq[i] > xq[i - 1] && return false
-            end
+            diff * state < 0 && return false
         end
     end
     return true

--- a/src/cubic/nd/cubic_nd_eval.jl
+++ b/src/cubic/nd/cubic_nd_eval.jl
@@ -42,8 +42,10 @@ itp((1.0, 0.5); deriv=(DerivOp(1), EvalValue()))  # ∂f/∂x only
     # Resolve bare GridIdx → GridIdx{Tg}(idx, val). No-op for Real/Dual.
     resolved = map(_resolve_grididx, query, itp.grids)
     ops = _resolve_deriv_nd(deriv, Val(N))
-    search_tuple = _resolve_search_nd(search, Val(N), resolved)
-    return _eval_nd_hermite(itp, resolved, ops, search_tuple, hint)
+    policies = _resolve_search_nd(search, Val(N))
+    hints = _ensure_hint_nd(hint, Val(N))
+    mono = ntuple(_ -> true, Val(N))
+    return _eval_nd_hermite(itp, resolved, ops, policies, hints, mono)
 end
 
 # In-place batch evaluation (SoA + AoS) is handled by the unified
@@ -65,11 +67,12 @@ end
 @inline function _locate_cell(
         itp::CubicInterpolantND{Tg, Tv, N},
         query::Tuple{Vararg{Real, N}},
-        search::SEARCH,
-        hints = nothing
-    ) where {Tg, Tv, N, SEARCH <: NTuple{N, AbstractSearchPolicy}}
+        policies::NTuple{N, AbstractSearchPolicy},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
+        mono::NTuple{N, Bool},
+    ) where {Tg, Tv, N}
     q_evals = _handle_all_extraps(query, itp.grids, itp.extraps)
-    indices, Ls, _ = _search_all_intervals(q_evals, itp.grids, itp.spacings, search, hints)
+    indices, Ls, _ = _search_all_intervals(q_evals, itp.grids, itp.spacings, policies, hints, mono)
     hs, inv_hs, dLs = _compute_all_local_params(q_evals, itp.spacings, indices, Ls)
 
     return (itp.nodal_derivs.partials, indices, hs, inv_hs, dLs)
@@ -79,11 +82,12 @@ end
 @inline function _locate_cell(
         itp::CubicInterpolantND{Tg, Tv, 2},
         query::Tuple{Vararg{Real, 2}},
-        search::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
-        hints = nothing
+        policies::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
+        hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
+        mono::Tuple{Bool, Bool},
     ) where {Tg, Tv}
     x_eval, y_eval, ix, iy, xL, yL = _locate_cell_2d_preamble(
-        query, itp.grids, itp.spacings, itp.extraps, search, hints
+        query, itp.grids, itp.spacings, itp.extraps, policies, hints, mono
     )
 
     hx = _get_h(itp.spacings[1], ix);  hy = _get_h(itp.spacings[2], iy)
@@ -114,14 +118,15 @@ end
 @inline function _eval_nd_hermite(
         itp::CubicInterpolantND{Tg, Tv, N},
         query::Tuple{Vararg{Real, N}},
-        ops::OPS,
-        search::SEARCH,
-        hints = nothing
-    ) where {Tg, Tv, N, OPS <: NTuple{N, AbstractEvalOp}, SEARCH <: NTuple{N, AbstractSearchPolicy}}
+        ops::NTuple{N, AbstractEvalOp},
+        policies::NTuple{N, AbstractSearchPolicy},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
+        mono::NTuple{N, Bool},
+    ) where {Tg, Tv, N}
     _validate_nd_domain(itp.grids, query, itp.extraps)
     oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
     oob_result !== nothing && return oob_result
-    cell = _locate_cell(itp, query, search, hints)
+    cell = _locate_cell(itp, query, policies, hints, mono)
     return _eval_at_cell(itp, cell, ops)
 end
 
@@ -130,13 +135,14 @@ end
         itp::CubicInterpolantND{Tg, Tv, 2},
         query::Tuple{Vararg{Real, 2}},
         ops::Tuple{<:AbstractEvalOp, <:AbstractEvalOp},
-        search::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
-        hints = nothing
+        policies::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
+        hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
+        mono::Tuple{Bool, Bool},
     ) where {Tg, Tv}
     _validate_nd_domain(itp.grids, query, itp.extraps)
     oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
     oob_result !== nothing && return oob_result
-    cell = _locate_cell(itp, query, search, hints)
+    cell = _locate_cell(itp, query, policies, hints, mono)
     return _eval_at_cell(itp, cell, ops)
 end
 

--- a/src/cubic/nd/cubic_nd_eval.jl
+++ b/src/cubic/nd/cubic_nd_eval.jl
@@ -44,7 +44,7 @@ itp((1.0, 0.5); deriv=(DerivOp(1), EvalValue()))  # ∂f/∂x only
     ops = _resolve_deriv_nd(deriv, Val(N))
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
-    mono = ntuple(_ -> true, Val(N))
+    mono = _scalar_mono(hint, Val(N))
     return _eval_nd_hermite(itp, resolved, ops, policies, hints, mono)
 end
 

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -163,9 +163,10 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
         queries,
         bcs::NTuple{N, AbstractBC},
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
-        searches::NTuple{N, AbstractSearchPolicy},
+        policies::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
-        hints = nothing
+        hints,  # Nothing or NTuple{N, Ref{Int}}
+        mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
@@ -188,7 +189,7 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
             output[k] = oob_val; continue
         end
         q_evals = _handle_all_extraps(query_k, grids_p, extraps_val)
-        indices, Ls, _ = _search_all_intervals(q_evals, grids_p, spacings, searches, hints)
+        indices, Ls, _ = _search_all_intervals(q_evals, grids_p, spacings, policies, hints, mono)
         hs, inv_hs, dLs = _compute_all_local_params(q_evals, spacings, indices, Ls)
         output[k] = _eval_nd_cell(partials, indices, hs, inv_hs, dLs, ops)
     end
@@ -198,8 +199,8 @@ end
 # Function barrier: forces Julia to runtime-dispatch on the concrete
 # searches tuple type, resolving per-element Union{BinarySearch,LinearBinarySearch} before
 # entering the @with_pool boundary. NOT @inline — specialization requires real call.
-function _cubic_nd_batch_dispatch!(output, grids, data, queries, bcs, extraps, searches, ops, hints)
-    return _cubic_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps, searches, ops, hints)
+function _cubic_nd_batch_dispatch!(output, grids, data, queries, bcs, extraps, policies, ops, hints, mono)
+    return _cubic_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps, policies, ops, hints, mono)
 end
 
 # ========================================
@@ -230,11 +231,13 @@ function cubic_interp!(
     _validate_nd_grids(grids_typed, data)
 
     bcs = _resolve_bcs_nd(bc, Val(N))
-    searches = _resolve_search_nd_uniform(search, Val(N), queries, hint)
+    policies = _resolve_search_nd(search, Val(N))
+    hints_nd = hint  # pass user hints as-is (nothing or NTuple{N,Ref{Int}})
+    mono = _check_mono_nd(policies, queries)
 
     _validate_nd_bcs!(grids_typed, bcs, data, Val(N))
 
     extraps_val = _resolve_extrap_nd(extrap, bcs, Val(N), Tv_p)
     ops = _resolve_deriv_nd(deriv, Val(N))
-    return _cubic_nd_batch_dispatch!(output, grids_typed, data, queries, bcs, extraps_val, searches, ops, hint)
+    return _cubic_nd_batch_dispatch!(output, grids_typed, data, queries, bcs, extraps_val, policies, ops, hints_nd, mono)
 end

--- a/src/hetero/hetero_eval.jl
+++ b/src/hetero/hetero_eval.jl
@@ -201,10 +201,11 @@ end
     end
 
     # Global-solve fallback (no pre-search, no slicing).
+    # Pass hints for persistent hint update in per-fiber 1D search.
     full_windows = map(Base.OneTo, size(itp.data))
     return _collapse_dims(
         Tr, itp.data, itp.grids, itp.methods, itp.extraps,
-        q_eval, ops, policies, nothing, full_windows,
+        q_eval, ops, policies, hints, full_windows,
     )
 end
 
@@ -286,7 +287,7 @@ end
     oob_result !== nothing && return oob_result
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
-    mono = ntuple(_ -> true, Val(N))
+    mono = _scalar_mono(hint, Val(N))
     return _eval_hetero_nd(itp, resolved, ops, policies, hints, mono)
 end
 
@@ -327,7 +328,7 @@ end
     end
 
     full_windows = map(Base.OneTo, size(itp.data))
-    return (itp.data, itp.grids, itp.methods, itp.extraps, q_eval, policies, nothing, full_windows)
+    return (itp.data, itp.grids, itp.methods, itp.extraps, q_eval, policies, hints, full_windows)
 end
 
 @inline function _eval_at_cell(

--- a/src/hetero/hetero_eval.jl
+++ b/src/hetero/hetero_eval.jl
@@ -328,8 +328,12 @@ end
         return (data_local, grids_local, itp.methods, itp.extraps, q_eval, policies, nothing, rel_windows)
     end
 
+    # Full-fiber fallback: pass hints for persistent hint update in per-fiber 1D search.
+    # (Unlike _eval_hetero_nd which passes nothing — that's the scalar path where
+    # auto-created Refs are throwaway. Here in _locate_cell, batch callers provide
+    # persistent Refs via _ensure_hint_nd.)
     full_windows = map(Base.OneTo, size(itp.data))
-    return (itp.data, itp.grids, itp.methods, itp.extraps, q_eval, policies, nothing, full_windows)
+    return (itp.data, itp.grids, itp.methods, itp.extraps, q_eval, policies, hints, full_windows)
 end
 
 @inline function _eval_at_cell(

--- a/src/hetero/hetero_eval.jl
+++ b/src/hetero/hetero_eval.jl
@@ -201,11 +201,12 @@ end
     end
 
     # Global-solve fallback (no pre-search, no slicing).
-    # Pass hints for persistent hint update in per-fiber 1D search.
+    # Pass nothing for hints — full-fiber 1D searches are O(n) anyway,
+    # hint write-back is negligible and avoids Ref allocation on scalar calls.
     full_windows = map(Base.OneTo, size(itp.data))
     return _collapse_dims(
         Tr, itp.data, itp.grids, itp.methods, itp.extraps,
-        q_eval, ops, policies, hints, full_windows,
+        q_eval, ops, policies, nothing, full_windows,
     )
 end
 
@@ -328,7 +329,7 @@ end
     end
 
     full_windows = map(Base.OneTo, size(itp.data))
-    return (itp.data, itp.grids, itp.methods, itp.extraps, q_eval, policies, hints, full_windows)
+    return (itp.data, itp.grids, itp.methods, itp.extraps, q_eval, policies, nothing, full_windows)
 end
 
 @inline function _eval_at_cell(

--- a/src/hetero/hetero_eval.jl
+++ b/src/hetero/hetero_eval.jl
@@ -150,9 +150,9 @@ end
 # threads concrete types (itp.methods, itp.grids, itp.data) through the
 # windowing logic. Inlining lets the compiler specialize on the interpolant's
 # concrete type and unroll the per-axis `map` calls into straight-line code.
-@inline function _build_windowed_cell(itp, q_eval, search_tuple, hints)
-    # Pre-search uses user hints (mutates them to absolute indices, preserving contract).
-    indices, _, _ = _search_all_intervals(q_eval, itp.grids, itp.spacings, search_tuple, hints)
+@inline function _build_windowed_cell(itp, q_eval, policies, hints, mono)
+    # Pre-search via per-axis adaptive function barriers (hint state mutated in-place).
+    indices, _, _ = _search_all_intervals(q_eval, itp.grids, itp.spacings, policies, hints, mono)
     # Per-axis window: cell-local for windowable methods, full axis for global-solve.
     # `map` over heterogeneous tuples is unrolled by the compiler with no closure
     # capture, which is more allocation-robust than `ntuple(d -> ..., Val(N))` for
@@ -183,45 +183,28 @@ end
         itp::HeteroInterpolantND{Tg, Tv, N, G, S, M, E, P, <:Array},
         query::Tuple{Vararg{Real, N}},
         ops::NTuple{N, AbstractEvalOp},
-        searches::NTuple{N, AbstractSearchPolicy},
-        hints,
+        policies::NTuple{N, AbstractSearchPolicy},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
+        mono::NTuple{N, Bool},
     ) where {Tg, Tv, N, G, S, M, E, P}
     q_eval = _handle_all_extraps(query, itp.grids, itp.extraps)
-    # Tr promotes data eltype with grid + query eltypes → Dual-safe pool buffers for AD.
-    # Grid eltype included: when grid is Dual, 1D oneshot returns Dual-typed results
-    # that must fit into _collapse_dims intermediate buffers.
     Tr = _output_eltype(Tv, Tg, typeof.(q_eval)...)
 
-    # Persistent-path gate: use `_has_any_windowable_method` (strict superset of
-    # `_has_any_local_method`) because `itp.spacings` is pre-computed at
-    # construction — no per-call allocation even when the windowable method is
-    # Linear/Constant (which would be a net loss in the scalar oneshot path,
-    # hence the asymmetry — see hetero_window.jl for the detailed rationale).
-    #
-    # GridIdx safety gate: `GridIdx(k)` means "evaluate exactly at grid[k]", i.e.
-    # the index is ABSOLUTE into the original grid. The windowed path slices the
-    # grid to a cell-local range (e.g. `view(grid, 7:10)`), at which point
-    # `GridIdx(8)` is out of bounds in the windowed view. The whole cell-local
-    # window is semantically pointless for a GridIdx axis (the kernel's search
-    # is O(1) direct lookup anyway), so we simply fall through to the full-fiber
-    # path whenever ANY query element is a GridIdx. `_has_grididx` is a compile-
-    # time type-level check (zero runtime cost on the common no-GridIdx path).
     if _has_any_windowable_method(itp.methods) && !_has_grididx(typeof(query))
-        data_local, grids_local, rel_windows = _build_windowed_cell(itp, q_eval, searches, hints)
-        # Inner kernel sees the pre-sliced data + grids. Pass `nothing` as hints — the
-        # tiny inner search on a 2–6 point fiber is negligible, and this prevents any
-        # relative-coordinate hint from leaking back to the user.
+        data_local, grids_local, rel_windows = _build_windowed_cell(itp, q_eval, policies, hints, mono)
+        # Inner kernel uses policies for fiber re-search on sliced grids.
+        # Pass `nothing` as hints — tiny inner search on 2–6 point fibers is negligible.
         return _collapse_dims(
             Tr, data_local, grids_local, itp.methods, itp.extraps,
-            q_eval, ops, searches, nothing, rel_windows,
+            q_eval, ops, policies, nothing, rel_windows,
         )
     end
 
-    # Global-solve fallback (no pre-search, no slicing — bit-for-bit current behavior).
+    # Global-solve fallback (no pre-search, no slicing).
     full_windows = map(Base.OneTo, size(itp.data))
     return _collapse_dims(
         Tr, itp.data, itp.grids, itp.methods, itp.extraps,
-        q_eval, ops, searches, hints, full_windows,
+        q_eval, ops, policies, nothing, full_windows,
     )
 end
 
@@ -230,12 +213,13 @@ end
         itp::HeteroInterpolantND{Tg, Tv, N, G, S, M, E, P, <:_HeteroPartials},
         query::Tuple{Vararg{Real, N}},
         ops::NTuple{N, AbstractEvalOp},
-        searches::NTuple{N, AbstractSearchPolicy},
-        hints,
+        policies::NTuple{N, AbstractSearchPolicy},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
+        mono::NTuple{N, Bool},
     ) where {Tg, Tv, N, G, S, M, E, P}
     return _eval_hetero_precomputed(
         itp.data, itp.grids, itp.spacings, itp.methods, itp.extraps,
-        query, ops, searches, hints
+        query, ops, policies, hints, mono,
     )
 end
 
@@ -300,8 +284,10 @@ end
     _validate_nd_domain(itp.grids, resolved, itp.extraps)
     oob_result = _try_fill_oob(resolved, itp.grids, itp.extraps, ops, _zero_ref(itp))
     oob_result !== nothing && return oob_result
-    search_tuple = _resolve_search_nd(search, Val(N), resolved)
-    return _eval_hetero_nd(itp, resolved, ops, search_tuple, hint)
+    policies = _resolve_search_nd(search, Val(N))
+    hints = _ensure_hint_nd(hint, Val(N))
+    mono = ntuple(_ -> true, Val(N))
+    return _eval_hetero_nd(itp, resolved, ops, policies, hints, mono)
 end
 
 # Vararg form: itp(0.5, 0.3) or itp(0.5, GridIdx(3)) → itp((0.5, ...))
@@ -328,23 +314,20 @@ end
 @inline function _locate_cell(
         itp::HeteroInterpolantND{Tg, Tv, N, G, S, M, E, P, <:Array},
         query::Tuple{Vararg{Real, N}},
-        search_tuple::NTuple{N, AbstractSearchPolicy},
-        hints = nothing,
+        policies::NTuple{N, AbstractSearchPolicy},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
+        mono::NTuple{N, Bool},
     ) where {Tg, Tv, N, G, S, M, E, P}
     q_eval = _handle_all_extraps(query, itp.grids, itp.extraps)
 
-    # Persistent-path gate — same asymmetric rule as `_eval_hetero_nd` above,
-    # plus the same GridIdx safety gate (windowing would alias GridIdx absolute
-    # indices into a sliced view).
     if _has_any_windowable_method(itp.methods) && !_has_grididx(typeof(query))
-        data_local, grids_local, rel_windows = _build_windowed_cell(itp, q_eval, search_tuple, hints)
-        # Cell tuple: pre-sliced data + grids + relative windows + nothing hints
-        # (the inner kernel must not see relative-coord hints — see hetero_window.jl invariant 2).
-        return (data_local, grids_local, itp.methods, itp.extraps, q_eval, search_tuple, nothing, rel_windows)
+        data_local, grids_local, rel_windows = _build_windowed_cell(itp, q_eval, policies, hints, mono)
+        # Inner kernel uses policies for fiber re-search on sliced grids.
+        return (data_local, grids_local, itp.methods, itp.extraps, q_eval, policies, nothing, rel_windows)
     end
 
     full_windows = map(Base.OneTo, size(itp.data))
-    return (itp.data, itp.grids, itp.methods, itp.extraps, q_eval, search_tuple, hints, full_windows)
+    return (itp.data, itp.grids, itp.methods, itp.extraps, q_eval, policies, nothing, full_windows)
 end
 
 @inline function _eval_at_cell(
@@ -362,11 +345,12 @@ end
 @inline function _locate_cell(
         itp::HeteroInterpolantND{Tg, Tv, N, G, S, M, E, P, <:_HeteroPartials},
         query::Tuple{Vararg{Real, N}},
-        search_tuple::NTuple{N, AbstractSearchPolicy},
-        hints = nothing,
+        policies::NTuple{N, AbstractSearchPolicy},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
+        mono::NTuple{N, Bool},
     ) where {Tg, Tv, N, G, S, M, E, P}
     q_eval = _handle_all_extraps(query, itp.grids, itp.extraps)
-    indices, Ls, _ = _search_all_intervals(q_eval, itp.grids, itp.spacings, search_tuple, hints)
+    indices, Ls, _ = _search_all_intervals(q_eval, itp.grids, itp.spacings, policies, hints, mono)
     hs, inv_hs, dLs = _compute_all_local_params(q_eval, itp.spacings, indices, Ls)
     return (itp.data.partials, indices, hs, inv_hs, dLs)
 end

--- a/src/hetero/hetero_oneshot.jl
+++ b/src/hetero/hetero_oneshot.jl
@@ -65,9 +65,10 @@ end
         queries,
         methods::Tuple{Vararg{AbstractInterpMethod, N}},
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
-        searches::NTuple{N, AbstractSearchPolicy},
+        policies::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
-        hints = nothing,
+        hints,  # Nothing or NTuple{N, Ref{Int}}
+        mono::NTuple{N, Bool},
     ) where {Tg, N}
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
@@ -95,7 +96,7 @@ end
             continue
         end
         q_eval = _handle_all_extraps(query_k, grids_p, extraps_val)
-        indices, Ls, _ = _search_all_intervals(q_eval, grids_p, spacings, searches, hints)
+        indices, Ls, _ = _search_all_intervals(q_eval, grids_p, spacings, policies, hints, mono)
         hs, inv_hs, dLs = _compute_all_local_params(q_eval, spacings, indices, Ls)
         output[k] = _eval_hetero_nd_cell(partials, indices, hs, inv_hs, dLs, ops, methods)
     end
@@ -108,8 +109,8 @@ end
 # Forces search type specialization before entering @with_pool boundary.
 # NOT @inline — specialization requires real call.
 
-function _interp_nd_hetero_batch_dispatch!(output, grids, data, queries, methods, extraps, searches, ops, hints)
-    return _interp_nd_hetero_oneshot_batch!(output, grids, data, queries, methods, extraps, searches, ops, hints)
+function _interp_nd_hetero_batch_dispatch!(output, grids, data, queries, methods, extraps, policies, ops, hints, mono)
+    return _interp_nd_hetero_oneshot_batch!(output, grids, data, queries, methods, extraps, policies, ops, hints, mono)
 end
 
 # ========================================
@@ -293,7 +294,8 @@ end
     _query_check_ndims(queries, Val(N))
 
     extraps_val = _resolve_extrap_nd(extrap, nothing, Val(N), Tv)
-    searches = _resolve_search_nd_uniform(search, Val(N), queries, hints)
+    policies = _resolve_search_nd(search, Val(N))
+    mono = _check_mono_nd(policies, queries)
     ops = _resolve_deriv_nd(deriv, Val(N))
     _validate_axis_methods(grids_typed, methods, extraps_val)
 
@@ -313,12 +315,12 @@ end
         spacings = _has_any_local_method(methods) ? _create_spacings_pooled(pool, grids_typed) : nothing
         @inbounds for k in 1:nq
             query_k = _extract_query_point(queries, k, Val(N))
-            output[k] = _interp_nd_oneshot_onthefly(grids_typed, data, query_k, methods, extraps_val, searches, ops, hints, spacings)
+            output[k] = _interp_nd_oneshot_onthefly(grids_typed, data, query_k, methods, extraps_val, policies, ops, hints, spacings)
         end
         return output
     end
 
-    return _interp_nd_hetero_batch_dispatch!(output, grids_typed, data, queries, methods, extraps_val, searches, ops, hints)
+    return _interp_nd_hetero_batch_dispatch!(output, grids_typed, data, queries, methods, extraps_val, policies, ops, hints, mono)
 end
 
 # ========================================

--- a/src/hetero/hetero_precomputed_eval.jl
+++ b/src/hetero/hetero_precomputed_eval.jl
@@ -137,14 +137,15 @@ end
         extraps,
         query::Tuple{Vararg{Real, N}},
         ops::NTuple{N, AbstractEvalOp},
-        searches::NTuple{N, AbstractSearchPolicy},
-        hints,
+        policies::Tuple{Vararg{AbstractSearchPolicy, N}},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
+        mono::NTuple{N, Bool},
     ) where {Tv, Tg, N}
     # Handle extrapolation
     q_eval = _handle_all_extraps(query, grids, extraps)
 
     # Cell location
-    indices, Ls, _ = _search_all_intervals(q_eval, grids, spacings, searches, hints)
+    indices, Ls, _ = _search_all_intervals(q_eval, grids, spacings, policies, hints, mono)
     hs, inv_hs, dLs = _compute_all_local_params(q_eval, spacings, indices, Ls)
 
     # Evaluate kernel with compact partials

--- a/src/linear/nd/linear_nd_eval.jl
+++ b/src/linear/nd/linear_nd_eval.jl
@@ -24,7 +24,7 @@
     ops = _resolve_deriv_nd(deriv, Val(N))
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
-    mono = ntuple(_ -> true, Val(N))
+    mono = _scalar_mono(hint, Val(N))
     return _eval_linear_nd(itp, resolved, ops, policies, hints, mono)
 end
 

--- a/src/linear/nd/linear_nd_eval.jl
+++ b/src/linear/nd/linear_nd_eval.jl
@@ -22,8 +22,10 @@
     ) where {Tg, Tv, N}
     resolved = map(_resolve_grididx, query, itp.grids)
     ops = _resolve_deriv_nd(deriv, Val(N))
-    search_tuple = _resolve_search_nd(search, Val(N), resolved)
-    return _eval_linear_nd(itp, resolved, ops, search_tuple, hint)
+    policies = _resolve_search_nd(search, Val(N))
+    hints = _ensure_hint_nd(hint, Val(N))
+    mono = ntuple(_ -> true, Val(N))
+    return _eval_linear_nd(itp, resolved, ops, policies, hints, mono)
 end
 
 # In-place batch evaluation (SoA + AoS) is handled by the unified
@@ -42,11 +44,12 @@ end
 @inline function _locate_cell(
         itp::LinearInterpolantND{Tg, Tv, N},
         query::Tuple{Vararg{Real, N}},
-        search_tuple::NTuple{N, AbstractSearchPolicy},
-        hints = nothing
+        policies::NTuple{N, AbstractSearchPolicy},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
+        mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
     q_eval = _handle_all_extraps(query, itp.grids, itp.extraps)
-    indices, Ls, _ = _search_all_intervals(q_eval, itp.grids, itp.spacings, search_tuple, hints)
+    indices, Ls, _ = _search_all_intervals(q_eval, itp.grids, itp.spacings, policies, hints, mono)
     hs, αs = _compute_linear_params(q_eval, itp.spacings, indices, Ls, Val(N))
     return (itp.data, indices, hs, αs)
 end
@@ -55,11 +58,12 @@ end
 @inline function _locate_cell(
         itp::LinearInterpolantND{Tg, Tv, 2},
         query::Tuple{Vararg{Real, 2}},
-        search_tuple::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
-        hints = nothing
+        policies::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
+        hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
+        mono::Tuple{Bool, Bool},
     ) where {Tg, Tv}
     x_eval, y_eval, ix, iy, xL, yL = _locate_cell_2d_preamble(
-        query, itp.grids, itp.spacings, itp.extraps, search_tuple, hints
+        query, itp.grids, itp.spacings, itp.extraps, policies, hints, mono
     )
 
     hx = _get_h(itp.spacings[1], ix)
@@ -95,8 +99,9 @@ end
         itp::LinearInterpolantND{Tg, Tv, N},
         query::Tuple{Vararg{Real, N}},
         ops::NTuple{N, AbstractEvalOp},
-        search_tuple::NTuple{N, AbstractSearchPolicy},
-        hints = nothing
+        policies::NTuple{N, AbstractSearchPolicy},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
+        mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
     _validate_nd_domain(itp.grids, query, itp.extraps)
     oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
@@ -104,7 +109,7 @@ end
     if _has_second_or_higher_derivative(ops, Val(N))
         return 0 * first(itp.data)
     end
-    cell = _locate_cell(itp, query, search_tuple, hints)
+    cell = _locate_cell(itp, query, policies, hints, mono)
     return _eval_at_cell(itp, cell, ops)
 end
 
@@ -113,8 +118,9 @@ end
         itp::LinearInterpolantND{Tg, Tv, 2},
         query::Tuple{Vararg{Real, 2}},
         ops::NTuple{2, AbstractEvalOp},
-        search_tuple::NTuple{2, AbstractSearchPolicy},
-        hints = nothing
+        policies::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
+        hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
+        mono::Tuple{Bool, Bool},
     ) where {Tg, Tv}
     _validate_nd_domain(itp.grids, query, itp.extraps)
     oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
@@ -123,7 +129,7 @@ end
     if op_x isa EvalDeriv2 || op_x isa EvalDeriv3 || op_y isa EvalDeriv2 || op_y isa EvalDeriv3
         return 0 * first(itp.data)
     end
-    cell = _locate_cell(itp, query, search_tuple, hints)
+    cell = _locate_cell(itp, query, policies, hints, mono)
     return _eval_at_cell(itp, cell, ops)
 end
 

--- a/src/linear/nd/linear_nd_oneshot.jl
+++ b/src/linear/nd/linear_nd_oneshot.jl
@@ -53,9 +53,10 @@ Writes results into `output`. No heap allocation beyond spacings.
         data::AbstractArray{Tv, N},
         queries,
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
-        searches::NTuple{N, AbstractSearchPolicy},
+        policies::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
-        hints = nothing
+        hints,  # Nothing or NTuple{N, Ref{Int}}
+        mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
@@ -69,7 +70,7 @@ Writes results into `output`. No heap allocation beyond spacings.
             output[k] = oob_val; continue
         end
         q_eval = _handle_all_extraps(query_k, grids, extraps_val)
-        indices, Ls, _ = _search_all_intervals(q_eval, grids, spacings, searches, hints)
+        indices, Ls, _ = _search_all_intervals(q_eval, grids, spacings, policies, hints, mono)
         hs, αs = _compute_linear_params(q_eval, spacings, indices, Ls, Val(N))
         output[k] = _multilinear_sum(data, indices, hs, αs, ops, Val(N))
     end
@@ -78,8 +79,8 @@ end
 
 # Function barrier: forces Julia to runtime-dispatch on the concrete
 # searches tuple type before entering the @with_pool boundary.
-function _linear_nd_batch_dispatch!(output, grids, data, queries, extraps, searches, ops, hints)
-    return _linear_interp_nd_oneshot_batch!(output, grids, data, queries, extraps, searches, ops, hints)
+function _linear_nd_batch_dispatch!(output, grids, data, queries, extraps, policies, ops, hints, mono)
+    return _linear_interp_nd_oneshot_batch!(output, grids, data, queries, extraps, policies, ops, hints, mono)
 end
 
 # ========================================
@@ -161,9 +162,11 @@ function linear_interp!(
     grids_typed, _, _, _ = _nd_promote_grids(grids, data)
     _validate_nd_grids(grids_typed, data)
 
-    searches = _resolve_search_nd_uniform(search, Val(N), queries, hint)
+    policies = _resolve_search_nd(search, Val(N))
+    hints_nd = hint
+    mono = _check_mono_nd(policies, queries)
 
     extraps_val = _resolve_extrap_nd(extrap, nothing, Val(N), Tv)
     ops = _resolve_deriv_nd(deriv, Val(N))
-    return _linear_nd_batch_dispatch!(output, grids_typed, data, queries, extraps_val, searches, ops, hint)
+    return _linear_nd_batch_dispatch!(output, grids_typed, data, queries, extraps_val, policies, ops, hints_nd, mono)
 end

--- a/src/quadratic/nd/quadratic_nd_eval.jl
+++ b/src/quadratic/nd/quadratic_nd_eval.jl
@@ -67,8 +67,10 @@ itp((1.0, 0.5); deriv=(DerivOp(1), EvalValue()))      # ∂f/∂x only
     ) where {Tg, Tv, N}
     resolved = map(_resolve_grididx, query, itp.grids)
     ops = _resolve_deriv_nd(deriv, Val(N))
-    search_tuple = _resolve_search_nd(search, Val(N), resolved)
-    return _eval_nd_quadratic(itp, resolved, ops, search_tuple, hint)
+    policies = _resolve_search_nd(search, Val(N))
+    hints = _ensure_hint_nd(hint, Val(N))
+    mono = ntuple(_ -> true, Val(N))
+    return _eval_nd_quadratic(itp, resolved, ops, policies, hints, mono)
 end
 
 # In-place batch evaluation (SoA + AoS) is handled by the unified
@@ -83,11 +85,12 @@ end
 @inline function _locate_cell(
         itp::QuadraticInterpolantND{Tg, Tv, N},
         query::Tuple{Vararg{Real, N}},
-        search::SEARCH,
-        hints = nothing
-    ) where {Tg, Tv, N, SEARCH <: NTuple{N, AbstractSearchPolicy}}
+        policies::NTuple{N, AbstractSearchPolicy},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
+        mono::NTuple{N, Bool},
+    ) where {Tg, Tv, N}
     q_evals = _handle_all_extraps(query, itp.grids, itp.extraps)
-    indices, Ls, _ = _search_all_intervals(q_evals, itp.grids, itp.spacings, search, hints)
+    indices, Ls, _ = _search_all_intervals(q_evals, itp.grids, itp.spacings, policies, hints, mono)
     hs, inv_hs, dLs = _compute_all_local_params(q_evals, itp.spacings, indices, Ls)
 
     return (itp.nodal_derivs.partials, indices, hs, inv_hs, dLs)
@@ -97,11 +100,12 @@ end
 @inline function _locate_cell(
         itp::QuadraticInterpolantND{Tg, Tv, 2},
         query::Tuple{Vararg{Real, 2}},
-        search::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
-        hints = nothing
+        policies::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
+        hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
+        mono::Tuple{Bool, Bool},
     ) where {Tg, Tv}
     x_eval, y_eval, ix, iy, xL, yL = _locate_cell_2d_preamble(
-        query, itp.grids, itp.spacings, itp.extraps, search, hints
+        query, itp.grids, itp.spacings, itp.extraps, policies, hints, mono
     )
 
     hx = _get_h(itp.spacings[1], ix);  hy = _get_h(itp.spacings[2], iy)
@@ -132,14 +136,15 @@ end
 @inline function _eval_nd_quadratic(
         itp::QuadraticInterpolantND{Tg, Tv, N},
         query::Tuple{Vararg{Real, N}},
-        ops::OPS,
-        search::SEARCH,
-        hints = nothing
-    ) where {Tg, Tv, N, OPS <: NTuple{N, AbstractEvalOp}, SEARCH <: NTuple{N, AbstractSearchPolicy}}
+        ops::NTuple{N, AbstractEvalOp},
+        policies::NTuple{N, AbstractSearchPolicy},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
+        mono::NTuple{N, Bool},
+    ) where {Tg, Tv, N}
     _validate_nd_domain(itp.grids, query, itp.extraps)
     oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
     oob_result !== nothing && return oob_result
-    cell = _locate_cell(itp, query, search, hints)
+    cell = _locate_cell(itp, query, policies, hints, mono)
     return _eval_at_cell(itp, cell, ops)
 end
 
@@ -148,13 +153,14 @@ end
         itp::QuadraticInterpolantND{Tg, Tv, 2},
         query::Tuple{Vararg{Real, 2}},
         ops::Tuple{<:AbstractEvalOp, <:AbstractEvalOp},
-        search::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
-        hints = nothing
+        policies::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
+        hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
+        mono::Tuple{Bool, Bool},
     ) where {Tg, Tv}
     _validate_nd_domain(itp.grids, query, itp.extraps)
     oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
     oob_result !== nothing && return oob_result
-    cell = _locate_cell(itp, query, search, hints)
+    cell = _locate_cell(itp, query, policies, hints, mono)
     return _eval_at_cell(itp, cell, ops)
 end
 

--- a/src/quadratic/nd/quadratic_nd_eval.jl
+++ b/src/quadratic/nd/quadratic_nd_eval.jl
@@ -69,7 +69,7 @@ itp((1.0, 0.5); deriv=(DerivOp(1), EvalValue()))      # ∂f/∂x only
     ops = _resolve_deriv_nd(deriv, Val(N))
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
-    mono = ntuple(_ -> true, Val(N))
+    mono = _scalar_mono(hint, Val(N))
     return _eval_nd_quadratic(itp, resolved, ops, policies, hints, mono)
 end
 

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -70,9 +70,10 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
         queries,
         bcs::NTuple{N, AbstractBC},
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
-        searches::NTuple{N, AbstractSearchPolicy},
+        policies::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
-        hints = nothing
+        hints,  # Nothing or NTuple{N, Ref{Int}}
+        mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
@@ -94,7 +95,7 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
             output[k] = oob_val; continue
         end
         q_eval = _handle_all_extraps(query_k, grids, extraps_val)
-        indices, Ls, _ = _search_all_intervals(q_eval, grids, spacings, searches, hints)
+        indices, Ls, _ = _search_all_intervals(q_eval, grids, spacings, policies, hints, mono)
         hs, inv_hs, dLs = _compute_all_local_params(q_eval, spacings, indices, Ls)
         output[k] = _eval_nd_quad_cell(partials, indices, hs, inv_hs, dLs, ops)
     end
@@ -103,8 +104,8 @@ end
 
 # Function barrier: forces Julia to runtime-dispatch on the concrete
 # searches tuple type before entering the @with_pool boundary.
-function _quadratic_nd_batch_dispatch!(output, grids, data, queries, bcs, extraps, searches, ops, hints)
-    return _quadratic_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps, searches, ops, hints)
+function _quadratic_nd_batch_dispatch!(output, grids, data, queries, bcs, extraps, policies, ops, hints, mono)
+    return _quadratic_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps, policies, ops, hints, mono)
 end
 
 # ========================================
@@ -224,9 +225,11 @@ function quadratic_interp!(
     _validate_nd_grids(grids_typed, data)
 
     bcs = _resolve_bcs_nd(bc, Val(N))
-    searches = _resolve_search_nd_uniform(search, Val(N), queries, hint)
+    policies = _resolve_search_nd(search, Val(N))
+    hints_nd = hint
+    mono = _check_mono_nd(policies, queries)
 
     extraps_val = _resolve_extrap_nd(extrap, bcs, Val(N), Tv)
     ops = _resolve_deriv_nd(deriv, Val(N))
-    return _quadratic_nd_batch_dispatch!(output, grids_typed, data, queries, bcs, extraps_val, searches, ops, hint)
+    return _quadratic_nd_batch_dispatch!(output, grids_typed, data, queries, bcs, extraps_val, policies, ops, hints_nd, mono)
 end

--- a/src/vector_calculus.jl
+++ b/src/vector_calculus.jl
@@ -38,12 +38,14 @@
 
     return quote
         query_r = map(_resolve_grididx, query, itp.grids)
-        search = _resolve_search_nd(itp.searches, Val($N), query_r)
+        policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
+        hints = _ensure_hint_nd(hint, Val($N))
+        mono = ntuple(_true_flag, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
             zref = _zero_ref(itp)
             return tuple($(zero_tuple...))
         end
-        cell = _locate_cell(itp, query_r, search, hint)
+        cell = _locate_cell(itp, query_r, policies, hints, mono)
         return tuple($(deriv_calls...))
     end
 end
@@ -111,7 +113,9 @@ end
                 "gradient output vector must have at least $($N) elements, got $(length(G))"
             )
         )
-        search = _resolve_search_nd(itp.searches, Val($N), query_r)
+        policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
+        hints = _ensure_hint_nd(hint, Val($N))
+        mono = ntuple(_true_flag, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
             zref = _zero_ref(itp)
             @inbounds for i in 1:$N
@@ -119,7 +123,7 @@ end
             end
             return G
         end
-        cell = _locate_cell(itp, query_r, search, hint)
+        cell = _locate_cell(itp, query_r, policies, hints, mono)
         @inbounds begin
             $(stmts...)
         end
@@ -195,13 +199,15 @@ end
 
     return quote
         query_r = map(_resolve_grididx, query, itp.grids)
-        search = _resolve_search_nd(itp.searches, Val($N), query_r)
+        policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
+        hints = _ensure_hint_nd(hint, Val($N))
+        mono = ntuple(_true_flag, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
             zref = _zero_ref(itp)
             fill_val = _first_fill_value(itp.extraps)
             return (fill_val, tuple($(zero_tuple...)))
         end
-        cell = _locate_cell(itp, query_r, search, hint)
+        cell = _locate_cell(itp, query_r, policies, hints, mono)
         val = $value_call
         grad = tuple($(deriv_calls...))
         return (val, grad)
@@ -300,12 +306,14 @@ end
         query_r = map(_resolve_grididx, query, itp.grids)
         Tq = promote_type(eltype(map(float, query_r)), $Tg, $Tv)
         H = Matrix{Tq}(undef, $N, $N)
-        search = _resolve_search_nd(itp.searches, Val($N), query_r)
+        policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
+        hints = _ensure_hint_nd(hint, Val($N))
+        mono = ntuple(_true_flag, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
             fill!(H, zero(Tq))
             return H
         end
-        cell = _locate_cell(itp, query_r, search, hint)
+        cell = _locate_cell(itp, query_r, policies, hints, mono)
         @inbounds begin
             $(stmts...)
         end
@@ -391,12 +399,14 @@ end
                 "Hessian output matrix must be $($N)×$($N), got $(size(H))"
             )
         )
-        search = _resolve_search_nd(itp.searches, Val($N), query_r)
+        policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
+        hints = _ensure_hint_nd(hint, Val($N))
+        mono = ntuple(_true_flag, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
             fill!(H, zero(eltype(H)))
             return H
         end
-        cell = _locate_cell(itp, query_r, search, hint)
+        cell = _locate_cell(itp, query_r, policies, hints, mono)
         @inbounds begin
             $(stmts...)
         end
@@ -468,11 +478,13 @@ end
 
     return quote
         query_r = map(_resolve_grididx, query, itp.grids)
-        search = _resolve_search_nd(itp.searches, Val($N), query_r)
+        policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
+        hints = _ensure_hint_nd(hint, Val($N))
+        mono = ntuple(_true_flag, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
             return 0 * _zero_ref(itp)
         end
-        cell = _locate_cell(itp, query_r, search, hint)
+        cell = _locate_cell(itp, query_r, policies, hints, mono)
         return +($(deriv_calls...))
     end
 end

--- a/src/vector_calculus.jl
+++ b/src/vector_calculus.jl
@@ -40,7 +40,7 @@
         query_r = map(_resolve_grididx, query, itp.grids)
         policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
         hints = _ensure_hint_nd(hint, Val($N))
-        mono = ntuple(_true_flag, Val($N))
+        mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
             zref = _zero_ref(itp)
             return tuple($(zero_tuple...))
@@ -115,7 +115,7 @@ end
         )
         policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
         hints = _ensure_hint_nd(hint, Val($N))
-        mono = ntuple(_true_flag, Val($N))
+        mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
             zref = _zero_ref(itp)
             @inbounds for i in 1:$N
@@ -201,7 +201,7 @@ end
         query_r = map(_resolve_grididx, query, itp.grids)
         policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
         hints = _ensure_hint_nd(hint, Val($N))
-        mono = ntuple(_true_flag, Val($N))
+        mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
             zref = _zero_ref(itp)
             fill_val = _first_fill_value(itp.extraps)
@@ -308,7 +308,7 @@ end
         H = Matrix{Tq}(undef, $N, $N)
         policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
         hints = _ensure_hint_nd(hint, Val($N))
-        mono = ntuple(_true_flag, Val($N))
+        mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
             fill!(H, zero(Tq))
             return H
@@ -401,7 +401,7 @@ end
         )
         policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
         hints = _ensure_hint_nd(hint, Val($N))
-        mono = ntuple(_true_flag, Val($N))
+        mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
             fill!(H, zero(eltype(H)))
             return H
@@ -480,7 +480,7 @@ end
         query_r = map(_resolve_grididx, query, itp.grids)
         policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
         hints = _ensure_hint_nd(hint, Val($N))
-        mono = ntuple(_true_flag, Val($N))
+        mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
             return 0 * _zero_ref(itp)
         end

--- a/src/vector_calculus.jl
+++ b/src/vector_calculus.jl
@@ -38,7 +38,7 @@
 
     return quote
         query_r = map(_resolve_grididx, query, itp.grids)
-        policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
+        policies = _resolve_search_nd(itp.searches, Val($N))
         hints = _ensure_hint_nd(hint, Val($N))
         mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
@@ -113,7 +113,7 @@ end
                 "gradient output vector must have at least $($N) elements, got $(length(G))"
             )
         )
-        policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
+        policies = _resolve_search_nd(itp.searches, Val($N))
         hints = _ensure_hint_nd(hint, Val($N))
         mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
@@ -199,7 +199,7 @@ end
 
     return quote
         query_r = map(_resolve_grididx, query, itp.grids)
-        policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
+        policies = _resolve_search_nd(itp.searches, Val($N))
         hints = _ensure_hint_nd(hint, Val($N))
         mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
@@ -306,7 +306,7 @@ end
         query_r = map(_resolve_grididx, query, itp.grids)
         Tq = promote_type(eltype(map(float, query_r)), $Tg, $Tv)
         H = Matrix{Tq}(undef, $N, $N)
-        policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
+        policies = _resolve_search_nd(itp.searches, Val($N))
         hints = _ensure_hint_nd(hint, Val($N))
         mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
@@ -399,7 +399,7 @@ end
                 "Hessian output matrix must be $($N)×$($N), got $(size(H))"
             )
         )
-        policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
+        policies = _resolve_search_nd(itp.searches, Val($N))
         hints = _ensure_hint_nd(hint, Val($N))
         mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
@@ -478,7 +478,7 @@ end
 
     return quote
         query_r = map(_resolve_grididx, query, itp.grids)
-        policies = _resolve_search_nd(itp.searches, Val($N), query_r, hint)
+        policies = _resolve_search_nd(itp.searches, Val($N))
         hints = _ensure_hint_nd(hint, Val($N))
         mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,6 +118,7 @@ else
     include("test_nd_oneshot_hint.jl")
     include("test_nd_autosearch_peraxis.jl")
     include("test_nd_batch_inplace.jl")
+    include("test_nd_batch_hint_persistence.jl")  # Unified Searcher path: zero-alloc + hint persistence
     include("test_gradient_hessian.jl")
     include("test_hetero_nd.jl")  # Hetero ND (per-axis methods, on-the-fly)
     include("test_hetero_precomputed.jl")  # Hetero ND (precomputed partials)

--- a/test/test_nd_autosearch_peraxis.jl
+++ b/test/test_nd_autosearch_peraxis.jl
@@ -1,7 +1,7 @@
 using Test
 using FastInterpolations
-using FastInterpolations: _resolve_search_nd, _resolve_search_nd_uniform, _resolve_search_policy,
-    _is_axis_likely_monotone, _query_extract, _query_length,
+using FastInterpolations: _resolve_search_nd, _resolve_search_policy,
+    _is_axis_likely_monotone, _check_mono_nd, _query_extract, _query_length,
     AutoSearch, BinarySearch, LinearBinarySearch
 
 @testset "ND Per-Axis Adaptive AutoSearch Resolution" begin
@@ -160,63 +160,49 @@ using FastInterpolations: _resolve_search_nd, _resolve_search_nd_uniform, _resol
     end
 
     # ========================================
-    # All-or-Nothing _resolve_search_nd_uniform (Oneshot SoA)
+    # Per-Axis _check_mono_nd (SoA)
     # ========================================
-    # Unlike per-axis _resolve_search_nd, _resolve_search_nd_uniform returns
-    # uniform types for all AutoSearch axes: if ANY is non-monotone, ALL get BinarySearch.
+    # Returns NTuple{N, Bool} — per-axis monotonicity flags for AutoSearch axes.
+    # Replaces the old _resolve_search_nd_uniform (all-or-nothing).
 
-    @testset "All-or-nothing: _resolve_search_nd_uniform" begin
+    @testset "Per-axis: _check_mono_nd (SoA)" begin
         sorted = collect(1.0:100.0)
         random = [
             3.0, 1.0, 4.0, 1.0, 5.0, 9.0, 2.0, 6.0, 5.0, 3.0,
             7.0, 8.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0,
         ]
 
-        @testset "both sorted → both LinearBinarySearch" begin
-            result = _resolve_search_nd_uniform(AutoSearch(), Val(2), (sorted, sorted), nothing)
-            @test result[1] isa LinearBinarySearch
-            @test result[2] isa LinearBinarySearch
+        @testset "both sorted → (true, true)" begin
+            mono = _check_mono_nd((AutoSearch(), AutoSearch()), (sorted, sorted))
+            @test mono == (true, true)
         end
 
-        @testset "both random → both BinarySearch" begin
-            result = _resolve_search_nd_uniform(AutoSearch(), Val(2), (random, random), nothing)
-            @test result[1] isa BinarySearch
-            @test result[2] isa BinarySearch
+        @testset "both random → (false, false)" begin
+            mono = _check_mono_nd((AutoSearch(), AutoSearch()), (random, random))
+            @test mono == (false, false)
         end
 
-        @testset "mixed sorted/random → ALL BinarySearch (unlike per-axis)" begin
-            result = _resolve_search_nd_uniform(AutoSearch(), Val(2), (sorted, random), nothing)
-            @test result[1] isa BinarySearch   # per-axis would give LB here
-            @test result[2] isa BinarySearch
+        @testset "mixed sorted/random → PER-AXIS (true, false)" begin
+            mono = _check_mono_nd((AutoSearch(), AutoSearch()), (sorted, random))
+            @test mono == (true, false)
         end
 
-        @testset "3D: all sorted → all LinearBinarySearch" begin
+        @testset "3D: all sorted → (true, true, true)" begin
             descending = collect(100.0:-1.0:1.0)
-            result = _resolve_search_nd_uniform(AutoSearch(), Val(3), (sorted, sorted, descending), nothing)
-            @test result[1] isa LinearBinarySearch
-            @test result[2] isa LinearBinarySearch
-            @test result[3] isa LinearBinarySearch
+            mono = _check_mono_nd((AutoSearch(), AutoSearch(), AutoSearch()), (sorted, sorted, descending))
+            @test mono == (true, true, true)
         end
 
-        @testset "3D: one random → all BinarySearch" begin
+        @testset "3D: one random → per-axis (true, false, true)" begin
             descending = collect(100.0:-1.0:1.0)
-            result = _resolve_search_nd_uniform(AutoSearch(), Val(3), (sorted, random, descending), nothing)
-            @test result[1] isa BinarySearch
-            @test result[2] isa BinarySearch
-            @test result[3] isa BinarySearch
+            mono = _check_mono_nd((AutoSearch(), AutoSearch(), AutoSearch()), (sorted, random, descending))
+            @test mono == (true, false, true)
         end
 
-        @testset "explicit policies pass through" begin
-            result = _resolve_search_nd_uniform((BinarySearch(), AutoSearch()), Val(2), (sorted, sorted), nothing)
-            @test result[1] isa BinarySearch        # explicit BinarySearch preserved
-            @test result[2] isa LinearBinarySearch   # AutoSearch resolved (both mono → LB)
-        end
-
-        @testset "hint present → fallback to type-based" begin
-            hints = (Ref(1), Ref(1))
-            result = _resolve_search_nd_uniform(AutoSearch(), Val(2), (sorted, sorted), hints)
-            @test result[1] isa LinearBinarySearch
-            @test result[2] isa LinearBinarySearch
+        @testset "explicit policies → true (flag ignored)" begin
+            mono = _check_mono_nd((BinarySearch(), AutoSearch()), (sorted, sorted))
+            @test mono[1] == true   # BinarySearch: flag always true (ignored by _search_axis_adaptive)
+            @test mono[2] == true   # AutoSearch: sorted → true
         end
     end
 
@@ -467,10 +453,10 @@ using FastInterpolations: _resolve_search_nd, _resolve_search_nd_uniform, _resol
     end
 
     # ========================================
-    # Generic (AoS) _resolve_search_nd_uniform: all-or-nothing
+    # Per-Axis _check_mono_nd (AoS)
     # ========================================
 
-    @testset "AoS AutoSearch: _resolve_search_nd_uniform all-or-nothing" begin
+    @testset "AoS AutoSearch: _check_mono_nd per-axis" begin
         sorted_aos = [(Float64(i), Float64(i)) for i in 1:20]
         random_aos = [
             (3.0, 8.0), (1.0, 2.0), (4.0, 5.0), (1.0, 9.0),
@@ -480,29 +466,26 @@ using FastInterpolations: _resolve_search_nd, _resolve_search_nd_uniform, _resol
             (14.0, 15.0), (15.0, 16.0), (16.0, 17.0), (17.0, 18.0),
         ]
 
-        @testset "both sorted → both LinearBinarySearch" begin
-            result = _resolve_search_nd_uniform(AutoSearch(), Val(2), sorted_aos, nothing)
-            @test result[1] isa LinearBinarySearch
-            @test result[2] isa LinearBinarySearch
+        @testset "both sorted → (true, true)" begin
+            mono = _check_mono_nd((AutoSearch(), AutoSearch()), sorted_aos)
+            @test mono == (true, true)
         end
 
-        @testset "both random → both BinarySearch" begin
-            result = _resolve_search_nd_uniform(AutoSearch(), Val(2), random_aos, nothing)
-            @test result[1] isa BinarySearch
-            @test result[2] isa BinarySearch
+        @testset "both random → (false, false)" begin
+            mono = _check_mono_nd((AutoSearch(), AutoSearch()), random_aos)
+            @test mono == (false, false)
         end
 
-        @testset "mixed → ALL BinarySearch (all-or-nothing)" begin
+        @testset "mixed → PER-AXIS (true, false)" begin
             mixed = [(Float64(i), random_aos[i][2]) for i in 1:20]
-            result = _resolve_search_nd_uniform(AutoSearch(), Val(2), mixed, nothing)
-            @test result[1] isa BinarySearch
-            @test result[2] isa BinarySearch
+            mono = _check_mono_nd((AutoSearch(), AutoSearch()), mixed)
+            @test mono == (true, false)
         end
 
-        @testset "explicit policy passthrough" begin
-            result = _resolve_search_nd_uniform((BinarySearch(), AutoSearch()), Val(2), sorted_aos, nothing)
-            @test result[1] isa BinarySearch
-            @test result[2] isa LinearBinarySearch
+        @testset "explicit policy → true (flag ignored)" begin
+            mono = _check_mono_nd((BinarySearch(), AutoSearch()), sorted_aos)
+            @test mono[1] == true   # BinarySearch: always true
+            @test mono[2] == true   # AutoSearch: sorted → true
         end
     end
 

--- a/test/test_nd_batch_hint_persistence.jl
+++ b/test/test_nd_batch_hint_persistence.jl
@@ -1,0 +1,247 @@
+# ═══════════════════════════════════════════════════════════════
+# ND batch hint persistence — zero-alloc + hint mutation contract
+# ═══════════════════════════════════════════════════════════════
+#
+# Verifies that the generic ND batch callable in `interpolant_protocol.jl`
+# auto-creates persistent hint Refs at batch entry (via `_ensure_hint_nd`),
+# eliminating:
+#   1. Union boxing from `_resolve_search_nd` (Finding #1)
+#   2. Per-query `RefHint()` heap allocation (Finding #2)
+#
+# Uses VECTOR grids (not Range) — Range grids use O(1) DirectSearch and
+# bypass the hint/search machinery entirely.
+#
+# Function-barrier pattern is mandatory: @testset wraps body in try/catch
+# → makes locals type-unstable → @allocated shows artifacts.
+
+@testset "ND batch hint persistence" begin
+
+    # ── Vector grid fixtures ─────────────────────────────────────
+    # Slightly perturbed uniform grids → Vector{Float64}, not Range
+
+    function _make_vector_grid(n, lo, hi)
+        g = collect(range(lo, hi, length = n))
+        if n > 2
+            g[2:(end - 1)] .+= 1.0e-12 .* (1:(n - 2))  # deterministic perturbation
+        end
+        return g
+    end
+
+    # ── Allocation tests ─────────────────────────────────────────
+    # All methods × 2D/3D must be zero-alloc on Vector grids.
+
+    @testset "Zero-alloc — $label $nd" for (label, builder) in [
+                ("Constant", (g, d) -> constant_interp(g, d)),
+                ("Linear", (g, d) -> linear_interp(g, d)),
+                ("Quadratic", (g, d) -> quadratic_interp(g, d)),
+                ("Cubic", (g, d) -> cubic_interp(g, d)),
+                ("PCHIP", (g, d) -> pchip_interp(g, d)),
+                ("Cardinal", (g, d) -> cardinal_interp(g, d)),
+                ("Akima", (g, d) -> akima_interp(g, d)),
+            ], (nd, alloc_fn) in [
+                (
+                    "2D", function (builder)
+                        x = _make_vector_grid(21, 0.0, 2π)
+                        y = _make_vector_grid(11, 0.0, π)
+                        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+                        itp = builder((x, y), data)
+                        xqs = [0.5, 1.0, 1.5, 2.0, 3.0]
+                        yqs = [0.2, 0.4, 0.6, 0.8, 1.0]
+                        out = Vector{Float64}(undef, 5)
+                        itp(out, (xqs, yqs)); itp(out, (xqs, yqs))
+                        return @allocated itp(out, (xqs, yqs))
+                end
+                ),
+                (
+                    "3D", function (builder)
+                        x = _make_vector_grid(21, 0.0, 2π)
+                        y = _make_vector_grid(11, 0.0, π)
+                        z = _make_vector_grid(7, 0.0, 1.0)
+                        data = [sin(xi) * cos(yj) * (1 + zk) for xi in x, yj in y, zk in z]
+                        itp = builder((x, y, z), data)
+                        xqs = [0.5, 1.0, 1.5, 2.0, 3.0]
+                        yqs = [0.2, 0.4, 0.6, 0.8, 1.0]
+                        zqs = [0.1, 0.3, 0.5, 0.7, 0.9]
+                        out = Vector{Float64}(undef, 5)
+                        itp(out, (xqs, yqs, zqs)); itp(out, (xqs, yqs, zqs))
+                        return @allocated itp(out, (xqs, yqs, zqs))
+                end
+                ),
+            ]
+        @test alloc_fn(builder) <= ND_ALLOC_THRESHOLD
+    end
+
+    # ── Heterogeneous method tuples (zero-alloc) ─────────────────
+
+    @testset "Zero-alloc — Hetero $label" for (label, methods, ndims) in [
+            ("Cubic×Linear 2D", (CubicInterp(), LinearInterp()), 2),
+            ("Cardinal×Cubic 2D", (CardinalInterp(), CubicInterp()), 2),
+            ("PCHIP×Linear 2D", (PchipInterp(), LinearInterp()), 2),
+            ("Cubic×Linear×PCHIP 3D", (CubicInterp(), LinearInterp(), PchipInterp()), 3),
+            ("Cardinal×Akima×Cubic 3D", (CardinalInterp(), AkimaInterp(), CubicInterp()), 3),
+        ]
+        function _alloc_hetero(methods, ndims)
+            x = _make_vector_grid(21, 0.0, 2π)
+            y = _make_vector_grid(11, 0.0, π)
+            grids = ndims == 2 ? (x, y) : (x, y, _make_vector_grid(7, 0.0, 1.0))
+            data = ndims == 2 ?
+                [sin(xi) * cos(yj) for xi in grids[1], yj in grids[2]] :
+                [sin(xi) * cos(yj) * (1 + zk) for xi in grids[1], yj in grids[2], zk in grids[3]]
+            itp = interp(grids, data; method = methods)
+            qs = ndims == 2 ?
+                ([0.5, 1.0, 1.5, 2.0, 3.0], [0.2, 0.4, 0.6, 0.8, 1.0]) :
+                ([0.5, 1.0, 1.5, 2.0, 3.0], [0.2, 0.4, 0.6, 0.8, 1.0], [0.1, 0.3, 0.5, 0.7, 0.9])
+            out = Vector{Float64}(undef, 5)
+            itp(out, qs); itp(out, qs)
+            return @allocated itp(out, qs)
+        end
+        @test _alloc_hetero(methods, ndims) <= ND_ALLOC_THRESHOLD
+    end
+
+    # ── Mixed search policies (zero-alloc + correctness) ─────────
+
+    @testset "Zero-alloc — Mixed search policies" begin
+        function _test_mixed_policy(policy)
+            x = _make_vector_grid(21, 0.0, 2π)
+            y = _make_vector_grid(11, 0.0, π)
+            z = _make_vector_grid(7, 0.0, 1.0)
+            data = [sin(xi) * cos(yj) * (1 + zk) for xi in x, yj in y, zk in z]
+            itp = cubic_interp((x, y, z), data)
+            qs = (
+                [0.5, 1.0, 1.5, 2.0, 3.0],
+                [0.2, 0.4, 0.6, 0.8, 1.0],
+                [0.1, 0.3, 0.5, 0.7, 0.9],
+            )
+            out = Vector{Float64}(undef, 5)
+            ref = Vector{Float64}(undef, 5)
+
+            # Reference: default search
+            itp(ref, qs)
+
+            # Mixed policy: correctness
+            itp(out, qs; search = policy)
+            @test out == ref
+
+            # Mixed policy: allocation
+            itp(out, qs; search = policy); itp(out, qs; search = policy)
+            allocs = @allocated itp(out, qs; search = policy)
+            @test allocs <= ND_ALLOC_THRESHOLD
+        end
+
+        _test_mixed_policy((BinarySearch(), AutoSearch(), BinarySearch()))
+        _test_mixed_policy((AutoSearch(), BinarySearch(), AutoSearch()))
+        _test_mixed_policy((LinearBinarySearch(), LinearBinarySearch(), BinarySearch()))
+    end
+
+    # ── Hint mutation tests ──────────────────────────────────────
+    # Verify that auto-generated hints are updated across queries in batch.
+
+    @testset "Hint mutation — $label" for (label, builder) in [
+            ("Cubic", (g, d) -> cubic_interp(g, d)),
+            ("Linear", (g, d) -> linear_interp(g, d)),
+            ("Cardinal", (g, d) -> cardinal_interp(g, d)),
+        ]
+
+        # 2D: sorted queries should leave hints near end of grid
+        x = _make_vector_grid(100, 0.0, 1.0)
+        y = _make_vector_grid(50, 0.0, 1.0)
+        data = [sin(2π * xi) * cos(2π * yj) for xi in x, yj in y]
+        itp = builder((x, y), data)
+
+        nq = 50
+        qs_sorted = (
+            collect(range(0.01, 0.99, length = nq)),
+            collect(range(0.01, 0.99, length = nq)),
+        )
+        out = Vector{Float64}(undef, nq)
+
+        # Auto-generated hints (hint=nothing): should still update internally
+        # We can't observe auto hints directly, but we can verify no regression.
+        itp(out, qs_sorted)  # should not error
+
+        # User-provided hints: must be mutated
+        hints = (Ref(1), Ref(1))
+        itp(out, qs_sorted; hint = hints)
+
+        # After sorted queries ending near 0.99, hints should be near end of grid
+        @test hints[1][] > length(x) ÷ 2   # x hint advanced past midpoint
+        @test hints[2][] > length(y) ÷ 2   # y hint advanced past midpoint
+    end
+
+    # ── User-provided hints preserved ────────────────────────────
+
+    @testset "User hints not overwritten" begin
+        x = _make_vector_grid(100, 0.0, 1.0)
+        y = _make_vector_grid(50, 0.0, 1.0)
+        data = [sin(2π * xi) * cos(2π * yj) for xi in x, yj in y]
+        itp = cubic_interp((x, y), data)
+
+        user_hints = (Ref(42), Ref(21))
+        qs = ([0.5, 0.6], [0.3, 0.4])
+        out = Vector{Float64}(undef, 2)
+
+        itp(out, qs; hint = user_hints)
+
+        # Hints should be updated (not stuck at original values)
+        # and should NOT be replaced by auto-generated Ref(1)
+        @test user_hints[1][] != 42 || user_hints[2][] != 21  # at least one updated
+    end
+
+    # ── Correctness: batch vs scalar reference ───────────────────
+
+    @testset "Correctness — batch vs scalar — $label" for (label, builder) in [
+            ("Cubic", (g, d) -> cubic_interp(g, d)),
+            ("Linear", (g, d) -> linear_interp(g, d)),
+            ("Quadratic", (g, d) -> quadratic_interp(g, d)),
+            ("Cardinal", (g, d) -> cardinal_interp(g, d)),
+            ("PCHIP", (g, d) -> pchip_interp(g, d)),
+        ]
+        x = _make_vector_grid(21, 0.0, 2π)
+        y = _make_vector_grid(11, 0.0, π)
+        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+        itp = builder((x, y), data)
+
+        nq = 20
+        xqs = collect(range(0.1, 6.0, length = nq))
+        yqs = collect(range(0.1, 3.0, length = nq))
+        out_batch = Vector{Float64}(undef, nq)
+        itp(out_batch, (xqs, yqs))
+
+        # Scalar reference
+        out_scalar = [itp((xqs[i], yqs[i])) for i in 1:nq]
+
+        @test out_batch == out_scalar  # bitwise identical
+    end
+
+    # ── Zero-alloc with search override + hint ───────────────────
+
+    @testset "Zero-alloc — search override + hint" begin
+        function _alloc_override(search, hint_mode)
+            x = _make_vector_grid(101, 0.0, 2π)
+            y = _make_vector_grid(51, 0.0, π)
+            data = [sin(xi) * cos(yj) for xi in x, yj in y]
+            itp = cubic_interp((x, y), data)
+            nq = 20
+            qs = (collect(range(0.1, 6.0, length = nq)),
+                  collect(range(0.1, 3.0, length = nq)))
+            out = Vector{Float64}(undef, nq)
+            if hint_mode == :hint
+                h = (Ref(1), Ref(1))
+                itp(out, qs; search = search, hint = h)
+                itp(out, qs; search = search, hint = h)
+                return @allocated itp(out, qs; search = search, hint = h)
+            else
+                itp(out, qs; search = search)
+                itp(out, qs; search = search)
+                return @allocated itp(out, qs; search = search)
+            end
+        end
+
+        @test _alloc_override(BinarySearch(), :nohint)             <= ND_ALLOC_THRESHOLD
+        @test _alloc_override(BinarySearch(), :hint)               <= ND_ALLOC_THRESHOLD
+        @test _alloc_override(LinearBinarySearch(), :nohint)       <= ND_ALLOC_THRESHOLD
+        @test _alloc_override(LinearBinarySearch(), :hint)         <= ND_ALLOC_THRESHOLD
+        @test _alloc_override(AutoSearch(), :nohint)               <= ND_ALLOC_THRESHOLD
+        @test _alloc_override(AutoSearch(), :hint)                 <= ND_ALLOC_THRESHOLD
+    end
+end

--- a/test/test_nd_batch_hint_persistence.jl
+++ b/test/test_nd_batch_hint_persistence.jl
@@ -382,4 +382,52 @@
         end
         @test _alloc_aos() <= ND_ALLOC_THRESHOLD
     end
+
+    # ── Hetero full-fiber hint persistence ──────────────────────
+    # Cubic×Cubic OnTheFly takes the full-fiber fallback (no windowable axis).
+    # Batch path must still mutate user hints via _locate_cell → _collapse_dims.
+
+    @testset "Hint mutation — Hetero full-fiber (Cubic×Cubic OnTheFly)" begin
+        x = _make_vector_grid(100, 0.0, 1.0)
+        y = _make_vector_grid(50, 0.0, 1.0)
+        data = [sin(2π * xi) * cos(2π * yj) for xi in x, yj in y]
+        itp = interp((x, y), data; method = (CubicInterp(), CubicInterp()), coeffs = OnTheFly())
+
+        nq = 50
+        qs = (collect(range(0.01, 0.99, length = nq)),
+              collect(range(0.01, 0.99, length = nq)))
+        out = Vector{Float64}(undef, nq)
+        hints = (Ref(1), Ref(1))
+        itp(out, qs; hint = hints)
+
+        # Full-fiber path must update hints — sorted queries → hints near end
+        @test hints[1][] > length(x) ÷ 2
+        @test hints[2][] > length(y) ÷ 2
+    end
+
+    # ── Generic protocol container monotonicity ─────────────────
+    # Custom wrapper implementing query protocol should get per-axis check.
+
+    @testset "Correctness — generic protocol container" begin
+        x = _make_vector_grid(21, 0.0, 2π)
+        y = _make_vector_grid(11, 0.0, π)
+        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+        itp = cubic_interp((x, y), data)
+
+        # Wrap queries in a non-AbstractVector container (NamedTuple of vectors via protocol)
+        nq = 10
+        xqs = collect(range(0.1, 6.0, length = nq))
+        yqs = collect(range(0.1, 3.0, length = nq))
+
+        # SoA reference
+        out_soa = Vector{Float64}(undef, nq)
+        itp(out_soa, (xqs, yqs))
+
+        # AoS reference (AbstractVector — tested elsewhere)
+        qs_aos = [(xqs[i], yqs[i]) for i in 1:nq]
+        out_aos = Vector{Float64}(undef, nq)
+        itp(out_aos, qs_aos)
+
+        @test out_aos == out_soa
+    end
 end

--- a/test/test_nd_batch_hint_persistence.jl
+++ b/test/test_nd_batch_hint_persistence.jl
@@ -341,8 +341,8 @@
     end
 
     # ── AoS batch queries — correctness ─────────────────────────
-    # Array-of-Structs queries: Vector{Tuple}. _check_mono_nd falls back
-    # to all-false (Binary), but should still produce correct results.
+    # Array-of-Structs queries: Vector{Tuple}. _check_mono_nd uses protocol-based
+    # _is_axis_likely_monotone for per-axis monotonicity check (no allocation).
 
     @testset "Correctness — AoS batch queries" begin
         x = _make_vector_grid(21, 0.0, 2π)
@@ -364,5 +364,22 @@
         itp(out_aos, qs_aos)
 
         @test out_aos == out_soa  # bitwise identical
+    end
+
+    @testset "Zero-alloc — AoS batch queries" begin
+        function _alloc_aos()
+            x = _make_vector_grid(101, 0.0, 2π)
+            y = _make_vector_grid(51, 0.0, π)
+            data = [sin(xi) * cos(yj) for xi in x, yj in y]
+            itp = cubic_interp((x, y), data)
+            nq = 20
+            xqs = collect(range(0.1, 6.0, length = nq))
+            yqs = collect(range(0.1, 3.0, length = nq))
+            qs = [(xqs[i], yqs[i]) for i in 1:nq]
+            out = Vector{Float64}(undef, nq)
+            itp(out, qs); itp(out, qs)
+            return @allocated itp(out, qs)
+        end
+        @test _alloc_aos() <= ND_ALLOC_THRESHOLD
     end
 end

--- a/test/test_nd_batch_hint_persistence.jl
+++ b/test/test_nd_batch_hint_persistence.jl
@@ -244,4 +244,125 @@
         @test _alloc_override(AutoSearch(), :nohint)               <= ND_ALLOC_THRESHOLD
         @test _alloc_override(AutoSearch(), :hint)                 <= ND_ALLOC_THRESHOLD
     end
+
+    # ── Range grid — zero-alloc + correctness ───────────────────
+    # Range grids dispatch to DirectSearch O(1). Verify they still work
+    # through the (policies, hints, mono) infrastructure without allocating.
+
+    @testset "Zero-alloc — Range grid $label" for (label, builder) in [
+            ("Cubic", (g, d) -> cubic_interp(g, d)),
+            ("Linear", (g, d) -> linear_interp(g, d)),
+        ]
+        function _alloc_range(builder)
+            x = range(0.0, 2π, 101)
+            y = range(0.0, π, 51)
+            data = [sin(xi) * cos(yj) for xi in x, yj in y]
+            itp = builder((x, y), data)
+            nq = 20
+            qs = (collect(range(0.1, 6.0, length = nq)),
+                  collect(range(0.1, 3.0, length = nq)))
+            out = Vector{Float64}(undef, nq)
+            itp(out, qs); itp(out, qs)
+            return @allocated itp(out, qs)
+        end
+        @test _alloc_range(builder) <= ND_ALLOC_THRESHOLD
+    end
+
+    @testset "Correctness — Range vs Vector — batch" begin
+        xr = range(0.0, 2π, 101)
+        yr = range(0.0, π, 51)
+        xv = collect(xr)
+        yv = collect(yr)
+        data = [sin(xi) * cos(yj) for xi in xr, yj in yr]
+        itp_r = cubic_interp((xr, yr), data)
+        itp_v = cubic_interp((xv, yv), data)
+
+        nq = 20
+        qs = (collect(range(0.1, 6.0, length = nq)),
+              collect(range(0.1, 3.0, length = nq)))
+        out_r = Vector{Float64}(undef, nq)
+        out_v = Vector{Float64}(undef, nq)
+        itp_r(out_r, qs)
+        itp_v(out_v, qs)
+        @test out_r ≈ out_v  atol = 1e-12  # Range vs Vector may differ at ULP level
+    end
+
+    @testset "Hint mutation — Range grid" begin
+        xr = range(0.0, 1.0, 100)
+        yr = range(0.0, 1.0, 50)
+        data = [sin(2π * xi) * cos(2π * yj) for xi in xr, yj in yr]
+        itp = cubic_interp((xr, yr), data)
+
+        nq = 50
+        qs = (collect(range(0.01, 0.99, length = nq)),
+              collect(range(0.01, 0.99, length = nq)))
+        out = Vector{Float64}(undef, nq)
+        hints = (Ref(1), Ref(1))
+        itp(out, qs; hint = hints)
+
+        @test hints[1][] > length(xr) ÷ 2
+        @test hints[2][] > length(yr) ÷ 2
+    end
+
+    # ── Mixed grid (Range × Vector) — zero-alloc + correctness ──
+
+    @testset "Zero-alloc — Mixed grid Range×Vector" begin
+        function _alloc_mixed_grid()
+            xr = range(0.0, 2π, 101)
+            yv = _make_vector_grid(51, 0.0, π)
+            data = [sin(xi) * cos(yj) for xi in xr, yj in yv]
+            itp = cubic_interp((xr, yv), data)
+            nq = 20
+            qs = (collect(range(0.1, 6.0, length = nq)),
+                  collect(range(0.1, 3.0, length = nq)))
+            out = Vector{Float64}(undef, nq)
+            itp(out, qs); itp(out, qs)
+            return @allocated itp(out, qs)
+        end
+        @test _alloc_mixed_grid() <= ND_ALLOC_THRESHOLD
+    end
+
+    @testset "Zero-alloc — Mixed grid 3D Range×Vector×Range" begin
+        function _alloc_mixed_3d()
+            xr = range(0.0, 2π, 21)
+            yv = _make_vector_grid(11, 0.0, π)
+            zr = range(0.0, 1.0, 7)
+            data = [sin(xi) * cos(yj) * (1 + zk) for xi in xr, yj in yv, zk in zr]
+            itp = cubic_interp((xr, yv, zr), data)
+            nq = 10
+            qs = (collect(range(0.1, 6.0, length = nq)),
+                  collect(range(0.1, 3.0, length = nq)),
+                  collect(range(0.1, 0.9, length = nq)))
+            out = Vector{Float64}(undef, nq)
+            itp(out, qs); itp(out, qs)
+            return @allocated itp(out, qs)
+        end
+        @test _alloc_mixed_3d() <= ND_ALLOC_THRESHOLD
+    end
+
+    # ── AoS batch queries — correctness ─────────────────────────
+    # Array-of-Structs queries: Vector{Tuple}. _check_mono_nd falls back
+    # to all-false (Binary), but should still produce correct results.
+
+    @testset "Correctness — AoS batch queries" begin
+        x = _make_vector_grid(21, 0.0, 2π)
+        y = _make_vector_grid(11, 0.0, π)
+        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+        itp = cubic_interp((x, y), data)
+
+        nq = 10
+        xqs = collect(range(0.1, 6.0, length = nq))
+        yqs = collect(range(0.1, 3.0, length = nq))
+
+        # SoA reference
+        out_soa = Vector{Float64}(undef, nq)
+        itp(out_soa, (xqs, yqs))
+
+        # AoS query
+        qs_aos = [(xqs[i], yqs[i]) for i in 1:nq]
+        out_aos = Vector{Float64}(undef, nq)
+        itp(out_aos, qs_aos)
+
+        @test out_aos == out_soa  # bitwise identical
+    end
 end

--- a/test/test_nd_batch_hint_persistence.jl
+++ b/test/test_nd_batch_hint_persistence.jl
@@ -222,8 +222,10 @@
             data = [sin(xi) * cos(yj) for xi in x, yj in y]
             itp = cubic_interp((x, y), data)
             nq = 20
-            qs = (collect(range(0.1, 6.0, length = nq)),
-                  collect(range(0.1, 3.0, length = nq)))
+            qs = (
+                collect(range(0.1, 6.0, length = nq)),
+                collect(range(0.1, 3.0, length = nq)),
+            )
             out = Vector{Float64}(undef, nq)
             if hint_mode == :hint
                 h = (Ref(1), Ref(1))
@@ -237,12 +239,12 @@
             end
         end
 
-        @test _alloc_override(BinarySearch(), :nohint)             <= ND_ALLOC_THRESHOLD
-        @test _alloc_override(BinarySearch(), :hint)               <= ND_ALLOC_THRESHOLD
-        @test _alloc_override(LinearBinarySearch(), :nohint)       <= ND_ALLOC_THRESHOLD
-        @test _alloc_override(LinearBinarySearch(), :hint)         <= ND_ALLOC_THRESHOLD
-        @test _alloc_override(AutoSearch(), :nohint)               <= ND_ALLOC_THRESHOLD
-        @test _alloc_override(AutoSearch(), :hint)                 <= ND_ALLOC_THRESHOLD
+        @test _alloc_override(BinarySearch(), :nohint) <= ND_ALLOC_THRESHOLD
+        @test _alloc_override(BinarySearch(), :hint) <= ND_ALLOC_THRESHOLD
+        @test _alloc_override(LinearBinarySearch(), :nohint) <= ND_ALLOC_THRESHOLD
+        @test _alloc_override(LinearBinarySearch(), :hint) <= ND_ALLOC_THRESHOLD
+        @test _alloc_override(AutoSearch(), :nohint) <= ND_ALLOC_THRESHOLD
+        @test _alloc_override(AutoSearch(), :hint) <= ND_ALLOC_THRESHOLD
     end
 
     # ── Range grid — zero-alloc + correctness ───────────────────
@@ -259,8 +261,10 @@
             data = [sin(xi) * cos(yj) for xi in x, yj in y]
             itp = builder((x, y), data)
             nq = 20
-            qs = (collect(range(0.1, 6.0, length = nq)),
-                  collect(range(0.1, 3.0, length = nq)))
+            qs = (
+                collect(range(0.1, 6.0, length = nq)),
+                collect(range(0.1, 3.0, length = nq)),
+            )
             out = Vector{Float64}(undef, nq)
             itp(out, qs); itp(out, qs)
             return @allocated itp(out, qs)
@@ -278,13 +282,15 @@
         itp_v = cubic_interp((xv, yv), data)
 
         nq = 20
-        qs = (collect(range(0.1, 6.0, length = nq)),
-              collect(range(0.1, 3.0, length = nq)))
+        qs = (
+            collect(range(0.1, 6.0, length = nq)),
+            collect(range(0.1, 3.0, length = nq)),
+        )
         out_r = Vector{Float64}(undef, nq)
         out_v = Vector{Float64}(undef, nq)
         itp_r(out_r, qs)
         itp_v(out_v, qs)
-        @test out_r ≈ out_v  atol = 1e-12  # Range vs Vector may differ at ULP level
+        @test out_r ≈ out_v  atol = 1.0e-12  # Range vs Vector may differ at ULP level
     end
 
     @testset "Hint mutation — Range grid" begin
@@ -294,8 +300,10 @@
         itp = cubic_interp((xr, yr), data)
 
         nq = 50
-        qs = (collect(range(0.01, 0.99, length = nq)),
-              collect(range(0.01, 0.99, length = nq)))
+        qs = (
+            collect(range(0.01, 0.99, length = nq)),
+            collect(range(0.01, 0.99, length = nq)),
+        )
         out = Vector{Float64}(undef, nq)
         hints = (Ref(1), Ref(1))
         itp(out, qs; hint = hints)
@@ -313,8 +321,10 @@
             data = [sin(xi) * cos(yj) for xi in xr, yj in yv]
             itp = cubic_interp((xr, yv), data)
             nq = 20
-            qs = (collect(range(0.1, 6.0, length = nq)),
-                  collect(range(0.1, 3.0, length = nq)))
+            qs = (
+                collect(range(0.1, 6.0, length = nq)),
+                collect(range(0.1, 3.0, length = nq)),
+            )
             out = Vector{Float64}(undef, nq)
             itp(out, qs); itp(out, qs)
             return @allocated itp(out, qs)
@@ -330,9 +340,11 @@
             data = [sin(xi) * cos(yj) * (1 + zk) for xi in xr, yj in yv, zk in zr]
             itp = cubic_interp((xr, yv, zr), data)
             nq = 10
-            qs = (collect(range(0.1, 6.0, length = nq)),
-                  collect(range(0.1, 3.0, length = nq)),
-                  collect(range(0.1, 0.9, length = nq)))
+            qs = (
+                collect(range(0.1, 6.0, length = nq)),
+                collect(range(0.1, 3.0, length = nq)),
+                collect(range(0.1, 0.9, length = nq)),
+            )
             out = Vector{Float64}(undef, nq)
             itp(out, qs); itp(out, qs)
             return @allocated itp(out, qs)
@@ -394,8 +406,10 @@
         itp = interp((x, y), data; method = (CubicInterp(), CubicInterp()), coeffs = OnTheFly())
 
         nq = 50
-        qs = (collect(range(0.01, 0.99, length = nq)),
-              collect(range(0.01, 0.99, length = nq)))
+        qs = (
+            collect(range(0.01, 0.99, length = nq)),
+            collect(range(0.01, 0.99, length = nq)),
+        )
         out = Vector{Float64}(undef, nq)
         hints = (Ref(1), Ref(1))
         itp(out, qs; hint = hints)

--- a/test/test_search.jl
+++ b/test/test_search.jl
@@ -778,17 +778,17 @@ using FastInterpolations: search_interval, _search_binary, _search_direct, _sear
             @test hint[] >= 540 && hint[] <= 570
         end
 
-        @testset "Override with BinarySearch + hint auto-upgrades to LinearBinarySearch{2}" begin
+        @testset "Override with BinarySearch + hint → LB{0} (hint tracks)" begin
             # Create with LinearBinarySearch default, but override with BinarySearch at call time
             itp = linear_interp(x, y; search = LinearBinarySearch())
             hint = Ref(100)
 
-            # Override with BinarySearch + hint → auto-upgrades to LinearBinarySearch{2}
+            # Override with BinarySearch + hint → LB{0}: direct-hit check + binary + hint write-back
             for xi in range(0.5, 0.6, 10)
                 yi = itp(xi; search = BinarySearch(), hint = hint)
             end
 
-            # hint should be updated (auto-upgraded to LinearBinarySearch{2})
+            # hint should be updated (LB{0} writes back after binary search)
             @test hint[] >= 500 && hint[] <= 610
         end
 
@@ -865,14 +865,14 @@ using FastInterpolations: search_interval, _search_binary, _search_direct, _sear
             @test length(outputs[1]) == 100
         end
 
-        @testset "Series override with BinarySearch + hint auto-upgrades" begin
+        @testset "Series override with BinarySearch + hint → LB{0} (hint tracks)" begin
             sitp = linear_interp(x, Series(y1, y2); search = LinearBinarySearch())
             hint = Ref(250)
 
-            # Override with BinarySearch + hint → auto-upgrades to LinearBinarySearch{2}
+            # Override with BinarySearch + hint → LB{0}: hint write-back
             yi = sitp(0.75; search = BinarySearch(), hint = hint)
 
-            # hint should be updated (auto-upgraded to LinearBinarySearch{2})
+            # hint should be updated (LB{0} writes back after binary search)
             @test hint[] >= 740 && hint[] <= 760
         end
     end
@@ -918,10 +918,11 @@ using FastInterpolations: search_interval, _search_binary, _search_direct, _sear
             @test s2.hint.idx[] == 75
         end
 
-        @testset "BinarySearch with hint auto-upgrades to LinearBinarySearch{2}" begin
-            # BinarySearch policy with hint auto-upgrades to LinearBinarySearch{2}
+        @testset "BinarySearch with hint → Binary + RefHint (write-back)" begin
+            # BinarySearch + hint → Binary stays Binary, hint used for write-back only
             ext_ref = Ref(100)
             s1 = _to_searcher(BinarySearch(), ext_ref)
+            @test s1 isa Searcher{BinarySearch, RefHint}
             @test s1.hint isa RefHint
             @test s1.hint.idx === ext_ref  # Uses external Ref
 
@@ -1188,7 +1189,7 @@ using FastInterpolations: search_interval, _search_binary, _search_direct, _sear
             # y = x^2, so itp(0.5) ≈ 0.25
             @test itp(0.5) ≈ 0.25 atol = 1.0e-6
 
-            # Scalar call with hint: BinarySearch+hint auto-upgrades to LinearBinarySearch{2} → hint updates
+            # Scalar call with hint: BinarySearch+hint → LB{0} → hint updated via write-back
             hint_scalar = Ref(1)
             itp(0.5; hint = hint_scalar)
             @test hint_scalar[] >= 490 && hint_scalar[] <= 510  # hint moved to ~500
@@ -1543,9 +1544,10 @@ using FastInterpolations: search_interval, _search_binary, _search_direct, _sear
             end
 
             @testset "Scalar query → fallback to _resolve_search" begin
-                # Scalar: _resolve_search_policy(AutoSearch(), scalar) → BinarySearch
+                # Scalar + no hint: AutoSearch → BinarySearch
                 @test _resolve_search_policy(auto, 0.5, nothing) isa BinarySearch
-                @test _resolve_search_policy(auto, 0.5, Ref(1)) isa BinarySearch
+                # Scalar + hint: AutoSearch → LB (hint implies locality intent)
+                @test _resolve_search_policy(auto, 0.5, Ref(1)) isa LinearBinarySearch
             end
         end
 

--- a/test/test_search.jl
+++ b/test/test_search.jl
@@ -1500,13 +1500,25 @@ using FastInterpolations: search_interval, _search_binary, _search_direct, _sear
             # Exactly K=8 elements → false if not sorted
             @test !_is_likely_monotone([1.0, 3.0, 2.0, 4.0, 5.0, 6.0, 7.0, 8.0])
 
-            # Flat (all equal) → ascending path returns true
+            # Flat (all equal) → trivially monotone
             @test _is_likely_monotone(fill(5.0, 10))
 
             # Monotone prefix but unsorted later → still true (only checks first K)
             v = collect(1.0:20.0)
             v[15] = 0.0  # break monotonicity beyond K=8
             @test _is_likely_monotone(v)
+
+            # Equal-valued prefix followed by descending → true (non-increasing)
+            @test _is_likely_monotone([0.0, 0.0, 0.0, -1.0, -1.0, -2.0, -2.0, -3.0])
+
+            # Equal-valued prefix followed by ascending → true (non-decreasing)
+            @test _is_likely_monotone([0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 3.0, 4.0])
+
+            # Equal prefix then direction reversal → false
+            @test !_is_likely_monotone([0.0, 0.0, 0.0, 0.0, 3.0, 1.0, 4.0, 2.0])
+
+            # Ascending then descending → false
+            @test !_is_likely_monotone([1.0, 2.0, 3.0, 4.0, 3.0, 2.0, 1.0, 0.0])
         end
 
         # ========================================

--- a/test/test_search_context_normalization.jl
+++ b/test/test_search_context_normalization.jl
@@ -84,9 +84,9 @@ using FastInterpolations: search_interval, Searcher, BinarySearch, LinearSearch,
             @test s isa Searcher{BinarySearch, NoHint}
         end
 
-        @testset "Vector grid + explicit BinarySearch + hint → auto-upgrade to LinearBinarySearch" begin
+        @testset "Vector grid + explicit BinarySearch + hint → Binary + RefHint" begin
             s = _resolve_search(x_vec, xq_scalar, BinarySearch(), Ref(1))
-            @test s isa Searcher{LinearBinarySearch{8}, RefHint}
+            @test s isa Searcher{BinarySearch, RefHint}
         end
 
         @testset "Vector grid + AutoSearch + scalar → BinarySearch" begin


### PR DESCRIPTION
## Summary

Refactor ND search resolution to use a unified `(policies, hints, mono)` pattern across **all** batch paths (persistent + oneshot). Eliminates per-query heap allocation, enables per-axis adaptive search (sorted axis -> LB{8}, random axis -> Binary), and preserves hint locality across batch queries.

**6.6x speedup** on sorted Vector-grid batch queries. Zero allocation regression on random queries.

## Problem

ND batch interpolation had two separate search strategies with different trade-offs:

- **Persistent batch** (`itp(out, qs)`): Created fresh `RefHint()` per-query per-axis inside `_locate_cell` -> 32 bytes x N axes x nq queries. Hint state lost between queries -> no LB{8} locality benefit.
- **Oneshot batch** (`cubic_interp!(out, grids, data, qs)`): Used `_resolve_search_nd_uniform` (all-or-nothing) -> if ANY axis is random, ALL axes forced to Binary. Per-axis adaptive lost.

Both caused Union boxing from `Tuple{Union{BinarySearch, LinearBinarySearch}, ...}` policy tuples.

## Solution

### Core pattern: Bool-flag + function barrier

```julia
# Once per batch call:
policies = _resolve_search_nd(search, Val(N))   # broadcast only, no resolution
hints    = _ensure_hint_nd(hint, Val(N))         # persistent Ref(1) tuples
mono     = _check_mono_nd(policies, queries)     # NTuple{N, Bool}, per-axis

# Per query, per axis (inside batch loop):
_search_axis_adaptive(q, grid, spacing, policy, hint, mono_flag)
# -> function barrier: Union{LB{8}, Binary} split internally
# -> return type (Int, Tg, Tg) always concrete, no boxing
```

### Key design decisions

| Decision | Rationale |
|----------|-----------|
| `NTuple{N, Bool}` mono flags | Concrete tuple type -> no Union boxing from heterogeneous policy resolution |
| `_search_axis_adaptive` function barrier | Union{Searcher} contained inside barrier; return type always concrete |
| `Searcher{BinarySearch, RefHint}` | Pure binary search + hint write-back (0% overhead vs stateless Binary) |
| `_AoSMonoChecker` callable struct | `map` over policies without closure capture -> no heap allocation |
| Oneshot: pass `hint` as-is (not `_ensure_hint_nd`) | `nothing` -> 4-arg stateless search (zero Ref alloc); user Refs -> 6-arg adaptive |

## Results

### Allocation (2D Cubic, 50 queries)

| Combo | Master | Branch |
|-------|--------|--------|
| Persistent batch Vec SoA sorted | 1,600 B | **0 B** |
| Persistent batch Vec AoS sorted | 1,600 B | **0 B** |
| Persistent batch Mix AoS sorted | 12,000 B | **0 B** |
| Hetero batch sorted | 8,160 B | **0 B** |
| All other combos | 0 B | 0 B |

### Performance (2D Cubic, 1000 queries, Vec 1000x100)

| Combo | Master | Branch | Speedup |
|-------|--------|--------|---------|
| Persistent Vec SoA sorted | 51.3 us | 7.8 us | **6.6x** |
| Persistent Vec SoA mixed (x sorted, y random) | 36.2 us | 19.9 us | **1.8x** |
| Persistent Vec SoA random | 28.3 us | 27.9 us | 1.0x |
| Persistent Vec AoS sorted | 52.0 us | 8.9 us | **5.8x** |
| Persistent Rng SoA sorted | 7.5 us | 7.5 us | 1.0x |
| Oneshot Vec SoA sorted | 1409.7 us | 1361.6 us | 1.0x |

### Dispatch verification (per-axis adaptive)

| Query pattern | Axis 1 (Vec) | Axis 2 (Vec) |
|---------------|-------------|-------------|
| SoA sorted (x up, y up) | LB{8} | LB{8} |
| SoA mixed (x up, y random) | LB{8} | Binary |
| SoA random | Binary | Binary |
| AoS sorted | LB{8} | LB{8} |
| AoS mixed (x up, y random) | LB{8} | Binary |

Range grids always dispatch to DirectSearch O(1) regardless of policy/mono.

## Scope

### Files modified

**Core infrastructure** (`src/core/`):
- `nd_utils.jl` — `_check_mono_nd`, `_search_axis_adaptive`, `_AoSMonoChecker`, remove `_resolve_search_nd_uniform`
- `search.jl` — `Searcher{BinarySearch, RefHint}` + `_search_interval_real` overload
- `interpolant_protocol.jl` — batch entry uses `(policies, hints, mono)`
- `query_protocol.jl` — `_validate_nd_domain` AoS: `map` replaces `for d in 1:N`

**Per-type scalar callables** (all use `_scalar_mono`):
- `cubic_nd_eval.jl`, `linear_nd_eval.jl`, `quadratic_nd_eval.jl`, `constant_nd_eval.jl`

**Per-type oneshot batch** (all use `_check_mono_nd` + `_search_axis_adaptive`):
- `cubic_nd_oneshot.jl`, `linear_nd_oneshot.jl`, `quadratic_nd_oneshot.jl`, `constant_nd_oneshot.jl`

**Hetero**:
- `hetero_eval.jl` — scalar + `_locate_cell` + `_build_windowed_cell`
- `hetero_precomputed_eval.jl` — precomputed eval
- `hetero_oneshot.jl` — PreCompute + OnTheFly batch

**Vector calculus**: `vector_calculus.jl` — 6 `@generated` sites (gradient/hessian/laplacian)

**Tests**:
- `test_nd_batch_hint_persistence.jl` — new: 57 tests (zero-alloc, hint mutation, correctness, Range/AoS/mixed grid, hetero full-fiber hints, generic protocol containers)
- `test_nd_autosearch_peraxis.jl` — updated: `_check_mono_nd` replaces `_resolve_search_nd_uniform`
- `test_search.jl`, `test_search_context_normalization.jl` — updated `_to_searcher` expectations

### Dead code removed

- `_resolve_search_nd_uniform` (3 overloads)
- `_autosearch_to_lb`, `_autosearch_to_binary`
- `_check_axis_monotone` (consolidated into `_check_axis_mono`)
- `_get_axis_hint`
- `_search_axis` -> renamed `_search_axis_oneshot`
- `_search_axis_hint` -> renamed `_search_axis_oneshot_hint`

## Public API

No changes. All modifications are internal. User-facing `search`, `hint` kwargs behave identically.