### PR TITLE
# (feat): PeriodicBC for Linear and Constant 

### DIFF
--- a/docs/src/api/types.md
+++ b/docs/src/api/types.md
@@ -95,6 +95,7 @@ laplacian
 
 ```@docs
 AbstractBC
+NoBC
 PointBC
 Deriv1
 Deriv2

--- a/docs/src/nd/unified_api.md
+++ b/docs/src/nd/unified_api.md
@@ -107,8 +107,10 @@ angle  = range(0.0, 2pi, 60)
 run_id = 1:200
 pressure = randn(100, 60, 200)
 
+# `check=false` skips the endpoint-match validation for this illustrative
+# random data (a real pressure(r, θ) field would have matching θ endpoints).
 itp = interp((radius, angle, run_id), pressure;
-    method = (CubicInterp(), CubicInterp(bc=PeriodicBC()), NoInterp()))
+    method = (CubicInterp(), CubicInterp(bc=PeriodicBC(check=false)), NoInterp()))
 
 # Query run #42 at (r=3.5, θ=1.2) — only 2D interpolation is performed
 itp((3.5, 1.2, GridIdx(42)))

--- a/src/FastInterpolations.jl
+++ b/src/FastInterpolations.jl
@@ -77,7 +77,7 @@ export AbstractSearchPolicy, BinarySearch, LinearSearch, LinearBinarySearch, Aut
 
 # Boundary condition types
 export AbstractBC, PointBC, Deriv1, Deriv2, Deriv3, BCPair
-export ZeroCurvBC, ZeroSlopeBC, PeriodicBC, MinCurvFit
+export NoBC, ZeroCurvBC, ZeroSlopeBC, PeriodicBC, MinCurvFit
 export PolyFit, LinearFit, QuadraticFit, CubicFit  # Polynomial fitting BCs
 export Left, Right
 

--- a/src/constant/constant_interpolant.jl
+++ b/src/constant/constant_interpolant.jl
@@ -48,7 +48,7 @@ end
 # ========================================
 
 """
-    constant_interp(x, y; bc=NoBC(), extrap=NoExtrap(), side=NearestSide(), search=AutoSearch()) -> ConstantInterpolant
+    constant_interp(x, y; bc=NoBC(), side=NearestSide(), extrap=NoExtrap(), search=AutoSearch()) -> ConstantInterpolant
 
 Create a callable interpolant for broadcast fusion and reuse.
 
@@ -109,8 +109,8 @@ end
         x::AbstractVector{TX},
         y::AbstractVector{TY};
         bc::AbstractBC = NoBC(),
-        extrap::AbstractExtrap = NoExtrap(),
         side::AbstractSide = NearestSide(),
+        extrap::AbstractExtrap = NoExtrap(),
         search::AbstractSearchPolicy = AutoSearch()
     ) where {TX, TY}
     Tg = _promote_grid_float(TX, TY)

--- a/src/constant/constant_interpolant.jl
+++ b/src/constant/constant_interpolant.jl
@@ -114,12 +114,7 @@ end
         search::AbstractSearchPolicy = AutoSearch()
     ) where {TX, TY}
     Tg = _promote_grid_float(TX, TY)
-    if _is_periodic_bc(bc)
-        x_ext, y_ext = _prepare_periodic(x, y, bc)
-        _check_periodic_endpoints(bc, y_ext)
-        extrap_p = _promote_extrap(WrapExtrap(), _value_type(TY, Tg))
-        return ConstantInterpolant(x_ext, y_ext; extrap = extrap_p, side, search)
-    end
-    extrap_p = _promote_extrap(extrap, _value_type(TY, Tg))
-    return ConstantInterpolant(x, y; extrap = extrap_p, side, search)
+    x_eff, y_eff, extrap_eff = _periodic_extend_1d(x, y, bc, extrap)
+    extrap_p = _promote_extrap(extrap_eff, _value_type(TY, Tg))
+    return ConstantInterpolant(x_eff, y_eff; extrap = extrap_p, side, search)
 end

--- a/src/constant/constant_interpolant.jl
+++ b/src/constant/constant_interpolant.jl
@@ -48,13 +48,16 @@ end
 # ========================================
 
 """
-    constant_interp(x, y; extrap=NoExtrap(), side=NearestSide(), search=AutoSearch()) -> ConstantInterpolant
+    constant_interp(x, y; bc=NoBC(), extrap=NoExtrap(), side=NearestSide(), search=AutoSearch()) -> ConstantInterpolant
 
 Create a callable interpolant for broadcast fusion and reuse.
 
 # Arguments
 - `x::AbstractVector`: x-coordinates (sorted, length ≥ 2)
 - `y::AbstractVector`: y-values
+- `bc::AbstractBC`: Boundary condition. Default `NoBC()` (no BC). Pass
+  `PeriodicBC(endpoint=:inclusive)` or `PeriodicBC(endpoint=:exclusive, period=L)`
+  to build a periodic interpolant (extrap is forced to `WrapExtrap()`).
 - `extrap::AbstractExtrap`: `NoExtrap()` (default), `ClampExtrap()`, `ExtendExtrap()`, or `WrapExtrap()`
 - `side::AbstractSide`: Side selection (NearestSide(), LeftSide(), RightSide())
 - `search::AbstractSearchPolicy`: Default search policy (default: `AutoSearch()`)
@@ -105,11 +108,18 @@ end
 @inline function constant_interp(
         x::AbstractVector{TX},
         y::AbstractVector{TY};
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         side::AbstractSide = NearestSide(),
         search::AbstractSearchPolicy = AutoSearch()
     ) where {TX, TY}
     Tg = _promote_grid_float(TX, TY)
+    if _is_periodic_bc(bc)
+        x_ext, y_ext = _prepare_periodic(x, y, bc)
+        _check_periodic_endpoints(bc, y_ext)
+        extrap_p = _promote_extrap(WrapExtrap(), _value_type(TY, Tg))
+        return ConstantInterpolant(x_ext, y_ext; extrap = extrap_p, side, search)
+    end
     extrap_p = _promote_extrap(extrap, _value_type(TY, Tg))
     return ConstantInterpolant(x, y; extrap = extrap_p, side, search)
 end

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -149,7 +149,7 @@ vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_wi
 # Public scalar one-shot API.
 # Zero-alloc: _prepare_grid returns Vector as-is, Range → _CachedRange (stack).
 # Kernel arithmetic auto-promotes Int×Float via _get_h float() wrappers.
-@inline @with_pool pool function constant_interp(
+@inline function constant_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         xi::Tq;
@@ -162,12 +162,24 @@ vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_wi
     ) where {Tg, Tv, Tq <: Real}
     @boundscheck length(y) == length(x) || throw(ArgumentError("x and y must have same length"))
 
-    x_eff, y_eff, extrap_eff = _prepare_1d_oneshot!(pool, x, y, bc, extrap)
-    searcher = _resolve_search(x_eff, xi, search, hint)
-    result = _constant_eval_at_point(x_eff, y_eff, xi, extrap_eff, side, deriv, searcher)
+    x_typed = _prepare_grid(x)
+    if _is_periodic_bc(bc)
+        result = _constant_interp_periodic_scalar(x_typed, y, xi, bc, extrap, side, deriv, search, hint)
+        return Tv <: _PromotableValue && !(Tv <: AbstractFloat) ? float(result) : result
+    end
+    searcher = _resolve_search(x_typed, xi, search, hint)
+    result = _constant_eval_at_point(x_typed, y, xi, extrap, side, deriv, searcher)
     # Constant returns y[idx] directly — promote Int/Rational to Float for
     # consistency with batch path and other methods (which auto-promote via arithmetic).
     return Tv <: _PromotableValue && !(Tv <: AbstractFloat) ? float(result) : result
+end
+
+@inline @with_pool pool function _constant_interp_periodic_scalar(
+        x, y, xi, bc, extrap, side, deriv, search, hint
+    )
+    x_eff, y_eff, extrap_eff = _periodic_extend_1d_pooled!(pool, x, y, bc, extrap)
+    searcher = _resolve_search(x_eff, xi, search, hint)
+    return _constant_eval_at_point(x_eff, y_eff, xi, extrap_eff, side, deriv, searcher)
 end
 
 # ========================================
@@ -201,7 +213,7 @@ constant_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear_
 """
 # Unified in-place entry point. Handles promotion internally via _promote_itp_inputs,
 # so no separate Real/Mixed-type wrapper is needed (same pattern as the scalar API).
-@with_pool pool function constant_interp!(
+function constant_interp!(
         output::AbstractVector,
         x::AbstractVector,
         y::AbstractVector,
@@ -215,7 +227,19 @@ constant_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear_
     @assert length(y) == length(x) "x and y must have same length"
     @assert length(output) == length(x_targets) "output must match x_targets length"
 
-    x_eff, y_eff, extrap_eff = _prepare_1d_oneshot!(pool, x, y, bc, extrap)
+    x_typed = _prepare_grid(x)
+    if _is_periodic_bc(bc)
+        return _constant_interp_periodic_vector!(output, x_typed, y, x_targets, bc, extrap, side, deriv, search)
+    end
+    searcher = _resolve_search(x_typed, x_targets, search, nothing)
+    _constant_vector_loop!(output, x_typed, y, x_targets, extrap, side, deriv, searcher)
+    return output
+end
+
+@inline @with_pool pool function _constant_interp_periodic_vector!(
+        output, x, y, x_targets, bc, extrap, side, deriv, search
+    )
+    x_eff, y_eff, extrap_eff = _periodic_extend_1d_pooled!(pool, x, y, bc, extrap)
     searcher = _resolve_search(x_eff, x_targets, search, nothing)
     _constant_vector_loop!(output, x_eff, y_eff, x_targets, extrap_eff, side, deriv, searcher)
     return output

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -163,14 +163,17 @@ vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_wi
     @boundscheck length(y) == length(x) || throw(ArgumentError("x and y must have same length"))
 
     x_typed = _prepare_grid(x)
-    if _is_periodic_bc(bc)
-        result = _constant_interp_periodic_scalar(x_typed, y, xi, bc, extrap, side, deriv, search, hint)
-        return Tv <: _PromotableValue && !(Tv <: AbstractFloat) ? float(result) : result
+    # Single-exit "compute → coerce" pattern: Constant returns `y[idx]`
+    # directly (no arithmetic auto-promotion), so Int/Rational results are
+    # promoted to Float once, regardless of which branch produced them.
+    # Other methods (Linear/Hermite/Quadratic) auto-promote via kernel
+    # arithmetic and use the simpler early-return template.
+    result = if _is_periodic_bc(bc)
+        _constant_interp_periodic_scalar(x_typed, y, xi, bc, extrap, side, deriv, search, hint)
+    else
+        searcher = _resolve_search(x_typed, xi, search, hint)
+        _constant_eval_at_point(x_typed, y, xi, extrap, side, deriv, searcher)
     end
-    searcher = _resolve_search(x_typed, xi, search, hint)
-    result = _constant_eval_at_point(x_typed, y, xi, extrap, side, deriv, searcher)
-    # Constant returns y[idx] directly — promote Int/Rational to Float for
-    # consistency with batch path and other methods (which auto-promote via arithmetic).
     return Tv <: _PromotableValue && !(Tv <: AbstractFloat) ? float(result) : result
 end
 

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -10,46 +10,8 @@
 # ║              Piecewise constant interpolation with side options           ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
-# ========================================
-# PeriodicBC pool-based grid/value extension
-# ========================================
-# Structurally identical to `_linear_periodic_extend!` (linear_oneshot.jl) and
-# the extension block of `_cubic_periodic_solve!` — extension logic is
-# method-agnostic. Each method keeps its own helper to keep dispatch simple and
-# avoid cross-method coupling; consolidation into core/periodic.jl is a future
-# refactor once Phase 2/3 methods land.
-@inline function _constant_periodic_extend!(
-        pool::AbstractArrayPool,
-        x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        bc::PeriodicBC
-    ) where {Tg, Tv}
-    if bc isa PeriodicBC{:exclusive}
-        period = _resolve_exclusive_period(x, bc)
-        x_end = first(x) + Tg(period)
-        last(x) < x_end || throw(
-            ArgumentError(
-                "period=$period places virtual endpoint at $x_end, " *
-                    "not after last grid point x[end]=$(last(x))"
-            )
-        )
-        n = length(x)
-        if x isa AbstractRange
-            x_p = _to_float_adding_endpoint(x, Tg)
-        else
-            x_p = acquire!(pool, Tg, n + 1)
-            @inbounds copyto!(x_p, 1, x, 1, n)
-            @inbounds x_p[n + 1] = x_end
-        end
-        y_p = acquire!(pool, Tv, n + 1)
-        @inbounds copyto!(y_p, 1, y, 1, n)
-        @inbounds y_p[n + 1] = y[1]
-    else
-        x_p, y_p = x, y
-    end
-    _check_periodic_endpoints(bc, y_p)
-    return x_p, y_p
-end
+# PeriodicBC 1D extension uses the shared `_extend_exclusive_pooled!` helper
+# from core/periodic.jl (same path Linear and Cubic oneshot use).
 
 # ========================================
 # Core eval: extrap dispatch → search → kernel (no intermediate layers)
@@ -199,7 +161,7 @@ vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_wi
 
     x_typed = _prepare_grid(x)
     if _is_periodic_bc(bc)
-        x_p, y_p = _constant_periodic_extend!(pool, x_typed, y, bc)
+        x_p, y_p = _extend_exclusive_pooled!(pool, x_typed, y, bc)
         searcher = _resolve_search(x_p, xi, search, hint)
         result = _constant_eval_at_point(x_p, y_p, xi, WrapExtrap(), side, deriv, searcher)
         return Tv <: _PromotableValue && !(Tv <: AbstractFloat) ? float(result) : result
@@ -258,7 +220,7 @@ constant_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear_
 
     x_typed = _prepare_grid(x)
     if _is_periodic_bc(bc)
-        x_p, y_p = _constant_periodic_extend!(pool, x_typed, y, bc)
+        x_p, y_p = _extend_exclusive_pooled!(pool, x_typed, y, bc)
         searcher = _resolve_search(x_p, x_targets, search, nothing)
         _constant_vector_loop!(output, x_p, y_p, x_targets, WrapExtrap(), side, deriv, searcher)
         return output

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -101,7 +101,7 @@ end
 # ========================================
 
 """
-    constant_interp(x, y, xi; extrap=NoExtrap(), side=NearestSide(), deriv=EvalValue(), search=AutoSearch())
+    constant_interp(x, y, xi; bc=NoBC(), side=NearestSide(), extrap=NoExtrap(), deriv=EvalValue(), search=AutoSearch())
 
 Constant (step/piecewise constant) interpolation at a single point.
 
@@ -109,6 +109,9 @@ Constant (step/piecewise constant) interpolation at a single point.
 - `x::AbstractVector`: x-coordinates (sorted, length ≥ 2)
 - `y::AbstractVector`: y-values (same length as x)
 - `xi::Real`: Query point
+- `bc::AbstractBC`: Boundary condition. Default `NoBC()` (no BC). Pass
+  `PeriodicBC(endpoint=:inclusive)` or `PeriodicBC(endpoint=:exclusive, period=L)`
+  for periodic interpolation (extrap is forced to `WrapExtrap()` in that case).
 - `extrap::AbstractExtrap`: Extrapolation mode
   - `NoExtrap()` (default): throws DomainError if outside domain
   - `ClampExtrap()`: clamp to boundary values
@@ -151,8 +154,8 @@ vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_wi
         y::AbstractVector{Tv},
         xi::Tq;
         bc::AbstractBC = NoBC(),
-        extrap::AbstractExtrap = NoExtrap(),
         side::AbstractSide = NearestSide(),
+        extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
@@ -172,14 +175,14 @@ end
 # ========================================
 
 """
-    constant_interp!(output, x, y, x_targets; extrap=NoExtrap(), side=NearestSide(), deriv=EvalValue(), search=AutoSearch())
+    constant_interp!(output, x, y, x_targets; bc=NoBC(), side=NearestSide(), extrap=NoExtrap(), deriv=EvalValue(), search=AutoSearch())
 
 Zero-allocation constant interpolation for multiple query points.
 
 # Arguments
 - `output`: Pre-allocated output vector
 - `x, y, x_targets`: Grid and query points
-- `extrap, side, deriv`: Same as `constant_interp`
+- `bc, extrap, side, deriv`: Same as `constant_interp`
 - `search::AbstractSearchPolicy`: Search algorithm for interval finding
 
 # Example
@@ -204,8 +207,8 @@ constant_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear_
         y::AbstractVector,
         x_targets::AbstractVector;
         bc::AbstractBC = NoBC(),
-        extrap::AbstractExtrap = NoExtrap(),
         side::AbstractSide = NearestSide(),
+        extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
     )
@@ -246,8 +249,8 @@ function constant_interp(
         y::AbstractVector,
         x_targets::AbstractVector;
         bc::AbstractBC = NoBC(),
-        extrap::AbstractExtrap = NoExtrap(),
         side::AbstractSide = NearestSide(),
+        extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
     )

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -11,6 +11,47 @@
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
 # ========================================
+# PeriodicBC pool-based grid/value extension
+# ========================================
+# Structurally identical to `_linear_periodic_extend!` (linear_oneshot.jl) and
+# the extension block of `_cubic_periodic_solve!` — extension logic is
+# method-agnostic. Each method keeps its own helper to keep dispatch simple and
+# avoid cross-method coupling; consolidation into core/periodic.jl is a future
+# refactor once Phase 2/3 methods land.
+@inline function _constant_periodic_extend!(
+        pool::AbstractArrayPool,
+        x::AbstractVector{Tg},
+        y::AbstractVector{Tv},
+        bc::PeriodicBC
+    ) where {Tg, Tv}
+    if bc isa PeriodicBC{:exclusive}
+        period = _resolve_exclusive_period(x, bc)
+        x_end = first(x) + Tg(period)
+        last(x) < x_end || throw(
+            ArgumentError(
+                "period=$period places virtual endpoint at $x_end, " *
+                    "not after last grid point x[end]=$(last(x))"
+            )
+        )
+        n = length(x)
+        if x isa AbstractRange
+            x_p = _to_float_adding_endpoint(x, Tg)
+        else
+            x_p = acquire!(pool, Tg, n + 1)
+            @inbounds copyto!(x_p, 1, x, 1, n)
+            @inbounds x_p[n + 1] = x_end
+        end
+        y_p = acquire!(pool, Tv, n + 1)
+        @inbounds copyto!(y_p, 1, y, 1, n)
+        @inbounds y_p[n + 1] = y[1]
+    else
+        x_p, y_p = x, y
+    end
+    _check_periodic_endpoints(bc, y_p)
+    return x_p, y_p
+end
+
+# ========================================
 # Core eval: extrap dispatch → search → kernel (no intermediate layers)
 # ========================================
 # _eval_extrapolation helper is defined in core/utils.jl (shared by all methods).
@@ -143,10 +184,11 @@ vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_wi
 # Public scalar one-shot API.
 # Zero-alloc: _prepare_grid returns Vector as-is, Range → _CachedRange (stack).
 # Kernel arithmetic auto-promotes Int×Float via _get_h float() wrappers.
-@inline function constant_interp(
+@inline @with_pool pool function constant_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         xi::Tq;
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         side::AbstractSide = NearestSide(),
         deriv::DerivOp = EvalValue(),
@@ -156,6 +198,12 @@ vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_wi
     @boundscheck length(y) == length(x) || throw(ArgumentError("x and y must have same length"))
 
     x_typed = _prepare_grid(x)
+    if _is_periodic_bc(bc)
+        x_p, y_p = _constant_periodic_extend!(pool, x_typed, y, bc)
+        searcher = _resolve_search(x_p, xi, search, hint)
+        result = _constant_eval_at_point(x_p, y_p, xi, WrapExtrap(), side, deriv, searcher)
+        return Tv <: _PromotableValue && !(Tv <: AbstractFloat) ? float(result) : result
+    end
     searcher = _resolve_search(x_typed, xi, search, hint)
     result = _constant_eval_at_point(x_typed, y, xi, extrap, side, deriv, searcher)
     # Constant returns y[idx] directly — promote Int/Rational to Float for
@@ -194,11 +242,12 @@ constant_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear_
 """
 # Unified in-place entry point. Handles promotion internally via _promote_itp_inputs,
 # so no separate Real/Mixed-type wrapper is needed (same pattern as the scalar API).
-function constant_interp!(
+@with_pool pool function constant_interp!(
         output::AbstractVector,
         x::AbstractVector,
         y::AbstractVector,
         x_targets::AbstractVector;
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         side::AbstractSide = NearestSide(),
         deriv::DerivOp = EvalValue(),
@@ -208,6 +257,12 @@ function constant_interp!(
     @assert length(output) == length(x_targets) "output must match x_targets length"
 
     x_typed = _prepare_grid(x)
+    if _is_periodic_bc(bc)
+        x_p, y_p = _constant_periodic_extend!(pool, x_typed, y, bc)
+        searcher = _resolve_search(x_p, x_targets, search, nothing)
+        _constant_vector_loop!(output, x_p, y_p, x_targets, WrapExtrap(), side, deriv, searcher)
+        return output
+    end
     searcher = _resolve_search(x_typed, x_targets, search, nothing)
     _constant_vector_loop!(output, x_typed, y, x_targets, extrap, side, deriv, searcher)
     return output
@@ -240,6 +295,7 @@ function constant_interp(
         x::AbstractVector,
         y::AbstractVector,
         x_targets::AbstractVector;
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         side::AbstractSide = NearestSide(),
         deriv::DerivOp = EvalValue(),
@@ -248,6 +304,6 @@ function constant_interp(
     Tg = _promote_grid_float(eltype(x), eltype(y))
     T_out = _output_eltype(eltype(y), Tg)
     output = Vector{T_out}(undef, length(x_targets))
-    constant_interp!(output, x, y, x_targets; extrap, side, deriv, search)
+    constant_interp!(output, x, y, x_targets; bc, extrap, side, deriv, search)
     return output
 end

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -10,7 +10,7 @@
 # ║              Piecewise constant interpolation with side options           ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
-# PeriodicBC 1D extension uses the shared `_extend_exclusive_pooled!` helper
+# PeriodicBC 1D dispatch uses the shared `_periodic_extend_1d_pooled!` helper
 # from core/periodic.jl (same path Linear and Cubic oneshot use).
 
 # ========================================
@@ -159,15 +159,9 @@ vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_wi
     ) where {Tg, Tv, Tq <: Real}
     @boundscheck length(y) == length(x) || throw(ArgumentError("x and y must have same length"))
 
-    x_typed = _prepare_grid(x)
-    if _is_periodic_bc(bc)
-        x_p, y_p = _extend_exclusive_pooled!(pool, x_typed, y, bc)
-        searcher = _resolve_search(x_p, xi, search, hint)
-        result = _constant_eval_at_point(x_p, y_p, xi, WrapExtrap(), side, deriv, searcher)
-        return Tv <: _PromotableValue && !(Tv <: AbstractFloat) ? float(result) : result
-    end
-    searcher = _resolve_search(x_typed, xi, search, hint)
-    result = _constant_eval_at_point(x_typed, y, xi, extrap, side, deriv, searcher)
+    x_eff, y_eff, extrap_eff = _prepare_1d_oneshot!(pool, x, y, bc, extrap)
+    searcher = _resolve_search(x_eff, xi, search, hint)
+    result = _constant_eval_at_point(x_eff, y_eff, xi, extrap_eff, side, deriv, searcher)
     # Constant returns y[idx] directly — promote Int/Rational to Float for
     # consistency with batch path and other methods (which auto-promote via arithmetic).
     return Tv <: _PromotableValue && !(Tv <: AbstractFloat) ? float(result) : result
@@ -218,15 +212,9 @@ constant_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear_
     @assert length(y) == length(x) "x and y must have same length"
     @assert length(output) == length(x_targets) "output must match x_targets length"
 
-    x_typed = _prepare_grid(x)
-    if _is_periodic_bc(bc)
-        x_p, y_p = _extend_exclusive_pooled!(pool, x_typed, y, bc)
-        searcher = _resolve_search(x_p, x_targets, search, nothing)
-        _constant_vector_loop!(output, x_p, y_p, x_targets, WrapExtrap(), side, deriv, searcher)
-        return output
-    end
-    searcher = _resolve_search(x_typed, x_targets, search, nothing)
-    _constant_vector_loop!(output, x_typed, y, x_targets, extrap, side, deriv, searcher)
+    x_eff, y_eff, extrap_eff = _prepare_1d_oneshot!(pool, x, y, bc, extrap)
+    searcher = _resolve_search(x_eff, x_targets, search, nothing)
+    _constant_vector_loop!(output, x_eff, y_eff, x_targets, extrap_eff, side, deriv, searcher)
     return output
 end
 

--- a/src/constant/constant_oneshot_series.jl
+++ b/src/constant/constant_oneshot_series.jl
@@ -7,6 +7,48 @@
 # Shared anchor eval: _constant_eval_at_anchor(y, x_last, aq, op, side, extrap) in constant_anchor.jl
 
 # ╔═══════════════════════════════════════════════════════════════════════════╗
+# ║                 INTERNAL: PERIODIC CORE                                  ║
+# ╚═══════════════════════════════════════════════════════════════════════════╝
+
+@inline @with_pool pool function _constant_oneshot_series_periodic!(
+        output::AbstractVector,
+        x::AbstractVector{Tg},
+        s::Series,
+        xq,
+        bc::PeriodicBC,
+        op::AbstractEvalOp,
+        side::AbstractSide,
+        searcher
+    ) where {Tg}
+    vecs = _series_vectors(s)
+    n = length(x)
+    x_p, y_p_first, _ = _periodic_extend_1d_pooled!(pool, x, first(vecs), bc, WrapExtrap())
+    n_p = length(x_p)
+    x_last = eltype(x_p)(last(x_p))
+    aq = _anchor_query(x_p, xq, Val(:constant), true, searcher)
+    @inbounds output[1] = _constant_eval_at_anchor(y_p_first, x_last, aq, op, side, WrapExtrap())
+
+    K = length(output)
+    if K > 1
+        if bc isa PeriodicBC{:exclusive}
+            Tv_buf = eltype(y_p_first)
+            y_p = acquire!(pool, Tv_buf, n_p)
+            @inbounds for k in 2:K
+                copyto!(y_p, 1, vecs[k], 1, n)
+                y_p[n + 1] = vecs[k][1]
+                output[k] = _constant_eval_at_anchor(y_p, x_last, aq, op, side, WrapExtrap())
+            end
+        else
+            @inbounds for k in 2:K
+                _check_periodic_endpoints(bc, vecs[k])
+                output[k] = _constant_eval_at_anchor(vecs[k], x_last, aq, op, side, WrapExtrap())
+            end
+        end
+    end
+    return output
+end
+
+# ╔═══════════════════════════════════════════════════════════════════════════╗
 # ║                         SCALAR ONE-SHOT API                              ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
@@ -16,6 +58,7 @@
         x::AbstractVector{Tg},
         s::Series,
         xq::Tq;
+        bc::AbstractBC = NoBC(),
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
@@ -24,14 +67,18 @@
     ) where {Tg, Tq <: Real}
     _validate_series_lengths(s, length(x))
     x = _to_float(x, Tg)
+    K = n_series(s)
+    Tv_out = _value_type(_series_eltype(s), Tg)
+    output = Vector{Tv_out}(undef, K)
+    if _is_periodic_bc(bc)
+        searcher = _resolve_search(x, xq, search, hint)
+        return _constant_oneshot_series_periodic!(output, x, s, xq, bc, deriv, side, searcher)
+    end
     _check_domain(x, xq, extrap)
     searcher = _resolve_search(x, xq, search, hint)
     aq = _anchor_query(x, xq, Val(:constant), extrap isa WrapExtrap, searcher)
     x_last = Tg(last(x))
     vecs = _series_vectors(s)
-    K = n_series(s)
-    Tv_out = _value_type(_series_eltype(s), Tg)
-    output = Vector{Tv_out}(undef, K)
     @inbounds for k in 1:K
         output[k] = _constant_eval_at_anchor(vecs[k], x_last, aq, deriv, side, extrap)
     end
@@ -45,6 +92,7 @@ end
         x::AbstractVector{Tg},
         s::Series,
         xq::Tq;
+        bc::AbstractBC = NoBC(),
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
@@ -54,6 +102,10 @@ end
     _validate_series_lengths(s, length(x))
     length(output) == n_series(s) || _throw_series_dim_mismatch(length(output), n_series(s))
     x = _to_float(x, Tg)
+    if _is_periodic_bc(bc)
+        searcher = _resolve_search(x, xq, search, hint)
+        return _constant_oneshot_series_periodic!(output, x, s, xq, bc, deriv, side, searcher)
+    end
     _check_domain(x, xq, extrap)
     searcher = _resolve_search(x, xq, search, hint)
     aq = _anchor_query(x, xq, Val(:constant), extrap isa WrapExtrap, searcher)
@@ -74,6 +126,7 @@ end
         x::AbstractVector{Tg},
         s::Series,
         xqs::AbstractVector{Tq};
+        bc::AbstractBC = NoBC(),
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
@@ -83,9 +136,44 @@ end
     x = _to_float(x, Tg)
     K = n_series(s)
     _validate_series_outputs(outputs, K, length(xqs))
+    vecs = _series_vectors(s)
+
+    if _is_periodic_bc(bc)
+        x_p, y_p_first, _ = _periodic_extend_1d_pooled!(pool, x, first(vecs), bc, WrapExtrap())
+        Tg_p = eltype(x_p)
+        x_last = Tg_p(last(x_p))
+        searcher = _resolve_search(x_p, xqs, search, nothing)
+        aq_vec = acquire!(pool, _ConstantAnchoredQuery{Tg_p, Tg_p}, length(xqs))
+        _fill_anchors!(aq_vec, x_p, xqs, Val(:constant), true, searcher)
+        @inbounds for j in eachindex(xqs)
+            outputs[1][j] = _constant_eval_at_anchor(y_p_first, x_last, aq_vec[j], deriv, side, WrapExtrap())
+        end
+        if K > 1
+            if bc isa PeriodicBC{:exclusive}
+                n = length(x)
+                Tv_buf = eltype(y_p_first)
+                y_p = acquire!(pool, Tv_buf, length(x_p))
+                @inbounds for k in 2:K
+                    copyto!(y_p, 1, vecs[k], 1, n)
+                    y_p[n + 1] = vecs[k][1]
+                    for j in eachindex(xqs)
+                        outputs[k][j] = _constant_eval_at_anchor(y_p, x_last, aq_vec[j], deriv, side, WrapExtrap())
+                    end
+                end
+            else
+                @inbounds for k in 2:K
+                    _check_periodic_endpoints(bc, vecs[k])
+                    for j in eachindex(xqs)
+                        outputs[k][j] = _constant_eval_at_anchor(vecs[k], x_last, aq_vec[j], deriv, side, WrapExtrap())
+                    end
+                end
+            end
+        end
+        return outputs
+    end
+
     # Domain check: NoExtrap → throws if OOB, returns InBounds(); others → pass-through
     extrap_eff = _check_domain(x, xqs, extrap)
-    vecs = _series_vectors(s)
     searcher = _resolve_search(x, xqs, search, nothing)
     wrap = extrap_eff isa WrapExtrap
     x_last = Tg(last(x))
@@ -104,6 +192,7 @@ function constant_interp(
         x::AbstractVector{Tg},
         s::Series,
         xqs::AbstractVector{Tq};
+        bc::AbstractBC = NoBC(),
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
@@ -112,7 +201,7 @@ function constant_interp(
     K = n_series(s)
     Tv_out = _value_type(_series_eltype(s), Tg)
     outputs = [Vector{Tv_out}(undef, length(xqs)) for _ in 1:K]
-    constant_interp!(outputs, x, s, xqs; side, extrap, deriv, search)
+    constant_interp!(outputs, x, s, xqs; bc, side, extrap, deriv, search)
     return outputs
 end
 

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -19,6 +19,13 @@
 Multi-series constant (step) interpolant with unified matrix storage and SIMD optimization.
 Shares a single x-grid across N y-series for efficient batch evaluation.
 
+!!! note "PeriodicBC on Series inputs"
+    `PeriodicBC` is not yet wired for the Series path — the `constant_interp(x, ys; ...)`
+    / `constant_interp(x, Series(...), xq; ...)` signatures have no `bc` kwarg. Build
+    one `ConstantInterpolant` per series with `bc=PeriodicBC(...)` if you need
+    periodic semantics on multi-series data. Series `bc` support is planned for a
+    later phase.
+
 # Type Parameters
 - `Tg`: Grid type (unconstrained — supports duck types like ForwardDiff.Dual)
 - `Tv`: Value type (unconstrained)

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -19,13 +19,6 @@
 Multi-series constant (step) interpolant with unified matrix storage and SIMD optimization.
 Shares a single x-grid across N y-series for efficient batch evaluation.
 
-!!! note "PeriodicBC on Series inputs"
-    `PeriodicBC` is not yet wired for the Series path — the `constant_interp(x, ys; ...)`
-    / `constant_interp(x, Series(...), xq; ...)` signatures have no `bc` kwarg. Build
-    one `ConstantInterpolant` per series with `bc=PeriodicBC(...)` if you need
-    periodic semantics on multi-series data. Series `bc` support is planned for a
-    later phase.
-
 # Type Parameters
 - `Tg`: Grid type (unconstrained — supports duck types like ForwardDiff.Dual)
 - `Tv`: Value type (unconstrained)
@@ -232,12 +225,16 @@ Outside-domain delegates to `_eval_series_at_anchor!` for extrapolation.
         return output
     end
 
-    # Inside domain: compute dL from original xq for AD support
+    # Inside domain: use the anchor's (already wrap-aware, Dual-preserving) dL.
+    # Recomputing `dL = xq - xL` from the original `xq` breaks when the anchor
+    # wrapped `xq` into the domain (e.g. PeriodicBC oneshot query past the seam):
+    # the kernel would see the unwrapped distance and pick the wrong side/index.
+    # `aq.dL` is `loc.xq - loc.xL` where `loc.xq` is the wrapped query — Dual is
+    # preserved through `_wrap_to_domain`, so AD chains survive.
     idx = aq.idx
     idx1 = idx + 1
     h = aq.h
-    @inbounds xL = sitp.x[idx]
-    dL = xq - xL  # Use original xq to preserve Dual for AD
+    dL = aq.dL
 
     # SIMD loop over series
     @inbounds @simd for k in axes(output, 1)
@@ -344,6 +341,7 @@ sitp = constant_interp(x, Series(sin.(2π .* x), cos.(2π .* x)))
 function constant_interp(
         x::AbstractVector{Tg},
         s::Series;
+        bc::AbstractBC = NoBC(),
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
         search::AbstractSearchPolicy = AutoSearch()
@@ -352,14 +350,23 @@ function constant_interp(
     Tv = _series_eltype(s)
     Tg_new = _promote_grid_float(Tg, Tv)
     if Tg_new !== Tg
-        return constant_interp(_to_float(x, Tg_new), s; side, extrap, search)
+        return constant_interp(_to_float(x, Tg_new), s; bc, side, extrap, search)
     end
 
     n_pts = length(x)
     Tv_out = _value_type(Tv, Tg)
     y_mat, _ = _build_series_mat(s, n_pts, Tv_out)
-    extrap_p = _promote_extrap(extrap, Tv_out)
 
+    # Periodic path: extend x + y_mat, validate :inclusive endpoints per series,
+    # force WrapExtrap.
+    if _is_periodic_bc(bc)
+        x_ext, y_mat_ext = _prepare_periodic(x, y_mat, bc)
+        _validate_series_endpoints(bc, y_mat_ext)
+        extrap_p = _promote_extrap(WrapExtrap(), Tv_out)
+        return ConstantSeriesInterpolant(x_ext, y_mat_ext, extrap_p, side, search)
+    end
+
+    extrap_p = _promote_extrap(extrap, Tv_out)
     return ConstantSeriesInterpolant(x, y_mat, extrap_p, side, search)
 end
 

--- a/src/constant/nd/constant_nd_interpolant.jl
+++ b/src/constant/nd/constant_nd_interpolant.jl
@@ -49,6 +49,7 @@ itp = constant_interp((x, y), data;
 function constant_interp(
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv_raw, N};
+        bc::Union{AbstractBC, NTuple{N, AbstractBC}} = NoBC(),
         side::Union{AbstractSide, Tuple{Vararg{AbstractSide}}} = NearestSide(),
         extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
         search::Union{AbstractSearchPolicy, NTuple{N, AbstractSearchPolicy}} = AutoSearch()
@@ -58,16 +59,20 @@ function constant_interp(
 
     # Promote grid/data types
     grids_typed, Tg, Tv, _ = _nd_promote_grids(grids, data)
-
-    # Create spacings
-    spacings = _create_spacings_typed(grids_typed)
     data_typed = Tv === Tv_raw ? data : Tv.(data)
 
     # Resolve per-axis configuration
+    bcs = _resolve_bcs_nd(bc, Val(N))
     sides = _resolve_side_nd(side, Val(N))
     searches = _resolve_search_nd(search, Val(N))
 
-    extrap_vals = _resolve_extrap_nd(extrap, nothing, Val(N), Tv)
+    # Extend grids/data for exclusive periodic axes (build-time only).
+    grids_typed, data_typed, _ = _prepare_periodic_nd(grids_typed, data_typed, bcs)
+    spacings = _create_spacings_typed(grids_typed)
+
+    # _resolve_extrap_nd(extrap, bcs, ...) validates periodic/extrap compatibility
+    # and auto-overrides per-axis extrap to WrapExtrap() on periodic axes.
+    extrap_vals = _resolve_extrap_nd(extrap, bcs, Val(N), Tv)
     return ConstantInterpolantND{
         Tg, Tv, N,
         typeof(grids_typed), typeof(spacings), typeof(extrap_vals), typeof(sides), typeof(searches),

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -22,6 +22,7 @@ Evaluates directly from grids + data without constructing a ConstantInterpolantN
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         query::Tuple{Vararg{Real, N}},
+        bcs::NTuple{N, AbstractBC},
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
         side_vals::Tuple{Vararg{AbstractSide, N}},
         searches::NTuple{N, AbstractSearchPolicy},
@@ -32,10 +33,11 @@ Evaluates directly from grids + data without constructing a ConstantInterpolantN
     oob_result = _try_fill_oob(query, grids, extraps_val, EvalValue(), @inbounds first(data))
     oob_result !== nothing && return oob_result
 
-    spacings = _create_spacings_pooled(pool, grids)
-    q_eval = _handle_all_extraps(query, grids, extraps_val)
-    indices, Ls, _ = _search_all_intervals(q_eval, grids, spacings, searches, hints)
-    return _constant_nd_kernel(data, spacings, side_vals, indices, q_eval, Ls)
+    grids_p, data_p, _ = _prepare_periodic_nd_pooled(pool, grids, data, bcs)
+    spacings = _create_spacings_pooled(pool, grids_p)
+    q_eval = _handle_all_extraps(query, grids_p, extraps_val)
+    indices, Ls, _ = _search_all_intervals(q_eval, grids_p, spacings, searches, hints)
+    return _constant_nd_kernel(data_p, spacings, side_vals, indices, q_eval, Ls)
 end
 
 """
@@ -50,6 +52,7 @@ Writes results into `output`. No heap allocation beyond spacings.
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         queries,
+        bcs::NTuple{N, AbstractBC},
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
         side_vals::Tuple{Vararg{AbstractSide, N}},
         policies::NTuple{N, AbstractSearchPolicy},
@@ -60,22 +63,23 @@ Writes results into `output`. No heap allocation beyond spacings.
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
     _validate_nd_domain(grids, queries, extraps_val)
-    spacings = _create_spacings_pooled(pool, grids)
+    grids_p, data_p, _ = _prepare_periodic_nd_pooled(pool, grids, data, bcs)
+    spacings = _create_spacings_pooled(pool, grids_p)
     @inbounds for k in 1:nq
         query_k = _extract_query_point(queries, k, Val(N))
-        oob_val = _try_fill_oob(query_k, grids, extraps_val, EvalValue(), first(data))
+        oob_val = _try_fill_oob(query_k, grids_p, extraps_val, EvalValue(), first(data_p))
         if oob_val !== nothing
             output[k] = oob_val; continue
         end
-        q_eval = _handle_all_extraps(query_k, grids, extraps_val)
-        indices, Ls, _ = _search_all_intervals(q_eval, grids, spacings, policies, hints, mono)
-        output[k] = _constant_nd_kernel(data, spacings, side_vals, indices, q_eval, Ls)
+        q_eval = _handle_all_extraps(query_k, grids_p, extraps_val)
+        indices, Ls, _ = _search_all_intervals(q_eval, grids_p, spacings, policies, hints, mono)
+        output[k] = _constant_nd_kernel(data_p, spacings, side_vals, indices, q_eval, Ls)
     end
     return output
 end
 
 """
-    _constant_interp_nd_oneshot_batch(grids, data, queries, extraps_val, side_vals, searches, hints=nothing)
+    _constant_interp_nd_oneshot_batch(grids, data, queries, bcs, extraps_val, side_vals, searches, hints=nothing)
 
 Allocating wrapper: creates output vector, delegates to in-place batch.
 """
@@ -83,6 +87,7 @@ function _constant_interp_nd_oneshot_batch(
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         queries,
+        bcs::NTuple{N, AbstractBC},
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
         side_vals::Tuple{Vararg{AbstractSide, N}},
         policies::NTuple{N, AbstractSearchPolicy},
@@ -90,7 +95,7 @@ function _constant_interp_nd_oneshot_batch(
         mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
     output = Vector{Tv}(undef, _query_length(queries))
-    return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, extraps_val, side_vals, policies, hints, mono)
+    return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps_val, side_vals, policies, hints, mono)
 end
 
 # ========================================
@@ -102,11 +107,11 @@ end
 
 # Function barrier: forces Julia to runtime-dispatch on the concrete
 # searches tuple type before entering the @with_pool boundary.
-function _constant_nd_batch_dispatch!(output, grids, data, queries, extraps, sides, policies, hints, mono)
-    return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, extraps, sides, policies, hints, mono)
+function _constant_nd_batch_dispatch!(output, grids, data, queries, bcs, extraps, sides, policies, hints, mono)
+    return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps, sides, policies, hints, mono)
 end
-function _constant_nd_batch_dispatch(grids, data, queries, extraps, sides, policies, hints, mono)
-    return _constant_interp_nd_oneshot_batch(grids, data, queries, extraps, sides, policies, hints, mono)
+function _constant_nd_batch_dispatch(grids, data, queries, bcs, extraps, sides, policies, hints, mono)
+    return _constant_interp_nd_oneshot_batch(grids, data, queries, bcs, extraps, sides, policies, hints, mono)
 end
 
 # ========================================
@@ -123,6 +128,7 @@ function constant_interp(
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         query::Tuple{Vararg{Real, N}};
+        bc::Union{AbstractBC, NTuple{N, AbstractBC}} = NoBC(),
         side::Union{AbstractSide, Tuple{Vararg{AbstractSide}}} = NearestSide(),
         extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
         search::Union{AbstractSearchPolicy, NTuple{N, AbstractSearchPolicy}} = AutoSearch(),
@@ -137,12 +143,13 @@ function constant_interp(
     grids_typed, _, _, _ = _nd_promote_grids(grids, data)
     _validate_nd_grids(grids_typed, data)
 
+    bcs = _resolve_bcs_nd(bc, Val(N))
     sides = _resolve_side_nd(side, Val(N))
     searches = _resolve_search_nd(search, Val(N), query)  # NTuple{N,Real} <: Tuple → BinarySearch/axis
 
-    extraps_val = _resolve_extrap_nd(extrap, nothing, Val(N), Tv)
+    extraps_val = _resolve_extrap_nd(extrap, bcs, Val(N), Tv)
     return _constant_interp_nd_oneshot(
-        grids_typed, data, query, extraps_val, sides, searches, hint
+        grids_typed, data, query, bcs, extraps_val, sides, searches, hint
     )::Tv
 end
 
@@ -157,6 +164,7 @@ function constant_interp(
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         queries;
+        bc::Union{AbstractBC, NTuple{N, AbstractBC}} = NoBC(),
         side::Union{AbstractSide, Tuple{Vararg{AbstractSide}}} = NearestSide(),
         extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
         search::Union{AbstractSearchPolicy, NTuple{N, AbstractSearchPolicy}} = AutoSearch(),
@@ -170,13 +178,14 @@ function constant_interp(
     grids_typed, _, _, _ = _nd_promote_grids(grids, data)
     _validate_nd_grids(grids_typed, data)
 
+    bcs = _resolve_bcs_nd(bc, Val(N))
     sides = _resolve_side_nd(side, Val(N))
     policies = _resolve_search_nd(search, Val(N))
     mono = _check_mono_nd(policies, queries)
 
-    extraps_val = _resolve_extrap_nd(extrap, nothing, Val(N), Tv)
+    extraps_val = _resolve_extrap_nd(extrap, bcs, Val(N), Tv)
     return _constant_nd_batch_dispatch(
-        grids_typed, data, queries, extraps_val, sides, policies, hint, mono
+        grids_typed, data, queries, bcs, extraps_val, sides, policies, hint, mono
     )::Vector{Tv}
 end
 
@@ -196,6 +205,7 @@ function constant_interp!(
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         queries;
+        bc::Union{AbstractBC, NTuple{N, AbstractBC}} = NoBC(),
         side::Union{AbstractSide, Tuple{Vararg{AbstractSide}}} = NearestSide(),
         extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
         search::Union{AbstractSearchPolicy, NTuple{N, AbstractSearchPolicy}} = AutoSearch(),
@@ -211,12 +221,13 @@ function constant_interp!(
     grids_typed, _, _, _ = _nd_promote_grids(grids, data)
     _validate_nd_grids(grids_typed, data)
 
+    bcs = _resolve_bcs_nd(bc, Val(N))
     sides = _resolve_side_nd(side, Val(N))
     policies = _resolve_search_nd(search, Val(N))
     mono = _check_mono_nd(policies, queries)
 
-    extraps_val = _resolve_extrap_nd(extrap, nothing, Val(N), Tv)
+    extraps_val = _resolve_extrap_nd(extrap, bcs, Val(N), Tv)
     return _constant_nd_batch_dispatch!(
-        output, grids_typed, data, queries, extraps_val, sides, policies, hint, mono
+        output, grids_typed, data, queries, bcs, extraps_val, sides, policies, hint, mono
     )
 end

--- a/src/core/bc_types.jl
+++ b/src/core/bc_types.jl
@@ -59,10 +59,12 @@ abstract type AbstractBC end
     NoBC <: AbstractBC
 
 Sentinel boundary-condition value meaning "no BC requested; use the method's
-built-in endpoint rule". Used as the default `bc` kwarg for methods that have a
-natural endpoint rule (Constant, Linear, PCHIP, Cardinal, Akima).
+built-in endpoint rule". Currently the default `bc` kwarg for **Constant and
+Linear** interpolation (the only non-cubic methods wired for `bc` in this
+release). PCHIP / Cardinal / Akima will adopt the same default when their
+`bc` kwarg is added (planned next phase).
 
-For these methods, `bc=NoBC()` preserves existing behavior, and
+For supported methods, `bc=NoBC()` preserves existing behavior, and
 `bc=PeriodicBC(...)` engages the periodic build path.
 
 Cubic and Quadratic do not use `NoBC` because their coefficient systems are

--- a/src/core/bc_types.jl
+++ b/src/core/bc_types.jl
@@ -19,6 +19,7 @@
 #
 # Type Hierarchy:
 #   AbstractBC                    # No type parameter
+#   ├── NoBC                      # Sentinel: "use the method's built-in endpoint rule"
 #   ├── PointBC                   # No type parameter (abstract)
 #   │   ├── Deriv1{Tv}            # User-specified first derivative (has Tv)
 #   │   ├── Deriv2{Tv}            # User-specified second derivative (has Tv)
@@ -43,6 +44,7 @@ Type-free design: no type parameter on the abstract type.
 Concrete subtypes with values (Deriv1, Deriv2, Deriv3) carry their own Tv parameter.
 
 # Subtypes
+- `NoBC`: Sentinel meaning "use the method's built-in endpoint rule" - singleton
 - `ZeroCurvBC`: Zero-Curvature BC (zero curvature at both ends) - singleton
 - `ZeroSlopeBC`: Zero-Slope BC (zero slope at both ends) - singleton
 - `PeriodicBC{E,P}`: Periodic boundary condition (inclusive/exclusive endpoint)
@@ -52,6 +54,25 @@ Concrete subtypes with values (Deriv1, Deriv2, Deriv3) carry their own Tv parame
 - `Right{B}`: Endpoint wrapper for BC at right (x[end]) - used by quadratic splines
 """
 abstract type AbstractBC end
+
+"""
+    NoBC <: AbstractBC
+
+Sentinel boundary-condition value meaning "no BC requested; use the method's
+built-in endpoint rule". Used as the default `bc` kwarg for methods that have a
+natural endpoint rule (Constant, Linear, PCHIP, Cardinal, Akima).
+
+For these methods, `bc=NoBC()` preserves existing behavior, and
+`bc=PeriodicBC(...)` engages the periodic build path.
+
+Cubic and Quadratic do not use `NoBC` because their coefficient systems are
+under-determined without a concrete closure condition (they default to
+`CubicFit()` and `Left(QuadraticFit())` respectively).
+
+`_is_periodic_bc(::NoBC)` falls through the `AbstractBC` default and returns
+`false`, so `NoBC` never triggers periodic dispatch.
+"""
+struct NoBC <: AbstractBC end
 
 """
     PointBC <: AbstractBC

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -102,6 +102,85 @@ end
     return nothing
 end
 
+@noinline function _throw_periodic_nd_slice_mismatch(d::Int)
+    throw(
+        ArgumentError(
+            "PeriodicBC(endpoint=:inclusive) on dim $d: first and last slices of " *
+                "`data` along that axis differ beyond tolerance. Either make the " *
+                "endpoint slices match, switch to PeriodicBC(endpoint=:exclusive) " *
+                "if your data does not repeat the first slice, or pass " *
+                "PeriodicBC(check=false) on that axis to skip this validation."
+        )
+    )
+end
+
+# ND per-axis :inclusive slice equality check.
+#
+# Mirrors 1D `_check_periodic_endpoints(y)` but on the first vs last slice along
+# axis `d`. `:exclusive` axes do not need this — extension constructs
+# `data[...,n+1,...] = data[...,1,...]` by construction, so the check is
+# trivially satisfied post-extension.
+#
+# Dispatch mirrors the 1D element-type split (Float / Complex / Integer-Rational /
+# duck). Uses array-level `isapprox` (norm-based) for Float/Complex, element-wise
+# `==` for the fallback. `atol = 8eps(T)` + `rtol = sqrt(eps(T))` matches 1D.
+@inline function _check_periodic_slice_inclusive(data::AbstractArray{T}, d::Int) where {T <: AbstractFloat}
+    n = size(data, d)
+    first_s = selectdim(data, d, 1)
+    last_s = selectdim(data, d, n)
+    isapprox(first_s, last_s; atol = 8 * eps(T), rtol = sqrt(eps(T))) ||
+        _throw_periodic_nd_slice_mismatch(d)
+    return nothing
+end
+
+@inline function _check_periodic_slice_inclusive(data::AbstractArray{Complex{T}}, d::Int) where {T <: AbstractFloat}
+    n = size(data, d)
+    first_s = selectdim(data, d, 1)
+    last_s = selectdim(data, d, n)
+    isapprox(first_s, last_s; atol = 8 * eps(T), rtol = sqrt(eps(T))) ||
+        _throw_periodic_nd_slice_mismatch(d)
+    return nothing
+end
+
+@inline function _check_periodic_slice_inclusive(data::AbstractArray{<:_PromotableValue}, d::Int)
+    n = size(data, d)
+    first_s = selectdim(data, d, 1)
+    last_s = selectdim(data, d, n)
+    isapprox(first_s, last_s) || _throw_periodic_nd_slice_mismatch(d)
+    return nothing
+end
+
+# Fallback: strict element-wise ==
+@inline function _check_periodic_slice_inclusive(data::AbstractArray, d::Int)
+    n = size(data, d)
+    first_s = selectdim(data, d, 1)
+    last_s = selectdim(data, d, n)
+    first_s == last_s || _throw_periodic_nd_slice_mismatch(d)
+    return nothing
+end
+
+# Per-axis inclusive check with compile-time `d` and runtime `check` flag.
+# No-op unless axis `d` is PeriodicBC{:inclusive} AND `check=true`.
+@inline function _check_periodic_axis_nd(data, bcs::NTuple{N, AbstractBC}, ::Val{d}) where {N, d}
+    @inbounds bc = bcs[d]
+    bc isa PeriodicBC{:inclusive} || return nothing
+    periodic_check(bc) || return nothing
+    _check_periodic_slice_inclusive(data, d)
+    return nothing
+end
+
+# Compile-time unroll over axes. Emits N straight-line calls so each `bcs[d]`
+# indexes into the heterogeneous tuple at a compile-time-known position,
+# avoiding runtime Union boxing (same pattern as `_extend_all_slices!`).
+@generated function _validate_periodic_slices_nd(
+        data::AbstractArray{Tv, N},
+        bcs::NTuple{N, AbstractBC},
+        ::Val{N}
+    ) where {Tv, N}
+    calls = [:(_check_periodic_axis_nd(data, bcs, Val($d))) for d in 1:N]
+    return Expr(:block, calls..., :(return nothing))
+end
+
 @noinline function _throw_periodic_endpoint_error(y1, yn)
     throw(
         ArgumentError(
@@ -175,7 +254,11 @@ function _resolve_exclusive_period(x, bc::PeriodicBC)
         # User provided period — cross-validate against Range inference.
         # Compare in grid precision (Tg) to avoid mixed-type ≈ using Float32's
         # generous rtol (~3e-4) when a Float32 period is given on a Float64 grid.
-        Tg = eltype(x)
+        # Duck-safe promotion: Integer/Rational grids lack a meaningful `eps`,
+        # so lift to `float(Tg)` for the tolerance math. Duck grids (Dual,
+        # Measurement, ...) keep their own eltype and use their own `eps`.
+        Tg_raw = eltype(x)
+        Tg = Tg_raw <: _PromotableValue ? float(Tg_raw) : Tg_raw
         if inferred !== nothing && !isapprox(Tg(bc.period), Tg(inferred); rtol = sqrt(eps(Tg)))
             x0 = first(x); x1 = x0 + inferred
             throw(
@@ -218,7 +301,15 @@ Preserves Range type for Range inputs (step consistency guaranteed by `_resolve_
 """
 function _extend_exclusive(x::AbstractVector, y::AbstractVector, bc::PeriodicBC)
     period = _resolve_exclusive_period(x, bc)
-    Tg = eltype(x)
+    # Duck-safe grid promotion. `_PromotableValue` (Integer / AbstractFloat /
+    # Rational / Complex) is promoted via `float(...)` so Int-typed Ranges can
+    # form a valid `_CachedRange{Float}` (otherwise `inv(step::Int)::Float64`
+    # cannot be stored in the `Int`-typed `inv_h` field → InexactError).
+    # Duck grids (Dual, Measurement, SVector, ...) fall through with their
+    # original type; they handle their own `inv`/arithmetic within their type.
+    # Mirrors `_promote_grid_float` and `_check_periodic_endpoints` dispatch.
+    Tg_raw = eltype(x)
+    Tg = Tg_raw <: _PromotableValue ? float(Tg_raw) : Tg_raw
     x_end = first(x) + Tg(period)
 
     # Validate: virtual endpoint must be strictly after last grid point
@@ -244,7 +335,9 @@ end
 # Matrix overload for CubicSeriesInterpolant
 function _extend_exclusive(x::AbstractVector, y_mat::AbstractMatrix, bc::PeriodicBC)
     period = _resolve_exclusive_period(x, bc)
-    Tg = eltype(x)
+    # Duck-safe grid promotion — see the Vector overload above for rationale.
+    Tg_raw = eltype(x)
+    Tg = Tg_raw <: _PromotableValue ? float(Tg_raw) : Tg_raw
     x_end = first(x) + Tg(period)
 
     last(x) < x_end || throw(
@@ -321,9 +414,15 @@ Akima/Quadratic oneshot paths. Cubic oneshot uses this via
         extrap::AbstractExtrap
     ) where {Tg, Tv}
     _is_periodic_bc(bc) || return x, y, extrap
+    # Duck-safe extension buffer type: promote Integer / Complex{Integer} grids
+    # to float so the extended pool buffer and `_CachedRange` `inv_h` field can
+    # hold `inv(step)`. Duck grids (Dual, Measurement, ...) keep their type so
+    # AD / uncertainty chains survive. Tv (value type) is never promoted here —
+    # user y-vector semantics are preserved.
+    Tg_ext = Tg <: _PromotableValue ? float(Tg) : Tg
     if bc isa PeriodicBC{:exclusive}
         period = _resolve_exclusive_period(x, bc)
-        x_end = first(x) + Tg(period)
+        x_end = first(x) + Tg_ext(period)
         last(x) < x_end || throw(
             ArgumentError(
                 "period=$period places virtual endpoint at $x_end, " *
@@ -332,9 +431,9 @@ Akima/Quadratic oneshot paths. Cubic oneshot uses this via
         )
         n = length(x)
         if x isa AbstractRange
-            x_p = _to_float_adding_endpoint(x, Tg)
+            x_p = _to_float_adding_endpoint(x, Tg_ext)
         else
-            x_p = acquire!(pool, Tg, n + 1)
+            x_p = acquire!(pool, Tg_ext, n + 1)
             @inbounds copyto!(x_p, 1, x, 1, n)
             @inbounds x_p[n + 1] = x_end
         end
@@ -387,6 +486,12 @@ function _prepare_periodic_nd(
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
     ) where {Tg, Tv, N}
+    # Validate :inclusive axes: for each periodic axis with endpoint=:inclusive,
+    # the first and last slices of `data` along that axis must match within
+    # tolerance. `:exclusive` axes do not need this — extension constructs the
+    # matching slice by definition.
+    _validate_periodic_slices_nd(data, bcs, Val(N))
+
     # Fast path: no exclusive axes
     has_exclusive = false
     for d in 1:N
@@ -480,6 +585,9 @@ via `acquire!`, so they must NOT escape the enclosing `@with_pool` scope.
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
     ) where {Tg, Tv, N}
+    # See `_prepare_periodic_nd` for validation semantics — mirrored here.
+    _validate_periodic_slices_nd(data, bcs, Val(N))
+
     # Fast path: no exclusive axes
     has_exclusive = false
     for d in 1:N

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -394,46 +394,40 @@ via `acquire!`, so they must NOT escape the enclosing `@with_pool` scope.
     end
     has_exclusive || return (grids, data, bcs)
 
-    # Build extended grids tuple directly (no heap Vector intermediary)
-    # Grid extensions are independent per dimension: grids[d] is unmodified input
-    grids_out = ntuple(Val(N)) do d
-        bc_d = bcs[d]
-        bc_d isa PeriodicBC{:exclusive} || return grids[d]
+    # Build (extended_grid, resolved_bc) pair per axis.
+    #
+    # CRITICAL: use `map(f, grids, bcs)` rather than `ntuple(Val(N)) do d ... end`.
+    # `map` dispatches per-element with concrete (grid, bc) types → each f call
+    # compiles to a specialization with concrete return type. `ntuple do d` with
+    # runtime indexing `bcs[d]` / `grids[d]` over a heterogeneous tuple leaves the
+    # return type as Union{Vector{Tg}, _CachedRange{Tg}, ...} → every tuple slot
+    # becomes a heap-boxed Ref, causing ~2 KB/query allocation on mixed grids.
+    # See MEMORY.md "ND Constructor Inferrability Pattern".
+    processed = map(grids, bcs) do grid_d, bc_d
+        bc_d isa PeriodicBC{:exclusive} || return (grid_d, bc_d)
 
-        grid_d = grids[d]
         period = _resolve_exclusive_period(grid_d, bc_d)
         x_end = first(grid_d) + Tg(period)
-
-        # Validate: virtual endpoint must be strictly after last grid point
         last(grid_d) < x_end || throw(
             ArgumentError(
-                "PeriodicBC(endpoint=:exclusive) on dim $d: period=$period places " *
+                "PeriodicBC(endpoint=:exclusive): period=$period places " *
                     "virtual endpoint at $x_end, not after last grid point x[end]=$(last(grid_d))"
             )
         )
 
-        # Extend grid: Range → _CachedRange (O(1)), Vector → pool
-        if grid_d isa AbstractRange
-            return _to_float_adding_endpoint(grid_d, Tg)
+        grid_ext = if grid_d isa AbstractRange
+            _to_float_adding_endpoint(grid_d, Tg)
         else
             n = length(grid_d)
             g_ext = acquire!(pool, Tg, n + 1)
             @inbounds copyto!(g_ext, 1, grid_d, 1, n)
             @inbounds g_ext[n + 1] = x_end
-            return g_ext
+            g_ext
         end
+        return (grid_ext, _with_resolved_period(bc_d, period))
     end
-
-    # Build extended BCs tuple
-    bcs_out = ntuple(Val(N)) do d
-        bc_d = bcs[d]
-        if bc_d isa PeriodicBC{:exclusive}
-            period = _resolve_exclusive_period(grids[d], bc_d)
-            return _with_resolved_period(bc_d, period)
-        else
-            return bc_d
-        end
-    end
+    grids_out = map(first, processed)
+    bcs_out = map(last, processed)
 
     # Extend data: pool-allocate final shape, then fill slices
     final_sizes = ntuple(Val(N)) do d
@@ -445,23 +439,50 @@ via `acquire!`, so they must NOT escape the enclosing `@with_pool` scope.
     orig_inds = ntuple(d -> 1:size(data, d), Val(N))
     copyto!(view(data_out, orig_inds...), data)
 
-    # Fill extended slices dim-by-dim (earlier extensions are visible to later dims)
-    for d in 1:N
-        bcs[d] isa PeriodicBC{:exclusive} || continue
-        nd = size(data, d)  # original size in this dim
-        cur_ranges = ntuple(Val(N)) do i
-            if i == d
-                1:1
-            elseif i < d && bcs[i] isa PeriodicBC{:exclusive}
-                1:(size(data, i) + 1)
-            else
-                1:size(data, i)
-            end
-        end
-        src_inds = ntuple(i -> i == d ? (1:1) : cur_ranges[i], Val(N))
-        dst_inds = ntuple(i -> i == d ? ((nd + 1):(nd + 1)) : cur_ranges[i], Val(N))
-        copyto!(view(data_out, dst_inds...), view(data_out, src_inds...))
-    end
+    # Fill extended slices dim-by-dim (earlier extensions are visible to later dims).
+    # `@generated` unrolls the N calls at compile time, so each `bcs[d]` index is
+    # literal and resolves to the concrete per-axis BC type — no runtime Union box.
+    # A naive `for d in 1:N` loop with runtime `d` leaked 48 bytes/query on mixed
+    # grids; `ntuple(Val(N)) do d ... end` returning NTuple{N,Nothing} allocated 64.
+    _extend_all_slices!(data_out, data, bcs, Val(N))
 
     return (grids_out, data_out, bcs_out)
+end
+
+# Per-axis slice extension with compile-time dimension index `d`.
+@inline function _extend_slice_along!(
+        data_out::AbstractArray{Tv, N},
+        data::AbstractArray{Tv, N},
+        bcs::NTuple{N, AbstractBC},
+        ::Val{d},
+        ::Val{N}
+    ) where {Tv, N, d}
+    bcs[d] isa PeriodicBC{:exclusive} || return nothing
+    nd = size(data, d)
+    cur_ranges = ntuple(Val(N)) do i
+        if i == d
+            1:1
+        elseif i < d && bcs[i] isa PeriodicBC{:exclusive}
+            1:(size(data, i) + 1)
+        else
+            1:size(data, i)
+        end
+    end
+    src_inds = ntuple(i -> i == d ? (1:1) : cur_ranges[i], Val(N))
+    dst_inds = ntuple(i -> i == d ? ((nd + 1):(nd + 1)) : cur_ranges[i], Val(N))
+    copyto!(view(data_out, dst_inds...), view(data_out, src_inds...))
+    return nothing
+end
+
+# Compile-time unroll of the per-axis extension loop. Emits N straight-line calls
+# to `_extend_slice_along!` with literal `Val(d)` — no runtime loop, no tuple of
+# Nothing returns, no closure capturing a runtime index.
+@generated function _extend_all_slices!(
+        data_out::AbstractArray{Tv, N},
+        data::AbstractArray{Tv, N},
+        bcs::NTuple{N, AbstractBC},
+        ::Val{N}
+    ) where {Tv, N}
+    calls = [:(_extend_slice_along!(data_out, data, bcs, Val($d), Val(N))) for d in 1:N]
+    return Expr(:block, calls..., :(return nothing))
 end

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -503,6 +503,25 @@ letting user-facing oneshot entry points use a single, non-misleading call.
 # ND Exclusive Endpoint Extension
 # ========================================
 
+# Compile-time predicates on the `bcs` tuple. `@generated` inspects the
+# concrete tuple type at specialization time and collapses to `true`/`false`,
+# so non-periodic callers (CubicFit, QuadraticFit, NoBC, ...) pay ZERO runtime
+# cost — no loop, no per-axis check, no validation. Crucial for the ND oneshot
+# hot path where `_prepare_periodic_nd_pooled` is called per query.
+@generated function _has_any_periodic_bc(bcs::NTuple{N, AbstractBC}, ::Val{N}) where {N}
+    for d in 1:N
+        fieldtype(bcs, d) <: PeriodicBC && return :(true)
+    end
+    return :(false)
+end
+
+@generated function _has_any_exclusive_bc(bcs::NTuple{N, AbstractBC}, ::Val{N}) where {N}
+    for d in 1:N
+        fieldtype(bcs, d) <: PeriodicBC{:exclusive} && return :(true)
+    end
+    return :(false)
+end
+
 """
     _prepare_periodic_nd(grids, data, bcs) -> (grids_ext, data_ext, bcs_resolved)
 
@@ -524,21 +543,20 @@ function _prepare_periodic_nd(
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
     ) where {Tg, Tv, N}
+    # Ultra-fast path: if no axis is periodic at all, skip everything.
+    # `@generated` predicate collapses to a literal `true`/`false` at compile
+    # time, so common non-periodic ND calls (CubicFit, NoBC, etc.) pay zero
+    # cost — no validation, no extension, no loop.
+    _has_any_periodic_bc(bcs, Val(N)) || return (grids, data, bcs)
+
     # Validate :inclusive axes: for each periodic axis with endpoint=:inclusive,
     # the first and last slices of `data` along that axis must match within
     # tolerance. `:exclusive` axes do not need this — extension constructs the
     # matching slice by definition.
     _validate_periodic_slices_nd(data, bcs, Val(N))
 
-    # Fast path: no exclusive axes
-    has_exclusive = false
-    for d in 1:N
-        if bcs[d] isa PeriodicBC{:exclusive}
-            has_exclusive = true
-            break
-        end
-    end
-    has_exclusive || return (grids, data, bcs)
+    # Fast path: no exclusive axes (but some inclusive ones — validation done above)
+    _has_any_exclusive_bc(bcs, Val(N)) || return (grids, data, bcs)
 
     # Per-axis grid extension + BC resolution via map (preserves concrete types per-element,
     # unlike Vector{AbstractVector} intermediary which erases concrete grid types)
@@ -623,18 +641,10 @@ via `acquire!`, so they must NOT escape the enclosing `@with_pool` scope.
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
     ) where {Tg, Tv, N}
-    # See `_prepare_periodic_nd` for validation semantics — mirrored here.
+    # Ultra-fast path — see `_prepare_periodic_nd` for rationale.
+    _has_any_periodic_bc(bcs, Val(N)) || return (grids, data, bcs)
     _validate_periodic_slices_nd(data, bcs, Val(N))
-
-    # Fast path: no exclusive axes
-    has_exclusive = false
-    for d in 1:N
-        if bcs[d] isa PeriodicBC{:exclusive}
-            has_exclusive = true
-            break
-        end
-    end
-    has_exclusive || return (grids, data, bcs)
+    _has_any_exclusive_bc(bcs, Val(N)) || return (grids, data, bcs)
 
     # Build (extended_grid, resolved_bc) pair per axis.
     #

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -125,11 +125,20 @@ end
 # duck). Uses array-level `isapprox` (norm-based) for Float/Complex, element-wise
 # `==` for the fallback. `atol = 8eps(T)` + `rtol = sqrt(eps(T))` matches 1D.
 @inline function _check_periodic_slice_inclusive(data::AbstractArray{T}, d::Int) where {T <: AbstractFloat}
+    # Element-wise (NOT norm-based) comparison matching the 1D scalar semantics.
+    # Array-`isapprox` with the same atol/rtol accumulates near-zero noise across
+    # slice elements and would reject legitimate periodic data (e.g. `sin(0)` vs
+    # `sin(2π)` across a fine y/z mesh, where per-element noise is ~eps but the
+    # slice norm scales with √N).
     n = size(data, d)
     first_s = selectdim(data, d, 1)
     last_s = selectdim(data, d, n)
-    isapprox(first_s, last_s; atol = 8 * eps(T), rtol = sqrt(eps(T))) ||
-        _throw_periodic_nd_slice_mismatch(d)
+    atol = 8 * eps(T)
+    rtol = sqrt(eps(T))
+    @inbounds for I in eachindex(first_s, last_s)
+        isapprox(first_s[I], last_s[I]; atol = atol, rtol = rtol) ||
+            _throw_periodic_nd_slice_mismatch(d)
+    end
     return nothing
 end
 
@@ -137,8 +146,12 @@ end
     n = size(data, d)
     first_s = selectdim(data, d, 1)
     last_s = selectdim(data, d, n)
-    isapprox(first_s, last_s; atol = 8 * eps(T), rtol = sqrt(eps(T))) ||
-        _throw_periodic_nd_slice_mismatch(d)
+    atol = 8 * eps(T)
+    rtol = sqrt(eps(T))
+    @inbounds for I in eachindex(first_s, last_s)
+        isapprox(first_s[I], last_s[I]; atol = atol, rtol = rtol) ||
+            _throw_periodic_nd_slice_mismatch(d)
+    end
     return nothing
 end
 
@@ -146,7 +159,9 @@ end
     n = size(data, d)
     first_s = selectdim(data, d, 1)
     last_s = selectdim(data, d, n)
-    isapprox(first_s, last_s) || _throw_periodic_nd_slice_mismatch(d)
+    @inbounds for I in eachindex(first_s, last_s)
+        isapprox(first_s[I], last_s[I]) || _throw_periodic_nd_slice_mismatch(d)
+    end
     return nothing
 end
 
@@ -202,6 +217,26 @@ end
                 "PeriodicBC(endpoint=:exclusive) if your data does not repeat the first point."
         )
     )
+end
+
+"""
+    _validate_series_endpoints(bc::PeriodicBC, y_mat::AbstractMatrix) -> Nothing
+
+Series analog of `_check_periodic_endpoints`. For `:inclusive` BC with
+`check=true`, validate that each column's first and last elements match
+within the usual tolerance (dispatch-driven, reuses 1D helper on column
+views). `:exclusive` is a no-op here because the extension phase writes
+`y_mat[end, :] = y_mat[1, :]` by construction.
+
+Used by Linear / Constant Series persistent + oneshot paths.
+"""
+@inline function _validate_series_endpoints(bc::PeriodicBC, y_mat::AbstractMatrix)
+    periodic_check(bc) || return nothing
+    bc isa PeriodicBC{:inclusive} || return nothing
+    @inbounds for k in axes(y_mat, 2)
+        _check_periodic_endpoints(bc, view(y_mat, :, k))
+    end
+    return nothing
 end
 
 @noinline function _throw_periodic_nd_error(d, v_first, v_last)

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -267,30 +267,60 @@ end
 _extend_values(y::AbstractVector) = vcat(y, first(y))
 
 """
-    _extend_exclusive_pooled!(pool, x, y, bc::PeriodicBC) -> (x_p, y_p)
+    _periodic_extend_1d(x, y, bc, extrap) -> (x_eff, y_eff, extrap_eff)
 
-Pool-based sibling of `_extend_exclusive`. Returns extended grid/value pair for
-the 1D one-shot hot path:
-- `:inclusive`: passthrough `(x, y)` (caller still holds the originals).
-- `:exclusive`: extend by one endpoint at `x[1] + period`, with value `y[1]`.
-  - Grid: `Range → _CachedRange` via `_to_float_adding_endpoint` (no heap);
-          `Vector → acquire!(pool, ...)` (zero-alloc after warmup).
-  - Values: always pool-acquired (even for Range grids, since `y` may be Vector).
+Non-pool 1D periodic dispatch for the **persistent-interpolant path**.
+Returns a single `(grid, values, extrap)` triple whether or not `bc` is
+periodic — callers invoke this once and feed the result into their normal
+build flow without branching on `_is_periodic_bc`:
 
-Calls `_check_periodic_endpoints(bc, y_p)` before returning — for `:inclusive`
-this validates `y[1] ≈ y[end]`; for `:exclusive` it is trivially satisfied by
-construction.
+- Non-periodic `bc` → `(x, y, extrap)` passthrough.
+- `PeriodicBC{:inclusive}` → `(x, y, WrapExtrap())` (validates `y[1] ≈ y[end]`).
+- `PeriodicBC{:exclusive}` → `(x_ext, y_ext, WrapExtrap())` where the grid/values
+  are extended by one virtual endpoint via `_extend_exclusive` (heap copy
+  consistent with existing non-periodic persistent-path copy semantics).
 
-Shared by `linear_interp` / `constant_interp` / `cubic_interp` one-shot paths;
-all three previously inlined a near-identical copy of this extension block.
-Lifetime of returned buffers is tied to the caller's `@with_pool` scope.
+Intended consumers: Linear, Constant, and (future Phase 2/3) PCHIP/Cardinal/
+Akima/Quadratic persistent interpolant constructors. Cubic stays on its
+dedicated `_build_interpolant_periodic` path because its solver branches on
+periodicity, not just on the grid representation.
 """
-@inline function _extend_exclusive_pooled!(
+@inline function _periodic_extend_1d(
+        x::AbstractVector,
+        y::AbstractVector,
+        bc::AbstractBC,
+        extrap::AbstractExtrap
+    )
+    _is_periodic_bc(bc) || return x, y, extrap
+    x_ext, y_ext = _prepare_periodic(x, y, bc)
+    _check_periodic_endpoints(bc, y_ext)
+    return x_ext, y_ext, WrapExtrap()
+end
+
+"""
+    _periodic_extend_1d_pooled!(pool, x, y, bc, extrap) -> (x_eff, y_eff, extrap_eff)
+
+Pool-based sibling of `_periodic_extend_1d` for the **one-shot hot path**.
+Same contract as the non-pool variant, but the `:exclusive` extension uses
+`acquire!(pool, …)` for the extended buffers (zero-alloc after warmup, caller's
+`@with_pool` scope owns the lifetime).
+
+Range grids are extended to `_CachedRange` via `_to_float_adding_endpoint`
+(heap-free); Vector grids go through the pool. Value buffers are always
+pool-acquired when extending.
+
+Intended consumers: Linear, Constant, and (future Phase 2/3) PCHIP/Cardinal/
+Akima/Quadratic oneshot paths. Cubic oneshot uses this via
+`_cubic_periodic_solve!`, which wraps the extension + tridiagonal solve.
+"""
+@inline function _periodic_extend_1d_pooled!(
         pool::AbstractArrayPool,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        bc::PeriodicBC
+        bc::AbstractBC,
+        extrap::AbstractExtrap
     ) where {Tg, Tv}
+    _is_periodic_bc(bc) || return x, y, extrap
     if bc isa PeriodicBC{:exclusive}
         period = _resolve_exclusive_period(x, bc)
         x_end = first(x) + Tg(period)
@@ -301,8 +331,6 @@ Lifetime of returned buffers is tied to the caller's `@with_pool` scope.
             )
         )
         n = length(x)
-        # _resolve_exclusive_period guarantees period = step(x)*length(x) for Range,
-        # so Range → _CachedRange extension is always valid and heap-free.
         if x isa AbstractRange
             x_p = _to_float_adding_endpoint(x, Tg)
         else
@@ -317,8 +345,22 @@ Lifetime of returned buffers is tied to the caller's `@with_pool` scope.
         x_p, y_p = x, y
     end
     _check_periodic_endpoints(bc, y_p)
-    return x_p, y_p
+    return x_p, y_p, WrapExtrap()
 end
+
+"""
+    _prepare_1d_oneshot!(pool, x, y, bc, extrap) -> (x_eff, y_eff, extrap_eff)
+
+Thin oneshot-API convenience that fuses `_prepare_grid(x)` with
+`_periodic_extend_1d_pooled!(pool, …, bc, extrap)`. Call once per 1D oneshot
+entry point; the return triple feeds directly into searcher + eval kernel.
+
+Separating this from `_periodic_extend_1d_pooled!` keeps the latter's name
+semantically accurate — it really only does work on periodic `bc` — while
+letting user-facing oneshot entry points use a single, non-misleading call.
+"""
+@inline _prepare_1d_oneshot!(pool, x, y, bc, extrap) =
+    _periodic_extend_1d_pooled!(pool, _prepare_grid(x), y, bc, extrap)
 
 # ========================================
 # ND Exclusive Endpoint Extension

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -386,7 +386,9 @@ periodicity, not just on the grid representation.
     )
     _is_periodic_bc(bc) || return x, y, extrap
     x_ext, y_ext = _prepare_periodic(x, y, bc)
-    _check_periodic_endpoints(bc, y_ext)
+    # Endpoint validation is meaningful only for `:inclusive` — `:exclusive` sets
+    # `y_ext[end] = y_ext[1]` by construction so the check is trivially true.
+    bc isa PeriodicBC{:inclusive} && _check_periodic_endpoints(bc, y_ext)
     return x_ext, y_ext, WrapExtrap()
 end
 
@@ -443,7 +445,9 @@ Akima/Quadratic oneshot paths. Cubic oneshot uses this via
     else
         x_p, y_p = x, y
     end
-    _check_periodic_endpoints(bc, y_p)
+    # `:exclusive` path constructs `y_p[end] = y_p[1]` by extension, so the check
+    # is trivially satisfied. Run validation only for `:inclusive`.
+    bc isa PeriodicBC{:inclusive} && _check_periodic_endpoints(bc, y_p)
     return x_p, y_p, WrapExtrap()
 end
 

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -124,21 +124,23 @@ end
 # Dispatch mirrors the 1D element-type split (Float / Complex / Integer-Rational /
 # duck). Uses array-level `isapprox` (norm-based) for Float/Complex, element-wise
 # `==` for the fallback. `atol = 8eps(T)` + `rtol = sqrt(eps(T))` matches 1D.
+# Element-wise (NOT norm-based) comparison matching 1D scalar semantics.
+# Array-`isapprox` accumulates near-zero noise across slice elements (e.g.
+# `sin(0)` vs `sin(2π)` on a fine y/z mesh: per-element noise ~eps, slice norm
+# ~√N·eps) and would reject legitimate periodic data.
+#
+# Using `all(splat, zip(...))` is stack-only and short-circuits on the first
+# mismatch. A broadcasted `isapprox.(a, b; atol, rtol)` would allocate a
+# BitArray and evaluate every element — strictly worse.
+
 @inline function _check_periodic_slice_inclusive(data::AbstractArray{T}, d::Int) where {T <: AbstractFloat}
-    # Element-wise (NOT norm-based) comparison matching the 1D scalar semantics.
-    # Array-`isapprox` with the same atol/rtol accumulates near-zero noise across
-    # slice elements and would reject legitimate periodic data (e.g. `sin(0)` vs
-    # `sin(2π)` across a fine y/z mesh, where per-element noise is ~eps but the
-    # slice norm scales with √N).
     n = size(data, d)
     first_s = selectdim(data, d, 1)
     last_s = selectdim(data, d, n)
     atol = 8 * eps(T)
     rtol = sqrt(eps(T))
-    @inbounds for I in eachindex(first_s, last_s)
-        isapprox(first_s[I], last_s[I]; atol = atol, rtol = rtol) ||
-            _throw_periodic_nd_slice_mismatch(d)
-    end
+    all(((a, b),) -> isapprox(a, b; atol = atol, rtol = rtol), zip(first_s, last_s)) ||
+        _throw_periodic_nd_slice_mismatch(d)
     return nothing
 end
 
@@ -148,10 +150,8 @@ end
     last_s = selectdim(data, d, n)
     atol = 8 * eps(T)
     rtol = sqrt(eps(T))
-    @inbounds for I in eachindex(first_s, last_s)
-        isapprox(first_s[I], last_s[I]; atol = atol, rtol = rtol) ||
-            _throw_periodic_nd_slice_mismatch(d)
-    end
+    all(((a, b),) -> isapprox(a, b; atol = atol, rtol = rtol), zip(first_s, last_s)) ||
+        _throw_periodic_nd_slice_mismatch(d)
     return nothing
 end
 
@@ -159,9 +159,8 @@ end
     n = size(data, d)
     first_s = selectdim(data, d, 1)
     last_s = selectdim(data, d, n)
-    @inbounds for I in eachindex(first_s, last_s)
-        isapprox(first_s[I], last_s[I]) || _throw_periodic_nd_slice_mismatch(d)
-    end
+    all(((a, b),) -> isapprox(a, b), zip(first_s, last_s)) ||
+        _throw_periodic_nd_slice_mismatch(d)
     return nothing
 end
 

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -266,6 +266,60 @@ end
 # Value extension: append first element
 _extend_values(y::AbstractVector) = vcat(y, first(y))
 
+"""
+    _extend_exclusive_pooled!(pool, x, y, bc::PeriodicBC) -> (x_p, y_p)
+
+Pool-based sibling of `_extend_exclusive`. Returns extended grid/value pair for
+the 1D one-shot hot path:
+- `:inclusive`: passthrough `(x, y)` (caller still holds the originals).
+- `:exclusive`: extend by one endpoint at `x[1] + period`, with value `y[1]`.
+  - Grid: `Range → _CachedRange` via `_to_float_adding_endpoint` (no heap);
+          `Vector → acquire!(pool, ...)` (zero-alloc after warmup).
+  - Values: always pool-acquired (even for Range grids, since `y` may be Vector).
+
+Calls `_check_periodic_endpoints(bc, y_p)` before returning — for `:inclusive`
+this validates `y[1] ≈ y[end]`; for `:exclusive` it is trivially satisfied by
+construction.
+
+Shared by `linear_interp` / `constant_interp` / `cubic_interp` one-shot paths;
+all three previously inlined a near-identical copy of this extension block.
+Lifetime of returned buffers is tied to the caller's `@with_pool` scope.
+"""
+@inline function _extend_exclusive_pooled!(
+        pool::AbstractArrayPool,
+        x::AbstractVector{Tg},
+        y::AbstractVector{Tv},
+        bc::PeriodicBC
+    ) where {Tg, Tv}
+    if bc isa PeriodicBC{:exclusive}
+        period = _resolve_exclusive_period(x, bc)
+        x_end = first(x) + Tg(period)
+        last(x) < x_end || throw(
+            ArgumentError(
+                "period=$period places virtual endpoint at $x_end, " *
+                    "not after last grid point x[end]=$(last(x))"
+            )
+        )
+        n = length(x)
+        # _resolve_exclusive_period guarantees period = step(x)*length(x) for Range,
+        # so Range → _CachedRange extension is always valid and heap-free.
+        if x isa AbstractRange
+            x_p = _to_float_adding_endpoint(x, Tg)
+        else
+            x_p = acquire!(pool, Tg, n + 1)
+            @inbounds copyto!(x_p, 1, x, 1, n)
+            @inbounds x_p[n + 1] = x_end
+        end
+        y_p = acquire!(pool, Tv, n + 1)
+        @inbounds copyto!(y_p, 1, y, 1, n)
+        @inbounds y_p[n + 1] = y[1]
+    else
+        x_p, y_p = x, y
+    end
+    _check_periodic_endpoints(bc, y_p)
+    return x_p, y_p
+end
+
 # ========================================
 # ND Exclusive Endpoint Extension
 # ========================================
@@ -403,14 +457,18 @@ via `acquire!`, so they must NOT escape the enclosing `@with_pool` scope.
     # return type as Union{Vector{Tg}, _CachedRange{Tg}, ...} → every tuple slot
     # becomes a heap-boxed Ref, causing ~2 KB/query allocation on mixed grids.
     # See MEMORY.md "ND Constructor Inferrability Pattern".
-    processed = map(grids, bcs) do grid_d, bc_d
+    # 3-arg `map` with `ntuple(identity, Val(N))` threads the axis index `d` into
+    # the closure so error messages can name the failing axis, while still keeping
+    # per-element concrete-type dispatch (no runtime Union boxing). Matches the
+    # pattern used by the non-pooled sibling `_prepare_periodic_nd`.
+    processed = map(ntuple(identity, Val(N)), grids, bcs) do d, grid_d, bc_d
         bc_d isa PeriodicBC{:exclusive} || return (grid_d, bc_d)
 
         period = _resolve_exclusive_period(grid_d, bc_d)
         x_end = first(grid_d) + Tg(period)
         last(grid_d) < x_end || throw(
             ArgumentError(
-                "PeriodicBC(endpoint=:exclusive): period=$period places " *
+                "PeriodicBC(endpoint=:exclusive) on dim $d: period=$period places " *
                     "virtual endpoint at $x_end, not after last grid point x[end]=$(last(grid_d))"
             )
         )

--- a/src/cubic/cubic_oneshot.jl
+++ b/src/cubic/cubic_oneshot.jl
@@ -140,36 +140,10 @@ manages their lifetime. Follows the `_create_spacing_pooled(pool, ...)` pattern.
     @assert length(x) == length(y) "x and y must have the same length"
 
     # ── Extend exclusive → inclusive (pool-based, zero-alloc after warmup) ──
-    if bc isa PeriodicBC{:exclusive}
-        period = _resolve_exclusive_period(x, bc)
-        x_end = first(x) + Tg(period)
-        last(x) < x_end || throw(
-            ArgumentError(
-                "period=$period places virtual endpoint at $x_end, " *
-                    "not after last grid point x[end]=$(last(x))"
-            )
-        )
-
-        n = length(x)
-        # Grid: Range → direct construction (type-stable, O(1)), Vector → pool
-        # Note: _resolve_exclusive_period guarantees period = step(x) * length(x) for Range,
-        # so x_end == last(x) + step(x) and direct Range extension is always valid.
-        if x isa AbstractRange
-            x_p = _to_float_adding_endpoint(x, Tg)
-        else
-            x_p = acquire!(pool, Tg, n + 1)
-            @inbounds copyto!(x_p, 1, x, 1, n)
-            @inbounds x_p[n + 1] = x_end
-        end
-        y_p = acquire!(pool, Tv, n + 1)
-        @inbounds copyto!(y_p, 1, y, 1, n)
-        @inbounds y_p[n + 1] = y[1]
-    else
-        x_p, y_p = x, y
-    end
+    # Shared helper also calls _check_periodic_endpoints on y_p.
+    x_p, y_p = _extend_exclusive_pooled!(pool, x, y, bc)
 
     # ── Solve periodic tridiagonal system ──
-    _check_periodic_endpoints(bc, y_p)
     cache = _get_cubic_cache(x_p, PeriodicBC(), _effective_autocache(autocache, Tg))
     Tz = _output_eltype(Tv, eltype(cache.x))
     z = acquire!(pool, Tz, length(y_p))

--- a/src/cubic/cubic_oneshot.jl
+++ b/src/cubic/cubic_oneshot.jl
@@ -140,8 +140,10 @@ manages their lifetime. Follows the `_create_spacing_pooled(pool, ...)` pattern.
     @assert length(x) == length(y) "x and y must have the same length"
 
     # ── Extend exclusive → inclusive (pool-based, zero-alloc after warmup) ──
-    # Shared helper also calls _check_periodic_endpoints on y_p.
-    x_p, y_p = _extend_exclusive_pooled!(pool, x, y, bc)
+    # Shared helper also calls _check_periodic_endpoints on y_p. `extrap` slot is
+    # vestigial for cubic (we always return WrapExtrap here), so pass WrapExtrap()
+    # and ignore the returned extrap.
+    x_p, y_p, _ = _periodic_extend_1d_pooled!(pool, x, y, bc, WrapExtrap())
 
     # ── Solve periodic tridiagonal system ──
     cache = _get_cubic_cache(x_p, PeriodicBC(), _effective_autocache(autocache, Tg))

--- a/src/linear/linear_interpolant.jl
+++ b/src/linear/linear_interpolant.jl
@@ -137,14 +137,9 @@ function linear_interp end
         search::AbstractSearchPolicy = AutoSearch()
     ) where {TX, TY}
     Tg = _promote_grid_float(TX, TY)
-    if _is_periodic_bc(bc)
-        # Periodic path: extend grid/data (for :exclusive) or validate (for :inclusive),
-        # then build a normal LinearInterpolant on the extended arrays with WrapExtrap.
-        x_ext, y_ext = _prepare_periodic(x, y, bc)
-        _check_periodic_endpoints(bc, y_ext)
-        extrap_p = _promote_extrap(WrapExtrap(), _value_type(TY, Tg))
-        return LinearInterpolant(x_ext, y_ext; extrap = extrap_p, search)
-    end
-    extrap_p = _promote_extrap(extrap, _value_type(TY, Tg))
-    return LinearInterpolant(x, y; extrap = extrap_p, search)
+    # Single code path — helper returns (x, y, extrap) passthrough for non-periodic,
+    # or (extended x, extended y, WrapExtrap()) for PeriodicBC (inclusive/exclusive).
+    x_eff, y_eff, extrap_eff = _periodic_extend_1d(x, y, bc, extrap)
+    extrap_p = _promote_extrap(extrap_eff, _value_type(TY, Tg))
+    return LinearInterpolant(x_eff, y_eff; extrap = extrap_p, search)
 end

--- a/src/linear/linear_interpolant.jl
+++ b/src/linear/linear_interpolant.jl
@@ -46,13 +46,17 @@ end
 # ========================================
 
 """
-    linear_interp(x, y; extrap=NoExtrap(), search=AutoSearch()) -> LinearInterpolant
+    linear_interp(x, y; bc=NoBC(), extrap=NoExtrap(), search=AutoSearch()) -> LinearInterpolant
 
 Create a callable interpolant for broadcast fusion and reuse.
 
 # Arguments
 - `x::AbstractVector`: x-coordinates (must be sorted)
 - `y::AbstractVector`: y-values
+- `bc::AbstractBC`: Boundary condition. Default `NoBC()` means "use the built-in
+  linear-interpolation behavior (no BC needed)". Pass `PeriodicBC(endpoint=:inclusive)`
+  or `PeriodicBC(endpoint=:exclusive, period=L)` to build a periodic interpolant
+  (extrap is forced to `WrapExtrap()` in that case).
 - `extrap::AbstractExtrap`: `NoExtrap()` (default), `ClampExtrap()`, `ExtendExtrap()`, or `WrapExtrap()`
 - `search::AbstractSearchPolicy`: Default search policy for interval lookup (default: `AutoSearch()`)
 
@@ -128,10 +132,19 @@ function linear_interp end
 @inline function linear_interp(
         x::AbstractVector{TX},
         y::AbstractVector{TY};
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         search::AbstractSearchPolicy = AutoSearch()
     ) where {TX, TY}
     Tg = _promote_grid_float(TX, TY)
+    if _is_periodic_bc(bc)
+        # Periodic path: extend grid/data (for :exclusive) or validate (for :inclusive),
+        # then build a normal LinearInterpolant on the extended arrays with WrapExtrap.
+        x_ext, y_ext = _prepare_periodic(x, y, bc)
+        _check_periodic_endpoints(bc, y_ext)
+        extrap_p = _promote_extrap(WrapExtrap(), _value_type(TY, Tg))
+        return LinearInterpolant(x_ext, y_ext; extrap = extrap_p, search)
+    end
     extrap_p = _promote_extrap(extrap, _value_type(TY, Tg))
     return LinearInterpolant(x, y; extrap = extrap_p, search)
 end

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -61,7 +61,12 @@ function linear_interp! end
 # Unified method for AbstractVector
 # Unified in-place entry point. Handles promotion internally via _promote_itp_inputs,
 # so no separate Real/Mixed-type wrapper is needed (same pattern as the scalar API).
-@with_pool pool function linear_interp!(
+#
+# Hot-path (non-periodic) stays pool-free — `@with_pool` is hoisted into the
+# periodic helper below. Directly wrapping the whole entry point added ~5-25 ns
+# per call on small queries even when the pool was unused, a measurable
+# regression vs master on the `4_linear_oneshot/q00001` benchmark.
+function linear_interp!(
         output::AbstractVector,
         x::AbstractVector,
         y::AbstractVector,
@@ -74,7 +79,20 @@ function linear_interp! end
     @assert length(y) == length(x) "x and y must have same length"
     @assert length(output) == length(x_targets) "output must match x_targets length"
 
-    x_eff, y_eff, extrap_eff = _prepare_1d_oneshot!(pool, x, y, bc, extrap)
+    x_typed = _prepare_grid(x)
+    if _is_periodic_bc(bc)
+        return _linear_interp_periodic_vector!(output, x_typed, y, x_targets, bc, extrap, deriv, search)
+    end
+    searcher = _resolve_search(x_typed, x_targets, search, nothing)
+    return _linear_interp_loop!(output, x_typed, y, x_targets, extrap, deriv, searcher)
+end
+
+# Pool-scoped helper for the periodic oneshot vector path. Isolated so the
+# common non-periodic path above doesn't pay the `@with_pool` overhead.
+@inline @with_pool pool function _linear_interp_periodic_vector!(
+        output, x, y, x_targets, bc, extrap, deriv, search
+    )
+    x_eff, y_eff, extrap_eff = _periodic_extend_1d_pooled!(pool, x, y, bc, extrap)
     searcher = _resolve_search(x_eff, x_targets, search, nothing)
     return _linear_interp_loop!(output, x_eff, y_eff, x_targets, extrap_eff, deriv, searcher)
 end
@@ -271,7 +289,7 @@ end
 # Public scalar one-shot API.
 # Zero-alloc: _prepare_grid returns Vector as-is, Range → _CachedRange (stack).
 # Kernel arithmetic auto-promotes Int×Float via _get_h float() wrappers.
-@inline @with_pool pool function linear_interp(
+@inline function linear_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         xq::Tq;
@@ -283,7 +301,19 @@ end
     ) where {Tg, Tv, Tq <: Real}
     @boundscheck length(y) == length(x) || throw(ArgumentError("x and y must have same length"))
 
-    x_eff, y_eff, extrap_eff = _prepare_1d_oneshot!(pool, x, y, bc, extrap)
+    x_typed = _prepare_grid(x)
+    if _is_periodic_bc(bc)
+        return _linear_interp_periodic_scalar(x_typed, y, xq, bc, extrap, deriv, search, hint)
+    end
+    searcher = _resolve_search(x_typed, xq, search, hint)
+    return _linear_eval_at_point(x_typed, y, xq, extrap, deriv, searcher)
+end
+
+# Pool-scoped scalar periodic helper — kept out of the hot non-periodic path.
+@inline @with_pool pool function _linear_interp_periodic_scalar(
+        x, y, xq, bc, extrap, deriv, search, hint
+    )
+    x_eff, y_eff, extrap_eff = _periodic_extend_1d_pooled!(pool, x, y, bc, extrap)
     searcher = _resolve_search(x_eff, xq, search, hint)
     return _linear_eval_at_point(x_eff, y_eff, xq, extrap_eff, deriv, searcher)
 end

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -11,7 +11,7 @@
 # ║                      Zero type conversion overhead                        ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
-# PeriodicBC 1D extension uses the shared `_extend_exclusive_pooled!` helper
+# PeriodicBC 1D dispatch uses the shared `_periodic_extend_1d_pooled!` helper
 # from core/periodic.jl (no method-specific logic needed — Linear has no
 # coefficient system, so extension alone suffices).
 
@@ -71,14 +71,9 @@ function linear_interp! end
     @assert length(y) == length(x) "x and y must have same length"
     @assert length(output) == length(x_targets) "output must match x_targets length"
 
-    x_typed = _prepare_grid(x)
-    if _is_periodic_bc(bc)
-        x_p, y_p = _extend_exclusive_pooled!(pool, x_typed, y, bc)
-        searcher = _resolve_search(x_p, x_targets, search, nothing)
-        return _linear_interp_loop!(output, x_p, y_p, x_targets, WrapExtrap(), deriv, searcher)
-    end
-    searcher = _resolve_search(x_typed, x_targets, search, nothing)
-    return _linear_interp_loop!(output, x_typed, y, x_targets, extrap, deriv, searcher)
+    x_eff, y_eff, extrap_eff = _prepare_1d_oneshot!(pool, x, y, bc, extrap)
+    searcher = _resolve_search(x_eff, x_targets, search, nothing)
+    return _linear_interp_loop!(output, x_eff, y_eff, x_targets, extrap_eff, deriv, searcher)
 end
 
 # Internal loop with AbstractExtrap dispatch and Searcher (type-stable)
@@ -282,14 +277,9 @@ end
     ) where {Tg, Tv, Tq <: Real}
     @boundscheck length(y) == length(x) || throw(ArgumentError("x and y must have same length"))
 
-    x_typed = _prepare_grid(x)
-    if _is_periodic_bc(bc)
-        x_p, y_p = _extend_exclusive_pooled!(pool, x_typed, y, bc)
-        searcher = _resolve_search(x_p, xq, search, hint)
-        return _linear_eval_at_point(x_p, y_p, xq, WrapExtrap(), deriv, searcher)
-    end
-    searcher = _resolve_search(x_typed, xq, search, hint)
-    return _linear_eval_at_point(x_typed, y, xq, extrap, deriv, searcher)
+    x_eff, y_eff, extrap_eff = _prepare_1d_oneshot!(pool, x, y, bc, extrap)
+    searcher = _resolve_search(x_eff, xq, search, hint)
+    return _linear_eval_at_point(x_eff, y_eff, xq, extrap_eff, deriv, searcher)
 end
 
 # ╔═══════════════════════════════════════════════════════════════════════════╗

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -20,7 +20,7 @@
 # ========================================
 
 """
-    linear_interp!(output, x, y, x_targets; extrap=NoExtrap(), deriv=EvalValue(), search=AutoSearch())
+    linear_interp!(output, x, y, x_targets; bc=NoBC(), extrap=NoExtrap(), deriv=EvalValue(), search=AutoSearch())
 
 Zero-allocation linear interpolation with automatic dispatch:
 - For `AbstractRange` x: O(1) direct indexing
@@ -28,6 +28,9 @@ Zero-allocation linear interpolation with automatic dispatch:
 
 # Arguments
 - `output`: Pre-allocated output vector (must be floating-point type)
+- `bc::AbstractBC`: Boundary condition. Default `NoBC()` (no BC). Pass
+  `PeriodicBC(endpoint=:inclusive)` or `PeriodicBC(endpoint=:exclusive, period=L)`
+  for periodic interpolation (extrap is forced to `WrapExtrap()` in that case).
 - `extrap::AbstractExtrap`: `NoExtrap()` (default, throws DomainError), `ClampExtrap()`, `ExtendExtrap()`, or `WrapExtrap()`
 - `deriv::DerivOp`: Derivative order (`EvalValue()` default, `DerivOp(1)` first derivative, `DerivOp(2)` second derivative)
 - `search::AbstractSearchPolicy`: Search algorithm for interval finding
@@ -139,7 +142,7 @@ end
 # ========================================
 
 """
-    linear_interp(x, y, xq::Real; extrap=NoExtrap(), deriv=EvalValue(), search=AutoSearch()) -> AbstractFloat
+    linear_interp(x, y, xq::Real; bc=NoBC(), extrap=NoExtrap(), deriv=EvalValue(), search=AutoSearch()) -> AbstractFloat
 
 Zero-allocation scalar linear interpolation with automatic dispatch:
 - For `AbstractRange` x: O(1) direct indexing
@@ -147,6 +150,9 @@ Zero-allocation scalar linear interpolation with automatic dispatch:
 
 # Arguments
 - `xq::Real`: Single interpolation query point
+- `bc::AbstractBC`: Boundary condition. Default `NoBC()` (no BC). Pass
+  `PeriodicBC(endpoint=:inclusive)` or `PeriodicBC(endpoint=:exclusive, period=L)`
+  for periodic interpolation (extrap is forced to `WrapExtrap()` in that case).
 - `extrap::AbstractExtrap`: `NoExtrap()` (default, throws DomainError), `ClampExtrap()`, `ExtendExtrap()`, or `WrapExtrap()`
 - `deriv::DerivOp`: Derivative order (`EvalValue()` default, `DerivOp(1)` first derivative)
 - `search::AbstractSearchPolicy`: Search algorithm for interval finding

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -12,6 +12,48 @@
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
 # ========================================
+# PeriodicBC pool-based grid/value extension
+# ========================================
+# Mirrors the extension block of `_cubic_periodic_solve!` (cubic_oneshot.jl:133),
+# but without any solve step — Linear has no coefficient system.
+#
+# `:inclusive`: no-op pass-through.
+# `:exclusive`: extend grid by 1 endpoint (pool for Vector, direct for Range) and
+#   append y[1] as y[n+1]. Caller's @with_pool scope owns the buffer lifetimes.
+@inline function _linear_periodic_extend!(
+        pool::AbstractArrayPool,
+        x::AbstractVector{Tg},
+        y::AbstractVector{Tv},
+        bc::PeriodicBC
+    ) where {Tg, Tv}
+    if bc isa PeriodicBC{:exclusive}
+        period = _resolve_exclusive_period(x, bc)
+        x_end = first(x) + Tg(period)
+        last(x) < x_end || throw(
+            ArgumentError(
+                "period=$period places virtual endpoint at $x_end, " *
+                    "not after last grid point x[end]=$(last(x))"
+            )
+        )
+        n = length(x)
+        if x isa AbstractRange
+            x_p = _to_float_adding_endpoint(x, Tg)
+        else
+            x_p = acquire!(pool, Tg, n + 1)
+            @inbounds copyto!(x_p, 1, x, 1, n)
+            @inbounds x_p[n + 1] = x_end
+        end
+        y_p = acquire!(pool, Tv, n + 1)
+        @inbounds copyto!(y_p, 1, y, 1, n)
+        @inbounds y_p[n + 1] = y[1]
+    else
+        x_p, y_p = x, y
+    end
+    _check_periodic_endpoints(bc, y_p)
+    return x_p, y_p
+end
+
+# ========================================
 # Vector interpolation (in-place, zero-allocation)
 # ========================================
 
@@ -54,11 +96,12 @@ function linear_interp! end
 # Unified method for AbstractVector
 # Unified in-place entry point. Handles promotion internally via _promote_itp_inputs,
 # so no separate Real/Mixed-type wrapper is needed (same pattern as the scalar API).
-function linear_interp!(
+@with_pool pool function linear_interp!(
         output::AbstractVector,
         x::AbstractVector,
         y::AbstractVector,
         x_targets::AbstractVector;
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
@@ -67,6 +110,11 @@ function linear_interp!(
     @assert length(output) == length(x_targets) "output must match x_targets length"
 
     x_typed = _prepare_grid(x)
+    if _is_periodic_bc(bc)
+        x_p, y_p = _linear_periodic_extend!(pool, x_typed, y, bc)
+        searcher = _resolve_search(x_p, x_targets, search, nothing)
+        return _linear_interp_loop!(output, x_p, y_p, x_targets, WrapExtrap(), deriv, searcher)
+    end
     searcher = _resolve_search(x_typed, x_targets, search, nothing)
     return _linear_interp_loop!(output, x_typed, y, x_targets, extrap, deriv, searcher)
 end
@@ -260,10 +308,11 @@ end
 # Public scalar one-shot API.
 # Zero-alloc: _prepare_grid returns Vector as-is, Range → _CachedRange (stack).
 # Kernel arithmetic auto-promotes Int×Float via _get_h float() wrappers.
-@inline function linear_interp(
+@inline @with_pool pool function linear_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         xq::Tq;
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
@@ -272,6 +321,11 @@ end
     @boundscheck length(y) == length(x) || throw(ArgumentError("x and y must have same length"))
 
     x_typed = _prepare_grid(x)
+    if _is_periodic_bc(bc)
+        x_p, y_p = _linear_periodic_extend!(pool, x_typed, y, bc)
+        searcher = _resolve_search(x_p, xq, search, hint)
+        return _linear_eval_at_point(x_p, y_p, xq, WrapExtrap(), deriv, searcher)
+    end
     searcher = _resolve_search(x_typed, xq, search, hint)
     return _linear_eval_at_point(x_typed, y, xq, extrap, deriv, searcher)
 end
@@ -291,6 +345,7 @@ function linear_interp(
         x::AbstractVector,
         y::AbstractVector,
         x_targets::AbstractVector;
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
@@ -298,7 +353,7 @@ function linear_interp(
     Tg = _promote_grid_float(eltype(x), eltype(y))
     T_out = _output_eltype(eltype(y), Tg)
     output = Vector{T_out}(undef, length(x_targets))
-    linear_interp!(output, x, y, x_targets; extrap, deriv, search)
+    linear_interp!(output, x, y, x_targets; bc, extrap, deriv, search)
     return output
 end
 

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -11,47 +11,9 @@
 # ║                      Zero type conversion overhead                        ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
-# ========================================
-# PeriodicBC pool-based grid/value extension
-# ========================================
-# Mirrors the extension block of `_cubic_periodic_solve!` (cubic_oneshot.jl:133),
-# but without any solve step — Linear has no coefficient system.
-#
-# `:inclusive`: no-op pass-through.
-# `:exclusive`: extend grid by 1 endpoint (pool for Vector, direct for Range) and
-#   append y[1] as y[n+1]. Caller's @with_pool scope owns the buffer lifetimes.
-@inline function _linear_periodic_extend!(
-        pool::AbstractArrayPool,
-        x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        bc::PeriodicBC
-    ) where {Tg, Tv}
-    if bc isa PeriodicBC{:exclusive}
-        period = _resolve_exclusive_period(x, bc)
-        x_end = first(x) + Tg(period)
-        last(x) < x_end || throw(
-            ArgumentError(
-                "period=$period places virtual endpoint at $x_end, " *
-                    "not after last grid point x[end]=$(last(x))"
-            )
-        )
-        n = length(x)
-        if x isa AbstractRange
-            x_p = _to_float_adding_endpoint(x, Tg)
-        else
-            x_p = acquire!(pool, Tg, n + 1)
-            @inbounds copyto!(x_p, 1, x, 1, n)
-            @inbounds x_p[n + 1] = x_end
-        end
-        y_p = acquire!(pool, Tv, n + 1)
-        @inbounds copyto!(y_p, 1, y, 1, n)
-        @inbounds y_p[n + 1] = y[1]
-    else
-        x_p, y_p = x, y
-    end
-    _check_periodic_endpoints(bc, y_p)
-    return x_p, y_p
-end
+# PeriodicBC 1D extension uses the shared `_extend_exclusive_pooled!` helper
+# from core/periodic.jl (no method-specific logic needed — Linear has no
+# coefficient system, so extension alone suffices).
 
 # ========================================
 # Vector interpolation (in-place, zero-allocation)
@@ -111,7 +73,7 @@ function linear_interp! end
 
     x_typed = _prepare_grid(x)
     if _is_periodic_bc(bc)
-        x_p, y_p = _linear_periodic_extend!(pool, x_typed, y, bc)
+        x_p, y_p = _extend_exclusive_pooled!(pool, x_typed, y, bc)
         searcher = _resolve_search(x_p, x_targets, search, nothing)
         return _linear_interp_loop!(output, x_p, y_p, x_targets, WrapExtrap(), deriv, searcher)
     end
@@ -322,7 +284,7 @@ end
 
     x_typed = _prepare_grid(x)
     if _is_periodic_bc(bc)
-        x_p, y_p = _linear_periodic_extend!(pool, x_typed, y, bc)
+        x_p, y_p = _extend_exclusive_pooled!(pool, x_typed, y, bc)
         searcher = _resolve_search(x_p, xq, search, hint)
         return _linear_eval_at_point(x_p, y_p, xq, WrapExtrap(), deriv, searcher)
     end

--- a/src/linear/linear_oneshot_series.jl
+++ b/src/linear/linear_oneshot_series.jl
@@ -10,6 +10,54 @@
 # Shared anchor eval: _linear_eval_at_anchor(y, aq, op, extrap) in linear_anchor.jl
 
 # ╔═══════════════════════════════════════════════════════════════════════════╗
+# ║                 INTERNAL: PERIODIC CORE                                  ║
+# ╚═══════════════════════════════════════════════════════════════════════════╝
+
+# Extend x once via the shared helper (bound to series 1 just to get x_p), then
+# reuse a single pool buffer across all other series to avoid reallocating.
+# Mirrors the cubic_oneshot_series periodic strategy without the tridiagonal
+# solve. Always uses WrapExtrap for the eval-at-anchor call.
+@inline @with_pool pool function _linear_oneshot_series_periodic!(
+        output::AbstractVector,
+        x::AbstractVector{Tg},
+        s::Series,
+        xq,
+        bc::PeriodicBC,
+        op::AbstractEvalOp,
+        searcher
+    ) where {Tg}
+    vecs = _series_vectors(s)
+    n = length(x)
+
+    # Phase 1: extend x + first series, build anchor on the extended grid
+    x_p, y_p_first, _ = _periodic_extend_1d_pooled!(pool, x, first(vecs), bc, WrapExtrap())
+    n_p = length(x_p)
+    aq = _anchor_query(x_p, xq, Val(:linear), true, searcher)
+    @inbounds output[1] = _linear_eval_at_anchor(y_p_first, aq, op, WrapExtrap())
+
+    # Phase 2: remaining series — reuse a single pool buffer (exclusive) or the
+    # user's vecs[k] directly (inclusive, already length n_p, just re-validated).
+    K = length(output)
+    if K > 1
+        if bc isa PeriodicBC{:exclusive}
+            Tv_buf = eltype(y_p_first)
+            y_p = acquire!(pool, Tv_buf, n_p)
+            @inbounds for k in 2:K
+                copyto!(y_p, 1, vecs[k], 1, n)
+                y_p[n + 1] = vecs[k][1]
+                output[k] = _linear_eval_at_anchor(y_p, aq, op, WrapExtrap())
+            end
+        else
+            @inbounds for k in 2:K
+                _check_periodic_endpoints(bc, vecs[k])
+                output[k] = _linear_eval_at_anchor(vecs[k], aq, op, WrapExtrap())
+            end
+        end
+    end
+    return output
+end
+
+# ╔═══════════════════════════════════════════════════════════════════════════╗
 # ║                         SCALAR ONE-SHOT API                              ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
@@ -36,6 +84,7 @@ vals = linear_interp(x, Series(y_sin, y_cos), 0.5)  # → [sin(0.5), cos(0.5)]
         x::AbstractVector{Tg},
         s::Series,
         xq::Tq;
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
@@ -44,14 +93,18 @@ vals = linear_interp(x, Series(y_sin, y_cos), 0.5)  # → [sin(0.5), cos(0.5)]
     _validate_series_lengths(s, length(x))
     Tg_p = _promote_grid_float(Tg, _series_eltype(s))
     x = _to_float(x, Tg_p)
+    K = n_series(s)
+    Tg_actual = eltype(x)
+    Tv = _series_output_type(_output_eltype(_series_eltype(s), Tg_actual), Tq)
+    output = Vector{Tv}(undef, K)
+    if _is_periodic_bc(bc)
+        searcher = _resolve_search(x, xq, search, hint)
+        return _linear_oneshot_series_periodic!(output, x, s, xq, bc, deriv, searcher)
+    end
     _check_domain(x, xq, extrap)
     searcher = _resolve_search(x, xq, search, hint)
     aq = _anchor_query(x, xq, Val(:linear), extrap isa WrapExtrap, searcher)
     vecs = _series_vectors(s)
-    K = n_series(s)
-    Tg_actual = eltype(x)  # after promotion via _to_float
-    Tv = _series_output_type(_output_eltype(_series_eltype(s), Tg_actual), Tq)
-    output = Vector{Tv}(undef, K)
     @inbounds for k in 1:K
         output[k] = _linear_eval_at_anchor(vecs[k], aq, deriv, extrap)
     end
@@ -70,6 +123,7 @@ In-place one-shot linear interpolation of multiple y-series at a single query po
         x::AbstractVector{Tg},
         s::Series,
         xq::Tq;
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
@@ -79,6 +133,10 @@ In-place one-shot linear interpolation of multiple y-series at a single query po
     length(output) == n_series(s) || _throw_series_dim_mismatch(length(output), n_series(s))
     Tg_p = _promote_grid_float(Tg, _series_eltype(s))
     x = _to_float(x, Tg_p)
+    if _is_periodic_bc(bc)
+        searcher = _resolve_search(x, xq, search, hint)
+        return _linear_oneshot_series_periodic!(output, x, s, xq, bc, deriv, searcher)
+    end
     _check_domain(x, xq, extrap)
     searcher = _resolve_search(x, xq, search, hint)
     aq = _anchor_query(x, xq, Val(:linear), extrap isa WrapExtrap, searcher)
@@ -104,6 +162,7 @@ In-place one-shot linear interpolation at multiple query points.
         x::AbstractVector{Tg},
         s::Series,
         xqs::AbstractVector{Tq};
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
@@ -114,9 +173,47 @@ In-place one-shot linear interpolation at multiple query points.
     Tg_actual = eltype(x)
     K = n_series(s)
     _validate_series_outputs(outputs, K, length(xqs))
+    vecs = _series_vectors(s)
+
+    # Periodic vector-xqs: extend x once, per-series extend y (exclusive) or
+    # reuse + validate (inclusive), pre-compute anchors on extended grid, then
+    # K outer × Q inner eval loop.
+    if _is_periodic_bc(bc)
+        x_p, y_p_first, _ = _periodic_extend_1d_pooled!(pool, x, first(vecs), bc, WrapExtrap())
+        Tg_p_actual = eltype(x_p)
+        Tq_promoted = promote_type(Tq, Tg_p_actual)
+        searcher = _resolve_search(x_p, xqs, search, nothing)
+        aq_vec = acquire!(pool, _LinearAnchoredQuery{Tg_p_actual, Tq_promoted}, length(xqs))
+        _fill_anchors!(aq_vec, x_p, xqs, Val(:linear), true, searcher)
+        @inbounds for j in eachindex(xqs)
+            outputs[1][j] = _linear_eval_at_anchor(y_p_first, aq_vec[j], deriv, WrapExtrap())
+        end
+        if K > 1
+            if bc isa PeriodicBC{:exclusive}
+                n = length(x)
+                Tv_buf = eltype(y_p_first)
+                y_p = acquire!(pool, Tv_buf, length(x_p))
+                @inbounds for k in 2:K
+                    copyto!(y_p, 1, vecs[k], 1, n)
+                    y_p[n + 1] = vecs[k][1]
+                    for j in eachindex(xqs)
+                        outputs[k][j] = _linear_eval_at_anchor(y_p, aq_vec[j], deriv, WrapExtrap())
+                    end
+                end
+            else
+                @inbounds for k in 2:K
+                    _check_periodic_endpoints(bc, vecs[k])
+                    for j in eachindex(xqs)
+                        outputs[k][j] = _linear_eval_at_anchor(vecs[k], aq_vec[j], deriv, WrapExtrap())
+                    end
+                end
+            end
+        end
+        return outputs
+    end
+
     # Domain check: NoExtrap → throws if OOB, returns InBounds(); others → pass-through
     extrap_eff = _check_domain(x, xqs, extrap)
-    vecs = _series_vectors(s)
     searcher = _resolve_search(x, xqs, search, nothing)
     wrap = extrap_eff isa WrapExtrap
     # Pre-compute anchors via pool, then K outer × Q inner for cache locality
@@ -141,6 +238,7 @@ function linear_interp(
         x::AbstractVector{Tg},
         s::Series,
         xqs::AbstractVector{Tq};
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
@@ -149,7 +247,7 @@ function linear_interp(
     Tg_p = _promote_grid_float(Tg, _series_eltype(s))
     Tv_out = _series_output_type(_output_eltype(_series_eltype(s), Tg_p), Tq)
     outputs = [Vector{Tv_out}(undef, length(xqs)) for _ in 1:K]
-    linear_interp!(outputs, x, s, xqs; extrap, deriv, search)
+    linear_interp!(outputs, x, s, xqs; bc, extrap, deriv, search)
     return outputs
 end
 

--- a/src/linear/linear_series_interp.jl
+++ b/src/linear/linear_series_interp.jl
@@ -19,12 +19,6 @@
 Multi-series linear interpolant with unified matrix storage and SIMD optimization.
 Shares a single x-grid across N y-series for efficient batch evaluation.
 
-!!! note "PeriodicBC on Series inputs"
-    `PeriodicBC` is not yet wired for the Series path — the `linear_interp(x, ys; ...)`
-    / `linear_interp(x, Series(...), xq; ...)` signatures have no `bc` kwarg. If you
-    need periodic semantics on multi-series data, build one `LinearInterpolant` per
-    series with `bc=PeriodicBC(...)`. Series `bc` support is planned for a later phase.
-
 # Type Parameters
 - `Tg`: Grid type (Float32 or Float64)
 - `Tv`: Value type (unconstrained)
@@ -344,6 +338,7 @@ sitp = linear_interp(x, Series(y_complex, y1))
 function linear_interp(
         x::AbstractVector{Tg},
         s::Series;
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         search::AbstractSearchPolicy = AutoSearch()
     ) where {Tg}
@@ -356,8 +351,17 @@ function linear_interp(
     # returns Tv unchanged (no widening to grid type).
     Tv_out = Tg_new <: AbstractFloat ? _value_type(Tv, Tg_new) : Tv
     y_mat, _ = _build_series_mat(s, n_pts, Tv_out)
-    extrap_p = Tg_new <: AbstractFloat ? _promote_extrap(extrap, Tv_out) : extrap
 
+    # Periodic path: extend x + y_mat once (matrix overload of `_prepare_periodic`),
+    # validate `:inclusive` endpoints per series, force WrapExtrap.
+    if _is_periodic_bc(bc)
+        x_typed, y_mat = _prepare_periodic(x_typed, y_mat, bc)
+        _validate_series_endpoints(bc, y_mat)
+        extrap_p = Tg_new <: AbstractFloat ? _promote_extrap(WrapExtrap(), Tv_out) : WrapExtrap()
+        return LinearSeriesInterpolant(x_typed, y_mat, extrap_p, search)
+    end
+
+    extrap_p = Tg_new <: AbstractFloat ? _promote_extrap(extrap, Tv_out) : extrap
     return LinearSeriesInterpolant(x_typed, y_mat, extrap_p, search)
 end
 

--- a/src/linear/linear_series_interp.jl
+++ b/src/linear/linear_series_interp.jl
@@ -19,6 +19,12 @@
 Multi-series linear interpolant with unified matrix storage and SIMD optimization.
 Shares a single x-grid across N y-series for efficient batch evaluation.
 
+!!! note "PeriodicBC on Series inputs"
+    `PeriodicBC` is not yet wired for the Series path — the `linear_interp(x, ys; ...)`
+    / `linear_interp(x, Series(...), xq; ...)` signatures have no `bc` kwarg. If you
+    need periodic semantics on multi-series data, build one `LinearInterpolant` per
+    series with `bc=PeriodicBC(...)`. Series `bc` support is planned for a later phase.
+
 # Type Parameters
 - `Tg`: Grid type (Float32 or Float64)
 - `Tv`: Value type (unconstrained)

--- a/src/linear/nd/linear_nd_interpolant.jl
+++ b/src/linear/nd/linear_nd_interpolant.jl
@@ -61,6 +61,7 @@ itp = linear_interp((x, y), data;
 function linear_interp(
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv_raw, N};
+        bc::Union{AbstractBC, NTuple{N, AbstractBC}} = NoBC(),
         extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
         search::Union{AbstractSearchPolicy, NTuple{N, AbstractSearchPolicy}} = AutoSearch()
     ) where {N, Tv_raw}
@@ -69,15 +70,20 @@ function linear_interp(
 
     # Promote grid/data types
     grids_typed, Tg, Tv, _ = _nd_promote_grids(grids, data)
-
-    # Create spacings
-    spacings = _create_spacings_typed(grids_typed)
     data_typed = Tv === Tv_raw ? data : Tv.(data)
 
     # Resolve per-axis configuration
+    bcs = _resolve_bcs_nd(bc, Val(N))
     searches = _resolve_search_nd(search, Val(N))
 
-    extrap_vals = _resolve_extrap_nd(extrap, nothing, Val(N), Tv)
+    # Extend grids/data for exclusive periodic axes (build-time only).
+    # After this, all periodic axes have inclusive-form data and WrapExtrap handles queries.
+    grids_typed, data_typed, _ = _prepare_periodic_nd(grids_typed, data_typed, bcs)
+    spacings = _create_spacings_typed(grids_typed)
+
+    # _resolve_extrap_nd(extrap, bcs, ...) validates periodic/extrap compatibility
+    # and auto-overrides per-axis extrap to WrapExtrap() on periodic axes.
+    extrap_vals = _resolve_extrap_nd(extrap, bcs, Val(N), Tv)
     return LinearInterpolantND{
         Tg, Tv, N,
         typeof(grids_typed), typeof(spacings), typeof(extrap_vals), typeof(searches),

--- a/src/linear/nd/linear_nd_oneshot.jl
+++ b/src/linear/nd/linear_nd_oneshot.jl
@@ -23,6 +23,7 @@ Evaluates directly from grids + data without constructing a LinearInterpolantND.
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         query::Tuple{Vararg{Real, N}},
+        bcs::NTuple{N, AbstractBC},
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
         searches::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
@@ -33,11 +34,15 @@ Evaluates directly from grids + data without constructing a LinearInterpolantND.
     oob_result = _try_fill_oob(query, grids, extraps_val, ops, @inbounds first(data))
     oob_result !== nothing && return oob_result
 
-    spacings = _create_spacings_pooled(pool, grids)
-    q_eval = _handle_all_extraps(query, grids, extraps_val)
-    indices, Ls, _ = _search_all_intervals(q_eval, grids, spacings, searches, hints)
+    # Extend exclusive periodic axes (pool-based, zero heap alloc).
+    # Non-periodic axes pass through unchanged.
+    grids_p, data_p, _ = _prepare_periodic_nd_pooled(pool, grids, data, bcs)
+
+    spacings = _create_spacings_pooled(pool, grids_p)
+    q_eval = _handle_all_extraps(query, grids_p, extraps_val)
+    indices, Ls, _ = _search_all_intervals(q_eval, grids_p, spacings, searches, hints)
     hs, αs = _compute_linear_params(q_eval, spacings, indices, Ls, Val(N))
-    return _multilinear_sum(data, indices, hs, αs, ops, Val(N))
+    return _multilinear_sum(data_p, indices, hs, αs, ops, Val(N))
 end
 
 """
@@ -52,6 +57,7 @@ Writes results into `output`. No heap allocation beyond spacings.
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         queries,
+        bcs::NTuple{N, AbstractBC},
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
         policies::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
@@ -62,25 +68,26 @@ Writes results into `output`. No heap allocation beyond spacings.
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
     _validate_nd_domain(grids, queries, extraps_val)
-    spacings = _create_spacings_pooled(pool, grids)
+    grids_p, data_p, _ = _prepare_periodic_nd_pooled(pool, grids, data, bcs)
+    spacings = _create_spacings_pooled(pool, grids_p)
     @inbounds for k in 1:nq
         query_k = _extract_query_point(queries, k, Val(N))
-        oob_val = _try_fill_oob(query_k, grids, extraps_val, ops, first(data))
+        oob_val = _try_fill_oob(query_k, grids_p, extraps_val, ops, first(data_p))
         if oob_val !== nothing
             output[k] = oob_val; continue
         end
-        q_eval = _handle_all_extraps(query_k, grids, extraps_val)
-        indices, Ls, _ = _search_all_intervals(q_eval, grids, spacings, policies, hints, mono)
+        q_eval = _handle_all_extraps(query_k, grids_p, extraps_val)
+        indices, Ls, _ = _search_all_intervals(q_eval, grids_p, spacings, policies, hints, mono)
         hs, αs = _compute_linear_params(q_eval, spacings, indices, Ls, Val(N))
-        output[k] = _multilinear_sum(data, indices, hs, αs, ops, Val(N))
+        output[k] = _multilinear_sum(data_p, indices, hs, αs, ops, Val(N))
     end
     return output
 end
 
 # Function barrier: forces Julia to runtime-dispatch on the concrete
 # searches tuple type before entering the @with_pool boundary.
-function _linear_nd_batch_dispatch!(output, grids, data, queries, extraps, policies, ops, hints, mono)
-    return _linear_interp_nd_oneshot_batch!(output, grids, data, queries, extraps, policies, ops, hints, mono)
+function _linear_nd_batch_dispatch!(output, grids, data, queries, bcs, extraps, policies, ops, hints, mono)
+    return _linear_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps, policies, ops, hints, mono)
 end
 
 # ========================================
@@ -97,6 +104,7 @@ function linear_interp(
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         query::Tuple{Vararg{Real, N}};
+        bc::Union{AbstractBC, NTuple{N, AbstractBC}} = NoBC(),
         extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
         search::Union{AbstractSearchPolicy, NTuple{N, AbstractSearchPolicy}} = AutoSearch(),
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
@@ -108,9 +116,10 @@ function linear_interp(
 
     searches = _resolve_search_nd(search, Val(N), query)  # scalar: type-based (no monotonicity check)
 
-    extraps_val = _resolve_extrap_nd(extrap, nothing, Val(N), Tv)
+    bcs = _resolve_bcs_nd(bc, Val(N))
+    extraps_val = _resolve_extrap_nd(extrap, bcs, Val(N), Tv)
     ops = _resolve_deriv_nd(deriv, Val(N))
-    return _linear_interp_nd_oneshot(grids_typed, data, query, extraps_val, searches, ops, hint)::Tr
+    return _linear_interp_nd_oneshot(grids_typed, data, query, bcs, extraps_val, searches, ops, hint)::Tr
 end
 
 """
@@ -124,6 +133,7 @@ function linear_interp(
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         queries;
+        bc::Union{AbstractBC, NTuple{N, AbstractBC}} = NoBC(),
         extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
         search::Union{AbstractSearchPolicy, NTuple{N, AbstractSearchPolicy}} = AutoSearch(),
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
@@ -133,7 +143,7 @@ function linear_interp(
     Tq = _query_eltype(queries)
     Tr = _output_eltype(Tv, Tg, Tq)
     output = Vector{Tr}(undef, _query_length(queries))
-    linear_interp!(output, grids, data, queries; extrap, search, deriv, hint)
+    linear_interp!(output, grids, data, queries; bc, extrap, search, deriv, hint)
     return output
 end
 
@@ -153,6 +163,7 @@ function linear_interp!(
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         queries;
+        bc::Union{AbstractBC, NTuple{N, AbstractBC}} = NoBC(),
         extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
         search::Union{AbstractSearchPolicy, NTuple{N, AbstractSearchPolicy}} = AutoSearch(),
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
@@ -166,7 +177,8 @@ function linear_interp!(
     hints_nd = hint
     mono = _check_mono_nd(policies, queries)
 
-    extraps_val = _resolve_extrap_nd(extrap, nothing, Val(N), Tv)
+    bcs = _resolve_bcs_nd(bc, Val(N))
+    extraps_val = _resolve_extrap_nd(extrap, bcs, Val(N), Tv)
     ops = _resolve_deriv_nd(deriv, Val(N))
-    return _linear_nd_batch_dispatch!(output, grids_typed, data, queries, extraps_val, policies, ops, hints_nd, mono)
+    return _linear_nd_batch_dispatch!(output, grids_typed, data, queries, bcs, extraps_val, policies, ops, hints_nd, mono)
 end

--- a/test/ext/test_constant_quadratic_dual_grid.jl
+++ b/test/ext/test_constant_quadratic_dual_grid.jl
@@ -196,16 +196,20 @@ const FI = FastInterpolations
     # through unchanged (Dual is not `<: _PromotableValue`).
     # ========================================================================
     @testset "Constant PeriodicBC — Dual grid preserves type" begin
-        T = ForwardDiff.Dual{:pbc, Float64, 1}
-        x_dual = [T(Float64(i), 0.0) for i in 0:5]
+        # Constant interp returns `y[idx]` directly — the Dual grid only affects
+        # which index is picked, not the returned value's type (no arithmetic
+        # with xq). The invariant being tested here is that the grid stores
+        # Dual (unchanged by the periodic extension path) and that the call
+        # succeeds without promoting/stripping the grid's Dual eltype.
+        x_dual = [ForwardDiff.Dual{:pbc}(Float64(i), 0.0) for i in 0:5]
         y = Float64[0, 1, 2, 3, 4, 5]
 
         itp = constant_interp(x_dual, y; bc = PeriodicBC(endpoint = :exclusive, period = 6.0))
-        @test eltype(itp.x) === T
+        @test eltype(itp.x) <: ForwardDiff.Dual
         @test length(itp.x) == 7
 
-        q = T(2.5, 1.0)
+        q = ForwardDiff.Dual{:pbc}(2.5, 1.0)
         out = constant_interp(x_dual, y, q; bc = PeriodicBC(endpoint = :exclusive, period = 6.0))
-        @test out isa ForwardDiff.Dual
+        @test out == 2.0 || out == 3.0  # one of the neighboring y-values
     end
 end

--- a/test/ext/test_constant_quadratic_dual_grid.jl
+++ b/test/ext/test_constant_quadratic_dual_grid.jl
@@ -189,4 +189,23 @@ const FI = FastInterpolations
         @test (@allocated itp_c(2.5)) <= ALLOC_THRESHOLD
         @test (@allocated itp_q(2.5)) <= ALLOC_THRESHOLD
     end
+
+    # ========================================================================
+    # PeriodicBC + Dual grid — verifies `_PromotableValue` guard in
+    # `_extend_exclusive` / `_periodic_extend_1d_pooled!` passes Dual eltype
+    # through unchanged (Dual is not `<: _PromotableValue`).
+    # ========================================================================
+    @testset "Constant PeriodicBC — Dual grid preserves type" begin
+        T = ForwardDiff.Dual{:pbc, Float64, 1}
+        x_dual = [T(Float64(i), 0.0) for i in 0:5]
+        y = Float64[0, 1, 2, 3, 4, 5]
+
+        itp = constant_interp(x_dual, y; bc = PeriodicBC(endpoint = :exclusive, period = 6.0))
+        @test eltype(itp.x) === T
+        @test length(itp.x) == 7
+
+        q = T(2.5, 1.0)
+        out = constant_interp(x_dual, y, q; bc = PeriodicBC(endpoint = :exclusive, period = 6.0))
+        @test out isa ForwardDiff.Dual
+    end
 end

--- a/test/ext/test_linear_dual_grid.jl
+++ b/test/ext/test_linear_dual_grid.jl
@@ -837,4 +837,40 @@ const FI = FastInterpolations
         itp(5.55)  # warmup
         @test (@allocated itp(5.55)) <= ALLOC_THRESHOLD
     end
+
+    # ========================================================================
+    # PeriodicBC + Dual grid — verifies the `_PromotableValue` guard in
+    # `_extend_exclusive` and `_periodic_extend_1d_pooled!` does NOT misfire on
+    # duck grids (Dual is not `<: _PromotableValue`, so eltype passes through
+    # unchanged to preserve AD chains).
+    # ========================================================================
+    @testset "PeriodicBC — Dual grid preserves type (persistent + oneshot)" begin
+        T = ForwardDiff.Dual{:pbc, Float64, 1}
+        x_dual = [T(Float64(i), 0.0) for i in 0:5]
+        y = sin.(2π .* (Float64(0):Float64(5)) ./ 6)
+
+        itp = linear_interp(x_dual, y; bc = PeriodicBC(endpoint = :exclusive, period = 6.0))
+        @test eltype(itp.x) === T
+        @test length(itp.x) == 7  # N+1 extension, Dual type preserved
+
+        q = T(2.5, 1.0)
+        out = linear_interp(x_dual, y, q; bc = PeriodicBC(endpoint = :exclusive, period = 6.0))
+        @test out isa ForwardDiff.Dual
+    end
+
+    @testset "PeriodicBC — AD through Int-grid oneshot derivative" begin
+        # Int Range + PeriodicBC + ForwardDiff.derivative: Int→Float promotion
+        # on the grid side must not interfere with the query's Dual AD path.
+        x = 0:10
+        y = sin.(2π .* (x ./ 10))
+        bc = PeriodicBC(endpoint = :exclusive, period = 11.0)
+        f(xq) = linear_interp(x, y, xq; bc = bc)
+        d = ForwardDiff.derivative(f, 2.5)
+        @test d isa Float64
+        @test isfinite(d)
+
+        h = 1.0e-6
+        fd = (f(2.5 + h) - f(2.5 - h)) / (2h)
+        @test isapprox(d, fd; atol = 1.0e-5)
+    end
 end

--- a/test/ext/test_linear_dual_grid.jl
+++ b/test/ext/test_linear_dual_grid.jl
@@ -845,15 +845,17 @@ const FI = FastInterpolations
     # unchanged to preserve AD chains).
     # ========================================================================
     @testset "PeriodicBC — Dual grid preserves type (persistent + oneshot)" begin
-        T = ForwardDiff.Dual{:pbc, Float64, 1}
-        x_dual = [T(Float64(i), 0.0) for i in 0:5]
+        # Use the tag-only `Dual{:tag}(value, partial)` form — the fully
+        # parameterized `Dual{T, V, N}` constructor wants `Partials`, not a raw
+        # Float for the second argument.
+        x_dual = [ForwardDiff.Dual{:pbc}(Float64(i), 0.0) for i in 0:5]
         y = sin.(2π .* (Float64(0):Float64(5)) ./ 6)
 
         itp = linear_interp(x_dual, y; bc = PeriodicBC(endpoint = :exclusive, period = 6.0))
-        @test eltype(itp.x) === T
+        @test eltype(itp.x) <: ForwardDiff.Dual
         @test length(itp.x) == 7  # N+1 extension, Dual type preserved
 
-        q = T(2.5, 1.0)
+        q = ForwardDiff.Dual{:pbc}(2.5, 1.0)
         out = linear_interp(x_dual, y, q; bc = PeriodicBC(endpoint = :exclusive, period = 6.0))
         @test out isa ForwardDiff.Dual
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,6 +76,7 @@ else
     include("test_random_grid.jl")
     include("test_periodic_bc.jl")
     include("test_periodic_exclusive.jl")
+    include("test_linear_periodic.jl")
     include("test_thomas_lu_solver.jl")
     include("test_generic_bc.jl")
     include("test_polyfit_bc.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,7 @@ else
     include("test_periodic_bc.jl")
     include("test_periodic_exclusive.jl")
     include("test_linear_periodic.jl")
+    include("test_constant_periodic.jl")
     include("test_thomas_lu_solver.jl")
     include("test_generic_bc.jl")
     include("test_polyfit_bc.jl")

--- a/test/test_constant_adjoint.jl
+++ b/test/test_constant_adjoint.jl
@@ -174,9 +174,18 @@ end
         xq32 = Float32.(xq)
         f32 = randn(Float32, n_grid)
         yb32 = randn(Float32, n_query)
+        # The dot-product identity LHS = Σᵢ f[W_idx[i]]·ȳ[i] (30 terms, ordered
+        # by query) vs RHS = Σⱼ f[j]·(Σ_{i:W_idx[i]=j} ȳ[i]) (50 terms, ordered
+        # by grid with regrouped ȳ sums) is mathematically exact but at Float32
+        # the different accumulation orders diverge by a few ULP when signs
+        # cancel. Platforms differ in their FMA / BLAS reduction lane choices
+        # (Windows+Julia 1.12 x86_64 observed to cross `sqrt(eps(Float32))`
+        # on the LeftSide random instance). Use a looser tolerance that is
+        # still tight enough to catch real adjoint-operator bugs (which fail
+        # by `O(1)` relative error, not a few ULP).
         _, _, ok = constant_dot_product_test(
             x32, xq32, f32, yb32;
-            side = side_mode, rtol = sqrt(eps(Float32))
+            side = side_mode, rtol = 10 * sqrt(eps(Float32))
         )
         @test ok
     end

--- a/test/test_constant_oneshot_series.jl
+++ b/test/test_constant_oneshot_series.jl
@@ -165,4 +165,67 @@ using FastInterpolations
         out_wrong = zeros(5)
         @test_throws DimensionMismatch constant_interp!(out_wrong, x, s, 0.5)
     end
+
+    @testset "PeriodicBC — scalar, :inclusive" begin
+        s = Series(y_sin, y_cos)
+        vals = constant_interp(x, s, 0.37; bc = PeriodicBC())
+        vals_wrap = constant_interp(x, s, 0.37 + 1.0; bc = PeriodicBC())
+        @test vals ≈ vals_wrap atol = 1.0e-12
+    end
+
+    @testset "PeriodicBC — scalar, :exclusive FVM" begin
+        xc = [0.5, 1.5, 2.5]
+        s = Series([10.0, 20.0, 30.0], [1.0, 2.0, 3.0])
+        bc = PeriodicBC(endpoint = :exclusive, period = 3.0)
+        vals_in = constant_interp(xc, s, 2.4; bc)
+        @test vals_in[1] ≈ 30.0
+        @test vals_in[2] ≈ 3.0
+    end
+
+    @testset "PeriodicBC — scalar in-place" begin
+        s = Series(y_sin, y_cos)
+        out = zeros(2)
+        constant_interp!(out, x, s, 0.37; bc = PeriodicBC())
+        @test out ≈ constant_interp(x, s, 0.37; bc = PeriodicBC())
+    end
+
+    @testset "PeriodicBC — vector in-place, :inclusive" begin
+        s = Series(y_sin, y_cos)
+        xqs = [0.1, 0.37, 0.9]
+        outputs = [zeros(length(xqs)) for _ in 1:2]
+        constant_interp!(outputs, x, s, xqs; bc = PeriodicBC())
+        outputs_wrap = [zeros(length(xqs)) for _ in 1:2]
+        constant_interp!(outputs_wrap, x, s, xqs .+ 1.0; bc = PeriodicBC())
+        @test outputs[1] ≈ outputs_wrap[1] atol = 1.0e-12
+        @test outputs[2] ≈ outputs_wrap[2] atol = 1.0e-12
+    end
+
+    @testset "PeriodicBC — vector in-place, :exclusive" begin
+        xc = [0.5, 1.5, 2.5]
+        s = Series([10.0, 20.0, 30.0], [1.0, 2.0, 3.0])
+        bc = PeriodicBC(endpoint = :exclusive, period = 3.0)
+        xqs = [0.6, 1.4, 2.4]
+        outputs = [zeros(3), zeros(3)]
+        constant_interp!(outputs, xc, s, xqs; bc)
+        @test outputs[1] ≈ [10.0, 20.0, 30.0]   # NearestSide picks closest cell center
+        @test outputs[2] ≈ [1.0, 2.0, 3.0]
+    end
+
+    @testset "PeriodicBC — vector allocating" begin
+        s = Series(y_sin, y_cos)
+        outs = constant_interp(x, s, [0.1, 0.37]; bc = PeriodicBC())
+        @test length(outs) == 2 && length(outs[1]) == 2
+    end
+
+    @testset "PeriodicBC — :inclusive endpoint mismatch raises" begin
+        s = Series(y_sin, y_exp)
+        @test_throws ArgumentError constant_interp(x, s, 0.37; bc = PeriodicBC())
+    end
+
+    @testset "PeriodicBC — :exclusive period too small raises" begin
+        xv = [0.0, 1.0, 2.0, 3.0]
+        s = Series([0.0, 1.0, 2.0, 3.0])
+        bc_bad = PeriodicBC(endpoint = :exclusive, period = 2.5)
+        @test_throws ArgumentError constant_interp(xv, s, 1.5; bc = bc_bad)
+    end
 end

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -1,0 +1,312 @@
+# Tests for PeriodicBC on Constant interpolation (Phase 1).
+#
+# Coverage mirrors test_linear_periodic.jl, with extra per-`side` coverage
+# (NearestSide/LeftSide/RightSide must all respect periodicity).
+
+using Test
+using FastInterpolations
+using FastInterpolations: _CachedRange
+
+@testset "Constant PeriodicBC" begin
+
+    @testset "NoBC default is no-op" begin
+        x = collect(range(0.0, 1.0, length = 11))
+        y = sin.(2π .* x)
+
+        itp_default = constant_interp(x, y)
+        itp_nobc    = constant_interp(x, y; bc = NoBC())
+
+        @test typeof(itp_default) === typeof(itp_nobc)
+        for xq in (0.0, 0.25, 0.5, 0.75, 1.0)
+            @test itp_default(xq) === itp_nobc(xq)
+        end
+    end
+
+    @testset "Inclusive — endpoint mismatch raises" begin
+        x = collect(range(0.0, 1.0, length = 5))
+        y = [0.0, 1.0, 2.0, 3.0, 4.0]
+        @test_throws ArgumentError constant_interp(x, y; bc = PeriodicBC())
+    end
+
+    @testset "Exclusive — FVM cell-centered, LeftSide" begin
+        x = range(0.5, step = 1.0, length = 3)
+        y = [10.0, 20.0, 30.0]
+        bc = PeriodicBC(endpoint = :exclusive, period = 3.0)
+        itp = constant_interp(x, y; bc = bc, side = LeftSide())
+
+        # LeftSide with extended endpoint: segment [2.5, 3.5] has left-value = 30.0
+        @test itp(2.6) ≈ 30.0 atol = 1e-12
+        @test itp(3.4) ≈ 30.0 atol = 1e-12   # still within [2.5, 3.5] → 30.0
+
+        # Wrap: query outside [0.5, 3.5) wraps back
+        @test itp(3.6) ≈ itp(0.6) atol = 1e-12
+    end
+
+    @testset "Exclusive — RightSide" begin
+        x = range(0.5, step = 1.0, length = 3)
+        y = [10.0, 20.0, 30.0]
+        bc = PeriodicBC(endpoint = :exclusive, period = 3.0)
+        itp = constant_interp(x, y; bc = bc, side = RightSide())
+
+        # RightSide on segment [2.5, 3.5] → right endpoint value = y[n+1] = y[1] = 10.0
+        @test itp(2.6) ≈ 10.0 atol = 1e-12
+    end
+
+    @testset "Exclusive — Vector grid (allocating path)" begin
+        x_vec = [0.5, 1.5, 2.5]
+        y = [10.0, 20.0, 30.0]
+        itp = constant_interp(x_vec, y; bc = PeriodicBC(endpoint = :exclusive, period = 3.0))
+
+        # NearestSide default — closest cell center
+        @test itp(2.5) ≈ 30.0 atol = 1e-12
+        @test itp(3.4) ≈ 10.0 atol = 1e-12   # closer to virtual x=3.5 (value=10) than to 2.5
+    end
+
+    @testset "Extrap is forced to WrapExtrap on periodic path" begin
+        x = range(0.0, 2π, length = 11)
+        y = sin.(x)
+        itp = constant_interp(x, y; bc = PeriodicBC(), extrap = ClampExtrap())
+        @test itp.extrap isa WrapExtrap
+    end
+
+    @testset "Oneshot scalar + vector + in-place — matches persistent" begin
+        x = range(0.5, step = 1.0, length = 3)
+        y = [10.0, 20.0, 30.0]
+        bc = PeriodicBC(endpoint = :exclusive, period = 3.0)
+        itp = constant_interp(x, y; bc = bc)
+
+        for xq in (0.5, 1.5, 2.5, 3.0, 3.4, 0.0, -0.5)
+            @test constant_interp(x, y, xq; bc = bc) ≈ itp(xq) atol = 1e-12
+        end
+
+        xq = [0.5, 1.0, 2.5, 3.0, 3.4]
+        @test constant_interp(x, y, xq; bc = bc) ≈ itp.(xq) atol = 1e-12
+
+        out = zeros(length(xq))
+        constant_interp!(out, x, y, xq; bc = bc)
+        @test out ≈ itp.(xq) atol = 1e-12
+    end
+
+    # ============================================================
+    # ND tests
+    # ============================================================
+    @testset "ND — scalar bc, periodic both axes" begin
+        x = range(0.5, step = 1.0, length = 3)
+        y = range(0.5, step = 1.0, length = 4)
+        data = [10.0 * i + j for i in 1:3, j in 1:4]
+
+        bc = PeriodicBC(endpoint = :exclusive)
+        itp = constant_interp((x, y), data; bc = bc)
+
+        # ND persistent path: extended Range axes must remain _CachedRange.
+        @test itp.grids[1] isa _CachedRange
+        @test itp.grids[2] isa _CachedRange
+        @test length(itp.grids[1]) == 4
+        @test length(itp.grids[2]) == 5
+        @test size(itp.data) == (4, 5)
+
+        q = (1.2, 0.8)
+        @test itp(q) ≈ constant_interp((x, y), data, q; bc = bc) atol = 1e-12
+    end
+
+    @testset "ND — per-axis mix (periodic + non-periodic)" begin
+        x = range(0.5, step = 1.0, length = 3)
+        y = collect(range(0.0, 1.0, length = 5))
+        data = [10.0 * i + j for i in 1:3, j in 1:5]
+        bc = (PeriodicBC(endpoint = :exclusive, period = 3.0), NoBC())
+        itp = constant_interp((x, y), data; bc = bc)
+
+        @test itp((0.5, 0.5)) ≈ itp((3.5, 0.5)) atol = 1e-12
+    end
+
+    @testset "ND — NoBC default is no-op" begin
+        x = range(0.0, 1.0, length = 5)
+        y = range(0.0, 1.0, length = 4)
+        data = rand(5, 4)
+
+        itp_default = constant_interp((x, y), data)
+        itp_nobc = constant_interp((x, y), data; bc = NoBC())
+
+        for q in ((0.3, 0.5), (0.9, 0.1), (0.0, 0.0), (1.0, 1.0))
+            @test itp_default(q) === itp_nobc(q)
+        end
+    end
+
+    @testset "ND — incompatible extrap with PeriodicBC raises" begin
+        x = range(0.5, step = 1.0, length = 3)
+        y = range(0.0, 1.0, length = 5)
+        data = rand(3, 5)
+        @test_throws ArgumentError constant_interp(
+            (x, y), data;
+            bc = (PeriodicBC(endpoint = :exclusive, period = 3.0), NoBC()),
+            extrap = (ClampExtrap(), NoExtrap())
+        )
+    end
+
+    # ============================================================
+    # Edge cases
+    # ============================================================
+    @testset "Edge — Vector grid :exclusive without period raises" begin
+        x = [0.0, 1.0, 2.0, 3.0]
+        y = sin.(x)
+        @test_throws ArgumentError constant_interp(x, y; bc = PeriodicBC(endpoint = :exclusive))
+    end
+
+    @testset "Edge — Range grid + conflicting period raises" begin
+        x = range(0.0, step = 0.1, length = 10)
+        y = sin.(x)
+        @test_throws ArgumentError constant_interp(x, y; bc = PeriodicBC(endpoint = :exclusive, period = 2.0))
+    end
+
+    @testset "Edge — oneshot Vector grid :exclusive without period raises" begin
+        x = [0.0, 1.0, 2.0, 3.0]
+        y = sin.(x)
+        @test_throws ArgumentError constant_interp(x, y, 1.5; bc = PeriodicBC(endpoint = :exclusive))
+    end
+
+    # ============================================================
+    # Interpolant path — extended copy storage
+    # ============================================================
+    @testset "Interpolant path stores extended copy (Vector grid)" begin
+        x = [0.0, 1.0, 2.0, 3.0]
+        y = [10.0, 20.0, 30.0, 40.0]
+        x_ref = copy(x)
+        y_ref = copy(y)
+
+        itp = constant_interp(x, y; bc = PeriodicBC(endpoint = :exclusive, period = 4.0))
+
+        @test length(itp.x) == 5
+        @test length(itp.y) == 5
+        @test itp.y[end] == itp.y[1]
+        @test itp.x[end] ≈ 4.0
+
+        # Original arrays unmodified.
+        @test x == x_ref
+        @test y == y_ref
+    end
+
+    @testset "Interpolant path stores extended copy (Range grid → _CachedRange)" begin
+        x = range(0.0, step = 1.0, length = 4)
+        y = [10.0, 20.0, 30.0, 40.0]
+
+        itp = constant_interp(x, y; bc = PeriodicBC(endpoint = :exclusive))
+
+        # Range input → extended grid must be _CachedRange (O(1) indexing preserved).
+        @test itp.x isa _CachedRange
+        @test length(itp.x) == 5
+        @test length(itp.y) == 5
+        @test itp.y[end] == itp.y[1]
+    end
+
+    # ============================================================
+    # Zero-allocation tests (one-shot, after warmup)
+    # ============================================================
+    # Function-barrier pattern for alloc tests (same rationale as Linear).
+    function _alloc_const_1d_range_scalar(side)
+        x = range(0.0, step = 2π / 16, length = 16)
+        y = sin.(x)
+        bc = PeriodicBC(endpoint = :exclusive)
+        constant_interp(x, y, 1.0; bc = bc, side = side)
+        constant_interp(x, y, 1.0; bc = bc, side = side)
+        return @allocated constant_interp(x, y, 1.0; bc = bc, side = side)
+    end
+
+    function _alloc_const_1d_range_vec(side)
+        x = range(0.0, step = 2π / 16, length = 16)
+        y = sin.(x)
+        bc = PeriodicBC(endpoint = :exclusive)
+        xq = [0.5, 1.0, 2.0, 3.5]
+        out = similar(xq)
+        constant_interp!(out, x, y, xq; bc = bc, side = side)
+        constant_interp!(out, x, y, xq; bc = bc, side = side)
+        return @allocated constant_interp!(out, x, y, xq; bc = bc, side = side)
+    end
+
+    function _alloc_const_1d_vector_scalar()
+        x = [0.0, 0.5, 1.5, 3.0, 5.0]
+        y = sin.(x)
+        bc = PeriodicBC(endpoint = :exclusive, period = 2π)
+        constant_interp(x, y, 1.0; bc = bc)
+        constant_interp(x, y, 1.0; bc = bc)
+        return @allocated constant_interp(x, y, 1.0; bc = bc)
+    end
+
+    function _alloc_const_1d_vector_vec()
+        x = [0.0, 0.5, 1.5, 3.0, 5.0]
+        y = sin.(x)
+        bc = PeriodicBC(endpoint = :exclusive, period = 2π)
+        xq = [0.5, 1.0, 2.0, 3.5]
+        out = similar(xq)
+        constant_interp!(out, x, y, xq; bc = bc)
+        constant_interp!(out, x, y, xq; bc = bc)
+        return @allocated constant_interp!(out, x, y, xq; bc = bc)
+    end
+
+    function _alloc_const_nd_range()
+        x = range(0.0, step = 2π / 8, length = 8)
+        y = range(0.0, step = 2π / 8, length = 8)
+        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+        bc = PeriodicBC(endpoint = :exclusive)
+        q = (1.0, 2.0)
+        constant_interp((x, y), data, q; bc = bc)
+        constant_interp((x, y), data, q; bc = bc)
+        return @allocated constant_interp((x, y), data, q; bc = bc)
+    end
+
+    function _alloc_const_nd_vector()
+        x = collect(range(0.0, step = 2π / 8, length = 8))
+        y = collect(range(0.0, step = 2π / 8, length = 8))
+        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+        bc_axis = PeriodicBC(endpoint = :exclusive, period = 2π)
+        bcs = (bc_axis, bc_axis)
+        q = (1.0, 2.0)
+        constant_interp((x, y), data, q; bc = bcs)
+        constant_interp((x, y), data, q; bc = bcs)
+        return @allocated constant_interp((x, y), data, q; bc = bcs)
+    end
+
+    function _alloc_const_nd_mixed()
+        x = [0.0, 0.5, 1.5, 3.0, 5.0]
+        y = range(0.0, 1.0, length = 7)
+        data = rand(length(x), length(y))
+        bcs = (PeriodicBC(endpoint = :exclusive, period = 2π), NoBC())
+        q = (1.0, 0.5)
+        constant_interp((x, y), data, q; bc = bcs)
+        constant_interp((x, y), data, q; bc = bcs)
+        return @allocated constant_interp((x, y), data, q; bc = bcs)
+    end
+
+    @testset "One-shot :exclusive zero-alloc — 1D Range (all sides)" begin
+        for side in (NearestSide(), LeftSide(), RightSide())
+            @test _alloc_const_1d_range_scalar(side) <= ALLOC_THRESHOLD
+            @test _alloc_const_1d_range_vec(side) <= ALLOC_THRESHOLD
+        end
+    end
+    @testset "One-shot :exclusive zero-alloc — 1D Vector scalar (pool)" begin
+        @test _alloc_const_1d_vector_scalar() <= ALLOC_THRESHOLD
+    end
+    @testset "One-shot :exclusive zero-alloc — 1D Vector vector in-place (pool)" begin
+        @test _alloc_const_1d_vector_vec() <= ALLOC_THRESHOLD
+    end
+    @testset "One-shot :exclusive zero-alloc — ND Range grids" begin
+        @test _alloc_const_nd_range() <= ND_ALLOC_THRESHOLD
+    end
+    @testset "One-shot :exclusive zero-alloc — ND Vector grids (pool)" begin
+        @test _alloc_const_nd_vector() <= ND_ALLOC_THRESHOLD
+    end
+    # See test_linear_periodic.jl for the full note — same shared-infrastructure issue.
+    @testset "One-shot :exclusive — ND mixed alloc (known non-zero, @test_broken)" begin
+        @test_broken _alloc_const_nd_mixed() <= ND_ALLOC_THRESHOLD
+    end
+
+    @testset "ND — Vector grid :exclusive without period raises" begin
+        x = [0.0, 1.0, 2.0, 3.0]
+        y = range(0.0, 1.0, length = 4)
+        data = rand(4, 4)
+        @test_throws ArgumentError constant_interp(
+            (x, y), data;
+            bc = (PeriodicBC(endpoint = :exclusive), NoBC())
+        )
+    end
+
+end

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -414,8 +414,8 @@ using FastInterpolations: _CachedRange
         itp2 = constant_interp(x, y2; bc = bc)
         for xq in (0.3, 1.7, 2π + 0.5, -0.2)
             out = sitp(xq)
-            @test out[1] ≈ itp1(xq) atol = 1e-12
-            @test out[2] ≈ itp2(xq) atol = 1e-12
+            @test out[1] ≈ itp1(xq) atol = 1.0e-12
+            @test out[2] ≈ itp2(xq) atol = 1.0e-12
         end
     end
 
@@ -434,7 +434,7 @@ using FastInterpolations: _CachedRange
         sitp = constant_interp(x, Series(y1, y2); bc = bc)
         for xq in (0.0, 0.5, 2.0, -0.1, 2π + 0.1)
             oneshot = constant_interp(x, Series(y1, y2), xq; bc = bc)
-            @test oneshot ≈ sitp(xq) atol = 1e-12
+            @test oneshot ≈ sitp(xq) atol = 1.0e-12
         end
     end
 
@@ -450,13 +450,13 @@ using FastInterpolations: _CachedRange
         @test length(out_vec) == 2
         for j in eachindex(xqs)
             ref = sitp(xqs[j])
-            @test out_vec[1][j] ≈ ref[1] atol = 1e-12
-            @test out_vec[2][j] ≈ ref[2] atol = 1e-12
+            @test out_vec[1][j] ≈ ref[1] atol = 1.0e-12
+            @test out_vec[2][j] ≈ ref[2] atol = 1.0e-12
         end
 
         outs = [similar(xqs) for _ in 1:2]
         constant_interp!(outs, x, Series(y1, y2), xqs; bc = bc)
-        @test outs[1] ≈ out_vec[1] atol = 1e-12
+        @test outs[1] ≈ out_vec[1] atol = 1.0e-12
     end
 
 end

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -200,6 +200,14 @@ using FastInterpolations: _CachedRange
         @test_throws ArgumentError constant_interp(x, y, 1.5; bc = PeriodicBC(endpoint = :exclusive))
     end
 
+    @testset "Edge — oneshot Vector grid :exclusive period too small raises" begin
+        x = [0.0, 1.0, 2.0, 3.0]
+        y = sin.(x)
+        bc_bad = PeriodicBC(endpoint = :exclusive, period = 2.5)
+        @test_throws ArgumentError constant_interp(x, y, 1.5; bc = bc_bad)
+        @test_throws ArgumentError constant_interp(x, y, [1.5, 2.5]; bc = bc_bad)
+    end
+
     # ============================================================
     # Interpolant path — extended copy storage
     # ============================================================

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -14,7 +14,7 @@ using FastInterpolations: _CachedRange
         y = sin.(2π .* x)
 
         itp_default = constant_interp(x, y)
-        itp_nobc    = constant_interp(x, y; bc = NoBC())
+        itp_nobc = constant_interp(x, y; bc = NoBC())
 
         @test typeof(itp_default) === typeof(itp_nobc)
         for xq in (0.0, 0.25, 0.5, 0.75, 1.0)
@@ -35,11 +35,11 @@ using FastInterpolations: _CachedRange
         itp = constant_interp(x, y; bc = bc, side = LeftSide())
 
         # LeftSide with extended endpoint: segment [2.5, 3.5] has left-value = 30.0
-        @test itp(2.6) ≈ 30.0 atol = 1e-12
-        @test itp(3.4) ≈ 30.0 atol = 1e-12   # still within [2.5, 3.5] → 30.0
+        @test itp(2.6) ≈ 30.0 atol = 1.0e-12
+        @test itp(3.4) ≈ 30.0 atol = 1.0e-12   # still within [2.5, 3.5] → 30.0
 
         # Wrap: query outside [0.5, 3.5) wraps back
-        @test itp(3.6) ≈ itp(0.6) atol = 1e-12
+        @test itp(3.6) ≈ itp(0.6) atol = 1.0e-12
     end
 
     @testset "Exclusive — RightSide" begin
@@ -49,7 +49,7 @@ using FastInterpolations: _CachedRange
         itp = constant_interp(x, y; bc = bc, side = RightSide())
 
         # RightSide on segment [2.5, 3.5] → right endpoint value = y[n+1] = y[1] = 10.0
-        @test itp(2.6) ≈ 10.0 atol = 1e-12
+        @test itp(2.6) ≈ 10.0 atol = 1.0e-12
     end
 
     @testset "Exclusive — Vector grid (allocating path)" begin
@@ -58,8 +58,8 @@ using FastInterpolations: _CachedRange
         itp = constant_interp(x_vec, y; bc = PeriodicBC(endpoint = :exclusive, period = 3.0))
 
         # NearestSide default — closest cell center
-        @test itp(2.5) ≈ 30.0 atol = 1e-12
-        @test itp(3.4) ≈ 10.0 atol = 1e-12   # closer to virtual x=3.5 (value=10) than to 2.5
+        @test itp(2.5) ≈ 30.0 atol = 1.0e-12
+        @test itp(3.4) ≈ 10.0 atol = 1.0e-12   # closer to virtual x=3.5 (value=10) than to 2.5
     end
 
     @testset "Extrap is forced to WrapExtrap on periodic path" begin
@@ -76,15 +76,15 @@ using FastInterpolations: _CachedRange
         itp = constant_interp(x, y; bc = bc)
 
         for xq in (0.5, 1.5, 2.5, 3.0, 3.4, 0.0, -0.5)
-            @test constant_interp(x, y, xq; bc = bc) ≈ itp(xq) atol = 1e-12
+            @test constant_interp(x, y, xq; bc = bc) ≈ itp(xq) atol = 1.0e-12
         end
 
         xq = [0.5, 1.0, 2.5, 3.0, 3.4]
-        @test constant_interp(x, y, xq; bc = bc) ≈ itp.(xq) atol = 1e-12
+        @test constant_interp(x, y, xq; bc = bc) ≈ itp.(xq) atol = 1.0e-12
 
         out = zeros(length(xq))
         constant_interp!(out, x, y, xq; bc = bc)
-        @test out ≈ itp.(xq) atol = 1e-12
+        @test out ≈ itp.(xq) atol = 1.0e-12
     end
 
     # ============================================================
@@ -106,7 +106,7 @@ using FastInterpolations: _CachedRange
         @test size(itp.data) == (4, 5)
 
         q = (1.2, 0.8)
-        @test itp(q) ≈ constant_interp((x, y), data, q; bc = bc) atol = 1e-12
+        @test itp(q) ≈ constant_interp((x, y), data, q; bc = bc) atol = 1.0e-12
     end
 
     @testset "ND — per-axis mix (periodic + non-periodic)" begin
@@ -116,7 +116,7 @@ using FastInterpolations: _CachedRange
         bc = (PeriodicBC(endpoint = :exclusive, period = 3.0), NoBC())
         itp = constant_interp((x, y), data; bc = bc)
 
-        @test itp((0.5, 0.5)) ≈ itp((3.5, 0.5)) atol = 1e-12
+        @test itp((0.5, 0.5)) ≈ itp((3.5, 0.5)) atol = 1.0e-12
     end
 
     @testset "ND — NoBC default is no-op" begin

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -382,4 +382,23 @@ using FastInterpolations: _CachedRange
     # Dual-grid + PeriodicBC coverage lives in
     # `test/ext/test_constant_quadratic_dual_grid.jl`.
 
+    # ============================================================
+    # Float32 + Complex smoke tests.
+    # ============================================================
+    @testset "Float32 Range + PeriodicBC(:exclusive)" begin
+        x = range(0.0f0, step = Float32(2π / 8), length = 8)
+        y = sin.(x)
+        itp = constant_interp(x, y; bc = PeriodicBC(endpoint = :exclusive))
+        @test eltype(itp.x) === Float32
+        @test itp(1.0f0) isa Float32
+    end
+
+    @testset "ComplexF64 values + PeriodicBC(:exclusive)" begin
+        x = collect(range(0.0, step = 2π / 8, length = 8))
+        y = @. exp(im * x)
+        itp = constant_interp(x, y; bc = PeriodicBC(endpoint = :exclusive, period = 2π))
+        @test eltype(itp.y) <: Complex
+        @test itp(0.5) isa Complex
+    end
+
 end

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -294,9 +294,8 @@ using FastInterpolations: _CachedRange
     @testset "One-shot :exclusive zero-alloc — ND Vector grids (pool)" begin
         @test _alloc_const_nd_vector() <= ND_ALLOC_THRESHOLD
     end
-    # See test_linear_periodic.jl for the full note — same shared-infrastructure issue.
-    @testset "One-shot :exclusive — ND mixed alloc (known non-zero, @test_broken)" begin
-        @test_broken _alloc_const_nd_mixed() <= ND_ALLOC_THRESHOLD
+    @testset "One-shot :exclusive zero-alloc — ND mixed (periodic Vector + non-periodic Range)" begin
+        @test _alloc_const_nd_mixed() <= ND_ALLOC_THRESHOLD
     end
 
     @testset "ND — Vector grid :exclusive without period raises" begin

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -401,4 +401,62 @@ using FastInterpolations: _CachedRange
         @test itp(0.5) isa Complex
     end
 
+    # ============================================================
+    # Series + PeriodicBC
+    # ============================================================
+    @testset "Series persistent + PeriodicBC — matches per-series interpolants" begin
+        x = collect(range(0.0, step = 2π / 16, length = 16))
+        y1 = sin.(x)
+        y2 = cos.(x)
+        bc = PeriodicBC(endpoint = :exclusive, period = 2π)
+        sitp = constant_interp(x, Series(y1, y2); bc = bc)
+        itp1 = constant_interp(x, y1; bc = bc)
+        itp2 = constant_interp(x, y2; bc = bc)
+        for xq in (0.3, 1.7, 2π + 0.5, -0.2)
+            out = sitp(xq)
+            @test out[1] ≈ itp1(xq) atol = 1e-12
+            @test out[2] ≈ itp2(xq) atol = 1e-12
+        end
+    end
+
+    @testset "Series persistent + PeriodicBC :inclusive mismatch raises" begin
+        x = collect(range(0.0, 2π, length = 17))
+        y1 = sin.(x)
+        y2 = collect(0.0:16)             # mismatched endpoints
+        @test_throws ArgumentError constant_interp(x, Series(y1, y2); bc = PeriodicBC())
+    end
+
+    @testset "Series oneshot scalar + PeriodicBC agrees with persistent" begin
+        x = collect(range(0.0, step = 2π / 16, length = 16))
+        y1 = sin.(x)
+        y2 = cos.(x)
+        bc = PeriodicBC(endpoint = :exclusive, period = 2π)
+        sitp = constant_interp(x, Series(y1, y2); bc = bc)
+        for xq in (0.0, 0.5, 2.0, -0.1, 2π + 0.1)
+            oneshot = constant_interp(x, Series(y1, y2), xq; bc = bc)
+            @test oneshot ≈ sitp(xq) atol = 1e-12
+        end
+    end
+
+    @testset "Series oneshot vector + PeriodicBC" begin
+        x = collect(range(0.0, step = 2π / 16, length = 16))
+        y1 = sin.(x)
+        y2 = cos.(x)
+        bc = PeriodicBC(endpoint = :exclusive, period = 2π)
+        sitp = constant_interp(x, Series(y1, y2); bc = bc)
+
+        xqs = [0.0, 0.5, 2.0, -0.1]
+        out_vec = constant_interp(x, Series(y1, y2), xqs; bc = bc)
+        @test length(out_vec) == 2
+        for j in eachindex(xqs)
+            ref = sitp(xqs[j])
+            @test out_vec[1][j] ≈ ref[1] atol = 1e-12
+            @test out_vec[2][j] ≈ ref[2] atol = 1e-12
+        end
+
+        outs = [similar(xqs) for _ in 1:2]
+        constant_interp!(outs, x, Series(y1, y2), xqs; bc = bc)
+        @test outs[1] ≈ out_vec[1] atol = 1e-12
+    end
+
 end

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -143,6 +143,42 @@ using FastInterpolations: _CachedRange
         )
     end
 
+    @testset "ND — :inclusive slice mismatch raises on build" begin
+        x = collect(range(0.0, 2π, length = 5))
+        y = collect(range(0.0, 2π, length = 5))
+        good = [sin(xi) * cos(yj) for xi in x, yj in y]
+        bad = copy(good)
+        bad[end, :] .+= 1.0
+
+        @test_throws ArgumentError constant_interp((x, y), bad; bc = PeriodicBC())
+        @test constant_interp((x, y), good; bc = PeriodicBC()) isa ConstantInterpolantND
+    end
+
+    @testset "ND — :inclusive slice mismatch raises on oneshot" begin
+        x = collect(range(0.0, 2π, length = 5))
+        y = collect(range(0.0, 2π, length = 5))
+        bad = [sin(xi) * cos(yj) for xi in x, yj in y]
+        bad[:, end] .+= 1.0
+
+        q = (1.0, 1.0)
+        @test_throws ArgumentError constant_interp((x, y), bad, q; bc = PeriodicBC())
+    end
+
+    @testset "ND — :inclusive + check=false skips validation" begin
+        x = range(0.0, 2π, length = 5)
+        y = range(0.0, 2π, length = 5)
+        bad = [sin(xi) * cos(yj) for xi in x, yj in y]
+        bad[end, :] .+= 1.0
+        itp = constant_interp(
+            (x, y), bad;
+            bc = (
+                PeriodicBC(endpoint = :inclusive, check = false),
+                PeriodicBC(endpoint = :inclusive, check = false),
+            )
+        )
+        @test itp isa ConstantInterpolantND
+    end
+
     # ============================================================
     # Edge cases
     # ============================================================
@@ -307,5 +343,43 @@ using FastInterpolations: _CachedRange
             bc = (PeriodicBC(endpoint = :exclusive), NoBC())
         )
     end
+
+    # ============================================================
+    # Integer grid + duck-type (Dual) smoke tests. See
+    # test_linear_periodic.jl for the rationale — same `_PromotableValue`
+    # gating in `_extend_exclusive` / `_periodic_extend_1d_pooled!`.
+    # ============================================================
+    @testset "Int Range + PeriodicBC(:exclusive) — persistent" begin
+        x = 0:10
+        y = Float64.(0:10)
+        itp = constant_interp(x, y; bc = PeriodicBC(endpoint = :exclusive, period = 11.0))
+        @test itp.x isa _CachedRange{Float64}
+        @test length(itp.x) == 12
+        ref = constant_interp(Float64.(0:10), y; bc = PeriodicBC(endpoint = :exclusive, period = 11.0))
+        for xq in (0.5, 5.5, 10.5)
+            @test itp(xq) ≈ ref(xq) atol = 1.0e-12
+        end
+    end
+
+    @testset "Int Range + PeriodicBC(:exclusive) — oneshot" begin
+        x = 0:10
+        y = Float64.(0:10)
+        bc = PeriodicBC(endpoint = :exclusive, period = 11.0)
+        for xq in (0.5, 5.5, 10.5)
+            @test constant_interp(x, y, xq; bc = bc) isa Float64
+        end
+    end
+
+    @testset "Int Vector + PeriodicBC(:exclusive) with Float period — oneshot" begin
+        x = [0, 1, 2, 3]
+        y = [10.0, 20.0, 30.0, 40.0]
+        bc = PeriodicBC(endpoint = :exclusive, period = 4.0)
+        @test constant_interp(x, y, 1.5; bc = bc) isa Float64
+        ref = constant_interp(Float64.(x), y, 1.5; bc = bc)
+        @test constant_interp(x, y, 1.5; bc = bc) ≈ ref atol = 1.0e-12
+    end
+
+    # Dual-grid + PeriodicBC coverage lives in
+    # `test/ext/test_constant_quadratic_dual_grid.jl`.
 
 end

--- a/test/test_linear_oneshot_series.jl
+++ b/test/test_linear_oneshot_series.jl
@@ -253,4 +253,68 @@ using FastInterpolations
         @test outputs[1] ≈ outputs_ref[1]
         @test outputs[2] ≈ outputs_ref[2]
     end
+
+    @testset "PeriodicBC — scalar, :inclusive" begin
+        s = Series(y_sin, y_cos)   # y[1] == y[end] = 0
+        vals = linear_interp(x, s, 0.37; bc = PeriodicBC())
+        vals_wrap = linear_interp(x, s, 0.37 + 1.0; bc = PeriodicBC())
+        @test vals ≈ vals_wrap atol = 1.0e-12
+    end
+
+    @testset "PeriodicBC — scalar, :exclusive FVM" begin
+        xc = [0.5, 1.5, 2.5]
+        s = Series([10.0, 20.0, 30.0], [1.0, 2.0, 3.0])
+        bc = PeriodicBC(endpoint = :exclusive, period = 3.0)
+        @test linear_interp(xc, s, 3.0; bc)[1] ≈ 20.0 atol = 1.0e-12   # midpoint of extended [2.5, 3.5]
+        @test linear_interp(xc, s, 3.0; bc)[2] ≈ 2.0 atol = 1.0e-12
+    end
+
+    @testset "PeriodicBC — scalar in-place" begin
+        s = Series(y_sin, y_cos)
+        out = zeros(2)
+        linear_interp!(out, x, s, 0.37; bc = PeriodicBC())
+        @test out ≈ linear_interp(x, s, 0.37; bc = PeriodicBC())
+    end
+
+    @testset "PeriodicBC — vector in-place, :inclusive" begin
+        s = Series(y_sin, y_cos)
+        xqs = [0.1, 0.37, 0.9]
+        outputs = [zeros(length(xqs)) for _ in 1:2]
+        linear_interp!(outputs, x, s, xqs; bc = PeriodicBC())
+        outputs_wrap = [zeros(length(xqs)) for _ in 1:2]
+        linear_interp!(outputs_wrap, x, s, xqs .+ 1.0; bc = PeriodicBC())
+        @test outputs[1] ≈ outputs_wrap[1] atol = 1.0e-12
+        @test outputs[2] ≈ outputs_wrap[2] atol = 1.0e-12
+    end
+
+    @testset "PeriodicBC — vector in-place, :exclusive" begin
+        xc = [0.5, 1.5, 2.5]
+        s = Series([10.0, 20.0, 30.0], [1.0, 2.0, 3.0])
+        bc = PeriodicBC(endpoint = :exclusive, period = 3.0)
+        xqs = [0.5, 2.5, 3.0]
+        outputs = [zeros(3), zeros(3)]
+        linear_interp!(outputs, xc, s, xqs; bc)
+        @test outputs[1][2] ≈ 30.0 atol = 1.0e-12
+        @test outputs[1][3] ≈ 20.0 atol = 1.0e-12   # midpoint
+        @test outputs[2][3] ≈ 2.0 atol = 1.0e-12
+    end
+
+    @testset "PeriodicBC — vector allocating" begin
+        s = Series(y_sin, y_cos)
+        outs = linear_interp(x, s, [0.1, 0.37]; bc = PeriodicBC())
+        @test length(outs) == 2 && length(outs[1]) == 2
+    end
+
+    @testset "PeriodicBC — :inclusive endpoint mismatch raises" begin
+        s = Series(y_sin, y_exp)   # y_exp[1] != y_exp[end]
+        @test_throws ArgumentError linear_interp(x, s, 0.37; bc = PeriodicBC())
+    end
+
+    @testset "PeriodicBC — :exclusive period too small raises" begin
+        # Vector grid span = 3.0, period = 2.5 → virtual endpoint < last(x) → throw
+        xv = [0.0, 1.0, 2.0, 3.0]
+        s = Series([0.0, 1.0, 2.0, 3.0])
+        bc_bad = PeriodicBC(endpoint = :exclusive, period = 2.5)
+        @test_throws ArgumentError linear_interp(xv, s, 1.5; bc = bc_bad)
+    end
 end

--- a/test/test_linear_periodic.jl
+++ b/test/test_linear_periodic.jl
@@ -1,0 +1,372 @@
+# Tests for PeriodicBC on Linear interpolation (Phase 1).
+#
+# Coverage:
+#   - `NoBC()` default is a no-op (regression guard against pre-change behavior).
+#   - `PeriodicBC(endpoint=:inclusive)` wraps correctly with y[1] == y[end] data.
+#   - `PeriodicBC(endpoint=:exclusive, period=L)` extends grid+data, forces WrapExtrap.
+#   - FVM cell-centered case: x = [0.5, 1.5, 2.5], period = 3.0.
+#   - Range grid (type-stable extension) vs Vector grid (vcat extension).
+#   - Inclusive check raises on mismatched endpoints.
+
+using Test
+using FastInterpolations
+using FastInterpolations: _is_periodic_bc, _CachedRange
+
+@testset "Linear PeriodicBC" begin
+
+    @testset "NoBC default is no-op" begin
+        x = collect(range(0.0, 1.0, length = 11))
+        y = sin.(2π .* x)
+
+        itp_default = linear_interp(x, y)                       # no bc kwarg
+        itp_nobc    = linear_interp(x, y; bc = NoBC())          # explicit NoBC
+
+        @test typeof(itp_default) === typeof(itp_nobc)
+        for xq in (0.0, 0.25, 0.5, 0.75, 1.0)
+            @test itp_default(xq) === itp_nobc(xq)
+        end
+    end
+
+    @testset "Inclusive — Range grid" begin
+        x = range(0.0, 2π, length = 11)                         # y[1] == y[end] for sin
+        y = sin.(x)
+        itp = linear_interp(x, y; bc = PeriodicBC())
+
+        # Round-trip at domain endpoints
+        @test itp(0.0) ≈ itp(2π) atol = 1e-12
+
+        # Query outside base domain wraps by `period = 2π`
+        @test itp(2π + 0.5) ≈ itp(0.5) atol = 1e-12
+        @test itp(-0.3)     ≈ itp(2π - 0.3) atol = 1e-12
+    end
+
+    @testset "Inclusive — endpoint mismatch raises" begin
+        x = collect(range(0.0, 1.0, length = 5))
+        y = [0.0, 1.0, 2.0, 3.0, 4.0]                          # y[1] != y[end]
+        @test_throws ArgumentError linear_interp(x, y; bc = PeriodicBC())
+    end
+
+    @testset "Exclusive — FVM cell-centered, Range grid" begin
+        # Cell centers x = [0.5, 1.5, 2.5], physical period L = 3.0
+        x = range(0.5, step = 1.0, length = 3)
+        y = [10.0, 20.0, 30.0]
+        itp = linear_interp(x, y; bc = PeriodicBC(endpoint = :exclusive, period = 3.0))
+
+        # Extended virtual endpoint: x[end+1] = 0.5 + 3.0 = 3.5, y = 10.0 (wraps to y[1])
+        # So segment [2.5, 3.5] interpolates linearly between 30.0 → 10.0.
+        @test itp(2.5) ≈ 30.0 atol = 1e-12
+        @test itp(3.0) ≈ 20.0 atol = 1e-12    # midpoint of [2.5,3.5]: (30+10)/2 = 20
+        @test itp(3.5) ≈ 10.0 atol = 1e-12    # wraps to x=0.5 via WrapExtrap
+
+        # Query to the left of x[1] wraps into the extended segment
+        @test itp(0.0) ≈ 20.0 atol = 1e-12    # 0.0 wraps to 3.0 → midpoint of [2.5, 3.5]
+    end
+
+    @testset "Exclusive — Vector grid (allocating path)" begin
+        x_vec = [0.5, 1.5, 2.5]                                # Vector, not Range
+        y = [10.0, 20.0, 30.0]
+        itp = linear_interp(x_vec, y; bc = PeriodicBC(endpoint = :exclusive, period = 3.0))
+
+        @test itp(2.5) ≈ 30.0 atol = 1e-12
+        @test itp(3.0) ≈ 20.0 atol = 1e-12
+        @test itp(3.5) ≈ 10.0 atol = 1e-12
+    end
+
+    @testset "Exclusive — auto-infer period from Range" begin
+        # period auto = step(x) * length(x) = 1.0 * 3 = 3.0
+        x = range(0.5, step = 1.0, length = 3)
+        y = [10.0, 20.0, 30.0]
+        itp = linear_interp(x, y; bc = PeriodicBC(endpoint = :exclusive))
+
+        @test itp(3.0) ≈ 20.0 atol = 1e-12
+    end
+
+    @testset "Extrap is forced to WrapExtrap on periodic path" begin
+        x = range(0.0, 2π, length = 11)
+        y = sin.(x)
+        # User-passed extrap is silently overridden (matches cubic 1D behavior).
+        itp = linear_interp(x, y; bc = PeriodicBC(), extrap = ClampExtrap())
+        @test itp.extrap isa WrapExtrap
+    end
+
+    @testset "Oneshot scalar — matches persistent interpolant" begin
+        x = range(0.5, step = 1.0, length = 3)
+        y = [10.0, 20.0, 30.0]
+        bc = PeriodicBC(endpoint = :exclusive, period = 3.0)
+        itp = linear_interp(x, y; bc = bc)
+
+        for xq in (0.5, 1.5, 2.5, 3.0, 3.4, 0.0, -0.5)
+            @test linear_interp(x, y, xq; bc = bc) ≈ itp(xq) atol = 1e-12
+        end
+    end
+
+    @testset "Oneshot vector (allocating) — matches persistent interpolant" begin
+        x = range(0.5, step = 1.0, length = 3)
+        y = [10.0, 20.0, 30.0]
+        bc = PeriodicBC(endpoint = :exclusive, period = 3.0)
+        itp = linear_interp(x, y; bc = bc)
+
+        xq = [0.5, 1.0, 2.5, 3.0, 3.4]
+        out_oneshot = linear_interp(x, y, xq; bc = bc)
+        out_itp = itp.(xq)
+        @test out_oneshot ≈ out_itp atol = 1e-12
+    end
+
+    @testset "Oneshot in-place — matches persistent interpolant" begin
+        x = range(0.5, step = 1.0, length = 3)
+        y = [10.0, 20.0, 30.0]
+        bc = PeriodicBC(endpoint = :exclusive, period = 3.0)
+        itp = linear_interp(x, y; bc = bc)
+
+        xq = [0.5, 1.0, 2.5, 3.0, 3.4]
+        out = zeros(length(xq))
+        linear_interp!(out, x, y, xq; bc = bc)
+        @test out ≈ itp.(xq) atol = 1e-12
+    end
+
+    @testset "Oneshot NoBC default — regression guard" begin
+        x = collect(range(0.0, 1.0, length = 11))
+        y = sin.(2π .* x)
+        xq = [0.05, 0.45, 0.95]
+
+        # Default (no bc kwarg) must equal explicit NoBC()
+        @test linear_interp(x, y, xq) == linear_interp(x, y, xq; bc = NoBC())
+        @test linear_interp(x, y, 0.5) === linear_interp(x, y, 0.5; bc = NoBC())
+    end
+
+    # ============================================================
+    # ND tests
+    # ============================================================
+    @testset "ND — scalar bc applied to all axes (2D)" begin
+        x = range(0.5, step = 1.0, length = 3)
+        y = range(0.0, 1.0, length = 5)
+        data = [10.0 * i + j for i in 1:3, j in 1:5]
+        # 2D periodic on both axes, auto-infer period
+        bc = PeriodicBC(endpoint = :exclusive)
+        itp = linear_interp((x, y), data; bc = bc)
+
+        # ND persistent path: extended Range axes must remain _CachedRange.
+        @test itp.grids[1] isa _CachedRange
+        @test itp.grids[2] isa _CachedRange
+        @test length(itp.grids[1]) == 4  # 3 + 1
+        @test length(itp.grids[2]) == 6  # 5 + 1
+        @test size(itp.data) == (4, 6)
+
+        # Interior query agrees between persistent and oneshot
+        q = (1.2, 0.5)
+        @test itp(q) ≈ linear_interp((x, y), data, q; bc = bc) atol = 1e-12
+    end
+
+    @testset "ND — per-axis bc tuple (periodic + non-periodic mix)" begin
+        x = range(0.5, step = 1.0, length = 3)                  # periodic axis
+        y = collect(range(0.0, 1.0, length = 5))                # non-periodic axis
+        data = [10.0 * i + j for i in 1:3, j in 1:5]
+        bc = (PeriodicBC(endpoint = :exclusive, period = 3.0), NoBC())
+        itp = linear_interp((x, y), data; bc = bc)
+
+        # Query at y=0.5 should wrap correctly on axis 1 when xq goes past x[end]
+        @test itp((0.5, 0.5)) ≈ itp((3.5, 0.5)) atol = 1e-12  # same by periodicity
+    end
+
+    @testset "ND — NoBC default is no-op" begin
+        x = range(0.0, 1.0, length = 5)
+        y = range(0.0, 1.0, length = 4)
+        data = rand(5, 4)
+
+        itp_default = linear_interp((x, y), data)
+        itp_nobc = linear_interp((x, y), data; bc = NoBC())
+
+        for q in ((0.3, 0.5), (0.9, 0.1), (0.0, 0.0), (1.0, 1.0))
+            @test itp_default(q) === itp_nobc(q)
+        end
+    end
+
+    @testset "ND — incompatible extrap with PeriodicBC raises" begin
+        x = range(0.5, step = 1.0, length = 3)
+        y = range(0.0, 1.0, length = 5)
+        data = rand(3, 5)
+        # ND strict check: ClampExtrap on a periodic axis must raise
+        @test_throws ArgumentError linear_interp(
+            (x, y), data;
+            bc = (PeriodicBC(endpoint = :exclusive, period = 3.0), NoBC()),
+            extrap = (ClampExtrap(), NoExtrap())
+        )
+    end
+
+    # ============================================================
+    # Edge cases (mirrors test_periodic_exclusive.jl for cubic)
+    # ============================================================
+    @testset "Edge — Vector grid :exclusive without period raises" begin
+        # period cannot be inferred from a Vector grid — must be supplied.
+        x = [0.0, 1.0, 2.0, 3.0]
+        y = sin.(x)
+        @test_throws ArgumentError linear_interp(x, y; bc = PeriodicBC(endpoint = :exclusive))
+    end
+
+    @testset "Edge — Range grid + conflicting period raises" begin
+        # step(x) * length(x) = 0.1 * 10 = 1.0, but user claims period=2.0 → mismatch.
+        x = range(0.0, step = 0.1, length = 10)
+        y = sin.(x)
+        @test_throws ArgumentError linear_interp(x, y; bc = PeriodicBC(endpoint = :exclusive, period = 2.0))
+    end
+
+    @testset "Edge — oneshot Vector grid :exclusive without period raises" begin
+        x = [0.0, 1.0, 2.0, 3.0]
+        y = sin.(x)
+        @test_throws ArgumentError linear_interp(x, y, 1.5; bc = PeriodicBC(endpoint = :exclusive))
+    end
+
+    # ============================================================
+    # Interpolant path — extended copy storage
+    # ============================================================
+    @testset "Interpolant path stores extended copy (Vector grid)" begin
+        x = [0.0, 1.0, 2.0, 3.0]
+        y = [10.0, 20.0, 30.0, 40.0]
+        x_ref = copy(x)
+        y_ref = copy(y)
+
+        itp = linear_interp(x, y; bc = PeriodicBC(endpoint = :exclusive, period = 4.0))
+
+        # Stored grid/values are length N+1 with the virtual endpoint appended.
+        @test length(itp.x) == 5
+        @test length(itp.y) == 5
+        @test itp.y[end] == itp.y[1]  # appended y[1] at the end
+        @test itp.x[end] ≈ 4.0
+
+        # Original user arrays are untouched.
+        @test x == x_ref
+        @test y == y_ref
+    end
+
+    @testset "Interpolant path stores extended copy (Range grid → _CachedRange)" begin
+        x = range(0.0, step = 1.0, length = 4)
+        y = [10.0, 20.0, 30.0, 40.0]
+
+        itp = linear_interp(x, y; bc = PeriodicBC(endpoint = :exclusive))
+
+        # Range input → extended grid must be _CachedRange (preserves O(1) indexing
+        # and zero-alloc lookup; _to_float_adding_endpoint guarantees this).
+        @test itp.x isa _CachedRange
+        @test length(itp.x) == 5
+        @test length(itp.y) == 5
+        @test itp.y[end] == itp.y[1]
+    end
+
+    # ============================================================
+    # Zero-allocation tests (one-shot, after warmup)
+    # ============================================================
+    # Function-barrier pattern: setup + warmup + @allocated must live in ONE
+    # function so @testset's try/catch wrapping doesn't make locals type-unstable.
+    # Double warmup primes both compilation and pool slab reuse (cubic pattern).
+    function _alloc_linear_1d_range_scalar()
+        x = range(0.0, step = 2π / 16, length = 16)
+        y = sin.(x)
+        bc = PeriodicBC(endpoint = :exclusive)
+        linear_interp(x, y, 1.0; bc = bc)
+        linear_interp(x, y, 1.0; bc = bc)
+        return @allocated linear_interp(x, y, 1.0; bc = bc)
+    end
+
+    function _alloc_linear_1d_range_vec()
+        x = range(0.0, step = 2π / 16, length = 16)
+        y = sin.(x)
+        bc = PeriodicBC(endpoint = :exclusive)
+        xq = [0.5, 1.0, 2.0, 3.5]
+        out = similar(xq)
+        linear_interp!(out, x, y, xq; bc = bc)
+        linear_interp!(out, x, y, xq; bc = bc)
+        return @allocated linear_interp!(out, x, y, xq; bc = bc)
+    end
+
+    function _alloc_linear_1d_vector_scalar()
+        x = [0.0, 0.5, 1.5, 3.0, 5.0]
+        y = sin.(x)
+        bc = PeriodicBC(endpoint = :exclusive, period = 2π)
+        linear_interp(x, y, 1.0; bc = bc)
+        linear_interp(x, y, 1.0; bc = bc)
+        return @allocated linear_interp(x, y, 1.0; bc = bc)
+    end
+
+    function _alloc_linear_1d_vector_vec()
+        x = [0.0, 0.5, 1.5, 3.0, 5.0]
+        y = sin.(x)
+        bc = PeriodicBC(endpoint = :exclusive, period = 2π)
+        xq = [0.5, 1.0, 2.0, 3.5]
+        out = similar(xq)
+        linear_interp!(out, x, y, xq; bc = bc)
+        linear_interp!(out, x, y, xq; bc = bc)
+        return @allocated linear_interp!(out, x, y, xq; bc = bc)
+    end
+
+    function _alloc_linear_nd_range()
+        x = range(0.0, step = 2π / 8, length = 8)
+        y = range(0.0, step = 2π / 8, length = 8)
+        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+        bc = PeriodicBC(endpoint = :exclusive)
+        q = (1.0, 2.0)
+        linear_interp((x, y), data, q; bc = bc)
+        linear_interp((x, y), data, q; bc = bc)
+        return @allocated linear_interp((x, y), data, q; bc = bc)
+    end
+
+    function _alloc_linear_nd_vector()
+        x = collect(range(0.0, step = 2π / 8, length = 8))
+        y = collect(range(0.0, step = 2π / 8, length = 8))
+        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+        bc_axis = PeriodicBC(endpoint = :exclusive, period = 2π)
+        bcs = (bc_axis, bc_axis)
+        q = (1.0, 2.0)
+        linear_interp((x, y), data, q; bc = bcs)
+        linear_interp((x, y), data, q; bc = bcs)
+        return @allocated linear_interp((x, y), data, q; bc = bcs)
+    end
+
+    function _alloc_linear_nd_mixed()
+        x = [0.0, 0.5, 1.5, 3.0, 5.0]
+        y = range(0.0, 1.0, length = 7)
+        data = rand(length(x), length(y))
+        bcs = (PeriodicBC(endpoint = :exclusive, period = 2π), NoBC())
+        q = (1.0, 0.5)
+        linear_interp((x, y), data, q; bc = bcs)
+        linear_interp((x, y), data, q; bc = bcs)
+        return @allocated linear_interp((x, y), data, q; bc = bcs)
+    end
+
+    @testset "One-shot :exclusive zero-alloc — 1D Range scalar" begin
+        @test _alloc_linear_1d_range_scalar() <= ALLOC_THRESHOLD
+    end
+    @testset "One-shot :exclusive zero-alloc — 1D Range vector in-place" begin
+        @test _alloc_linear_1d_range_vec() <= ALLOC_THRESHOLD
+    end
+    @testset "One-shot :exclusive zero-alloc — 1D Vector scalar (pool)" begin
+        @test _alloc_linear_1d_vector_scalar() <= ALLOC_THRESHOLD
+    end
+    @testset "One-shot :exclusive zero-alloc — 1D Vector vector in-place (pool)" begin
+        @test _alloc_linear_1d_vector_vec() <= ALLOC_THRESHOLD
+    end
+    @testset "One-shot :exclusive zero-alloc — ND Range grids" begin
+        @test _alloc_linear_nd_range() <= ND_ALLOC_THRESHOLD
+    end
+    @testset "One-shot :exclusive zero-alloc — ND Vector grids (pool)" begin
+        @test _alloc_linear_nd_vector() <= ND_ALLOC_THRESHOLD
+    end
+    # Known issue: heterogeneous grids (periodic Vector + non-periodic Range) trigger
+    # ~2.3 KB allocation inside `_prepare_periodic_nd_pooled` — likely from closure
+    # type-instability in the `ntuple do d ... end` that returns different grid types
+    # per axis. Homogeneous cases (all Range, all Vector) are zero-alloc. Functional
+    # correctness is unaffected. Tracked as follow-up optimization in shared core helper.
+    @testset "One-shot :exclusive — ND mixed alloc (known non-zero, @test_broken)" begin
+        @test_broken _alloc_linear_nd_mixed() <= ND_ALLOC_THRESHOLD
+    end
+
+    @testset "ND — Vector grid :exclusive without period raises" begin
+        x = [0.0, 1.0, 2.0, 3.0]          # Vector
+        y = range(0.0, 1.0, length = 4)
+        data = rand(4, 4)
+        @test_throws ArgumentError linear_interp(
+            (x, y), data;
+            bc = (PeriodicBC(endpoint = :exclusive), NoBC())
+        )
+    end
+
+end

--- a/test/test_linear_periodic.jl
+++ b/test/test_linear_periodic.jl
@@ -193,6 +193,44 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
         )
     end
 
+    @testset "ND — :inclusive slice mismatch raises on build" begin
+        # `:inclusive` default requires data[1,...] ≈ data[end,...] along each
+        # periodic axis. Mismatched endpoint slices must raise, mirroring 1D.
+        x = collect(range(0.0, 2π, length = 5))
+        y = collect(range(0.0, 2π, length = 5))
+        good = [sin(xi) * cos(yj) for xi in x, yj in y]  # endpoints match
+        bad = copy(good)
+        bad[end, :] .+= 1.0  # break periodicity along axis 1
+
+        @test_throws ArgumentError linear_interp((x, y), bad; bc = PeriodicBC())
+        @test linear_interp((x, y), good; bc = PeriodicBC()) isa LinearInterpolantND
+    end
+
+    @testset "ND — :inclusive slice mismatch raises on oneshot" begin
+        x = collect(range(0.0, 2π, length = 5))
+        y = collect(range(0.0, 2π, length = 5))
+        bad = [sin(xi) * cos(yj) for xi in x, yj in y]
+        bad[:, end] .+= 1.0  # break along axis 2
+
+        q = (1.0, 1.0)
+        @test_throws ArgumentError linear_interp((x, y), bad, q; bc = PeriodicBC())
+    end
+
+    @testset "ND — :inclusive + check=false skips validation" begin
+        x = range(0.0, 2π, length = 5)
+        y = range(0.0, 2π, length = 5)
+        bad = [sin(xi) * cos(yj) for xi in x, yj in y]
+        bad[end, :] .+= 1.0
+        itp = linear_interp(
+            (x, y), bad;
+            bc = (
+                PeriodicBC(endpoint = :inclusive, check = false),
+                PeriodicBC(endpoint = :inclusive, check = false),
+            )
+        )
+        @test itp isa LinearInterpolantND
+    end
+
     # ============================================================
     # Edge cases (mirrors test_periodic_exclusive.jl for cubic)
     # ============================================================
@@ -363,5 +401,48 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
             bc = (PeriodicBC(endpoint = :exclusive), NoBC())
         )
     end
+
+    # ============================================================
+    # Integer grid + duck-type (Dual) smoke tests.
+    # The periodic extension helpers use `_PromotableValue` to decide whether
+    # to `float(Tg)`-promote. Integer grids must work (previously threw
+    # InexactError on `_CachedRange{Int}`), duck grids must pass through
+    # with their original type (AD chains preserved).
+    # ============================================================
+    @testset "Int Range + PeriodicBC(:exclusive) — persistent" begin
+        x = 0:10                                       # UnitRange{Int}
+        y = sin.(2π .* (x ./ 10))
+        itp = linear_interp(x, y; bc = PeriodicBC(endpoint = :exclusive, period = 11.0))
+        @test itp.x isa _CachedRange{Float64}          # Int Range → Float _CachedRange
+        @test length(itp.x) == 12                      # N+1 extension
+        # Query agrees with Float-equivalent grid
+        ref = linear_interp(Float64.(0:10), y; bc = PeriodicBC(endpoint = :exclusive, period = 11.0))
+        for xq in (0.5, 5.5, 10.5)
+            @test itp(xq) ≈ ref(xq) atol = 1.0e-12
+        end
+    end
+
+    @testset "Int Range + PeriodicBC(:exclusive) — oneshot" begin
+        x = 0:10
+        y = sin.(2π .* (x ./ 10))
+        bc = PeriodicBC(endpoint = :exclusive, period = 11.0)
+        for xq in (0.5, 5.5, 10.5)
+            @test linear_interp(x, y, xq; bc = bc) isa Float64
+        end
+    end
+
+    @testset "Int Vector + PeriodicBC(:exclusive) with Float period — oneshot" begin
+        # The edge case: Vector{Int} without Range-auto-promotion, Float period.
+        x = [0, 1, 2, 3]
+        y = [0.0, 1.0, 0.0, -1.0]
+        bc = PeriodicBC(endpoint = :exclusive, period = 4.0)
+        @test linear_interp(x, y, 1.5; bc = bc) isa Float64
+        ref = linear_interp(Float64.(x), y, 1.5; bc = bc)
+        @test linear_interp(x, y, 1.5; bc = bc) ≈ ref atol = 1.0e-12
+    end
+
+    # Duck-type grid (ForwardDiff.Dual) + PeriodicBC coverage lives in
+    # `test/ext/test_linear_dual_grid.jl` alongside the existing Dual tests,
+    # so base test runs do not pull in ForwardDiff.
 
 end

--- a/test/test_linear_periodic.jl
+++ b/test/test_linear_periodic.jl
@@ -350,13 +350,8 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
     @testset "One-shot :exclusive zero-alloc — ND Vector grids (pool)" begin
         @test _alloc_linear_nd_vector() <= ND_ALLOC_THRESHOLD
     end
-    # Known issue: heterogeneous grids (periodic Vector + non-periodic Range) trigger
-    # ~2.3 KB allocation inside `_prepare_periodic_nd_pooled` — likely from closure
-    # type-instability in the `ntuple do d ... end` that returns different grid types
-    # per axis. Homogeneous cases (all Range, all Vector) are zero-alloc. Functional
-    # correctness is unaffected. Tracked as follow-up optimization in shared core helper.
-    @testset "One-shot :exclusive — ND mixed alloc (known non-zero, @test_broken)" begin
-        @test_broken _alloc_linear_nd_mixed() <= ND_ALLOC_THRESHOLD
+    @testset "One-shot :exclusive zero-alloc — ND mixed (periodic Vector + non-periodic Range)" begin
+        @test _alloc_linear_nd_mixed() <= ND_ALLOC_THRESHOLD
     end
 
     @testset "ND — Vector grid :exclusive without period raises" begin

--- a/test/test_linear_periodic.jl
+++ b/test/test_linear_periodic.jl
@@ -19,7 +19,7 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
         y = sin.(2π .* x)
 
         itp_default = linear_interp(x, y)                       # no bc kwarg
-        itp_nobc    = linear_interp(x, y; bc = NoBC())          # explicit NoBC
+        itp_nobc = linear_interp(x, y; bc = NoBC())          # explicit NoBC
 
         @test typeof(itp_default) === typeof(itp_nobc)
         for xq in (0.0, 0.25, 0.5, 0.75, 1.0)
@@ -33,11 +33,11 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
         itp = linear_interp(x, y; bc = PeriodicBC())
 
         # Round-trip at domain endpoints
-        @test itp(0.0) ≈ itp(2π) atol = 1e-12
+        @test itp(0.0) ≈ itp(2π) atol = 1.0e-12
 
         # Query outside base domain wraps by `period = 2π`
-        @test itp(2π + 0.5) ≈ itp(0.5) atol = 1e-12
-        @test itp(-0.3)     ≈ itp(2π - 0.3) atol = 1e-12
+        @test itp(2π + 0.5) ≈ itp(0.5) atol = 1.0e-12
+        @test itp(-0.3) ≈ itp(2π - 0.3) atol = 1.0e-12
     end
 
     @testset "Inclusive — endpoint mismatch raises" begin
@@ -54,12 +54,12 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
 
         # Extended virtual endpoint: x[end+1] = 0.5 + 3.0 = 3.5, y = 10.0 (wraps to y[1])
         # So segment [2.5, 3.5] interpolates linearly between 30.0 → 10.0.
-        @test itp(2.5) ≈ 30.0 atol = 1e-12
-        @test itp(3.0) ≈ 20.0 atol = 1e-12    # midpoint of [2.5,3.5]: (30+10)/2 = 20
-        @test itp(3.5) ≈ 10.0 atol = 1e-12    # wraps to x=0.5 via WrapExtrap
+        @test itp(2.5) ≈ 30.0 atol = 1.0e-12
+        @test itp(3.0) ≈ 20.0 atol = 1.0e-12    # midpoint of [2.5,3.5]: (30+10)/2 = 20
+        @test itp(3.5) ≈ 10.0 atol = 1.0e-12    # wraps to x=0.5 via WrapExtrap
 
         # Query to the left of x[1] wraps into the extended segment
-        @test itp(0.0) ≈ 20.0 atol = 1e-12    # 0.0 wraps to 3.0 → midpoint of [2.5, 3.5]
+        @test itp(0.0) ≈ 20.0 atol = 1.0e-12    # 0.0 wraps to 3.0 → midpoint of [2.5, 3.5]
     end
 
     @testset "Exclusive — Vector grid (allocating path)" begin
@@ -67,9 +67,9 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
         y = [10.0, 20.0, 30.0]
         itp = linear_interp(x_vec, y; bc = PeriodicBC(endpoint = :exclusive, period = 3.0))
 
-        @test itp(2.5) ≈ 30.0 atol = 1e-12
-        @test itp(3.0) ≈ 20.0 atol = 1e-12
-        @test itp(3.5) ≈ 10.0 atol = 1e-12
+        @test itp(2.5) ≈ 30.0 atol = 1.0e-12
+        @test itp(3.0) ≈ 20.0 atol = 1.0e-12
+        @test itp(3.5) ≈ 10.0 atol = 1.0e-12
     end
 
     @testset "Exclusive — auto-infer period from Range" begin
@@ -78,7 +78,7 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
         y = [10.0, 20.0, 30.0]
         itp = linear_interp(x, y; bc = PeriodicBC(endpoint = :exclusive))
 
-        @test itp(3.0) ≈ 20.0 atol = 1e-12
+        @test itp(3.0) ≈ 20.0 atol = 1.0e-12
     end
 
     @testset "Extrap is forced to WrapExtrap on periodic path" begin
@@ -96,7 +96,7 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
         itp = linear_interp(x, y; bc = bc)
 
         for xq in (0.5, 1.5, 2.5, 3.0, 3.4, 0.0, -0.5)
-            @test linear_interp(x, y, xq; bc = bc) ≈ itp(xq) atol = 1e-12
+            @test linear_interp(x, y, xq; bc = bc) ≈ itp(xq) atol = 1.0e-12
         end
     end
 
@@ -109,7 +109,7 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
         xq = [0.5, 1.0, 2.5, 3.0, 3.4]
         out_oneshot = linear_interp(x, y, xq; bc = bc)
         out_itp = itp.(xq)
-        @test out_oneshot ≈ out_itp atol = 1e-12
+        @test out_oneshot ≈ out_itp atol = 1.0e-12
     end
 
     @testset "Oneshot in-place — matches persistent interpolant" begin
@@ -121,7 +121,7 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
         xq = [0.5, 1.0, 2.5, 3.0, 3.4]
         out = zeros(length(xq))
         linear_interp!(out, x, y, xq; bc = bc)
-        @test out ≈ itp.(xq) atol = 1e-12
+        @test out ≈ itp.(xq) atol = 1.0e-12
     end
 
     @testset "Oneshot NoBC default — regression guard" begin
@@ -154,7 +154,7 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
 
         # Interior query agrees between persistent and oneshot
         q = (1.2, 0.5)
-        @test itp(q) ≈ linear_interp((x, y), data, q; bc = bc) atol = 1e-12
+        @test itp(q) ≈ linear_interp((x, y), data, q; bc = bc) atol = 1.0e-12
     end
 
     @testset "ND — per-axis bc tuple (periodic + non-periodic mix)" begin
@@ -165,7 +165,7 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
         itp = linear_interp((x, y), data; bc = bc)
 
         # Query at y=0.5 should wrap correctly on axis 1 when xq goes past x[end]
-        @test itp((0.5, 0.5)) ≈ itp((3.5, 0.5)) atol = 1e-12  # same by periodicity
+        @test itp((0.5, 0.5)) ≈ itp((3.5, 0.5)) atol = 1.0e-12  # same by periodicity
     end
 
     @testset "ND — NoBC default is no-op" begin

--- a/test/test_linear_periodic.jl
+++ b/test/test_linear_periodic.jl
@@ -489,9 +489,9 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
         itp3 = linear_interp(x, y3; bc = PeriodicBC())
         for xq in (0.3, 1.7, 2π + 0.5, -0.2)
             out = sitp(xq)
-            @test out[1] ≈ itp1(xq) atol = 1e-12
-            @test out[2] ≈ itp2(xq) atol = 1e-12
-            @test out[3] ≈ itp3(xq) atol = 1e-12
+            @test out[1] ≈ itp1(xq) atol = 1.0e-12
+            @test out[2] ≈ itp2(xq) atol = 1.0e-12
+            @test out[3] ≈ itp3(xq) atol = 1.0e-12
         end
     end
 
@@ -502,8 +502,8 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
         y2 = cos.(x)
         sitp = linear_interp(x, Series(y1, y2); bc = PeriodicBC(endpoint = :exclusive, period = 2π))
         # Wrap test: query past the domain should equal the wrapped query
-        @test sitp(0.3)[1] ≈ sitp(2π + 0.3)[1] atol = 1e-12
-        @test sitp(0.3)[2] ≈ sitp(2π + 0.3)[2] atol = 1e-12
+        @test sitp(0.3)[1] ≈ sitp(2π + 0.3)[1] atol = 1.0e-12
+        @test sitp(0.3)[2] ≈ sitp(2π + 0.3)[2] atol = 1.0e-12
     end
 
     @testset "Series persistent + PeriodicBC :inclusive mismatch raises" begin
@@ -521,7 +521,7 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
         sitp = linear_interp(x, Series(y1, y2); bc = bc)
         for xq in (0.0, 0.5, 2.0, 5.0, -0.1, 2π + 0.1)
             oneshot = linear_interp(x, Series(y1, y2), xq; bc = bc)
-            @test oneshot ≈ sitp(xq) atol = 1e-12
+            @test oneshot ≈ sitp(xq) atol = 1.0e-12
         end
     end
 
@@ -538,15 +538,15 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
         @test length(out_vec[1]) == length(xqs)
         for j in eachindex(xqs)
             ref = sitp(xqs[j])
-            @test out_vec[1][j] ≈ ref[1] atol = 1e-12
-            @test out_vec[2][j] ≈ ref[2] atol = 1e-12
+            @test out_vec[1][j] ≈ ref[1] atol = 1.0e-12
+            @test out_vec[2][j] ≈ ref[2] atol = 1.0e-12
         end
 
         # In-place variant
         outs = [similar(xqs) for _ in 1:2]
         linear_interp!(outs, x, Series(y1, y2), xqs; bc = bc)
-        @test outs[1] ≈ out_vec[1] atol = 1e-12
-        @test outs[2] ≈ out_vec[2] atol = 1e-12
+        @test outs[1] ≈ out_vec[1] atol = 1.0e-12
+        @test outs[2] ≈ out_vec[2] atol = 1.0e-12
     end
 
 end

--- a/test/test_linear_periodic.jl
+++ b/test/test_linear_periodic.jl
@@ -254,6 +254,15 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
         @test_throws ArgumentError linear_interp(x, y, 1.5; bc = PeriodicBC(endpoint = :exclusive))
     end
 
+    @testset "Edge — oneshot Vector grid :exclusive period too small raises" begin
+        # first(x) + period = 0 + 2.5 = 2.5 < last(x) = 3.0 → virtual endpoint not beyond grid
+        x = [0.0, 1.0, 2.0, 3.0]
+        y = sin.(x)
+        bc_bad = PeriodicBC(endpoint = :exclusive, period = 2.5)
+        @test_throws ArgumentError linear_interp(x, y, 1.5; bc = bc_bad)
+        @test_throws ArgumentError linear_interp(x, y, [1.5, 2.5]; bc = bc_bad)   # vector oneshot path
+    end
+
     # ============================================================
     # Interpolant path — extended copy storage
     # ============================================================

--- a/test/test_linear_periodic.jl
+++ b/test/test_linear_periodic.jl
@@ -445,4 +445,33 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
     # `test/ext/test_linear_dual_grid.jl` alongside the existing Dual tests,
     # so base test runs do not pull in ForwardDiff.
 
+    # ============================================================
+    # Float32 + Complex smoke tests (precision/value-type coverage).
+    # ============================================================
+    @testset "Float32 Range + PeriodicBC(:exclusive)" begin
+        x = range(0.0f0, step = Float32(2π / 16), length = 16)
+        y = sin.(x)                                                # Vector{Float32}
+        itp = linear_interp(x, y; bc = PeriodicBC(endpoint = :exclusive))
+        @test eltype(itp.x) === Float32
+        @test itp(1.0f0) isa Float32
+        # Wrap equivalence at the seam
+        @test itp(0.0f0) ≈ itp(Float32(step(x) * length(x))) atol = Float32(1.0e-6)
+    end
+
+    @testset "ComplexF64 values + PeriodicBC(:exclusive)" begin
+        x = collect(range(0.0, 2π, length = 17))
+        y = @. exp(im * x)                                         # Vector{ComplexF64}, y[1] == y[end]
+        # :inclusive path
+        itp_inc = linear_interp(x, y; bc = PeriodicBC())
+        @test itp_inc(0.0) ≈ itp_inc(2π) atol = 1.0e-12
+        @test itp_inc(2π + 0.5) ≈ itp_inc(0.5) atol = 1.0e-12
+
+        # :exclusive path, Vector of length 16 (drop repeated endpoint)
+        x_ex = collect(range(0.0, step = 2π / 16, length = 16))
+        y_ex = @. exp(im * x_ex)
+        itp_ex = linear_interp(x_ex, y_ex; bc = PeriodicBC(endpoint = :exclusive, period = 2π))
+        @test eltype(itp_ex.y) <: Complex
+        @test itp_ex(0.5) isa Complex
+    end
+
 end

--- a/test/test_linear_periodic.jl
+++ b/test/test_linear_periodic.jl
@@ -474,4 +474,79 @@ using FastInterpolations: _is_periodic_bc, _CachedRange
         @test itp_ex(0.5) isa Complex
     end
 
+    # ============================================================
+    # Series + PeriodicBC
+    # ============================================================
+    @testset "Series persistent + PeriodicBC — matches per-series interpolants" begin
+        x = collect(range(0.0, 2π, length = 17))
+        y1 = sin.(x)
+        y2 = cos.(x)
+        y3 = @. sin(2 * x)
+        # :inclusive (endpoints match for sin/cos/sin(2x) at 0, 2π)
+        sitp = linear_interp(x, Series(y1, y2, y3); bc = PeriodicBC())
+        itp1 = linear_interp(x, y1; bc = PeriodicBC())
+        itp2 = linear_interp(x, y2; bc = PeriodicBC())
+        itp3 = linear_interp(x, y3; bc = PeriodicBC())
+        for xq in (0.3, 1.7, 2π + 0.5, -0.2)
+            out = sitp(xq)
+            @test out[1] ≈ itp1(xq) atol = 1e-12
+            @test out[2] ≈ itp2(xq) atol = 1e-12
+            @test out[3] ≈ itp3(xq) atol = 1e-12
+        end
+    end
+
+    @testset "Series persistent + PeriodicBC(:exclusive)" begin
+        # Drop the repeated endpoint — both series, same length as x
+        x = collect(range(0.0, step = 2π / 16, length = 16))
+        y1 = sin.(x)
+        y2 = cos.(x)
+        sitp = linear_interp(x, Series(y1, y2); bc = PeriodicBC(endpoint = :exclusive, period = 2π))
+        # Wrap test: query past the domain should equal the wrapped query
+        @test sitp(0.3)[1] ≈ sitp(2π + 0.3)[1] atol = 1e-12
+        @test sitp(0.3)[2] ≈ sitp(2π + 0.3)[2] atol = 1e-12
+    end
+
+    @testset "Series persistent + PeriodicBC :inclusive mismatch raises" begin
+        x = collect(range(0.0, 2π, length = 17))
+        y1 = sin.(x)
+        y2 = collect(0.0:16)             # y2[1] != y2[end]
+        @test_throws ArgumentError linear_interp(x, Series(y1, y2); bc = PeriodicBC())
+    end
+
+    @testset "Series oneshot scalar + PeriodicBC agrees with persistent" begin
+        x = collect(range(0.0, step = 2π / 16, length = 16))
+        y1 = sin.(x)
+        y2 = cos.(x)
+        bc = PeriodicBC(endpoint = :exclusive, period = 2π)
+        sitp = linear_interp(x, Series(y1, y2); bc = bc)
+        for xq in (0.0, 0.5, 2.0, 5.0, -0.1, 2π + 0.1)
+            oneshot = linear_interp(x, Series(y1, y2), xq; bc = bc)
+            @test oneshot ≈ sitp(xq) atol = 1e-12
+        end
+    end
+
+    @testset "Series oneshot vector + PeriodicBC" begin
+        x = collect(range(0.0, step = 2π / 16, length = 16))
+        y1 = sin.(x)
+        y2 = cos.(x)
+        bc = PeriodicBC(endpoint = :exclusive, period = 2π)
+        sitp = linear_interp(x, Series(y1, y2); bc = bc)
+
+        xqs = [0.0, 0.5, 2.0, -0.1]
+        out_vec = linear_interp(x, Series(y1, y2), xqs; bc = bc)
+        @test length(out_vec) == 2
+        @test length(out_vec[1]) == length(xqs)
+        for j in eachindex(xqs)
+            ref = sitp(xqs[j])
+            @test out_vec[1][j] ≈ ref[1] atol = 1e-12
+            @test out_vec[2][j] ≈ ref[2] atol = 1e-12
+        end
+
+        # In-place variant
+        outs = [similar(xqs) for _ in 1:2]
+        linear_interp!(outs, x, Series(y1, y2), xqs; bc = bc)
+        @test outs[1] ≈ out_vec[1] atol = 1e-12
+        @test outs[2] ≈ out_vec[2] atol = 1e-12
+    end
+
 end


### PR DESCRIPTION
## Summary

`PeriodicBC` currently works only with `cubic_interp` (see #115). This
PR extends it to `linear_interp` and `constant_interp`, for both 1D
and ND APIs. Motivating use case: FVM cell-centered grids where the
physical period `L` does not equal `x[end] - x[1]`.

```julia
# FVM cell-centered grid, L ≠ x[end]-x[1]
itp = linear_interp([0.5, 1.5, 2.5], y; bc=PeriodicBC(endpoint=:exclusive, period=3.0))
```

This is Phase 1 of 3. Hermite family (PCHIP/Cardinal/Akima) and
Quadratic follow in separate PRs.

## Design

**`PeriodicBC` is a build-time contract, not runtime state.** The
interpolant struct is unchanged; periodicity reduces to *extended
grid + `WrapExtrap()`* at the API boundary, then stored as a normal
`LinearInterpolant` / `ConstantInterpolant`. Eval kernels, search,
spacing — all untouched. Everything reuses the existing cubic
pipeline (`_prepare_periodic`, `_prepare_periodic_nd_pooled`,
`_is_periodic_bc`, `_resolve_bcs_nd`, etc.).

**`NoBC()` sentinel** is the new default `bc` kwarg for methods with
a natural built-in endpoint rule. It falls through the default
`_is_periodic_bc === false` dispatch — pre-change call sites are
byte-identical.

**Memory strategy**:
- Persistent: extend once, copy into struct. Range grids preserved
  as `_CachedRange` via `_to_float_adding_endpoint` — no heap.
- Oneshot: `@with_pool pool` + `acquire!` for extended buffers.
  Zero-alloc after warmup. Vector grids require explicit `period=L`.

## Zero-alloc fix (bonus)

While testing heterogeneous ND cases (periodic Vector axis +
non-periodic Range axis), I hit a **2336 B/query** allocation inside
the shared `_prepare_periodic_nd_pooled` — latent bug never exposed
because cubic/hetero tests don't mix grid types. Root cause: two
runtime-indexed patterns on heterogeneous tuples forced Union boxing.

Fixed at the shared helper:
- Grid extension: `ntuple(Val(N)) do d ... end` → `map(f, grids, bcs)`
  for per-element concrete-type dispatch.
- Data extension: `for d in 1:N` → `@generated _extend_all_slices!`
  for compile-time unroll with `Val{d}` literals.

Result: **0 B** on all combinations (hom/het grids × hom/het BCs).
Cubic and hetero ND oneshot automatically benefit.

## Roadmap

Phase 1 of three:

1. **Phase 1 (this PR)**: Linear + Constant — C⁰ from grid extension.
2. **Phase 2**: PCHIP / Cardinal / Akima — C⁰ → C¹ via periodic
   endpoint stencils.
3. **Phase 3**: Quadratic — C¹ closure, odd-`n` constraint.

`NoBC` becomes the default for PCHIP/Cardinal/Akima in Phase 2.
Cubic (`CubicFit()`) and Quadratic (`Left(QuadraticFit())`) retain
existing defaults (their coefficient systems need closure).

## Commits

| Commit | Scope |
|---|---|
| `feat(bc)` | `NoBC` sentinel + export. Pure no-op. |
| `feat(linear)` | `linear_interp` 1D + ND `bc` kwarg + tests |
| `feat(constant)` | `constant_interp` 1D + ND `bc` kwarg + tests |
| `fix(core)` | `_prepare_periodic_nd_pooled` zero-alloc on heterogeneous ND |

## Tests

`test/test_linear_periodic.jl` + `test/test_constant_periodic.jl`:

- Inclusive + exclusive correctness (1D and ND, Range and Vector).
- Error paths: Vector without `period`, Range + conflicting period,
  incompatible extrap on periodic axis (ND strict).
- Interpolant storage: extended length `N+1`, original arrays
  unmodified, Range → `itp.x isa _CachedRange`.
- Zero-alloc (function-barrier, double warmup): 1D Range/Vector
  scalar+in-place, ND Range/Vector, **ND mixed grid types**.
  Constant per-`side` coverage.
- `NoBC` default regression guard (byte-identical to baseline).

All existing tests pass unchanged (`test_linear`, `test_nd_linear`,
`test_constant`, `test_nd_constant`, `test_allocation`,
`test_periodic_bc`, `test_periodic_exclusive`, `test_cubic_nd_oneshot`).
