### PR TITLE
 (refac): Zero-Pool Linear/Constant Series — Anchor Pair-Index Extension

### DIFF
--- a/src/constant/constant_adjoint.jl
+++ b/src/constant/constant_adjoint.jl
@@ -121,7 +121,7 @@ end
             f_bar[grid_size] += y_bar[q]
         else
             offset = _compute_single_offset(side, aq.h, aq.dL)
-            f_bar[aq.idx + offset] += y_bar[q]
+            f_bar[aq.idxL + offset] += y_bar[q]
         end
     end
     return nothing
@@ -173,7 +173,7 @@ function _fixup_constant_anchor_state!(
         state = xq_i < x_lo ? OOB_LEFT : OOB_RIGHT
         aq = anchors[i]
         anchors[i] = _ConstantAnchoredQuery{Tg, Tg}(
-            aq.idx, aq.xq, state, aq.h, aq.dL
+            aq.idxL, aq.idxR, aq.xq, state, aq.h, aq.dL
         )
     end
     return nothing

--- a/src/constant/constant_adjoint.jl
+++ b/src/constant/constant_adjoint.jl
@@ -6,9 +6,10 @@
 # Pure single-point scatter (simpler than linear's 2-point scatter).
 #
 # Reuses _ConstantAnchoredQuery from constant_anchor.jl:
-# - idx   → interval index
-# - h     → interval width (for NearestSide offset computation)
-# - dL    → offset from left boundary (for offset computation)
+# - idxL  → left cell index (used directly; this path never sees seam pairs)
+# - idxR  → right cell index (unused here; present on the shared struct for periodic-exclusive callers)
+# - h     → interval width (for side-offset computation)
+# - dL    → offset from left boundary (for side-offset computation)
 # - state → OOB detection: IN_DOMAIN, OOB_LEFT, OOB_RIGHT
 # - xq    → query point (for right-boundary special case)
 #

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -22,7 +22,8 @@ matches the interpolant grid.
 - `T`: Grid type (unconstrained)
 
 # Fields
-- `idx`: Interval index where xq falls
+- `idxL`: Left cell index (`1 ≤ idxL ≤ n-1` normally; equals `n` at periodic-exclusive seam)
+- `idxR`: Right cell index (`idxL + 1` normally; wraps to `1` at periodic-exclusive seam)
 - `xq`: Original query point (or wrapped value for periodic)
 - `state`: Domain state (`IN_DOMAIN`, `OOB_LEFT`, or `OOB_RIGHT`)
 - `h`: Interval width (for :nearest comparison)
@@ -45,7 +46,8 @@ Anchored evaluation is faster than `itp(xq)` for non-uniform grids,
 as it eliminates O(log n) binary search.
 """
 struct _ConstantAnchoredQuery{Tg, Tq <: Real}
-    idx::Int                   # interval index
+    idxL::Int                  # left cell index
+    idxR::Int                  # right cell index (idxL+1 normally; 1 at periodic-exclusive seam)
     xq::Tq                     # query point (possibly wrapped, may be Dual for AD)
     state::UInt8               # IN_DOMAIN / OOB_LEFT / OOB_RIGHT
     h::Tg                      # interval width
@@ -53,7 +55,7 @@ struct _ConstantAnchoredQuery{Tg, Tq <: Real}
 end
 
 # Convenience: single type param for backward compat (non-AD paths)
-_ConstantAnchoredQuery{T}(idx, xq, state, h, dL) where {T} = _ConstantAnchoredQuery{T, T}(idx, xq, state, h, dL)
+_ConstantAnchoredQuery{T}(idxL, idxR, xq, state, h, dL) where {T} = _ConstantAnchoredQuery{T, T}(idxL, idxR, xq, state, h, dL)
 
 # ========================================
 # Anchor Construction
@@ -198,7 +200,10 @@ Internal implementation of _anchor_query for constant interpolation.
     # Promote xq to match dL type (Float64 query + Dual grid → dL is Dual)
     xq_promoted = oftype(dL, loc.xq)
 
-    return _ConstantAnchoredQuery(loc.idx, xq_promoted, loc.state, h, dL)
+    # `_anchor_loc` never returns a periodic-exclusive seam pair, so
+    # `idxR = idxL + 1` here. Seam-pair anchors are constructed directly in
+    # the exclusive periodic series helper via `_ConstantAnchoredQuery(...)`.
+    return _ConstantAnchoredQuery(loc.idx, loc.idx + 1, xq_promoted, loc.state, h, dL)
 end
 
 # ========================================
@@ -248,7 +253,7 @@ end
         op::AbstractEvalOp, side_param::AbstractSide, ::AbstractExtrap
     )
     aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[end]) : 0 * first(y))
-    @inbounds return _constant_kernel(op, y[aq.idx], y[aq.idx + 1], aq.h, aq.dL, side_param)
+    @inbounds return _constant_kernel(op, y[aq.idxL], y[aq.idxR], aq.h, aq.dL, side_param)
 end
 
 # No extrapolation: throw DomainError if outside domain
@@ -258,7 +263,7 @@ end
     )
     aq.state != IN_DOMAIN && throw(DomainError(aq.xq, "query point outside domain"))
     aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[end]) : 0 * first(y))
-    @inbounds return _constant_kernel(op, y[aq.idx], y[aq.idx + 1], aq.h, aq.dL, side_param)
+    @inbounds return _constant_kernel(op, y[aq.idxL], y[aq.idxR], aq.h, aq.dL, side_param)
 end
 
 # Clamp/Fill extrapolation: boundary value if OOB
@@ -271,7 +276,7 @@ end
         return _eval_extrapolation(op, y_bnd, extrap, aq.xq)
     end
     aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[end]) : 0 * first(y))
-    @inbounds return _constant_kernel(op, y[aq.idx], y[aq.idx + 1], aq.h, aq.dL, side_param)
+    @inbounds return _constant_kernel(op, y[aq.idxL], y[aq.idxR], aq.h, aq.dL, side_param)
 end
 
 # ExtendExtrap → ClampExtrap for constant (zero slope → extend = clamp)
@@ -300,7 +305,7 @@ end
     if aq.xq == last(itp.x)
         return op isa EvalValue ? (@inbounds itp.y[end]) : zero(T)
     end
-    @inbounds return _constant_kernel(op, itp.y[aq.idx], itp.y[aq.idx + 1], aq.h, aq.dL, itp.side)
+    @inbounds return _constant_kernel(op, itp.y[aq.idxL], itp.y[aq.idxR], aq.h, aq.dL, itp.side)
 end
 
 # Inside domain or extension mode: delegate to shared

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -12,22 +12,26 @@
 # ========================================
 
 """
-    _ConstantAnchoredQuery{T}
+    _ConstantAnchoredQuery{Tg, Tq}
 
 Precomputed geometry for ultra-fast constant interpolation at a fixed query point.
 Internal API: no runtime grid validation; callers must ensure the anchor
 matches the interpolant grid.
 
 # Type Parameters
-- `T`: Grid type (unconstrained)
+- `Tg`: Grid element type (stored in `h`)
+- `Tq <: Real`: Query point type (stored in `xq`, `dL`); may widen `Tg` (e.g. `Dual` for AD)
+
+A convenience constructor `_ConstantAnchoredQuery{T}(args...)` is provided for the
+common non-AD case where `Tg == Tq`.
 
 # Fields
 - `idxL`: Left cell index (`1 ≤ idxL ≤ n-1` normally; equals `n` at periodic-exclusive seam)
 - `idxR`: Right cell index (`idxL + 1` normally; wraps to `1` at periodic-exclusive seam)
 - `xq`: Original query point (or wrapped value for periodic)
 - `state`: Domain state (`IN_DOMAIN`, `OOB_LEFT`, or `OOB_RIGHT`)
-- `h`: Interval width (for :nearest comparison)
-- `dL`: Offset from left boundary (for :nearest comparison)
+- `h`: Interval width (used by all side modes via `_compute_single_offset`)
+- `dL`: Offset from left boundary (used by all side modes via `_compute_single_offset`)
 
 # Usage
 ```julia
@@ -145,11 +149,12 @@ end
 """
     _fill_anchors!(buffer, x, xq, ::Val{:constant}; wrap=false) -> buffer
 
-Fill a pre-allocated buffer with anchored queries for constant interpolation.
-In-place version of `_anchor_query(x, xq, Val(:constant))` for zero-allocation pooled usage.
+Fill a caller-allocated buffer with anchored queries for constant interpolation.
+In-place version of `_anchor_query(x, xq, Val(:constant))` — zero-allocation as long as
+the caller reuses `buffer`. Writes `length(xq)` entries.
 
 # Arguments
-- `buffer::Vector{_ConstantAnchoredQuery{T}}`: Pre-allocated buffer (length >= length(xq))
+- `buffer::Vector{_ConstantAnchoredQuery{T,T}}`: Caller-allocated buffer (length >= length(xq))
 - `x::AbstractVector{T}`: Grid points (must match interpolant's grid)
 - `xq::AbstractVector`: Query points (any Real type, auto-promoted to T)
 - `::Val{:constant}`: Type tag for constant interpolation

--- a/src/constant/constant_oneshot_series.jl
+++ b/src/constant/constant_oneshot_series.jl
@@ -39,7 +39,7 @@
     extrap_p = _resolve_extrap(NoExtrap(), bc, x, first(vecs))
     xq_wrapped = _wrap_to_domain(xq, extrap_p)
     idxL, idxR, xL, xR = search_interval(searcher, x, xq_wrapped)
-    h  = xR - xL
+    h = xR - xL
     dL = xq_wrapped - xL
     # Promote xq to match dL type (Float64 query + Dual grid → dL is Dual).
     xq_promoted = oftype(dL, xq_wrapped)
@@ -156,11 +156,11 @@ end
         end
         extrap_p = _resolve_extrap(NoExtrap(), bc, x, first(vecs))
         searcher = _resolve_search(x, xqs, search, nothing, bc)
-        x_last   = @inbounds Tg_actual(last(x))
+        x_last = @inbounds Tg_actual(last(x))
         @inbounds for j in eachindex(xqs)
             xq_wrapped = _wrap_to_domain(xqs[j], extrap_p)
             idxL, idxR, xL, xR = search_interval(searcher, x, xq_wrapped)
-            h  = xR - xL
+            h = xR - xL
             dL = xq_wrapped - xL
             xq_promoted = oftype(dL, xq_wrapped)
             aq = _ConstantAnchoredQuery(idxL, idxR, xq_promoted, IN_DOMAIN, h, dL)
@@ -173,9 +173,9 @@ end
 
     # Non-periodic: `_anchor_query` handles WrapExtrap query-wrap + OOB state.
     extrap_eff = _check_domain(x, xqs, extrap)
-    searcher   = _resolve_search(x, xqs, search, nothing)
-    wrap       = extrap_eff isa WrapExtrap
-    x_last     = @inbounds Tg_actual(last(x))
+    searcher = _resolve_search(x, xqs, search, nothing)
+    wrap = extrap_eff isa WrapExtrap
+    x_last = @inbounds Tg_actual(last(x))
     @inbounds for j in eachindex(xqs)
         aq = _anchor_query(x, xqs[j], Val(:constant), wrap, searcher)
         for k in 1:K

--- a/src/constant/constant_oneshot_series.jl
+++ b/src/constant/constant_oneshot_series.jl
@@ -10,7 +10,14 @@
 # ║                 INTERNAL: PERIODIC CORE                                  ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
-@inline @with_pool pool function _constant_oneshot_series_periodic!(
+# Zero-copy scalar-series periodic anchor + K-loop eval. Mirrors the Linear
+# counterpart: wrap `xq` using a BC-materialized `WrapExtrap`, search once,
+# reuse the pair-aware anchor for all K series. The `x_last` passed to
+# `_constant_eval_at_anchor` is the ORIGINAL grid's right endpoint (x[n]) —
+# it preserves the right-continuous special case for inclusive queries at
+# exactly `xq == x[n]` (returns `y[end]`), matching the non-series constant
+# convention.
+@inline function _constant_oneshot_series_periodic!(
         output::AbstractVector,
         x::AbstractVector{Tg},
         s::Series,
@@ -21,29 +28,27 @@
         searcher
     ) where {Tg}
     vecs = _series_vectors(s)
-    n = length(x)
-    x_p, y_p_first, extrap_p = _periodic_extend_1d_pooled!(pool, x, first(vecs), bc, WrapExtrap())
-    n_p = length(x_p)
-    x_last = eltype(x_p)(last(x_p))
-    aq = _anchor_query(x_p, xq, Val(:constant), true, searcher)
-    @inbounds output[1] = _constant_eval_at_anchor(y_p_first, x_last, aq, op, side, extrap_p)
-
     K = length(output)
-    if K > 1
-        if bc isa PeriodicBC{:exclusive}
-            Tv_buf = eltype(y_p_first)
-            y_p = acquire!(pool, Tv_buf, n_p)
-            @inbounds for k in 2:K
-                copyto!(y_p, 1, vecs[k], 1, n)
-                y_p[n + 1] = vecs[k][1]
-                output[k] = _constant_eval_at_anchor(y_p, x_last, aq, op, side, extrap_p)
-            end
-        else
-            @inbounds for k in 2:K
-                _check_periodic_endpoints(bc, vecs[k])
-                output[k] = _constant_eval_at_anchor(vecs[k], x_last, aq, op, side, extrap_p)
-            end
+
+    if bc isa PeriodicBC{:inclusive}
+        @inbounds for k in 1:K
+            _check_periodic_endpoints(bc, vecs[k])
         end
+    end
+
+    extrap_p = _resolve_extrap(NoExtrap(), bc, x, first(vecs))
+    xq_wrapped = _wrap_to_domain(xq, extrap_p)
+    idxL, idxR, xL, xR = search_interval(searcher, x, xq_wrapped)
+    h  = xR - xL
+    dL = xq_wrapped - xL
+    # Promote xq to match dL type (Float64 query + Dual grid → dL is Dual).
+    xq_promoted = oftype(dL, xq_wrapped)
+    aq = _ConstantAnchoredQuery(idxL, idxR, xq_promoted, IN_DOMAIN, h, dL)
+
+    x_last = @inbounds Tg(last(x))
+
+    @inbounds for k in 1:K
+        output[k] = _constant_eval_at_anchor(vecs[k], x_last, aq, op, side, extrap_p)
     end
     return output
 end
@@ -71,7 +76,7 @@ end
     Tv_out = _value_type(_series_eltype(s), Tg)
     output = Vector{Tv_out}(undef, K)
     if _is_periodic_bc(bc)
-        searcher = _resolve_search(x, xq, search, hint)
+        searcher = _resolve_search(x, xq, search, hint, bc)
         return _constant_oneshot_series_periodic!(output, x, s, xq, bc, deriv, side, searcher)
     end
     _check_domain(x, xq, extrap)
@@ -103,7 +108,7 @@ end
     length(output) == n_series(s) || _throw_series_dim_mismatch(length(output), n_series(s))
     x = _to_float(x, Tg)
     if _is_periodic_bc(bc)
-        searcher = _resolve_search(x, xq, search, hint)
+        searcher = _resolve_search(x, xq, search, hint, bc)
         return _constant_oneshot_series_periodic!(output, x, s, xq, bc, deriv, side, searcher)
     end
     _check_domain(x, xq, extrap)

--- a/src/constant/constant_oneshot_series.jl
+++ b/src/constant/constant_oneshot_series.jl
@@ -39,7 +39,9 @@
     extrap_p = _resolve_extrap(NoExtrap(), bc, x, first(vecs))
     xq_wrapped = _wrap_to_domain(xq, extrap_p)
     idxL, idxR, xL, xR = search_interval(searcher, x, xq_wrapped)
-    h = xR - xL
+    # Use _get_h so _CachedRange returns its exact cached step instead of
+    # the cancellation-prone `xR - xL` on large-offset grids.
+    h = _get_h(x, xR, xL)
     dL = xq_wrapped - xL
     # Promote xq to match dL type (Float64 query + Dual grid → dL is Dual).
     xq_promoted = oftype(dL, xq_wrapped)
@@ -160,7 +162,8 @@ end
         @inbounds for j in eachindex(xqs)
             xq_wrapped = _wrap_to_domain(xqs[j], extrap_p)
             idxL, idxR, xL, xR = search_interval(searcher, x, xq_wrapped)
-            h = xR - xL
+            # Cached-step-preserving dispatch (matches scalar/persistent paths).
+            h = _get_h(x, xR, xL)
             dL = xq_wrapped - xL
             xq_promoted = oftype(dL, xq_wrapped)
             aq = _ConstantAnchoredQuery(idxL, idxR, xq_promoted, IN_DOMAIN, h, dL)

--- a/src/constant/constant_oneshot_series.jl
+++ b/src/constant/constant_oneshot_series.jl
@@ -126,7 +126,11 @@ end
 # ║                         VECTOR ONE-SHOT API                              ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
-@with_pool pool function constant_interp!(
+# Zero-pool vector-batch: Q outer × K inner, mirrors the Linear counterpart
+# with `side` + `x_last` propagation. `x_last = Tg(last(x))` on the ORIGINAL
+# grid — preserves the right-continuous short-circuit inside
+# `_constant_eval_at_anchor` for inclusive queries at `xq == x[n]`.
+@inline function constant_interp!(
         outputs::AbstractVector{<:AbstractVector},
         x::AbstractVector{Tg},
         s::Series,
@@ -142,52 +146,40 @@ end
     K = n_series(s)
     _validate_series_outputs(outputs, K, length(xqs))
     vecs = _series_vectors(s)
+    Tg_actual = eltype(x)
 
     if _is_periodic_bc(bc)
-        x_p, y_p_first, extrap_p = _periodic_extend_1d_pooled!(pool, x, first(vecs), bc, WrapExtrap())
-        Tg_p = eltype(x_p)
-        x_last = Tg_p(last(x_p))
-        searcher = _resolve_search(x_p, xqs, search, nothing)
-        aq_vec = acquire!(pool, _ConstantAnchoredQuery{Tg_p, Tg_p}, length(xqs))
-        _fill_anchors!(aq_vec, x_p, xqs, Val(:constant), true, searcher)
-        @inbounds for j in eachindex(xqs)
-            outputs[1][j] = _constant_eval_at_anchor(y_p_first, x_last, aq_vec[j], deriv, side, extrap_p)
+        if bc isa PeriodicBC{:inclusive}
+            @inbounds for k in 1:K
+                _check_periodic_endpoints(bc, vecs[k])
+            end
         end
-        if K > 1
-            if bc isa PeriodicBC{:exclusive}
-                n = length(x)
-                Tv_buf = eltype(y_p_first)
-                y_p = acquire!(pool, Tv_buf, length(x_p))
-                @inbounds for k in 2:K
-                    copyto!(y_p, 1, vecs[k], 1, n)
-                    y_p[n + 1] = vecs[k][1]
-                    for j in eachindex(xqs)
-                        outputs[k][j] = _constant_eval_at_anchor(y_p, x_last, aq_vec[j], deriv, side, extrap_p)
-                    end
-                end
-            else
-                @inbounds for k in 2:K
-                    _check_periodic_endpoints(bc, vecs[k])
-                    for j in eachindex(xqs)
-                        outputs[k][j] = _constant_eval_at_anchor(vecs[k], x_last, aq_vec[j], deriv, side, extrap_p)
-                    end
-                end
+        extrap_p = _resolve_extrap(NoExtrap(), bc, x, first(vecs))
+        searcher = _resolve_search(x, xqs, search, nothing, bc)
+        x_last   = @inbounds Tg_actual(last(x))
+        @inbounds for j in eachindex(xqs)
+            xq_wrapped = _wrap_to_domain(xqs[j], extrap_p)
+            idxL, idxR, xL, xR = search_interval(searcher, x, xq_wrapped)
+            h  = xR - xL
+            dL = xq_wrapped - xL
+            xq_promoted = oftype(dL, xq_wrapped)
+            aq = _ConstantAnchoredQuery(idxL, idxR, xq_promoted, IN_DOMAIN, h, dL)
+            for k in 1:K
+                outputs[k][j] = _constant_eval_at_anchor(vecs[k], x_last, aq, deriv, side, extrap_p)
             end
         end
         return outputs
     end
 
-    # Domain check: NoExtrap → throws if OOB, returns InBounds(); others → pass-through
+    # Non-periodic: `_anchor_query` handles WrapExtrap query-wrap + OOB state.
     extrap_eff = _check_domain(x, xqs, extrap)
-    searcher = _resolve_search(x, xqs, search, nothing)
-    wrap = extrap_eff isa WrapExtrap
-    x_last = Tg(last(x))
-    # Pre-compute anchors via pool, then K outer × Q inner for cache locality
-    aq_vec = acquire!(pool, _ConstantAnchoredQuery{Tg, Tg}, length(xqs))
-    _fill_anchors!(aq_vec, x, xqs, Val(:constant), wrap, searcher)
-    @inbounds for k in 1:K
-        for j in eachindex(xqs)
-            outputs[k][j] = _constant_eval_at_anchor(vecs[k], x_last, aq_vec[j], deriv, side, extrap_eff)
+    searcher   = _resolve_search(x, xqs, search, nothing)
+    wrap       = extrap_eff isa WrapExtrap
+    x_last     = @inbounds Tg_actual(last(x))
+    @inbounds for j in eachindex(xqs)
+        aq = _anchor_query(x, xqs[j], Val(:constant), wrap, searcher)
+        for k in 1:K
+            outputs[k][j] = _constant_eval_at_anchor(vecs[k], x_last, aq, deriv, side, extrap_eff)
         end
     end
     return outputs

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -513,29 +513,6 @@ function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
 end
 
 """
-Internal: Evaluate a single series for vector of query points.
-Uses argument-passing pattern for optimal performance.
-"""
-@inline function _eval_constant_series_vector!(
-        out::AbstractVector{Tv},
-        y::Matrix{Tv},
-        x::AbstractVector{Tg},
-        n_pts::Int,
-        x_min::Tg,
-        x_max::Tg,
-        k::Int,
-        aq_vec::AbstractVector{<:_ConstantAnchoredQuery{Tg}},
-        extrap::AbstractExtrap,
-        side_val::AbstractSide,
-        op::AbstractEvalOp
-    ) where {Tg, Tv}
-    @inbounds for j in eachindex(out, aq_vec)
-        out[j] = _eval_constant_series_with_extrap(y, x, n_pts, x_min, x_max, k, aq_vec[j], extrap, side_val, op)
-    end
-    return out
-end
-
-"""
 Internal: Evaluate single series at single query point with extrapolation handling.
 """
 @inline function _eval_constant_series_with_extrap(

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -485,21 +485,21 @@ function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
     ) where {Tg, Tv, P}
     # Normalize queries to the grid's base float type (not Tg itself, which may be Dual)
     xq_typed = _promote_query_typed(xq, Tg)
-    n_query  = length(xq_typed)
-    n_ser    = n_series(sitp)
+    n_query = length(xq_typed)
+    n_ser = n_series(sitp)
 
     # Validate dimensions
     _validate_series_outputs(outputs, n_ser, n_query)
 
     searcher = _resolve_search(sitp.x, xq_typed, search, hint)
-    wrap     = _should_wrap(sitp)
-    y        = sitp.y
-    x_grid   = sitp.x
-    n_pts    = n_points(sitp)
-    extrap   = sitp.extrap
+    wrap = _should_wrap(sitp)
+    y = sitp.y
+    x_grid = sitp.x
+    n_pts = n_points(sitp)
+    extrap = sitp.extrap
     side_val = sitp.side
-    x_min    = Tg(first(sitp.x))
-    x_max    = Tg(last(sitp.x))
+    x_min = Tg(first(sitp.x))
+    x_max = Tg(last(sitp.x))
 
     @inbounds for j in eachindex(xq_typed)
         aq = _anchor_query(x_grid, xq_typed[j], Val(:constant), wrap, searcher)

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -472,10 +472,11 @@ Evaluate multi-Y interpolant at multiple query points (in-place, zero allocation
 - `xq`: Query points
 - `deriv`: Derivative order (0, 1, or 2)
 
-This is the KILLER FEATURE: zero-allocation batch evaluation for hot loops.
-Uses task-local pool for anchor vector to achieve zero allocation after warmup.
+Zero-alloc by construction (Q outer × K inner): anchor is built once per
+query on the stack and reused for all K series, staying in registers across
+the K evals. No pool, no `aq_vec` scratch.
 """
-@with_pool pool function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
+function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
         outputs::AbstractVector{<:AbstractVector{Tv}},
         xq::AbstractVector{<:Real};
         deriv::DerivOp = EvalValue(),
@@ -484,29 +485,29 @@ Uses task-local pool for anchor vector to achieve zero allocation after warmup.
     ) where {Tg, Tv, P}
     # Normalize queries to the grid's base float type (not Tg itself, which may be Dual)
     xq_typed = _promote_query_typed(xq, Tg)
-    n_query = length(xq_typed)
-    n_ser = n_series(sitp)
+    n_query  = length(xq_typed)
+    n_ser    = n_series(sitp)
 
     # Validate dimensions
     _validate_series_outputs(outputs, n_ser, n_query)
 
-    # Build anchors from pool (zero allocation after warmup)
-    aq_vec = acquire!(pool, _ConstantAnchoredQuery{Tg, Tg}, length(xq_typed))
     searcher = _resolve_search(sitp.x, xq_typed, search, hint)
-    _fill_anchors!(aq_vec, sitp.x, xq_typed, Val(:constant), _should_wrap(sitp), searcher)
-
-    # Extract matrices for argument-passing pattern
-    y = sitp.y
-    x_grid = sitp.x
-    n_pts = n_points(sitp)
-    n = n_series(sitp)
-    extrap = sitp.extrap
+    wrap     = _should_wrap(sitp)
+    y        = sitp.y
+    x_grid   = sitp.x
+    n_pts    = n_points(sitp)
+    extrap   = sitp.extrap
     side_val = sitp.side
-    x_min, x_max = Tg(first(sitp.x)), Tg(last(sitp.x))
+    x_min    = Tg(first(sitp.x))
+    x_max    = Tg(last(sitp.x))
 
-    # Evaluate all series with derivative dispatch
-    @inbounds for k in 1:n
-        _eval_constant_series_vector!(outputs[k], y, x_grid, n_pts, x_min, x_max, k, aq_vec, extrap, side_val, deriv)
+    @inbounds for j in eachindex(xq_typed)
+        aq = _anchor_query(x_grid, xq_typed[j], Val(:constant), wrap, searcher)
+        for k in 1:n_ser
+            outputs[k][j] = _eval_constant_series_with_extrap(
+                y, x_grid, n_pts, x_min, x_max, k, aq, extrap, side_val, deriv
+            )
+        end
     end
     return outputs
 end

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -231,15 +231,15 @@ Outside-domain delegates to `_eval_series_at_anchor!` for extrapolation.
     # the kernel would see the unwrapped distance and pick the wrong side/index.
     # `aq.dL` is `loc.xq - loc.xL` where `loc.xq` is the wrapped query — Dual is
     # preserved through `_wrap_to_domain`, so AD chains survive.
-    idx = aq.idx
-    idx1 = idx + 1
+    idxL = aq.idxL
+    idxR = aq.idxR
     h = aq.h
     dL = aq.dL
 
     # SIMD loop over series
     @inbounds @simd for k in axes(output, 1)
-        y_left = y_point[k, idx]
-        y_right = y_point[k, idx1]
+        y_left = y_point[k, idxL]
+        y_right = y_point[k, idxR]
         output[k] = _constant_kernel(op, y_left, y_right, h, dL, sitp.side)
     end
 
@@ -295,15 +295,15 @@ end
         ::UInt8
     ) where {Tg, Tv}
     # Use boundary interval for extension (inline evaluation, no xq needed)
-    idx = aq.idx
-    idx1 = idx + 1
+    idxL = aq.idxL
+    idxR = aq.idxR
     h = aq.h
     dL = aq.dL
 
     # SIMD loop over series
     @inbounds @simd for k in axes(out, 1)
-        y_left = y_point[k, idx]
-        y_right = y_point[k, idx1]
+        y_left = y_point[k, idxL]
+        y_right = y_point[k, idxR]
         out[k] = _constant_kernel(op, y_left, y_right, h, dL, side_val)
     end
     return out
@@ -588,10 +588,11 @@ Internal: Core constant evaluation for series k at anchored query point.
         return 0 * first(y)
     end
 
-    idx = aq.idx
+    idxL = aq.idxL
+    idxR = aq.idxR
     @inbounds begin
-        y_left = y[idx, k]
-        y_right = y[idx + 1, k]
+        y_left = y[idxL, k]
+        y_right = y[idxR, k]
     end
     return _constant_kernel(EvalValue(), y_left, y_right, aq.h, aq.dL, side_val)
 end

--- a/src/constant/nd/constant_nd_adjoint.jl
+++ b/src/constant/nd/constant_nd_adjoint.jl
@@ -44,7 +44,7 @@ function _bake_constant_nd_anchors(
         per_axis = ntuple(Val(N)) do d
             xq_raw = Tg(query_q[d])
             xq_d = _extrap_axis(xq_raw, grids[d], extraps[d])
-            idx, _, xL, _ = search_interval(DEFAULT_SEARCHER, grids[d], spacings[d], xq_d)
+            idx, idxR, xL, _ = search_interval(DEFAULT_SEARCHER, grids[d], spacings[d], xq_d)
             h = _get_h(spacings[d], idx)
             dL = xq_d - xL
 
@@ -56,7 +56,7 @@ function _bake_constant_nd_anchors(
                 IN_DOMAIN
             end
 
-            return _ConstantAnchoredQuery{Tg, Tg}(idx, xq_d, state_flag, h, dL)
+            return _ConstantAnchoredQuery{Tg, Tg}(idx, idxR, xq_d, state_flag, h, dL)
         end
         anchors[q] = per_axis
     end
@@ -80,7 +80,7 @@ Uses `_compute_single_offset` per axis — matches the ND forward kernel exactly
     ) where {N, Tg}
     return ntuple(Val(N)) do d
         aq = per_axis[d]
-        aq.idx + _compute_single_offset(sides[d], aq.h, aq.dL)
+        aq.idxL + _compute_single_offset(sides[d], aq.h, aq.dL)
     end
 end
 

--- a/src/linear/linear_adjoint.jl
+++ b/src/linear/linear_adjoint.jl
@@ -108,8 +108,8 @@ end
         aq = anchors[q]
         _is_oob_skip(aq.state, extrap) && continue
         yb = y_bar[q]
-        f_bar[aq.idx] += (one(aq.alpha) - aq.alpha) * yb
-        f_bar[aq.idx + 1] += aq.alpha * yb
+        f_bar[aq.idxL] += (one(aq.alpha) - aq.alpha) * yb
+        f_bar[aq.idxR] += aq.alpha * yb
     end
     return nothing
 end
@@ -129,8 +129,8 @@ end
         aq = anchors[q]
         _is_oob_skip_deriv(aq.state, extrap) && continue
         yb = y_bar[q]
-        f_bar[aq.idx] -= aq.inv_h * yb
-        f_bar[aq.idx + 1] += aq.inv_h * yb
+        f_bar[aq.idxL] -= aq.inv_h * yb
+        f_bar[aq.idxR] += aq.inv_h * yb
     end
     return nothing
 end
@@ -181,7 +181,7 @@ function _fixup_linear_anchor_state!(
         state = xq_i < x_lo ? OOB_LEFT : OOB_RIGHT
         aq = anchors[i]
         anchors[i] = typeof(aq)(
-            aq.idx, aq.xq, state, aq.xL, aq.h, aq.inv_h, aq.alpha
+            aq.idxL, aq.idxR, aq.xq, state, aq.xL, aq.h, aq.inv_h, aq.alpha
         )
     end
     return nothing

--- a/src/linear/linear_anchor.jl
+++ b/src/linear/linear_anchor.jl
@@ -23,10 +23,11 @@ matches the interpolant grid.
 - `Tq`: Query type (widened to `promote_type(Tq, Tg)` by the outer constructor)
 
 # Fields
-- `idx`: Interval index where xq falls
+- `idxL`: Left cell index (`1 ≤ idxL ≤ n-1` normally; equals `n` at periodic-exclusive seam)
+- `idxR`: Right cell index (`idxL + 1` normally; wraps to `1` at periodic-exclusive seam)
 - `xq`: Original query point (or wrapped value for periodic), preserves original precision
 - `state`: Domain state (`IN_DOMAIN`, `OOB_LEFT`, or `OOB_RIGHT`)
-- `xL`: Left grid point of the interval (avoids re-indexing x[idx] which triggers TwicePrecision on Range)
+- `xL`: Left grid point of the interval (avoids re-indexing x[idxL] which triggers TwicePrecision on Range)
 - `h`: Interval width (xR - xL)
 - `inv_h`: Precomputed reciprocal (1/h) for fast derivative computation
 - `alpha`: Normalized position within interval: (xq - xL) / h, preserves precision
@@ -52,7 +53,8 @@ as it eliminates O(log n) binary search.
 - `inv_h` for EvalDeriv1: `(yR - yL) * inv_h` (no division)
 """
 struct _LinearAnchoredQuery{Tg, Tq <: Real}
-    idx::Int                   # interval index
+    idxL::Int                  # left cell index
+    idxR::Int                  # right cell index (idxL+1 normally; 1 at periodic-exclusive seam)
     xq::Tq                     # query point (possibly wrapped)
     state::UInt8               # IN_DOMAIN / OOB_LEFT / OOB_RIGHT
     xL::Tg                     # left grid point
@@ -68,10 +70,10 @@ end
 # For Float grids:  alpha::Tq, xq::Tq — no conversion (identity).
 # For Dual grids + Float query:  alpha::Dual (from grid arithmetic),
 #   xq promoted to Dual via convert (zero partials = "query has no grid sensitivity").
-@inline function _LinearAnchoredQuery(idx::Int, xq, state::UInt8, xL::Tg, h::Tg, inv_h::Tg, alpha) where {Tg}
+@inline function _LinearAnchoredQuery(idxL::Int, idxR::Int, xq, state::UInt8, xL::Tg, h::Tg, inv_h::Tg, alpha) where {Tg}
     Ta = typeof(alpha)
     xq_p = convert(Ta, xq)
-    return _LinearAnchoredQuery{Tg, Ta}(idx, xq_p, state, xL, h, inv_h, alpha)
+    return _LinearAnchoredQuery{Tg, Ta}(idxL, idxR, xq_p, state, xL, h, inv_h, alpha)
 end
 
 # ========================================
@@ -259,7 +261,11 @@ in `xq` and `alpha` fields. The interval search uses `_extract_primal(xq)` for c
     inv_h = _get_inv_h(x, loc.xR, loc.xL)
     alpha = (loc.xq - loc.xL) * inv_h
 
-    return _LinearAnchoredQuery(loc.idx, loc.xq, loc.state, loc.xL, h, inv_h, alpha)
+    # `_anchor_loc` never returns a periodic-exclusive seam pair — it operates
+    # on a fixed grid with at most wrap-to-domain remapping — so `idxR = idxL+1`
+    # here. Periodic-exclusive seam anchors are constructed via `_LinearAnchoredQuery(...)`
+    # directly in the exclusive periodic one-shot helpers (bypassing `_anchor_loc`).
+    return _LinearAnchoredQuery(loc.idx, loc.idx + 1, loc.xq, loc.state, loc.xL, h, inv_h, alpha)
 end
 
 # ========================================
@@ -310,7 +316,7 @@ end
         op::AbstractEvalOp,
         ::AbstractExtrap
     )
-    @inbounds return _linear_kernel(op, y[aq.idx], y[aq.idx + 1], aq)
+    @inbounds return _linear_kernel(op, y[aq.idxL], y[aq.idxR], aq)
 end
 
 # No extrapolation: throw DomainError if outside domain
@@ -321,7 +327,7 @@ end
         ::NoExtrap
     )
     aq.state != IN_DOMAIN && throw(DomainError(aq.xq, "query point outside domain"))
-    @inbounds return _linear_kernel(op, y[aq.idx], y[aq.idx + 1], aq)
+    @inbounds return _linear_kernel(op, y[aq.idxL], y[aq.idxR], aq)
 end
 
 # Clamp/Fill extrapolation: boundary value if OOB
@@ -335,7 +341,7 @@ end
         y_bnd = aq.state == OOB_LEFT ? first(y) : last(y)
         return _eval_extrapolation(op, y_bnd, extrap, aq.xq)
     end
-    @inbounds return _linear_kernel(op, y[aq.idx], y[aq.idx + 1], aq)
+    @inbounds return _linear_kernel(op, y[aq.idxL], y[aq.idxR], aq)
 end
 
 # ========================================
@@ -358,7 +364,7 @@ end
         x_min, x_max = first(itp.x), last(itp.x)
         throw(DomainError(aq.xq, "query point outside domain [$x_min, $x_max]"))
     end
-    @inbounds return _linear_kernel(op, itp.y[aq.idx], itp.y[aq.idx + 1], aq)
+    @inbounds return _linear_kernel(op, itp.y[aq.idxL], itp.y[aq.idxR], aq)
 end
 
 # Clamp/Fill: delegate to shared

--- a/src/linear/linear_anchor.jl
+++ b/src/linear/linear_anchor.jl
@@ -167,7 +167,8 @@ end
 Create anchored queries for multiple query points with precision preservation.
 
 # Precision Preservation
-Uses `_promote_for_anchor` to preserve wider precision when `Tq` differs from `Tg`.
+The outer `_LinearAnchoredQuery` constructor promotes via `promote_type(Tq, Tg)`,
+so wider precision is preserved when `Tq` differs from `Tg`.
 
 # Example
 ```julia
@@ -203,18 +204,20 @@ end
 """
     _fill_anchors!(buffer, x, xq, ::Val{:linear}; wrap=false) -> buffer
 
-Fill a pre-allocated buffer with anchored queries for linear interpolation.
-In-place version of `_anchor_query(x, xq, Val(:linear))` for zero-allocation pooled usage.
+Fill a caller-allocated buffer with anchored queries for linear interpolation.
+In-place version of `_anchor_query(x, xq, Val(:linear))` — zero-allocation as long as
+the caller reuses `buffer`. Writes `length(xq)` entries.
 
 # Arguments
-- `buffer::Vector{_LinearAnchoredQuery{Tg,Tq}}`: Pre-allocated buffer (length >= length(xq))
+- `buffer::Vector{_LinearAnchoredQuery{Tg,Tq}}`: Caller-allocated buffer (length >= length(xq))
 - `x::AbstractVector{Tg}`: Grid points (must match interpolant's grid)
 - `xq::AbstractVector`: Query points (any Real type)
 - `::Val{:linear}`: Type tag for linear interpolation
 - `wrap::Bool=false`: If true, wrap query points to domain [x[1], x[end])
 
 # Precision Preservation
-Uses `_promote_for_anchor` to preserve wider precision when `S` differs from `Tg`.
+The outer `_LinearAnchoredQuery` constructor promotes via `promote_type(S, Tg)`,
+so wider precision is preserved when `S` differs from `Tg`.
 """
 @inline function _fill_anchors!(
         buffer::AbstractVector{_LinearAnchoredQuery{Tg, Tq}},

--- a/src/linear/linear_oneshot_series.jl
+++ b/src/linear/linear_oneshot_series.jl
@@ -165,7 +165,11 @@ end
 In-place one-shot linear interpolation at multiple query points.
 `outputs` is a `Vector{<:AbstractVector}` of length `n_series`, each of length `length(xqs)`.
 """
-@with_pool pool function linear_interp!(
+# Zero-pool vector-batch: Q outer × K inner. Anchor is register-resident for
+# the K-inner loop — no aq_vec scratch, no grid/value extension. Periodic
+# mirrors the scalar helper's wrap-first pattern; non-periodic uses the
+# pair-aware `_anchor_query` (Stage 1) directly.
+@inline function linear_interp!(
         outputs::AbstractVector{<:AbstractVector},
         x::AbstractVector{Tg},
         s::Series,
@@ -178,59 +182,42 @@ In-place one-shot linear interpolation at multiple query points.
     _validate_series_lengths(s, length(x))
     Tg_p = _promote_grid_float(Tg, _series_eltype(s))
     x = _to_float(x, Tg_p)
-    Tg_actual = eltype(x)
     K = n_series(s)
     _validate_series_outputs(outputs, K, length(xqs))
     vecs = _series_vectors(s)
 
-    # Periodic vector-xqs: extend x once, per-series extend y (exclusive) or
-    # reuse + validate (inclusive), pre-compute anchors on extended grid, then
-    # K outer × Q inner eval loop.
     if _is_periodic_bc(bc)
-        x_p, y_p_first, extrap_p = _periodic_extend_1d_pooled!(pool, x, first(vecs), bc, WrapExtrap())
-        Tg_p_actual = eltype(x_p)
-        Tq_promoted = promote_type(Tq, Tg_p_actual)
-        searcher = _resolve_search(x_p, xqs, search, nothing)
-        aq_vec = acquire!(pool, _LinearAnchoredQuery{Tg_p_actual, Tq_promoted}, length(xqs))
-        _fill_anchors!(aq_vec, x_p, xqs, Val(:linear), true, searcher)
-        @inbounds for j in eachindex(xqs)
-            outputs[1][j] = _linear_eval_at_anchor(y_p_first, aq_vec[j], deriv, extrap_p)
+        # Per-series `:inclusive` endpoint guarantee. `:exclusive` needs no
+        # per-series check; the anchor's seam pair handles wrap.
+        if bc isa PeriodicBC{:inclusive}
+            @inbounds for k in 1:K
+                _check_periodic_endpoints(bc, vecs[k])
+            end
         end
-        if K > 1
-            if bc isa PeriodicBC{:exclusive}
-                n = length(x)
-                Tv_buf = eltype(y_p_first)
-                y_p = acquire!(pool, Tv_buf, length(x_p))
-                @inbounds for k in 2:K
-                    copyto!(y_p, 1, vecs[k], 1, n)
-                    y_p[n + 1] = vecs[k][1]
-                    for j in eachindex(xqs)
-                        outputs[k][j] = _linear_eval_at_anchor(y_p, aq_vec[j], deriv, extrap_p)
-                    end
-                end
-            else
-                @inbounds for k in 2:K
-                    _check_periodic_endpoints(bc, vecs[k])
-                    for j in eachindex(xqs)
-                        outputs[k][j] = _linear_eval_at_anchor(vecs[k], aq_vec[j], deriv, extrap_p)
-                    end
-                end
+        extrap_p = _resolve_extrap(NoExtrap(), bc, x, first(vecs))
+        searcher = _resolve_search(x, xqs, search, nothing, bc)
+        @inbounds for j in eachindex(xqs)
+            xq_wrapped = _wrap_to_domain(xqs[j], extrap_p)
+            idxL, idxR, xL, xR = search_interval(searcher, x, xq_wrapped)
+            h     = xR - xL
+            inv_h = inv(h)
+            alpha = (xq_wrapped - xL) * inv_h
+            aq = _LinearAnchoredQuery(idxL, idxR, xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
+            for k in 1:K
+                outputs[k][j] = _linear_eval_at_anchor(vecs[k], aq, deriv, extrap_p)
             end
         end
         return outputs
     end
 
-    # Domain check: NoExtrap → throws if OOB, returns InBounds(); others → pass-through
+    # Non-periodic: `_anchor_query` handles WrapExtrap query-wrap + OOB state.
     extrap_eff = _check_domain(x, xqs, extrap)
-    searcher = _resolve_search(x, xqs, search, nothing)
-    wrap = extrap_eff isa WrapExtrap
-    # Pre-compute anchors via pool, then K outer × Q inner for cache locality
-    Tq_promoted = promote_type(Tq, Tg_actual)
-    aq_vec = acquire!(pool, _LinearAnchoredQuery{Tg_actual, Tq_promoted}, length(xqs))
-    _fill_anchors!(aq_vec, x, xqs, Val(:linear), wrap, searcher)
-    @inbounds for k in 1:K
-        for j in eachindex(xqs)
-            outputs[k][j] = _linear_eval_at_anchor(vecs[k], aq_vec[j], deriv, extrap_eff)
+    searcher   = _resolve_search(x, xqs, search, nothing)
+    wrap       = extrap_eff isa WrapExtrap
+    @inbounds for j in eachindex(xqs)
+        aq = _anchor_query(x, xqs[j], Val(:linear), wrap, searcher)
+        for k in 1:K
+            outputs[k][j] = _linear_eval_at_anchor(vecs[k], aq, deriv, extrap_eff)
         end
     end
     return outputs

--- a/src/linear/linear_oneshot_series.jl
+++ b/src/linear/linear_oneshot_series.jl
@@ -52,8 +52,10 @@
     extrap_p = _resolve_extrap(NoExtrap(), bc, x, first(vecs))
     xq_wrapped = _wrap_to_domain(xq, extrap_p)
     idxL, idxR, xL, xR = search_interval(searcher, x, xq_wrapped)
-    h = xR - xL
-    inv_h = inv(h)
+    # Use _get_h/_get_inv_h so _CachedRange returns its exact cached step
+    # instead of the cancellation-prone `xR - xL` on large-offset grids.
+    h = _get_h(x, xR, xL)
+    inv_h = _get_inv_h(x, xR, xL)
     alpha = (xq_wrapped - xL) * inv_h
     aq = _LinearAnchoredQuery(idxL, idxR, xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
 
@@ -199,8 +201,9 @@ In-place one-shot linear interpolation at multiple query points.
         @inbounds for j in eachindex(xqs)
             xq_wrapped = _wrap_to_domain(xqs[j], extrap_p)
             idxL, idxR, xL, xR = search_interval(searcher, x, xq_wrapped)
-            h = xR - xL
-            inv_h = inv(h)
+            # Cached-step-preserving dispatch (matches scalar/persistent paths).
+            h = _get_h(x, xR, xL)
+            inv_h = _get_inv_h(x, xR, xL)
             alpha = (xq_wrapped - xL) * inv_h
             aq = _LinearAnchoredQuery(idxL, idxR, xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
             for k in 1:K

--- a/src/linear/linear_oneshot_series.jl
+++ b/src/linear/linear_oneshot_series.jl
@@ -52,7 +52,7 @@
     extrap_p = _resolve_extrap(NoExtrap(), bc, x, first(vecs))
     xq_wrapped = _wrap_to_domain(xq, extrap_p)
     idxL, idxR, xL, xR = search_interval(searcher, x, xq_wrapped)
-    h     = xR - xL
+    h = xR - xL
     inv_h = inv(h)
     alpha = (xq_wrapped - xL) * inv_h
     aq = _LinearAnchoredQuery(idxL, idxR, xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
@@ -199,7 +199,7 @@ In-place one-shot linear interpolation at multiple query points.
         @inbounds for j in eachindex(xqs)
             xq_wrapped = _wrap_to_domain(xqs[j], extrap_p)
             idxL, idxR, xL, xR = search_interval(searcher, x, xq_wrapped)
-            h     = xR - xL
+            h = xR - xL
             inv_h = inv(h)
             alpha = (xq_wrapped - xL) * inv_h
             aq = _LinearAnchoredQuery(idxL, idxR, xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
@@ -212,8 +212,8 @@ In-place one-shot linear interpolation at multiple query points.
 
     # Non-periodic: `_anchor_query` handles WrapExtrap query-wrap + OOB state.
     extrap_eff = _check_domain(x, xqs, extrap)
-    searcher   = _resolve_search(x, xqs, search, nothing)
-    wrap       = extrap_eff isa WrapExtrap
+    searcher = _resolve_search(x, xqs, search, nothing)
+    wrap = extrap_eff isa WrapExtrap
     @inbounds for j in eachindex(xqs)
         aq = _anchor_query(x, xqs[j], Val(:linear), wrap, searcher)
         for k in 1:K

--- a/src/linear/linear_oneshot_series.jl
+++ b/src/linear/linear_oneshot_series.jl
@@ -10,14 +10,26 @@
 # Shared anchor eval: _linear_eval_at_anchor(y, aq, op, extrap) in linear_anchor.jl
 
 # ╔═══════════════════════════════════════════════════════════════════════════╗
-# ║                 INTERNAL: PERIODIC CORE                                  ║
+# ║                 INTERNAL: PERIODIC CORE (zero-copy)                       ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
-# Extend x once via the shared helper (bound to series 1 just to get x_p), then
-# reuse a single pool buffer across all other series to avoid reallocating.
-# Mirrors the cubic_oneshot_series periodic strategy without the tridiagonal
-# solve. Always uses WrapExtrap for the eval-at-anchor call.
-@inline @with_pool pool function _linear_oneshot_series_periodic!(
+# Zero-copy scalar-series periodic anchor + K-loop eval. One search, K evals.
+# No pool, no grid/value extension — the anchor carries pair indices
+# (`idxL`/`idxR`) so `y[aq.idxR]` reads `vecs[k][1]` automatically at the
+# exclusive seam.
+#
+# Mirrors the non-series scalar periodic pattern in `linear_oneshot.jl`:
+# resolve a `WrapExtrap` carrying the BC's period, wrap `xq` into the periodic
+# domain, then call `search_interval` on the wrapped query. For exclusive,
+# the searcher's seam branch fires when the wrapped `xq` lands in
+# `[x[n], x[1]+period)` and returns the `(n, 1)` seam pair. For inclusive,
+# the wrap uses `x[n] - x[1]` (= period) and search returns a regular pair
+# guarded by the user's `y[1] ≈ y[end]` invariant.
+#
+# The only `bc`-distinguished work is the per-series endpoint validation for
+# inclusive — a compile-time `bc isa PeriodicBC{:inclusive}` branch that LLVM
+# drops in the exclusive specialization.
+@inline function _linear_oneshot_series_periodic!(
         output::AbstractVector,
         x::AbstractVector{Tg},
         s::Series,
@@ -27,34 +39,26 @@
         searcher
     ) where {Tg}
     vecs = _series_vectors(s)
-    n = length(x)
-
-    # Phase 1: extend x + first series, build anchor on the extended grid.
-    # `_periodic_extend_1d_pooled!` now returns a materialized WrapExtrap — capture
-    # it so the kernel never sees WrapExtrap{Nothing}.
-    x_p, y_p_first, extrap_p = _periodic_extend_1d_pooled!(pool, x, first(vecs), bc, WrapExtrap())
-    n_p = length(x_p)
-    aq = _anchor_query(x_p, xq, Val(:linear), true, searcher)
-    @inbounds output[1] = _linear_eval_at_anchor(y_p_first, aq, op, extrap_p)
-
-    # Phase 2: remaining series — reuse a single pool buffer (exclusive) or the
-    # user's vecs[k] directly (inclusive, already length n_p, just re-validated).
     K = length(output)
-    if K > 1
-        if bc isa PeriodicBC{:exclusive}
-            Tv_buf = eltype(y_p_first)
-            y_p = acquire!(pool, Tv_buf, n_p)
-            @inbounds for k in 2:K
-                copyto!(y_p, 1, vecs[k], 1, n)
-                y_p[n + 1] = vecs[k][1]
-                output[k] = _linear_eval_at_anchor(y_p, aq, op, extrap_p)
-            end
-        else
-            @inbounds for k in 2:K
-                _check_periodic_endpoints(bc, vecs[k])
-                output[k] = _linear_eval_at_anchor(vecs[k], aq, op, extrap_p)
-            end
+
+    if bc isa PeriodicBC{:inclusive}
+        @inbounds for k in 1:K
+            _check_periodic_endpoints(bc, vecs[k])
         end
+    end
+
+    # Materialize WrapExtrap with BC-correct period (inclusive: x[n]-x[1];
+    # exclusive: bc.period). `first(vecs)` only contributes element-type info.
+    extrap_p = _resolve_extrap(NoExtrap(), bc, x, first(vecs))
+    xq_wrapped = _wrap_to_domain(xq, extrap_p)
+    idxL, idxR, xL, xR = search_interval(searcher, x, xq_wrapped)
+    h     = xR - xL
+    inv_h = inv(h)
+    alpha = (xq_wrapped - xL) * inv_h
+    aq = _LinearAnchoredQuery(idxL, idxR, xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
+
+    @inbounds for k in 1:K
+        output[k] = _linear_eval_at_anchor(vecs[k], aq, op, extrap_p)
     end
     return output
 end
@@ -100,7 +104,9 @@ vals = linear_interp(x, Series(y_sin, y_cos), 0.5)  # → [sin(0.5), cos(0.5)]
     Tv = _series_output_type(_output_eltype(_series_eltype(s), Tg_actual), Tq)
     output = Vector{Tv}(undef, K)
     if _is_periodic_bc(bc)
-        searcher = _resolve_search(x, xq, search, hint)
+        # Thread `bc` into the Searcher type param so `search_interval` performs
+        # the seam-wrap for `PeriodicBC{:exclusive}` inside the helper.
+        searcher = _resolve_search(x, xq, search, hint, bc)
         return _linear_oneshot_series_periodic!(output, x, s, xq, bc, deriv, searcher)
     end
     _check_domain(x, xq, extrap)
@@ -136,7 +142,7 @@ In-place one-shot linear interpolation of multiple y-series at a single query po
     Tg_p = _promote_grid_float(Tg, _series_eltype(s))
     x = _to_float(x, Tg_p)
     if _is_periodic_bc(bc)
-        searcher = _resolve_search(x, xq, search, hint)
+        searcher = _resolve_search(x, xq, search, hint, bc)
         return _linear_oneshot_series_periodic!(output, x, s, xq, bc, deriv, searcher)
     end
     _check_domain(x, xq, extrap)

--- a/src/linear/linear_series_interp.jl
+++ b/src/linear/linear_series_interp.jl
@@ -462,14 +462,15 @@ Evaluate multi-Y interpolant at multiple query points (in-place, zero allocation
 - `xq`: Query points (any Real type, auto-promoted for search)
 - `deriv`: Derivative order (0 or 1)
 
-This is the KILLER FEATURE: zero-allocation batch evaluation for hot loops.
-Uses task-local pool for anchor vector to achieve zero allocation after warmup.
+Zero-alloc by construction (Q outer × K inner): anchor is built once per
+query on the stack and reused for all K series in an inner loop, staying in
+registers across the K evals. No pool, no `aq_vec` scratch.
 
 # Precision Preservation
-Uses pooled anchors with promoted type `promote_type(Tq, Tg)` to preserve precision in alpha.
-Pool handles both same-type and mixed-type cases efficiently.
+Per-query anchor is typed `_LinearAnchoredQuery{Tg, promote_type(Tq, Tg)}`
+via the outer constructor's alpha-type inference.
 """
-@with_pool pool function (sitp::LinearSeriesInterpolant{Tg, Tv, P})(
+function (sitp::LinearSeriesInterpolant{Tg, Tv, P})(
         outputs::AbstractVector{<:AbstractVector},
         xq::AbstractVector{Tq};
         deriv::DerivOp = EvalValue(),
@@ -482,22 +483,22 @@ Pool handles both same-type and mixed-type cases efficiently.
     # Validate dimensions
     _validate_series_outputs(outputs, n_ser, n_query)
 
-    # Build anchors - pool handles both same-type and mixed-type cases
-    Tq_eff = promote_type(Tq, Tg)
-    aq_vec = acquire!(pool, _LinearAnchoredQuery{Tg, Tq_eff}, n_query)
     searcher = _resolve_search(sitp.x, xq, search, hint)
-    _fill_anchors!(aq_vec, sitp.x, xq, Val(:linear), _should_wrap(sitp), searcher)
+    wrap     = _should_wrap(sitp)
+    y        = sitp.y
+    x_grid   = sitp.x
+    n_pts    = n_points(sitp)
+    extrap   = sitp.extrap
+    x_min    = Tg(first(sitp.x))
+    x_max    = Tg(last(sitp.x))
 
-    # Extract matrices for argument-passing pattern
-    y = sitp.y
-    x_grid = sitp.x
-    n_pts = n_points(sitp)
-    extrap = sitp.extrap
-    x_min, x_max = Tg(first(sitp.x)), Tg(last(sitp.x))
-
-    # Evaluate all series - anchor already has correct alpha precision
-    @inbounds for k in 1:n_ser
-        _eval_linear_series_vector!(outputs[k], y, x_grid, n_pts, x_min, x_max, k, aq_vec, extrap, deriv)
+    @inbounds for j in eachindex(xq)
+        aq = _anchor_query(x_grid, xq[j], Val(:linear), wrap, searcher)
+        for k in 1:n_ser
+            outputs[k][j] = _eval_linear_series_with_extrap(
+                y, x_grid, n_pts, x_min, x_max, k, aq, extrap, deriv
+            )
+        end
     end
     return outputs
 end

--- a/src/linear/linear_series_interp.jl
+++ b/src/linear/linear_series_interp.jl
@@ -484,13 +484,13 @@ function (sitp::LinearSeriesInterpolant{Tg, Tv, P})(
     _validate_series_outputs(outputs, n_ser, n_query)
 
     searcher = _resolve_search(sitp.x, xq, search, hint)
-    wrap     = _should_wrap(sitp)
-    y        = sitp.y
-    x_grid   = sitp.x
-    n_pts    = n_points(sitp)
-    extrap   = sitp.extrap
-    x_min    = Tg(first(sitp.x))
-    x_max    = Tg(last(sitp.x))
+    wrap = _should_wrap(sitp)
+    y = sitp.y
+    x_grid = sitp.x
+    n_pts = n_points(sitp)
+    extrap = sitp.extrap
+    x_min = Tg(first(sitp.x))
+    x_max = Tg(last(sitp.x))
 
     @inbounds for j in eachindex(xq)
         aq = _anchor_query(x_grid, xq[j], Val(:linear), wrap, searcher)

--- a/src/linear/linear_series_interp.jl
+++ b/src/linear/linear_series_interp.jl
@@ -255,13 +255,12 @@ constructor), so `dL = aq.xq - aq.xL` correctly propagates grid-side partials.
 # Arguments
 - `output`: Pre-allocated output vector (length = n_series)
 - `sitp`: LinearSeriesInterpolant
-- `aq`: Anchor with precomputed index/side (from primal value)
-- `xq`: Original query point (any Real type, including ForwardDiff.Dual)
+- `aq`: Anchor with precomputed indices (`idxL`/`idxR`) and widened `xq`
 - `op`: Evaluation operation (value, derivative)
 
 # AD Support
-Supports ForwardDiff.Dual input: anchor provides index/side from primal,
-while `xq` is used directly in arithmetic to preserve derivative information.
+Supports ForwardDiff.Dual input: the anchor's indices come from the primal value,
+while `aq.xq` carries the Dual payload so `dL = aq.xq - aq.xL` preserves derivatives.
 """
 @inline function _eval_linear_series_point!(
         output::AbstractVector,
@@ -501,32 +500,6 @@ function (sitp::LinearSeriesInterpolant{Tg, Tv, P})(
         end
     end
     return outputs
-end
-
-"""
-Internal: Evaluate a single series for vector of query points.
-Uses argument-passing pattern for optimal performance.
-
-# Precision Preservation
-The anchor's `alpha` field already contains precision-preserving normalized position
-computed as `(xq - xL) / h` with the query's original precision.
-"""
-@inline function _eval_linear_series_vector!(
-        out::AbstractVector,
-        y::Matrix{Tv},
-        x::AbstractVector{Tg},
-        n_pts::Int,
-        x_min::Tg,
-        x_max::Tg,
-        k::Int,
-        aq_vec::AbstractVector{<:_LinearAnchoredQuery{Tg}},
-        extrap::AbstractExtrap,
-        op::AbstractEvalOp
-    ) where {Tg, Tv}
-    @inbounds for j in eachindex(out, aq_vec)
-        out[j] = _eval_linear_series_with_extrap(y, x, n_pts, x_min, x_max, k, aq_vec[j], extrap, op)
-    end
-    return out
 end
 
 """

--- a/src/linear/linear_series_interp.jl
+++ b/src/linear/linear_series_interp.jl
@@ -276,15 +276,15 @@ while `xq` is used directly in arithmetic to preserve derivative information.
 
     # Inside domain: SIMD evaluation with point-contiguous layout
     y_point = _ensure_point_layout!(sitp)
-    idx = aq.idx
-    idx1 = idx + 1
+    idxL = aq.idxL
+    idxR = aq.idxR
 
     inv_h = aq.inv_h
     dL = aq.xq - aq.xL  # aq.xq carries Dual info (widened by outer constructor)
 
     @inbounds @simd for k in axes(output, 1)
-        yL = y_point[k, idx]
-        yR = y_point[k, idx1]
+        yL = y_point[k, idxL]
+        yR = y_point[k, idxR]
         output[k] = _linear_kernel(op, yL, yR, inv_h, dL)
     end
     return output
@@ -575,8 +575,8 @@ The kernel internally extracts alpha (for EvalValue) or inv_h (for derivatives).
         op::AbstractEvalOp
     ) where {Tg, Tv}
     @inbounds begin
-        yL = y[aq.idx, k]
-        yR = y[aq.idx + 1, k]
+        yL = y[aq.idxL, k]
+        yR = y[aq.idxR, k]
     end
     return _linear_kernel(op, yL, yR, aq)
 end

--- a/test/test_constant_anchor.jl
+++ b/test/test_constant_anchor.jl
@@ -17,14 +17,16 @@ using FastInterpolations
         aq = FastInterpolations._anchor_query(x, xq, Val(:constant))
 
         @test aq isa FastInterpolations._ConstantAnchoredQuery{Float64}
-        @test hasfield(typeof(aq), :idx)
+        @test hasfield(typeof(aq), :idxL)
+        @test hasfield(typeof(aq), :idxR)
         @test hasfield(typeof(aq), :xq)
         @test hasfield(typeof(aq), :state)
         @test hasfield(typeof(aq), :h)
         @test hasfield(typeof(aq), :dL)
 
         # Verify field types
-        @test aq.idx isa Int
+        @test aq.idxL isa Int
+        @test aq.idxR isa Int
         @test aq.xq isa Float64
         @test aq.state isa UInt8
         @test aq.h isa Float64
@@ -39,7 +41,8 @@ using FastInterpolations
 
         # Query inside domain
         aq = FastInterpolations._anchor_query(x, 0.35, Val(:constant))
-        @test aq.idx == 4  # interval [0.3, 0.4]
+        @test aq.idxL == 4  # interval [0.3, 0.4]
+        @test aq.idxR == 5
         @test aq.xq == 0.35
         @test aq.state == FastInterpolations.IN_DOMAIN  # inside
         @test aq.h ≈ 0.1
@@ -47,7 +50,8 @@ using FastInterpolations
 
         # Query at left boundary
         aq_left = FastInterpolations._anchor_query(x, 0.0, Val(:constant))
-        @test aq_left.idx == 1
+        @test aq_left.idxL == 1
+        @test aq_left.idxR == 2
         @test aq_left.state == FastInterpolations.IN_DOMAIN
         @test aq_left.dL ≈ 0.0
 
@@ -66,9 +70,9 @@ using FastInterpolations
         aq_vec = FastInterpolations._anchor_query(x, xq_vec, Val(:constant))
 
         @test length(aq_vec) == 3
-        @test aq_vec[1].idx == 2   # interval [0.1, 0.2]
-        @test aq_vec[2].idx == 4   # interval [0.3, 0.4]
-        @test aq_vec[3].idx == 8   # interval [0.7, 0.8]
+        @test aq_vec[1].idxL == 2   # interval [0.1, 0.2]
+        @test aq_vec[2].idxL == 4   # interval [0.3, 0.4]
+        @test aq_vec[3].idxL == 8   # interval [0.7, 0.8]
 
         @test all(aq.h ≈ 0.1 for aq in aq_vec)
     end
@@ -227,7 +231,7 @@ using FastInterpolations
         xq = 0.45  # interval [0.3, 0.6]
         aq = FastInterpolations._anchor_query(x, xq, Val(:constant))
 
-        @test aq.idx == 3  # interval [0.3, 0.6]
+        @test aq.idxL == 3  # interval [0.3, 0.6]
         @test aq.xq == 0.45
         @test aq.h ≈ 0.3  # 0.6 - 0.3
         @test aq.dL ≈ 0.15  # 0.45 - 0.3
@@ -366,7 +370,7 @@ using FastInterpolations
             FI._fill_anchors!(buffer, x, xq, Val(:constant))
 
             for i in eachindex(xq)
-                @test buffer[i].idx == expected[i].idx
+                @test buffer[i].idxL == expected[i].idxL
                 @test buffer[i].xq == expected[i].xq
                 @test buffer[i].state == expected[i].state
                 @test buffer[i].h == expected[i].h
@@ -383,7 +387,7 @@ using FastInterpolations
             FI._fill_anchors!(buffer, x, xq, Val(:constant), true)
 
             for i in eachindex(xq)
-                @test buffer[i].idx == expected[i].idx
+                @test buffer[i].idxL == expected[i].idxL
                 @test buffer[i].xq == expected[i].xq
                 @test buffer[i].state == expected[i].state
             end

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -600,9 +600,11 @@ using FastInterpolations: _CachedRange
     # Series OneShot Scalar + PeriodicBC — Zero-Copy Migration (A-2)
     # ============================================================
     # Mirrors the Linear zero-copy migration. Notable constant-specific
-    # behavior: at xq == x[1] + period (exclusive right endpoint), the new
-    # path returns y[n] via LeftSide convention — aligning series with the
-    # already-in-place non-series constant semantics (D5 in plan).
+    # behavior: `constant_interp` defaults to `NearestSide()`, which tie-breaks
+    # to the left at `dL == h/2`. At `xq == x[1] + period` (exclusive right
+    # endpoint), `_wrap_to_domain` maps the query back to `x[1]` — the series
+    # path now returns the same value as the non-series constant path there
+    # (i.e. `y[1]`), closing the former series/non-series gap.
 
     function _alloc_constant_series_scalar_range_exclusive()
         x = range(0.0, step = 2π / 16, length = 16)
@@ -658,7 +660,8 @@ using FastInterpolations: _CachedRange
         s = Series(y1, y2)
         bc = PeriodicBC(endpoint = :exclusive, period = 4.0)
 
-        # Inside seam cell at xq = 3.5: LeftSide default → y[idxL] = y[n]
+        # Inside seam cell at xq = 3.5: default `NearestSide()` ties left at
+        # `dL == h/2`, so the result is `y[idxL] = y[n]`.
         out = constant_interp(x, s, 3.5; bc = bc)
         @test out[1] == 40.0
         @test out[2] == 4.0
@@ -668,13 +671,14 @@ using FastInterpolations: _CachedRange
         @test out_at_n[1] == 40.0
         @test out_at_n[2] == 4.0
 
-        # D5 delta — at xq == x[1] + period = 4.0 the NEW path returns y[n]
-        # via LeftSide convention, matching the non-series constant path.
-        # CURRENT pool-extended code returns y[1] here; this assertion is the
-        # RED test that drives the refactor toward series↔non-series alignment.
+        # Series↔non-series alignment at the exclusive right endpoint.
+        # `_wrap_to_domain` sends xq = x[1] + period back onto the base domain
+        # [x[1], x[1]+period), so the resolved value is `y[1]` (the wrapped
+        # endpoint), not `y[n]`. Before this refactor the pool-extended series
+        # path returned `y[n]` here instead; the assertion pins down the fix.
         out_endpoint = constant_interp(x, s, 4.0; bc = bc)
-        @test out_endpoint[1] == constant_interp(x, y1, 4.0; bc = bc)
-        @test out_endpoint[2] == constant_interp(x, y2, 4.0; bc = bc)
+        @test out_endpoint[1] == constant_interp(x, y1, 4.0; bc = bc) == y1[1]
+        @test out_endpoint[2] == constant_interp(x, y2, 4.0; bc = bc) == y2[1]
 
         # Cross-check series↔non-series at mid-seam
         @test out[1] == constant_interp(x, y1, 3.5; bc = bc)

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -652,21 +652,21 @@ using FastInterpolations: _CachedRange
 
     @testset "Series scalar + PeriodicBC(:exclusive) seam semantic" begin
         # 4-point grid, period = 4.0 → seam cell [x[n], x[1]+period) = [3, 4)
-        x  = collect(0.0:3.0)
+        x = collect(0.0:3.0)
         y1 = [10.0, 20.0, 30.0, 40.0]
         y2 = [1.0, 2.0, 3.0, 4.0]
-        s  = Series(y1, y2)
+        s = Series(y1, y2)
         bc = PeriodicBC(endpoint = :exclusive, period = 4.0)
 
         # Inside seam cell at xq = 3.5: LeftSide default → y[idxL] = y[n]
         out = constant_interp(x, s, 3.5; bc = bc)
         @test out[1] == 40.0
-        @test out[2] ==  4.0
+        @test out[2] == 4.0
 
         # At xq == x[n] = 3.0: `aq.xq == x_last` short-circuit → y[end] = y[n]
         out_at_n = constant_interp(x, s, 3.0; bc = bc)
         @test out_at_n[1] == 40.0
-        @test out_at_n[2] ==  4.0
+        @test out_at_n[2] == 4.0
 
         # D5 delta — at xq == x[1] + period = 4.0 the NEW path returns y[n]
         # via LeftSide convention, matching the non-series constant path.
@@ -751,10 +751,10 @@ using FastInterpolations: _CachedRange
         # returns yL if dL ≤ h/2, else yR. Inside seam cell: yL=y[n], yR=y[1].
         # `_constant_eval_at_anchor` short-circuits at `aq.xq == x_last`
         # (x_last = x[n] = 3.0) → returns y[end] = y[n] = 40.
-        x  = collect(0.0:3.0)
+        x = collect(0.0:3.0)
         y1 = [10.0, 20.0, 30.0, 40.0]
         y2 = [1.0, 2.0, 3.0, 4.0]
-        s  = Series(y1, y2)
+        s = Series(y1, y2)
         bc = PeriodicBC(endpoint = :exclusive, period = 4.0)
 
         # Batch covering:
@@ -775,11 +775,11 @@ using FastInterpolations: _CachedRange
         @test outs[1][5] == 10.0   # seam 75%, NearestSide → yR=y[1] (wrap)
 
         # y2 series
-        @test outs[2][1] ==  3.0
-        @test outs[2][2] ==  4.0
-        @test outs[2][3] ==  4.0
-        @test outs[2][4] ==  4.0
-        @test outs[2][5] ==  1.0
+        @test outs[2][1] == 3.0
+        @test outs[2][2] == 4.0
+        @test outs[2][3] == 4.0
+        @test outs[2][4] == 4.0
+        @test outs[2][5] == 1.0
 
         # Cross-check: batch path agrees with per-query scalar path, series-wise.
         for j in eachindex(xqs)

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -686,4 +686,64 @@ using FastInterpolations: _CachedRange
         @test out[2] == sitp(3.5)[2]
     end
 
+    # ============================================================
+    # Series OneShot Vector-Batch + PeriodicBC — Zero-Copy (Stage 2)
+    # ============================================================
+
+    function _alloc_constant_series_vector_range_exclusive()
+        x = range(0.0, step = 2π / 16, length = 16)
+        s = Series(sin.(x), cos.(x))
+        bc = PeriodicBC(endpoint = :exclusive, period = 2π)
+        xqs = [0.5, 1.0, 2.0, 3.5]
+        outs = [similar(xqs) for _ in 1:2]
+        constant_interp!(outs, x, s, xqs; bc = bc)
+        constant_interp!(outs, x, s, xqs; bc = bc)
+        return @allocated constant_interp!(outs, x, s, xqs; bc = bc)
+    end
+
+    function _alloc_constant_series_vector_vector_exclusive()
+        x = [0.0, 0.5, 1.5, 3.0, 5.0]
+        s = Series(sin.(x), cos.(x))
+        bc = PeriodicBC(endpoint = :exclusive, period = 2π)
+        xqs = [0.5, 1.0, 2.0, 3.5]
+        outs = [similar(xqs) for _ in 1:2]
+        constant_interp!(outs, x, s, xqs; bc = bc)
+        constant_interp!(outs, x, s, xqs; bc = bc)
+        return @allocated constant_interp!(outs, x, s, xqs; bc = bc)
+    end
+
+    function _alloc_constant_series_vector_inclusive()
+        x = collect(range(0.0, 2π, length = 17))
+        s = Series(sin.(x), cos.(x))
+        bc = PeriodicBC()
+        xqs = [0.5, 1.0, 2.0, 3.5]
+        outs = [similar(xqs) for _ in 1:2]
+        constant_interp!(outs, x, s, xqs; bc = bc)
+        constant_interp!(outs, x, s, xqs; bc = bc)
+        return @allocated constant_interp!(outs, x, s, xqs; bc = bc)
+    end
+
+    function _alloc_constant_series_vector_nobc()
+        x = range(0.0, step = 2π / 16, length = 16)
+        s = Series(sin.(x), cos.(x))
+        xqs = [0.5, 1.0, 2.0, 3.5]
+        outs = [similar(xqs) for _ in 1:2]
+        constant_interp!(outs, x, s, xqs)
+        constant_interp!(outs, x, s, xqs)
+        return @allocated constant_interp!(outs, x, s, xqs)
+    end
+
+    @testset "Series vector + PeriodicBC zero-alloc — Range exclusive (T-series-alloc)" begin
+        @test _alloc_constant_series_vector_range_exclusive() <= ALLOC_THRESHOLD
+    end
+    @testset "Series vector + PeriodicBC zero-alloc — Vector exclusive (T-series-alloc)" begin
+        @test _alloc_constant_series_vector_vector_exclusive() <= ALLOC_THRESHOLD
+    end
+    @testset "Series vector + PeriodicBC zero-alloc — inclusive (T-series-alloc)" begin
+        @test _alloc_constant_series_vector_inclusive() <= ALLOC_THRESHOLD
+    end
+    @testset "Series vector + NoBC zero-alloc (T-series-alloc)" begin
+        @test _alloc_constant_series_vector_nobc() <= ALLOC_THRESHOLD
+    end
+
 end

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -686,6 +686,33 @@ using FastInterpolations: _CachedRange
         @test out[2] == sitp(3.5)[2]
     end
 
+    @testset "Series oneshot + PeriodicBC(:exclusive) preserves cached step on large-offset Range" begin
+        # Parallel to the Linear test: `_CachedRange.h` stores the exact step
+        # while `xR - xL` suffers float cancellation near 1e8. Constant uses
+        # `h`/`dL` for side-offset computation, so nearest/left/right-side
+        # decisions must see the cached step to match scalar/persistent paths.
+        x = range(1.0e8, step = 0.1, length = 10)
+        y1 = Float64.(1:10)
+        y2 = Float64.(11:20)
+        s = Series(y1, y2)
+        bc = PeriodicBC(endpoint = :exclusive)
+        xq = 1.0e8 + 0.95
+
+        for side in (LeftSide(), RightSide(), NearestSide())
+            v_scalar = constant_interp(x, y1, xq; bc = bc, side = side)
+            v_oneshot = constant_interp(x, s, xq; bc = bc, side = side)
+            v_persist = constant_interp(x, s; bc = bc, side = side)(xq)
+            @test v_oneshot[1] === v_scalar
+            @test v_oneshot[1] === v_persist[1]
+
+            xqs = [1.0e8 + 0.95, 1.0e8 + 0.55]
+            outs = [similar(xqs) for _ in 1:2]
+            constant_interp!(outs, x, s, xqs; bc = bc, side = side)
+            @test outs[1][1] === v_scalar
+            @test outs[1][2] === constant_interp(x, y1, xqs[2]; bc = bc, side = side)
+        end
+    end
+
     # ============================================================
     # Series OneShot Vector-Batch + PeriodicBC — Zero-Copy (Stage 2)
     # ============================================================

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -795,4 +795,48 @@ using FastInterpolations: _CachedRange
         end
     end
 
+    # ============================================================
+    # Persistent Series callable + PeriodicBC — Zero-Copy (Stage 3)
+    # ============================================================
+
+    function _alloc_constant_persistent_vector_range_exclusive()
+        x = range(0.0, step = 2π / 16, length = 16)
+        s = Series(sin.(x), cos.(x))
+        sitp = constant_interp(x, s; bc = PeriodicBC(endpoint = :exclusive, period = 2π))
+        xqs = [0.5, 1.0, 2.0, 3.5]
+        outs = [similar(xqs) for _ in 1:2]
+        sitp(outs, xqs); sitp(outs, xqs)
+        return @allocated sitp(outs, xqs)
+    end
+
+    function _alloc_constant_persistent_vector_vector_exclusive()
+        x = [0.0, 0.5, 1.5, 3.0, 5.0]
+        s = Series(sin.(x), cos.(x))
+        sitp = constant_interp(x, s; bc = PeriodicBC(endpoint = :exclusive, period = 2π))
+        xqs = [0.5, 1.0, 2.0, 3.5]
+        outs = [similar(xqs) for _ in 1:2]
+        sitp(outs, xqs); sitp(outs, xqs)
+        return @allocated sitp(outs, xqs)
+    end
+
+    function _alloc_constant_persistent_vector_inclusive()
+        x = collect(range(0.0, 2π, length = 17))
+        s = Series(sin.(x), cos.(x))
+        sitp = constant_interp(x, s; bc = PeriodicBC())
+        xqs = [0.5, 1.0, 2.0, 3.5]
+        outs = [similar(xqs) for _ in 1:2]
+        sitp(outs, xqs); sitp(outs, xqs)
+        return @allocated sitp(outs, xqs)
+    end
+
+    @testset "Persistent callable + PeriodicBC zero-alloc — Range exclusive (T-persistent-alloc)" begin
+        @test _alloc_constant_persistent_vector_range_exclusive() <= ALLOC_THRESHOLD
+    end
+    @testset "Persistent callable + PeriodicBC zero-alloc — Vector exclusive (T-persistent-alloc)" begin
+        @test _alloc_constant_persistent_vector_vector_exclusive() <= ALLOC_THRESHOLD
+    end
+    @testset "Persistent callable + PeriodicBC zero-alloc — inclusive (T-persistent-alloc)" begin
+        @test _alloc_constant_persistent_vector_inclusive() <= ALLOC_THRESHOLD
+    end
+
 end

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -596,4 +596,94 @@ using FastInterpolations: _CachedRange
         @test outs[1] ≈ out_vec[1] atol = 1.0e-12
     end
 
+    # ============================================================
+    # Series OneShot Scalar + PeriodicBC — Zero-Copy Migration (A-2)
+    # ============================================================
+    # Mirrors the Linear zero-copy migration. Notable constant-specific
+    # behavior: at xq == x[1] + period (exclusive right endpoint), the new
+    # path returns y[n] via LeftSide convention — aligning series with the
+    # already-in-place non-series constant semantics (D5 in plan).
+
+    function _alloc_constant_series_scalar_range_exclusive()
+        x = range(0.0, step = 2π / 16, length = 16)
+        y1 = sin.(x)
+        y2 = cos.(x)
+        s = Series(y1, y2)
+        bc = PeriodicBC(endpoint = :exclusive, period = 2π)
+        out = Vector{Float64}(undef, 2)
+        constant_interp!(out, x, s, 1.0; bc = bc)
+        constant_interp!(out, x, s, 1.0; bc = bc)
+        return @allocated constant_interp!(out, x, s, 1.0; bc = bc)
+    end
+
+    function _alloc_constant_series_scalar_vector_exclusive()
+        x = [0.0, 0.5, 1.5, 3.0, 5.0]
+        y1 = sin.(x)
+        y2 = cos.(x)
+        s = Series(y1, y2)
+        bc = PeriodicBC(endpoint = :exclusive, period = 2π)
+        out = Vector{Float64}(undef, 2)
+        constant_interp!(out, x, s, 1.0; bc = bc)
+        constant_interp!(out, x, s, 1.0; bc = bc)
+        return @allocated constant_interp!(out, x, s, 1.0; bc = bc)
+    end
+
+    function _alloc_constant_series_scalar_inclusive()
+        x = collect(range(0.0, 2π, length = 17))
+        y1 = sin.(x)
+        y2 = cos.(x)
+        s = Series(y1, y2)
+        bc = PeriodicBC()
+        out = Vector{Float64}(undef, 2)
+        constant_interp!(out, x, s, 1.0; bc = bc)
+        constant_interp!(out, x, s, 1.0; bc = bc)
+        return @allocated constant_interp!(out, x, s, 1.0; bc = bc)
+    end
+
+    @testset "Series scalar + PeriodicBC zero-alloc — Range exclusive (T-series-alloc)" begin
+        @test _alloc_constant_series_scalar_range_exclusive() <= ALLOC_THRESHOLD
+    end
+    @testset "Series scalar + PeriodicBC zero-alloc — Vector exclusive (T-series-alloc)" begin
+        @test _alloc_constant_series_scalar_vector_exclusive() <= ALLOC_THRESHOLD
+    end
+    @testset "Series scalar + PeriodicBC zero-alloc — inclusive (T-series-alloc)" begin
+        @test _alloc_constant_series_scalar_inclusive() <= ALLOC_THRESHOLD
+    end
+
+    @testset "Series scalar + PeriodicBC(:exclusive) seam semantic" begin
+        # 4-point grid, period = 4.0 → seam cell [x[n], x[1]+period) = [3, 4)
+        x  = collect(0.0:3.0)
+        y1 = [10.0, 20.0, 30.0, 40.0]
+        y2 = [1.0, 2.0, 3.0, 4.0]
+        s  = Series(y1, y2)
+        bc = PeriodicBC(endpoint = :exclusive, period = 4.0)
+
+        # Inside seam cell at xq = 3.5: LeftSide default → y[idxL] = y[n]
+        out = constant_interp(x, s, 3.5; bc = bc)
+        @test out[1] == 40.0
+        @test out[2] ==  4.0
+
+        # At xq == x[n] = 3.0: `aq.xq == x_last` short-circuit → y[end] = y[n]
+        out_at_n = constant_interp(x, s, 3.0; bc = bc)
+        @test out_at_n[1] == 40.0
+        @test out_at_n[2] ==  4.0
+
+        # D5 delta — at xq == x[1] + period = 4.0 the NEW path returns y[n]
+        # via LeftSide convention, matching the non-series constant path.
+        # CURRENT pool-extended code returns y[1] here; this assertion is the
+        # RED test that drives the refactor toward series↔non-series alignment.
+        out_endpoint = constant_interp(x, s, 4.0; bc = bc)
+        @test out_endpoint[1] == constant_interp(x, y1, 4.0; bc = bc)
+        @test out_endpoint[2] == constant_interp(x, y2, 4.0; bc = bc)
+
+        # Cross-check series↔non-series at mid-seam
+        @test out[1] == constant_interp(x, y1, 3.5; bc = bc)
+        @test out[2] == constant_interp(x, y2, 3.5; bc = bc)
+
+        # Cross-check series oneshot == persistent series interpolant (mid-seam)
+        sitp = constant_interp(x, s; bc = bc)
+        @test out[1] == sitp(3.5)[1]
+        @test out[2] == sitp(3.5)[2]
+    end
+
 end

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -746,4 +746,53 @@ using FastInterpolations: _CachedRange
         @test _alloc_constant_series_vector_nobc() <= ALLOC_THRESHOLD
     end
 
+    @testset "Series vector + PeriodicBC(:exclusive) seam cell semantic" begin
+        # 4-point grid, period=4.0 → seam cell [3, 4). NearestSide default:
+        # returns yL if dL ≤ h/2, else yR. Inside seam cell: yL=y[n], yR=y[1].
+        # `_constant_eval_at_anchor` short-circuits at `aq.xq == x_last`
+        # (x_last = x[n] = 3.0) → returns y[end] = y[n] = 40.
+        x  = collect(0.0:3.0)
+        y1 = [10.0, 20.0, 30.0, 40.0]
+        y2 = [1.0, 2.0, 3.0, 4.0]
+        s  = Series(y1, y2)
+        bc = PeriodicBC(endpoint = :exclusive, period = 4.0)
+
+        # Batch covering:
+        #   2.25  — interior cell [2,3], dL=0.25 ≤ 0.5 → yL = y[3] = 30
+        #   3.0   — exact x[n], x_last short-circuit → y[end] = y[n] = 40
+        #   3.25  — seam, dL=0.25 ≤ 0.5 → yL = y[n] = 40
+        #   3.5   — seam mid, dL=0.5 = h/2 (tie) → yL = y[n] = 40
+        #   3.75  — seam, dL=0.75 > 0.5 → yR = y[1] = 10 (wrap)
+        xqs = [2.25, 3.0, 3.25, 3.5, 3.75]
+        outs = [Vector{Float64}(undef, length(xqs)) for _ in 1:2]
+        constant_interp!(outs, x, s, xqs; bc = bc)
+
+        # y1 series
+        @test outs[1][1] == 30.0   # interior, NearestSide → yL
+        @test outs[1][2] == 40.0   # at x[n] (x_last short-circuit)
+        @test outs[1][3] == 40.0   # seam 25%, NearestSide → yL=y[n]
+        @test outs[1][4] == 40.0   # seam mid (tie-break to yL)
+        @test outs[1][5] == 10.0   # seam 75%, NearestSide → yR=y[1] (wrap)
+
+        # y2 series
+        @test outs[2][1] ==  3.0
+        @test outs[2][2] ==  4.0
+        @test outs[2][3] ==  4.0
+        @test outs[2][4] ==  4.0
+        @test outs[2][5] ==  1.0
+
+        # Cross-check: batch path agrees with per-query scalar path, series-wise.
+        for j in eachindex(xqs)
+            scalar_out = constant_interp(x, s, xqs[j]; bc = bc)
+            @test outs[1][j] == scalar_out[1]
+            @test outs[2][j] == scalar_out[2]
+        end
+
+        # Cross-check: batch path agrees with non-series constant.
+        for j in eachindex(xqs)
+            @test outs[1][j] == constant_interp(x, y1, xqs[j]; bc = bc)
+            @test outs[2][j] == constant_interp(x, y2, xqs[j]; bc = bc)
+        end
+    end
+
 end

--- a/test/test_linear_anchor.jl
+++ b/test/test_linear_anchor.jl
@@ -18,7 +18,8 @@ using FastInterpolations
         aq = FastInterpolations._anchor_query(x, xq, Val(:linear))
 
         @test aq isa FastInterpolations._LinearAnchoredQuery{Float64}
-        @test hasfield(typeof(aq), :idx)
+        @test hasfield(typeof(aq), :idxL)
+        @test hasfield(typeof(aq), :idxR)
         @test hasfield(typeof(aq), :xq)
         @test hasfield(typeof(aq), :state)
         @test hasfield(typeof(aq), :h)
@@ -26,7 +27,8 @@ using FastInterpolations
         @test hasfield(typeof(aq), :alpha)
 
         # Verify field types
-        @test aq.idx isa Int
+        @test aq.idxL isa Int
+        @test aq.idxR isa Int
         @test aq.xq isa Float64
         @test aq.state isa UInt8
         @test aq.h isa Float64
@@ -42,7 +44,8 @@ using FastInterpolations
 
         # Query inside domain
         aq = FastInterpolations._anchor_query(x, 0.35, Val(:linear))
-        @test aq.idx == 4  # interval [0.3, 0.4]
+        @test aq.idxL == 4  # interval [0.3, 0.4]
+        @test aq.idxR == 5
         @test aq.xq == 0.35
         @test aq.state == FastInterpolations.IN_DOMAIN  # inside
         @test aq.h ≈ 0.1            # interval width
@@ -51,13 +54,15 @@ using FastInterpolations
 
         # Query at left boundary
         aq_left = FastInterpolations._anchor_query(x, 0.0, Val(:linear))
-        @test aq_left.idx == 1
+        @test aq_left.idxL == 1
+        @test aq_left.idxR == 2
         @test aq_left.state == FastInterpolations.IN_DOMAIN  # inside (at boundary)
         @test aq_left.alpha ≈ 0.0   # at left boundary, alpha = 0
 
         # Query at right boundary
         aq_right = FastInterpolations._anchor_query(x, 1.0, Val(:linear))
-        @test aq_right.idx == 10  # last interval
+        @test aq_right.idxL == 10  # last interval
+        @test aq_right.idxR == 11
         @test aq_right.state == FastInterpolations.IN_DOMAIN
         @test aq_right.alpha ≈ 1.0  # (1.0 - 0.9) / 0.1 = 1.0
     end
@@ -72,9 +77,9 @@ using FastInterpolations
         aq_vec = FastInterpolations._anchor_query(x, xq_vec, Val(:linear))
 
         @test length(aq_vec) == 3
-        @test aq_vec[1].idx == 2   # interval [0.1, 0.2]
-        @test aq_vec[2].idx == 4   # interval [0.3, 0.4]
-        @test aq_vec[3].idx == 8   # interval [0.7, 0.8]
+        @test aq_vec[1].idxL == 2   # interval [0.1, 0.2]
+        @test aq_vec[2].idxL == 4   # interval [0.3, 0.4]
+        @test aq_vec[3].idxL == 8   # interval [0.7, 0.8]
 
         # alpha = (xq - xL) / h = 0.05 / 0.1 = 0.5 for all
         @test aq_vec[1].alpha ≈ 0.5  # (0.15 - 0.1) / 0.1
@@ -222,7 +227,7 @@ using FastInterpolations
         xq = 0.45  # interval [0.3, 0.6]
         aq = FastInterpolations._anchor_query(x, xq, Val(:linear))
 
-        @test aq.idx == 3  # interval [0.3, 0.6]
+        @test aq.idxL == 3  # interval [0.3, 0.6]
         @test aq.xq == 0.45
         @test aq.h ≈ 0.3           # 0.6 - 0.3 = 0.3
         @test aq.alpha ≈ 0.5       # (0.45 - 0.3) / 0.3 = 0.5
@@ -372,7 +377,7 @@ using FastInterpolations
 
             # Verify all fields match exactly (bit-wise)
             for i in eachindex(xq)
-                @test buffer[i].idx == expected[i].idx
+                @test buffer[i].idxL == expected[i].idxL
                 @test buffer[i].xq == expected[i].xq
                 @test buffer[i].state == expected[i].state
                 @test buffer[i].h == expected[i].h
@@ -390,7 +395,7 @@ using FastInterpolations
             FI._fill_anchors!(buffer, x, xq, Val(:linear), true)
 
             for i in eachindex(xq)
-                @test buffer[i].idx == expected[i].idx
+                @test buffer[i].idxL == expected[i].idxL
                 @test buffer[i].xq == expected[i].xq
                 @test buffer[i].state == expected[i].state
             end

--- a/test/test_linear_periodic.jl
+++ b/test/test_linear_periodic.jl
@@ -1053,4 +1053,51 @@ end
         end
     end
 
+    # ============================================================
+    # Persistent Series callable + PeriodicBC — Zero-Copy (Stage 3)
+    # ============================================================
+    # `sitp(outs, xqs)` callable must be zero-alloc under Q outer × K inner
+    # refactor. These guards complement the existing non-periodic alloc
+    # tests in test_linear_series_interp.jl (lines 101-121).
+
+    function _alloc_linear_persistent_vector_range_exclusive()
+        x = range(0.0, step = 2π / 16, length = 16)
+        s = Series(sin.(x), cos.(x))
+        sitp = linear_interp(x, s; bc = PeriodicBC(endpoint = :exclusive, period = 2π))
+        xqs = [0.5, 1.0, 2.0, 3.5]
+        outs = [similar(xqs) for _ in 1:2]
+        sitp(outs, xqs); sitp(outs, xqs)
+        return @allocated sitp(outs, xqs)
+    end
+
+    function _alloc_linear_persistent_vector_vector_exclusive()
+        x = [0.0, 0.5, 1.5, 3.0, 5.0]
+        s = Series(sin.(x), cos.(x))
+        sitp = linear_interp(x, s; bc = PeriodicBC(endpoint = :exclusive, period = 2π))
+        xqs = [0.5, 1.0, 2.0, 3.5]
+        outs = [similar(xqs) for _ in 1:2]
+        sitp(outs, xqs); sitp(outs, xqs)
+        return @allocated sitp(outs, xqs)
+    end
+
+    function _alloc_linear_persistent_vector_inclusive()
+        x = collect(range(0.0, 2π, length = 17))
+        s = Series(sin.(x), cos.(x))
+        sitp = linear_interp(x, s; bc = PeriodicBC())
+        xqs = [0.5, 1.0, 2.0, 3.5]
+        outs = [similar(xqs) for _ in 1:2]
+        sitp(outs, xqs); sitp(outs, xqs)
+        return @allocated sitp(outs, xqs)
+    end
+
+    @testset "Persistent callable + PeriodicBC zero-alloc — Range exclusive (T-persistent-alloc)" begin
+        @test _alloc_linear_persistent_vector_range_exclusive() <= ALLOC_THRESHOLD
+    end
+    @testset "Persistent callable + PeriodicBC zero-alloc — Vector exclusive (T-persistent-alloc)" begin
+        @test _alloc_linear_persistent_vector_vector_exclusive() <= ALLOC_THRESHOLD
+    end
+    @testset "Persistent callable + PeriodicBC zero-alloc — inclusive (T-persistent-alloc)" begin
+        @test _alloc_linear_persistent_vector_inclusive() <= ALLOC_THRESHOLD
+    end
+
 end

--- a/test/test_linear_periodic.jl
+++ b/test/test_linear_periodic.jl
@@ -1005,4 +1005,52 @@ end
         @test _alloc_linear_series_vector_nobc() <= ALLOC_THRESHOLD
     end
 
+    @testset "Series vector + PeriodicBC(:exclusive) seam cell semantic" begin
+        # 4-point grid, period=4.0 → seam cell [x[n], x[1]+period) = [3, 4).
+        x  = collect(0.0:3.0)
+        y1 = [10.0, 20.0, 30.0, 40.0]
+        y2 = [1.0, 2.0, 3.0, 4.0]
+        s  = Series(y1, y2)
+        bc = PeriodicBC(endpoint = :exclusive, period = 4.0)
+
+        # Batch of xqs covering:
+        #   2.5   — interior cell [2,3], α=0.5 → y[3]*0.5 + y[4]*0.5
+        #   3.0   — exactly x[n], α=0 in seam cell → yL = y[n]
+        #   3.25  — seam cell, α=0.25 → y[n]*0.75 + y[1]*0.25
+        #   3.5   — seam mid, α=0.5 → y[n]*0.5 + y[1]*0.5
+        #   3.875 — seam cell near right, α=0.875 → y[n]*0.125 + y[1]*0.875
+        xqs = [2.5, 3.0, 3.25, 3.5, 3.875]
+        outs = [Vector{Float64}(undef, length(xqs)) for _ in 1:2]
+        linear_interp!(outs, x, s, xqs; bc = bc)
+
+        # Linear blend expected values, y1 series
+        @test outs[1][1] ≈ 30.0 * 0.5   + 40.0 * 0.5   atol = 1.0e-12  # interior
+        @test outs[1][2] ≈ 40.0                        atol = 1.0e-12  # at x[n]
+        @test outs[1][3] ≈ 40.0 * 0.75  + 10.0 * 0.25  atol = 1.0e-12  # seam 25%
+        @test outs[1][4] ≈ 40.0 * 0.5   + 10.0 * 0.5   atol = 1.0e-12  # seam mid
+        @test outs[1][5] ≈ 40.0 * 0.125 + 10.0 * 0.875 atol = 1.0e-12  # seam 87.5%
+
+        # Linear blend expected values, y2 series
+        @test outs[2][1] ≈  3.0 * 0.5   +  4.0 * 0.5   atol = 1.0e-12
+        @test outs[2][2] ≈  4.0                        atol = 1.0e-12
+        @test outs[2][3] ≈  4.0 * 0.75  +  1.0 * 0.25  atol = 1.0e-12
+        @test outs[2][4] ≈  4.0 * 0.5   +  1.0 * 0.5   atol = 1.0e-12
+        @test outs[2][5] ≈  4.0 * 0.125 +  1.0 * 0.875 atol = 1.0e-12
+
+        # Cross-check: batch path agrees with per-query scalar path, series-wise.
+        for j in eachindex(xqs)
+            scalar_out = linear_interp(x, s, xqs[j]; bc = bc)
+            @test outs[1][j] ≈ scalar_out[1] atol = 1.0e-12
+            @test outs[2][j] ≈ scalar_out[2] atol = 1.0e-12
+        end
+
+        # Cross-check: batch path agrees with persistent interpolants (non-series).
+        itp1 = linear_interp(x, y1; bc = bc)
+        itp2 = linear_interp(x, y2; bc = bc)
+        for j in eachindex(xqs)
+            @test outs[1][j] ≈ itp1(xqs[j]) atol = 1.0e-12
+            @test outs[2][j] ≈ itp2(xqs[j]) atol = 1.0e-12
+        end
+    end
+
 end

--- a/test/test_linear_periodic.jl
+++ b/test/test_linear_periodic.jl
@@ -917,21 +917,21 @@ end
 
     @testset "Series scalar + PeriodicBC(:exclusive) seam semantic" begin
         # Simple 4-point grid, period = 4.0 → seam cell [x[n], x[1]+period) = [3, 4)
-        x  = collect(0.0:3.0)
+        x = collect(0.0:3.0)
         y1 = [10.0, 20.0, 30.0, 40.0]
         y2 = [1.0, 2.0, 3.0, 4.0]
-        s  = Series(y1, y2)
+        s = Series(y1, y2)
         bc = PeriodicBC(endpoint = :exclusive, period = 4.0)
 
         # Inside seam cell at xq = 3.5, α = 0.5 → y[n]*(1-α) + y[1]*α
         out = linear_interp(x, s, 3.5; bc = bc)
         @test out[1] ≈ 40.0 * 0.5 + 10.0 * 0.5 atol = 1.0e-12
-        @test out[2] ≈  4.0 * 0.5 +  1.0 * 0.5 atol = 1.0e-12
+        @test out[2] ≈ 4.0 * 0.5 + 1.0 * 0.5 atol = 1.0e-12
 
         # At xq = x[n] = 3.0 (α = 0 in seam cell → yL = y[n])
         out_left = linear_interp(x, s, 3.0; bc = bc)
         @test out_left[1] ≈ 40.0 atol = 1.0e-12
-        @test out_left[2] ≈  4.0 atol = 1.0e-12
+        @test out_left[2] ≈ 4.0 atol = 1.0e-12
 
         # Cross-check: series oneshot == per-series non-series scalar
         @test out[1] ≈ linear_interp(x, y1, 3.5; bc = bc) atol = 1.0e-12
@@ -1007,10 +1007,10 @@ end
 
     @testset "Series vector + PeriodicBC(:exclusive) seam cell semantic" begin
         # 4-point grid, period=4.0 → seam cell [x[n], x[1]+period) = [3, 4).
-        x  = collect(0.0:3.0)
+        x = collect(0.0:3.0)
         y1 = [10.0, 20.0, 30.0, 40.0]
         y2 = [1.0, 2.0, 3.0, 4.0]
-        s  = Series(y1, y2)
+        s = Series(y1, y2)
         bc = PeriodicBC(endpoint = :exclusive, period = 4.0)
 
         # Batch of xqs covering:
@@ -1024,18 +1024,18 @@ end
         linear_interp!(outs, x, s, xqs; bc = bc)
 
         # Linear blend expected values, y1 series
-        @test outs[1][1] ≈ 30.0 * 0.5   + 40.0 * 0.5   atol = 1.0e-12  # interior
+        @test outs[1][1] ≈ 30.0 * 0.5 + 40.0 * 0.5   atol = 1.0e-12  # interior
         @test outs[1][2] ≈ 40.0                        atol = 1.0e-12  # at x[n]
-        @test outs[1][3] ≈ 40.0 * 0.75  + 10.0 * 0.25  atol = 1.0e-12  # seam 25%
-        @test outs[1][4] ≈ 40.0 * 0.5   + 10.0 * 0.5   atol = 1.0e-12  # seam mid
+        @test outs[1][3] ≈ 40.0 * 0.75 + 10.0 * 0.25  atol = 1.0e-12  # seam 25%
+        @test outs[1][4] ≈ 40.0 * 0.5 + 10.0 * 0.5   atol = 1.0e-12  # seam mid
         @test outs[1][5] ≈ 40.0 * 0.125 + 10.0 * 0.875 atol = 1.0e-12  # seam 87.5%
 
         # Linear blend expected values, y2 series
-        @test outs[2][1] ≈  3.0 * 0.5   +  4.0 * 0.5   atol = 1.0e-12
-        @test outs[2][2] ≈  4.0                        atol = 1.0e-12
-        @test outs[2][3] ≈  4.0 * 0.75  +  1.0 * 0.25  atol = 1.0e-12
-        @test outs[2][4] ≈  4.0 * 0.5   +  1.0 * 0.5   atol = 1.0e-12
-        @test outs[2][5] ≈  4.0 * 0.125 +  1.0 * 0.875 atol = 1.0e-12
+        @test outs[2][1] ≈ 3.0 * 0.5 + 4.0 * 0.5   atol = 1.0e-12
+        @test outs[2][2] ≈ 4.0                        atol = 1.0e-12
+        @test outs[2][3] ≈ 4.0 * 0.75 + 1.0 * 0.25  atol = 1.0e-12
+        @test outs[2][4] ≈ 4.0 * 0.5 + 1.0 * 0.5   atol = 1.0e-12
+        @test outs[2][5] ≈ 4.0 * 0.125 + 1.0 * 0.875 atol = 1.0e-12
 
         # Cross-check: batch path agrees with per-query scalar path, series-wise.
         for j in eachindex(xqs)

--- a/test/test_linear_periodic.jl
+++ b/test/test_linear_periodic.jl
@@ -862,4 +862,85 @@ end
         @test outs[2] ≈ out_vec[2] atol = 1.0e-12
     end
 
+    # ============================================================
+    # Series OneShot Scalar + PeriodicBC — Zero-Copy Migration (A-2)
+    # ============================================================
+    # These tests drive and lock down the scalar-series zero-copy refactor
+    # (TODO: linear_constant_series_zero_copy.md, Stage 1).
+    # Function-barrier pattern mirrors the non-series alloc-guards above.
+
+    function _alloc_linear_series_scalar_range_exclusive()
+        x = range(0.0, step = 2π / 16, length = 16)
+        y1 = sin.(x)
+        y2 = cos.(x)
+        s = Series(y1, y2)
+        bc = PeriodicBC(endpoint = :exclusive, period = 2π)
+        out = Vector{Float64}(undef, 2)
+        linear_interp!(out, x, s, 1.0; bc = bc)
+        linear_interp!(out, x, s, 1.0; bc = bc)
+        return @allocated linear_interp!(out, x, s, 1.0; bc = bc)
+    end
+
+    function _alloc_linear_series_scalar_vector_exclusive()
+        x = [0.0, 0.5, 1.5, 3.0, 5.0]
+        y1 = sin.(x)
+        y2 = cos.(x)
+        s = Series(y1, y2)
+        bc = PeriodicBC(endpoint = :exclusive, period = 2π)
+        out = Vector{Float64}(undef, 2)
+        linear_interp!(out, x, s, 1.0; bc = bc)
+        linear_interp!(out, x, s, 1.0; bc = bc)
+        return @allocated linear_interp!(out, x, s, 1.0; bc = bc)
+    end
+
+    function _alloc_linear_series_scalar_inclusive()
+        x = collect(range(0.0, 2π, length = 17))
+        y1 = sin.(x)                          # y1[1] == y1[end] == 0
+        y2 = cos.(x)                          # y2[1] == y2[end] == 1
+        s = Series(y1, y2)
+        bc = PeriodicBC()                     # :inclusive default
+        out = Vector{Float64}(undef, 2)
+        linear_interp!(out, x, s, 1.0; bc = bc)
+        linear_interp!(out, x, s, 1.0; bc = bc)
+        return @allocated linear_interp!(out, x, s, 1.0; bc = bc)
+    end
+
+    @testset "Series scalar + PeriodicBC zero-alloc — Range exclusive (T-series-alloc)" begin
+        @test _alloc_linear_series_scalar_range_exclusive() <= ALLOC_THRESHOLD
+    end
+    @testset "Series scalar + PeriodicBC zero-alloc — Vector exclusive (T-series-alloc)" begin
+        @test _alloc_linear_series_scalar_vector_exclusive() <= ALLOC_THRESHOLD
+    end
+    @testset "Series scalar + PeriodicBC zero-alloc — inclusive (T-series-alloc)" begin
+        @test _alloc_linear_series_scalar_inclusive() <= ALLOC_THRESHOLD
+    end
+
+    @testset "Series scalar + PeriodicBC(:exclusive) seam semantic" begin
+        # Simple 4-point grid, period = 4.0 → seam cell [x[n], x[1]+period) = [3, 4)
+        x  = collect(0.0:3.0)
+        y1 = [10.0, 20.0, 30.0, 40.0]
+        y2 = [1.0, 2.0, 3.0, 4.0]
+        s  = Series(y1, y2)
+        bc = PeriodicBC(endpoint = :exclusive, period = 4.0)
+
+        # Inside seam cell at xq = 3.5, α = 0.5 → y[n]*(1-α) + y[1]*α
+        out = linear_interp(x, s, 3.5; bc = bc)
+        @test out[1] ≈ 40.0 * 0.5 + 10.0 * 0.5 atol = 1.0e-12
+        @test out[2] ≈  4.0 * 0.5 +  1.0 * 0.5 atol = 1.0e-12
+
+        # At xq = x[n] = 3.0 (α = 0 in seam cell → yL = y[n])
+        out_left = linear_interp(x, s, 3.0; bc = bc)
+        @test out_left[1] ≈ 40.0 atol = 1.0e-12
+        @test out_left[2] ≈  4.0 atol = 1.0e-12
+
+        # Cross-check: series oneshot == per-series non-series scalar
+        @test out[1] ≈ linear_interp(x, y1, 3.5; bc = bc) atol = 1.0e-12
+        @test out[2] ≈ linear_interp(x, y2, 3.5; bc = bc) atol = 1.0e-12
+
+        # Cross-check: series oneshot == persistent series interpolant
+        sitp = linear_interp(x, s; bc = bc)
+        @test out[1] ≈ sitp(3.5)[1] atol = 1.0e-12
+        @test out[2] ≈ sitp(3.5)[2] atol = 1.0e-12
+    end
+
 end

--- a/test/test_linear_periodic.jl
+++ b/test/test_linear_periodic.jl
@@ -943,6 +943,34 @@ end
         @test out[2] ≈ sitp(3.5)[2] atol = 1.0e-12
     end
 
+    @testset "Series oneshot + PeriodicBC(:exclusive) preserves cached step on large-offset Range" begin
+        # On `range(1e8, step=0.1, …)`, `x[i+1] - x[i]` loses precision to float
+        # cancellation (~1.5e-8 ulp at 1e8), while `_CachedRange.h` stores the
+        # exact step. The periodic series one-shot paths must dispatch through
+        # `_get_h`/`_get_inv_h` so they match the non-series scalar and
+        # persistent series evaluators on such grids.
+        x = range(1.0e8, step = 0.1, length = 10)
+        y1 = Float64.(1:10)
+        y2 = Float64.(11:20)
+        s = Series(y1, y2)
+        bc = PeriodicBC(endpoint = :exclusive)
+        xq = 1.0e8 + 0.95  # lands in seam cell [x[10], x[1]+period)
+
+        v_scalar = linear_interp(x, y1, xq; bc = bc)
+        v_oneshot = linear_interp(x, s, xq; bc = bc)
+        v_persist = linear_interp(x, s; bc = bc)(xq)
+
+        @test v_oneshot[1] === v_scalar
+        @test v_oneshot[1] === v_persist[1]
+
+        # Batch path must agree element-wise
+        xqs = [1.0e8 + 0.95, 1.0e8 + 0.55]
+        outs = [similar(xqs) for _ in 1:2]
+        linear_interp!(outs, x, s, xqs; bc = bc)
+        @test outs[1][1] === v_scalar
+        @test outs[1][2] === linear_interp(x, y1, xqs[2]; bc = bc)
+    end
+
     # ============================================================
     # Series OneShot Vector-Batch + PeriodicBC — Zero-Copy (Stage 2)
     # ============================================================

--- a/test/test_linear_periodic.jl
+++ b/test/test_linear_periodic.jl
@@ -943,4 +943,66 @@ end
         @test out[2] ≈ sitp(3.5)[2] atol = 1.0e-12
     end
 
+    # ============================================================
+    # Series OneShot Vector-Batch + PeriodicBC — Zero-Copy (Stage 2)
+    # ============================================================
+    # Drives the Q outer × K inner zero-pool refactor. Function-barrier +
+    # double-warmup pattern matches the scalar T-series-alloc convention.
+
+    function _alloc_linear_series_vector_range_exclusive()
+        x = range(0.0, step = 2π / 16, length = 16)
+        s = Series(sin.(x), cos.(x))
+        bc = PeriodicBC(endpoint = :exclusive, period = 2π)
+        xqs = [0.5, 1.0, 2.0, 3.5]
+        outs = [similar(xqs) for _ in 1:2]
+        linear_interp!(outs, x, s, xqs; bc = bc)
+        linear_interp!(outs, x, s, xqs; bc = bc)
+        return @allocated linear_interp!(outs, x, s, xqs; bc = bc)
+    end
+
+    function _alloc_linear_series_vector_vector_exclusive()
+        x = [0.0, 0.5, 1.5, 3.0, 5.0]
+        s = Series(sin.(x), cos.(x))
+        bc = PeriodicBC(endpoint = :exclusive, period = 2π)
+        xqs = [0.5, 1.0, 2.0, 3.5]
+        outs = [similar(xqs) for _ in 1:2]
+        linear_interp!(outs, x, s, xqs; bc = bc)
+        linear_interp!(outs, x, s, xqs; bc = bc)
+        return @allocated linear_interp!(outs, x, s, xqs; bc = bc)
+    end
+
+    function _alloc_linear_series_vector_inclusive()
+        x = collect(range(0.0, 2π, length = 17))
+        s = Series(sin.(x), cos.(x))
+        bc = PeriodicBC()
+        xqs = [0.5, 1.0, 2.0, 3.5]
+        outs = [similar(xqs) for _ in 1:2]
+        linear_interp!(outs, x, s, xqs; bc = bc)
+        linear_interp!(outs, x, s, xqs; bc = bc)
+        return @allocated linear_interp!(outs, x, s, xqs; bc = bc)
+    end
+
+    function _alloc_linear_series_vector_nobc()
+        x = range(0.0, step = 2π / 16, length = 16)
+        s = Series(sin.(x), cos.(x))
+        xqs = [0.5, 1.0, 2.0, 3.5]
+        outs = [similar(xqs) for _ in 1:2]
+        linear_interp!(outs, x, s, xqs)
+        linear_interp!(outs, x, s, xqs)
+        return @allocated linear_interp!(outs, x, s, xqs)
+    end
+
+    @testset "Series vector + PeriodicBC zero-alloc — Range exclusive (T-series-alloc)" begin
+        @test _alloc_linear_series_vector_range_exclusive() <= ALLOC_THRESHOLD
+    end
+    @testset "Series vector + PeriodicBC zero-alloc — Vector exclusive (T-series-alloc)" begin
+        @test _alloc_linear_series_vector_vector_exclusive() <= ALLOC_THRESHOLD
+    end
+    @testset "Series vector + PeriodicBC zero-alloc — inclusive (T-series-alloc)" begin
+        @test _alloc_linear_series_vector_inclusive() <= ALLOC_THRESHOLD
+    end
+    @testset "Series vector + NoBC zero-alloc (T-series-alloc)" begin
+        @test _alloc_linear_series_vector_nobc() <= ALLOC_THRESHOLD
+    end
+
 end

--- a/test/test_search_anchor_integration.jl
+++ b/test/test_search_anchor_integration.jl
@@ -16,7 +16,8 @@ using FastInterpolations: _anchor_query, _fill_anchors!,
         @testset "Single Query - Default Policy" begin
             aq = _anchor_query(x, 0.5, Val(:linear))
             @test aq isa _LinearAnchoredQuery{Float64, Float64}
-            @test aq.idx == 51
+            @test aq.idxL == 51
+            @test aq.idxR == 52
         end
 
         @testset "Vector Query - Policy Used in _fill_anchors!" begin
@@ -28,7 +29,7 @@ using FastInterpolations: _anchor_query, _fill_anchors!,
 
             # Verify correct anchors
             for i in eachindex(xq)
-                @test buffer[i].idx == round(Int, xq[i] * 100) + 1
+                @test buffer[i].idxL == round(Int, xq[i] * 100) + 1
             end
         end
 
@@ -43,7 +44,7 @@ using FastInterpolations: _anchor_query, _fill_anchors!,
             # Verify all anchors correct
             for i in eachindex(xq_monotonic)
                 expected_idx = round(Int, xq_monotonic[i] * 100) + 1
-                @test buffer[i].idx == expected_idx || buffer[i].idx == expected_idx - 1
+                @test buffer[i].idxL == expected_idx || buffer[i].idxL == expected_idx - 1
             end
         end
     end
@@ -58,7 +59,8 @@ using FastInterpolations: _anchor_query, _fill_anchors!,
         @testset "Single Query" begin
             aq = _anchor_query(x, 0.5, Val(:constant))
             @test aq isa _ConstantAnchoredQuery{Float64}
-            @test aq.idx == 51
+            @test aq.idxL == 51
+            @test aq.idxR == 52
         end
 
         @testset "Vector Query" begin
@@ -133,7 +135,7 @@ using FastInterpolations: _anchor_query, _fill_anchors!,
         @testset "Existing API Still Works" begin
             # Single query (no policy exposed)
             aq_linear = _anchor_query(x, 0.5, Val(:linear))
-            @test aq_linear.idx == 51
+            @test aq_linear.idxL == 51
 
             aq_cubic = _anchor_query(x, 0.5, Val(:cubic))
             @test aq_cubic.idx == 51


### PR DESCRIPTION
## Summary

Completes the `PeriodicBC(:exclusive)` zero-copy migration started in #126 by eliminating `@with_pool` from **all** Linear/Constant 1D Series paths:
scalar/vector × one-shot/persistent × non-periodic/inclusive/exclusive. 

Key idea — extend `_LinearAnchoredQuery` / `_ConstantAnchoredQuery` with explicit
`(idxL, idxR)` pair indices so the seam-wrap pair `(n, 1)` is carried by the
anchor itself, then reorder all vector-batch paths to **Q outer × K inner**
with per-query on-stack anchor.

**2–14× speedup** across configs; Linear/Constant 1D become fully
`@with_pool`-free (only `src/pchip/*` and `src/cubic/*` retain pool scopes).

## Core changes

**1. Anchor struct gains pair indices.** `_LinearAnchoredQuery` /
`_ConstantAnchoredQuery` rename `idx → idxL` and add `idxR::Int`. Normally
`idxR = idxL + 1`; at a periodic-exclusive seam it wraps to `1`. Eval kernels
(`_linear_eval_at_anchor`, `_constant_eval_at_anchor`) read both fields
directly — seam wrap flows through without grid/data copy. Naming mirrors the
existing `xL` / `dL` convention.

**2. Scalar series periodic helper.** Drops `@with_pool` +
`_periodic_extend_1d_pooled!`. Single anchor built via
`_resolve_extrap(NoExtrap(), bc, x, first(vecs))` → `_wrap_to_domain` →
BC-aware `search_interval` 4-tuple, then reused across the K-series eval
loop. Inclusive validation is a compile-time `bc isa PeriodicBC{:inclusive}`
branch (LLVM drops it in the exclusive specialization). This is the pattern
the rest of the PR reuses.

**3. Vector-batch & persistent callable — Q outer × K inner.** The prior
K-outer × Q-inner + `aq_vec`-pool pattern is inverted: anchor is built per
query on the stack and stays register-resident across the K-element inner
loop.

```julia
# Before
aq_vec = acquire!(pool, _LinearAnchoredQuery{…}, length(xqs))
_fill_anchors!(aq_vec, x, xqs, Val(:linear), wrap, searcher)
for k in 1:K, j in eachindex(xqs)
    outputs[k][j] = _linear_eval_at_anchor(vecs[k], aq_vec[j], …)
end

# After — no pool, no aq_vec, no _fill_anchors!
for j in eachindex(xqs)
    aq = _anchor_query(x, xqs[j], Val(:linear), wrap, searcher)
    for k in 1:K
        outputs[k][j] = _linear_eval_at_anchor(vecs[k], aq, …)
    end
end
```

Applies to both one-shot vector-batch (`linear_interp!(outs, x, s, xqs; bc)`)
and persistent callable (`sitp(outs, xqs)`).

**4. D5 — Constant series↔non-series seam alignment.** At `xq ==
x[1]+period` for `:exclusive`, the old pool-extended path returned `y[1]` via
the `aq.xq == x_last` short-circuit (`x_last` = extended grid end). The new
path keeps `x_last = x[end]` on the **original** grid, so the short-circuit
no longer fires at that query — falls through to the `NearestSide`/`LeftSide`
convention matching non-series constant. Pinned by a dedicated test.

## Performance

Master vs this PR; N=16, K=5, NQ=8, @btime in-place.

### Scalar series (1 query × K series)

| Config | Master | This PR | Δ |
|---|---|---|---|
| Linear Range :exclusive | 48.0 ns | 12.1 ns | **−75%** |
| Linear Vector :exclusive | 91.0 ns | 11.5 ns | **−87%** |
| Constant Range :exclusive | 82.9 ns | 10.6 ns | **−87%** |
| Constant Vector :exclusive | 131.4 ns | 9.5 ns | **−93%** |

### Vector-batch series (8 queries × K series, one-shot)

| Config | Master | This PR | Δ |
|---|---|---|---|
| Linear Range :exclusive | 128.9 ns | 51.2 ns | **−60%** |
| Linear Vector :exclusive | 154.8 ns | 48.9 ns | **−68%** |
| Constant Range :exclusive | 174.4 ns | 41.5 ns | **−76%** |
| Constant Vector :exclusive | 199.2 ns | 43.2 ns | **−78%** |

### Persistent callable (8 queries × K series)

| Config | Pre-PR (pool) | This PR | Δ |
|---|---|---|---|
| Linear Range :exclusive | 107.8 ns | 43.9 ns | **−59%** |
| Linear Vector :exclusive | 118.9 ns | 57.0 ns | **−52%** |
| Constant Range :exclusive | 150.9 ns | 41.6 ns | **−72%** |
| Constant Vector :exclusive | 163.5 ns | 58.7 ns | **−64%** |

Persistent now matches or beats one-shot per call — amortized build
(pre-extension) and register-resident anchor yield comparable per-query cost.


## Public API

No user-facing signature changes. Internal: anchor struct field `idx` →
`idxL` and new `idxR` (`_`-prefixed internal type). Series one-shot helpers
now require a BC-aware searcher from 5-arg `_resolve_search(..., bc)`.

## Dead-code audit

- `_periodic_extend_1d_pooled!` one-shot callers: 3 → **1** (only
  `cubic_oneshot.jl:155` remains).
- `_fill_anchors!` in Linear/Constant one-shot: **removed** (still live via
  persistent Cubic/Quadratic + public-API tests).
- `@with_pool` in Linear/Constant 1D src: **zero**.