### PR TITLE
(refac): `_IdxStencil{K}` — Unified Corner Addressing + Layer Cleanup

### DIFF
--- a/src/constant/constant_adjoint.jl
+++ b/src/constant/constant_adjoint.jl
@@ -174,7 +174,7 @@ function _fixup_constant_anchor_state!(
         state = xq_i < x_lo ? OOB_LEFT : OOB_RIGHT
         aq = anchors[i]
         anchors[i] = _ConstantAnchoredQuery{Tg, Tg}(
-            aq.idxL, aq.idxR, aq.xq, state, aq.h, aq.dL
+            aq.stencil, aq.xq, state, aq.h, aq.dL
         )
     end
     return nothing

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -74,15 +74,11 @@ end
 @inline Base.propertynames(::_ConstantAnchoredQuery) =
     (:stencil, :idxL, :idxR, :xq, :state, :h, :dL)
 
-# Outer constructors — preserve both the legacy 6-arg positional pair shape
-# (used by `_anchor_query`, Series one-shot, adjoint) and the stencil-native form.
-@inline _ConstantAnchoredQuery(idxL::Int, idxR::Int, xq::Tq, state::UInt8, h::Tg, dL::Tq) where {Tg, Tq} =
-    _ConstantAnchoredQuery{Tg, Tq}(_pair(idxL, idxR), xq, state, h, dL)
-
-# Parametric stencil-native alias used by legacy typeof(aq)(...) fixup sites
-# (e.g. `_fixup_constant_anchor_state!` in constant_adjoint.jl).
-@inline _ConstantAnchoredQuery{Tg, Tq}(idxL::Int, idxR::Int, xq, state, h, dL) where {Tg, Tq} =
-    _ConstantAnchoredQuery{Tg, Tq}(_pair(idxL, idxR), xq, state, h, dL)
+# Stencil-native outer — infers `Tg, Tq` from arg types so callers can write
+# `_ConstantAnchoredQuery(_IdxPair(idxL, idxR), xq, state, h, dL)` without
+# specifying type params. Mirrors Linear's stencil-native outer.
+@inline _ConstantAnchoredQuery(stencil::_IdxStencil{2}, xq::Tq, state::UInt8, h::Tg, dL::Tq) where {Tg, Tq} =
+    _ConstantAnchoredQuery{Tg, Tq}(stencil, xq, state, h, dL)
 
 # ========================================
 # Anchor Construction
@@ -231,7 +227,7 @@ Internal implementation of _anchor_query for constant interpolation.
     # `_anchor_loc` never returns a periodic-exclusive seam pair, so
     # `idxR = idxL + 1` here. Seam-pair anchors are constructed directly in
     # the exclusive periodic series helper via `_ConstantAnchoredQuery(...)`.
-    return _ConstantAnchoredQuery(loc.idx, loc.idx + 1, xq_promoted, loc.state, h, dL)
+    return _ConstantAnchoredQuery(_IdxPair(loc.idx, loc.idx + 1), xq_promoted, loc.state, h, dL)
 end
 
 # ========================================

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -23,8 +23,9 @@ matches the interpolant grid.
 - `Tq <: Real`: Query point type (stored in `xq`, `dL`); may widen `Tg` (e.g. `Dual` for AD)
 
 # Fields
-- `idxL`: Left cell index (`1 ≤ idxL ≤ n-1` normally; equals `n` at periodic-exclusive seam)
-- `idxR`: Right cell index (`idxL + 1` normally; wraps to `1` at periodic-exclusive seam)
+- `stencil::_IdxStencil{2}`: Corner-index stencil; `stencil[1]` is the left index, `stencil[2]` the right
+  (legacy `aq.idxL` / `aq.idxR` virtual properties read through `getproperty` — see below).
+  For non-periodic cells `idxR == idxL + 1`; at periodic-exclusive seam `idxL == n`, `idxR == 1` (wrap).
 - `xq`: Original query point (or wrapped value for periodic)
 - `state`: Domain state (`IN_DOMAIN`, `OOB_LEFT`, or `OOB_RIGHT`)
 - `h`: Interval width (used by all side modes via `_compute_single_offset`)

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -22,9 +22,6 @@ matches the interpolant grid.
 - `Tg`: Grid element type (stored in `h`)
 - `Tq <: Real`: Query point type (stored in `xq`, `dL`); may widen `Tg` (e.g. `Dual` for AD)
 
-A convenience constructor `_ConstantAnchoredQuery{T}(args...)` is provided for the
-common non-AD case where `Tg == Tq`.
-
 # Fields
 - `idxL`: Left cell index (`1 ≤ idxL ≤ n-1` normally; equals `n` at periodic-exclusive seam)
 - `idxR`: Right cell index (`idxL + 1` normally; wraps to `1` at periodic-exclusive seam)
@@ -82,10 +79,8 @@ end
 @inline _ConstantAnchoredQuery(idxL::Int, idxR::Int, xq::Tq, state::UInt8, h::Tg, dL::Tq) where {Tg, Tq} =
     _ConstantAnchoredQuery{Tg, Tq}(_pair(idxL, idxR), xq, state, h, dL)
 
-# Convenience: single type param for backward compat (non-AD paths) — Tq==Tg
-@inline _ConstantAnchoredQuery{T}(idxL::Int, idxR::Int, xq, state, h, dL) where {T} =
-    _ConstantAnchoredQuery{T, T}(_pair(idxL, idxR), xq, state, h, dL)
-# Parametric stencil-native alias used by legacy typeof(aq)(...) fixup sites.
+# Parametric stencil-native alias used by legacy typeof(aq)(...) fixup sites
+# (e.g. `_fixup_constant_anchor_state!` in constant_adjoint.jl).
 @inline _ConstantAnchoredQuery{Tg, Tq}(idxL::Int, idxR::Int, xq, state, h, dL) where {Tg, Tq} =
     _ConstantAnchoredQuery{Tg, Tq}(_pair(idxL, idxR), xq, state, h, dL)
 

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -50,16 +50,44 @@ Anchored evaluation is faster than `itp(xq)` for non-uniform grids,
 as it eliminates O(log n) binary search.
 """
 struct _ConstantAnchoredQuery{Tg, Tq <: Real}
-    idxL::Int                  # left cell index
-    idxR::Int                  # right cell index (idxL+1 normally; 1 at periodic-exclusive seam)
+    # Corner-index stencil: `stencil[1]` is the left index (idxL),
+    # `stencil[2]` is the right index (idxR). For non-periodic cells
+    # `idxR == idxL + 1`; for periodic-exclusive seam cells `idxR == 1` (wrap).
+    # Unified across all wrap-aware methods via `_IdxStencil{K}`
+    # (src/core/idx_stencil.jl). Legacy `aq.idxL` / `aq.idxR` accessors are
+    # preserved via `getproperty` below.
+    stencil::_IdxStencil{2}
     xq::Tq                     # query point (possibly wrapped, may be Dual for AD)
     state::UInt8               # IN_DOMAIN / OOB_LEFT / OOB_RIGHT
     h::Tg                      # interval width
     dL::Tq                     # offset from left boundary (same type as xq for AD)
 end
 
-# Convenience: single type param for backward compat (non-AD paths)
-_ConstantAnchoredQuery{T}(idxL, idxR, xq, state, h, dL) where {T} = _ConstantAnchoredQuery{T, T}(idxL, idxR, xq, state, h, dL)
+# ──────────────────────────────────────────────────────────────
+# Virtual property accessors — legacy `aq.idxL` / `aq.idxR` ergonomics
+# ──────────────────────────────────────────────────────────────
+# Val-dispatch pattern (see linear_anchor.jl for rationale): one method per
+# property symbol so the compiler specializes each access to a single `getfield`
+# (+ tuple index) with concrete return type — no boxing from union-wide
+# `getproperty` return.
+@inline Base.getproperty(aq::_ConstantAnchoredQuery, s::Symbol) = _get_const_prop(aq, Val(s))
+@inline _get_const_prop(aq::_ConstantAnchoredQuery, ::Val{:idxL}) = getfield(aq, :stencil)[1]
+@inline _get_const_prop(aq::_ConstantAnchoredQuery, ::Val{:idxR}) = getfield(aq, :stencil)[2]
+@inline _get_const_prop(aq::_ConstantAnchoredQuery, ::Val{s}) where {s} = getfield(aq, s)
+@inline Base.propertynames(::_ConstantAnchoredQuery) =
+    (:stencil, :idxL, :idxR, :xq, :state, :h, :dL)
+
+# Outer constructors — preserve both the legacy 6-arg positional pair shape
+# (used by `_anchor_query`, Series one-shot, adjoint) and the stencil-native form.
+@inline _ConstantAnchoredQuery(idxL::Int, idxR::Int, xq::Tq, state::UInt8, h::Tg, dL::Tq) where {Tg, Tq} =
+    _ConstantAnchoredQuery{Tg, Tq}(_pair(idxL, idxR), xq, state, h, dL)
+
+# Convenience: single type param for backward compat (non-AD paths) — Tq==Tg
+@inline _ConstantAnchoredQuery{T}(idxL::Int, idxR::Int, xq, state, h, dL) where {T} =
+    _ConstantAnchoredQuery{T, T}(_pair(idxL, idxR), xq, state, h, dL)
+# Parametric stencil-native alias used by legacy typeof(aq)(...) fixup sites.
+@inline _ConstantAnchoredQuery{Tg, Tq}(idxL::Int, idxR::Int, xq, state, h, dL) where {Tg, Tq} =
+    _ConstantAnchoredQuery{Tg, Tq}(_pair(idxL, idxR), xq, state, h, dL)
 
 # ========================================
 # Anchor Construction

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -219,7 +219,7 @@ Internal implementation of _anchor_query for constant interpolation.
     loc = _anchor_loc(x, xq, wrap, policy)
 
     # Compute geometry (constant-internal concern)
-    h = _get_h(x, loc.xR, loc.xL)
+    h = _get_h(x, loc.xL, loc.xR)
     dL = loc.xq - loc.xL
     # Promote xq to match dL type (Float64 query + Dual grid → dL is Dual)
     xq_promoted = oftype(dL, loc.xq)

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -14,7 +14,7 @@
 # Core eval: extrap dispatch → search → kernel (no intermediate layers)
 # ========================================
 # _eval_extrapolation helper is defined in core/utils.jl (shared by all methods).
-# _get_h(x, xR, xL) dispatches to x.h (_CachedRange) or xR-xL (Vector).
+# _get_h(x, xL, xR) dispatches to x.h (_CachedRange) or xR-xL (Vector).
 
 # NoExtrap / InBounds: domain check + search + kernel.
 # (OOB impossible: NoExtrap throws, InBounds guarantees in-domain)
@@ -33,7 +33,7 @@
     end
     idx, idx_R, xL, xR = search_interval(searcher, x, xi)
     dL = xi - xL
-    @inbounds return _constant_kernel(op, y[idx], y[idx_R], _get_h(x, xR, xL), dL, side)
+    @inbounds return _constant_kernel(op, y[idx], y[idx_R], _get_h(x, xL, xR), dL, side)
 end
 
 # ExtendExtrap: constant function has zero slope → extend = clamp.
@@ -68,7 +68,7 @@ end
     end
     idx, idx_R, xL, xR = search_interval(searcher, x, xi)
     dL = xi - xL
-    @inbounds return _constant_kernel(op, y[idx], y[idx_R], _get_h(x, xR, xL), dL, side)
+    @inbounds return _constant_kernel(op, y[idx], y[idx_R], _get_h(x, xL, xR), dL, side)
 end
 
 # WrapExtrap: wrap query to domain → search + kernel.
@@ -88,7 +88,7 @@ end
     xi_wrapped = _wrap_to_domain(xi, extrap)
     idx, idx_R, xL, xR = search_interval(searcher, x, xi_wrapped)
     dL = xi_wrapped - xL
-    @inbounds return _constant_kernel(op, y[idx], y[idx_R], _get_h(x, xR, xL), dL, side)
+    @inbounds return _constant_kernel(op, y[idx], y[idx_R], _get_h(x, xL, xR), dL, side)
 end
 
 

--- a/src/constant/constant_oneshot_series.jl
+++ b/src/constant/constant_oneshot_series.jl
@@ -41,7 +41,7 @@
     idxL, idxR, xL, xR = search_interval(searcher, x, xq_wrapped)
     # Use _get_h so _CachedRange returns its exact cached step instead of
     # the cancellation-prone `xR - xL` on large-offset grids.
-    h = _get_h(x, xR, xL)
+    h = _get_h(x, xL, xR)
     dL = xq_wrapped - xL
     # Promote xq to match dL type (Float64 query + Dual grid → dL is Dual).
     xq_promoted = oftype(dL, xq_wrapped)
@@ -163,7 +163,7 @@ end
             xq_wrapped = _wrap_to_domain(xqs[j], extrap_p)
             idxL, idxR, xL, xR = search_interval(searcher, x, xq_wrapped)
             # Cached-step-preserving dispatch (matches scalar/persistent paths).
-            h = _get_h(x, xR, xL)
+            h = _get_h(x, xL, xR)
             dL = xq_wrapped - xL
             xq_promoted = oftype(dL, xq_wrapped)
             aq = _ConstantAnchoredQuery(_IdxPair(idxL, idxR), xq_promoted, IN_DOMAIN, h, dL)

--- a/src/constant/constant_oneshot_series.jl
+++ b/src/constant/constant_oneshot_series.jl
@@ -45,7 +45,7 @@
     dL = xq_wrapped - xL
     # Promote xq to match dL type (Float64 query + Dual grid → dL is Dual).
     xq_promoted = oftype(dL, xq_wrapped)
-    aq = _ConstantAnchoredQuery(idxL, idxR, xq_promoted, IN_DOMAIN, h, dL)
+    aq = _ConstantAnchoredQuery(_IdxPair(idxL, idxR), xq_promoted, IN_DOMAIN, h, dL)
 
     x_last = @inbounds Tg(last(x))
 
@@ -166,7 +166,7 @@ end
             h = _get_h(x, xR, xL)
             dL = xq_wrapped - xL
             xq_promoted = oftype(dL, xq_wrapped)
-            aq = _ConstantAnchoredQuery(idxL, idxR, xq_promoted, IN_DOMAIN, h, dL)
+            aq = _ConstantAnchoredQuery(_IdxPair(idxL, idxR), xq_promoted, IN_DOMAIN, h, dL)
             for k in 1:K
                 outputs[k][j] = _constant_eval_at_anchor(vecs[k], x_last, aq, deriv, side, extrap_p)
             end

--- a/src/constant/nd/constant_nd_adjoint.jl
+++ b/src/constant/nd/constant_nd_adjoint.jl
@@ -56,7 +56,7 @@ function _bake_constant_nd_anchors(
                 IN_DOMAIN
             end
 
-            return _ConstantAnchoredQuery{Tg, Tg}(idx, idxR, xq_d, state_flag, h, dL)
+            return _ConstantAnchoredQuery{Tg, Tg}(_IdxPair(idx, idxR), xq_d, state_flag, h, dL)
         end
         anchors[q] = per_axis
     end

--- a/src/constant/nd/constant_nd_eval.jl
+++ b/src/constant/nd/constant_nd_eval.jl
@@ -125,12 +125,14 @@ end
     # Lift h + wrap indices into stencils, matching the generic-N path.
     hx = _get_h(itp.spacings[1], ix)
     hy = _get_h(itp.spacings[2], iy)
-    return (itp.data,
-            (_IdxPair(ix, ix + 1), _IdxPair(iy, iy + 1)),
-            (hx, hy),
-            itp.sides,
-            (x_eval, y_eval),
-            (xL, yL))
+    return (
+        itp.data,
+        (_IdxPair(ix, ix + 1), _IdxPair(iy, iy + 1)),
+        (hx, hy),
+        itp.sides,
+        (x_eval, y_eval),
+        (xL, yL),
+    )
 end
 
 # Evaluate kernel at a pre-located cell with given derivative ops
@@ -223,9 +225,15 @@ paths share this signature.
     idx_parts = Expr[]
     for d in 1:N
         offset_sym = Symbol("offset_", d)
-        push!(idx_parts, :(ifelse($offset_sym == 0,
-                                  @inbounds(stencils[$d][1]),
-                                  @inbounds(stencils[$d][2]))))
+        push!(
+            idx_parts, :(
+                ifelse(
+                    $offset_sym == 0,
+                    @inbounds(stencils[$d][1]),
+                    @inbounds(stencils[$d][2])
+                )
+            )
+        )
     end
     idx_expr = Expr(:tuple, idx_parts...)
 

--- a/src/constant/nd/constant_nd_eval.jl
+++ b/src/constant/nd/constant_nd_eval.jl
@@ -101,7 +101,14 @@ end
     ) where {Tg, Tv, N}
     q_eval = _handle_all_extraps(query, itp.grids, itp.extraps)
     indices, Ls, _ = _search_all_intervals(q_eval, itp.grids, itp.spacings, policies, hints, mono)
-    return (itp.data, itp.spacings, itp.sides, indices, q_eval, Ls)
+    # h-lift: the kernel now takes precomputed `hs` instead of computing
+    # `_get_h(spacings[d], indices[d])` inside the @generated body. Persistent
+    # fast lane: 2-arg `_get_h` reads cached `spacings[d].h`.
+    hs = map(_get_h, itp.spacings, indices)
+    # Wrap raw indices into the unified stencil shape so the kernel has a
+    # single signature across persistent and BC oneshot callers.
+    stencils = map(i -> _IdxPair(i, i + 1), indices)
+    return (itp.data, stencils, hs, itp.sides, q_eval, Ls)
 end
 
 # N=2 specialization: direct destructuring eliminates ntuple closure overhead
@@ -115,8 +122,15 @@ end
     x_eval, y_eval, ix, iy, xL, yL = _locate_cell_2d_preamble(
         query, itp.grids, itp.spacings, itp.extraps, policies, hints, mono
     )
-
-    return (itp.data, itp.spacings, itp.sides, (ix, iy), (x_eval, y_eval), (xL, yL))
+    # Lift h + wrap indices into stencils, matching the generic-N path.
+    hx = _get_h(itp.spacings[1], ix)
+    hy = _get_h(itp.spacings[2], iy)
+    return (itp.data,
+            (_IdxPair(ix, ix + 1), _IdxPair(iy, iy + 1)),
+            (hx, hy),
+            itp.sides,
+            (x_eval, y_eval),
+            (xL, yL))
 end
 
 # Evaluate kernel at a pre-located cell with given derivative ops
@@ -128,8 +142,8 @@ end
     if _has_any_derivative(ops, Val(N))
         return 0 * first(itp.data)
     end
-    data, spacings, sides, indices, q_eval, Ls = cell
-    return _constant_nd_kernel(data, spacings, sides, indices, q_eval, Ls)
+    data, stencils, hs, sides, q_eval, Ls = cell
+    return _constant_nd_kernel(data, stencils, hs, sides, q_eval, Ls)
 end
 
 # ========================================
@@ -150,94 +164,48 @@ end
 # ========================================
 
 """
-    _constant_nd_kernel(data, spacings, sides, indices, q_eval, Ls)
+    _constant_nd_kernel(data, stencils, hs, sides, q_eval, Ls)
 
 @generated kernel that unrolls the constant interpolation lookup for N dimensions.
-Computes cell widths, distances from left edge, side-based offsets, and returns data value.
+
+`stencils[d]::_IdxStencil{2}` carries `(idx_L_d, idx_R_d)` — corner address
+on axis `d` is `stencils[d][offset_d + 1]` (offset 0 → left `idx_L`, offset 1
+→ right `idx_R`). For non-periodic cells `idx_R == idx_L + 1`; for
+periodic-exclusive seam cells `idx_R == 1` (wrap), so the kernel reads the
+wrapped neighbor without any data extension.
+
+`hs::NTuple{N, …}` is the precomputed cell width per axis. Lifted out of
+the kernel — call sites compute it via `map(_get_h, …)` (2-arg cached form
+on the persistent fast lane, 3-arg dispatch form on the BC oneshot path).
+The kernel itself is now geometry-agnostic and matches the shape of
+`_multilinear_sum`.
+
+Single-overload, stencil-only kernel — both persistent and BC oneshot
+paths share this signature.
 """
 @generated function _constant_nd_kernel(
         data::AbstractArray{Tv, N},
-        spacings::NTuple{N, AbstractGridSpacing},
-        sides::Tuple{Vararg{AbstractSide, N}},
-        indices::NTuple{N, Int},
-        q_eval::Tuple{Vararg{Real, N}},
-        Ls::Tuple{Vararg{Real, N}}
-    ) where {Tv, N}
-    # Build list of expressions at compile-time (loops here are fine)
-    exprs = Expr[]
-
-    # Generate: h_d = _get_h(spacings[d], indices[d]) for each dimension
-    for d in 1:N
-        h_sym = Symbol("h_", d)
-        push!(exprs, :($h_sym = @inbounds _get_h(spacings[$d], indices[$d])))
-    end
-
-    # Generate: dL_d = q_eval[d] - Ls[d] for each dimension
-    for d in 1:N
-        dL_sym = Symbol("dL_", d)
-        push!(exprs, :($dL_sym = @inbounds q_eval[$d] - Ls[$d]))
-    end
-
-    # Generate: offset_d = _compute_single_offset(sides[d], h_d, dL_d) for each dimension
-    for d in 1:N
-        h_sym = Symbol("h_", d)
-        dL_sym = Symbol("dL_", d)
-        offset_sym = Symbol("offset_", d)
-        push!(exprs, :($offset_sym = _compute_single_offset(sides[$d], $h_sym, $dL_sym)))
-    end
-
-    # Build final index expression: (indices[1]+offset_1, indices[2]+offset_2, ...)
-    idx_parts = Expr[]
-    for d in 1:N
-        offset_sym = Symbol("offset_", d)
-        push!(idx_parts, :(indices[$d] + $offset_sym))
-    end
-    idx_expr = Expr(:tuple, idx_parts...)
-
-    # Build the final data access
-    push!(exprs, :(@inbounds data[$idx_expr...]))
-
-    # Build final block expression (no comprehensions/generators in returned AST)
-    return Expr(:block, :(Base.@_inline_meta), exprs...)
-end
-
-"""
-    _constant_nd_kernel_stencil(data, stencils, Rs, sides, q_eval, Ls)
-
-Stencil-variant for zero-copy periodic ND evaluation.
-
-`stencils[d]::_IdxStencil{2}` carries `(idx_L_d, idx_R_d)` — corner address
-on axis `d` is `stencils[d][offset_d + 1]` (offset 0 → left idx_L, offset 1
-→ right idx_R). For non-periodic cells, `idx_R == idx_L + 1`; for
-periodic-exclusive seam cells, `idx_R == 1` (wrap) so the kernel reads the
-wrapped neighbor without any data extension. Cell width
-`h_d = Rs[d] - Ls[d]` — sidesteps the `_get_h(spacings[d], indices[d])`
-lookup which would be out-of-bounds for periodic-exclusive seam cells.
-
-Distinct name (not an overload) because at `N=0` `NTuple{0, Int}` and
-`NTuple{0, _IdxStencil{2}}` both collapse to `Tuple{}`, making
-overload-style dispatch ambiguous (caught by Aqua static analysis).
-"""
-@generated function _constant_nd_kernel_stencil(
-        data::AbstractArray{Tv, N},
         stencils::NTuple{N, _IdxStencil{2}},
-        Rs::Tuple{Vararg{Real, N}},
+        hs::Tuple{Vararg{Real, N}},
         sides::Tuple{Vararg{AbstractSide, N}},
         q_eval::Tuple{Vararg{Real, N}},
         Ls::Tuple{Vararg{Real, N}}
     ) where {Tv, N}
     exprs = Expr[]
 
+    # h_d = @inbounds hs[d]  (precomputed at call site — see _locate_cell)
     for d in 1:N
         h_sym = Symbol("h_", d)
-        push!(exprs, :($h_sym = @inbounds Rs[$d] - Ls[$d]))
+        push!(exprs, :($h_sym = @inbounds hs[$d]))
     end
 
+    # dL_d = q_eval[d] - Ls[d]
     for d in 1:N
         dL_sym = Symbol("dL_", d)
         push!(exprs, :($dL_sym = @inbounds q_eval[$d] - Ls[$d]))
     end
 
+    # offset_d = _compute_single_offset(sides[d], h_d, dL_d)
     for d in 1:N
         h_sym = Symbol("h_", d)
         dL_sym = Symbol("dL_", d)
@@ -245,11 +213,19 @@ overload-style dispatch ambiguous (caught by Aqua static analysis).
         push!(exprs, :($offset_sym = _compute_single_offset(sides[$d], $h_sym, $dL_sym)))
     end
 
-    # Corner address: offset 0 → stencils[d][1] (idx_L); offset 1 → stencils[d][2] (idx_R)
+    # Corner address: offset 0 → stencils[d][1] (idx_L), offset 1 → stencils[d][2] (idx_R).
+    # `ifelse` produces a branchless CSEL on x86/ARM and avoids the dynamic
+    # NTuple lookup `stencils[d][offset_d + 1]`, which would compile to a
+    # bounds-check + indexed load. Constant's `offset_d` is runtime (from
+    # `_compute_single_offset`), unlike Linear where bit patterns are
+    # compile-time constants — so the explicit `ifelse` is what keeps the
+    # 1-cycle-per-axis cost matching the pre-unification integer-add path.
     idx_parts = Expr[]
     for d in 1:N
         offset_sym = Symbol("offset_", d)
-        push!(idx_parts, :(stencils[$d][$offset_sym + 1]))
+        push!(idx_parts, :(ifelse($offset_sym == 0,
+                                  @inbounds(stencils[$d][1]),
+                                  @inbounds(stencils[$d][2]))))
     end
     idx_expr = Expr(:tuple, idx_parts...)
 

--- a/src/constant/nd/constant_nd_eval.jl
+++ b/src/constant/nd/constant_nd_eval.jl
@@ -202,22 +202,25 @@ Computes cell widths, distances from left edge, side-based offsets, and returns 
 end
 
 """
-    _constant_nd_kernel_lr(data, indices_pairs, Rs, sides, q_eval, Ls)
+    _constant_nd_kernel_stencil(data, stencils, Rs, sides, q_eval, Ls)
 
-Pair-valued indices variant for zero-copy periodic ND evaluation (Phase 6).
+Stencil-variant for zero-copy periodic ND evaluation.
 
-`indices_pairs[d] = (idx_L_d, idx_R_d)` — corner address on axis `d` is
-`indices_pairs[d][offset_d + 1]` (offset 0 → left idx_L, offset 1 → right idx_R).
-Cell width `h_d = Rs[d] - Ls[d]` — sidesteps the `_get_h(spacings[d], indices[d])`
+`stencils[d]::_IdxStencil{2}` carries `(idx_L_d, idx_R_d)` — corner address
+on axis `d` is `stencils[d][offset_d + 1]` (offset 0 → left idx_L, offset 1
+→ right idx_R). For non-periodic cells, `idx_R == idx_L + 1`; for
+periodic-exclusive seam cells, `idx_R == 1` (wrap) so the kernel reads the
+wrapped neighbor without any data extension. Cell width
+`h_d = Rs[d] - Ls[d]` — sidesteps the `_get_h(spacings[d], indices[d])`
 lookup which would be out-of-bounds for periodic-exclusive seam cells.
 
-Distinct name (not an overload) because at `N=0` the two possible
-`NTuple{0, ...}` element types both collapse to `Tuple{}`, making
+Distinct name (not an overload) because at `N=0` `NTuple{0, Int}` and
+`NTuple{0, _IdxStencil{2}}` both collapse to `Tuple{}`, making
 overload-style dispatch ambiguous (caught by Aqua static analysis).
 """
-@generated function _constant_nd_kernel_lr(
+@generated function _constant_nd_kernel_stencil(
         data::AbstractArray{Tv, N},
-        indices_pairs::NTuple{N, NTuple{2, Int}},
+        stencils::NTuple{N, _IdxStencil{2}},
         Rs::Tuple{Vararg{Real, N}},
         sides::Tuple{Vararg{AbstractSide, N}},
         q_eval::Tuple{Vararg{Real, N}},
@@ -242,11 +245,11 @@ overload-style dispatch ambiguous (caught by Aqua static analysis).
         push!(exprs, :($offset_sym = _compute_single_offset(sides[$d], $h_sym, $dL_sym)))
     end
 
-    # Corner address: offset 0 → indices_pairs[d][1] (idx_L); offset 1 → indices_pairs[d][2] (idx_R)
+    # Corner address: offset 0 → stencils[d][1] (idx_L); offset 1 → stencils[d][2] (idx_R)
     idx_parts = Expr[]
     for d in 1:N
         offset_sym = Symbol("offset_", d)
-        push!(idx_parts, :(indices_pairs[$d][$offset_sym + 1]))
+        push!(idx_parts, :(stencils[$d][$offset_sym + 1]))
     end
     idx_expr = Expr(:tuple, idx_parts...)
 

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -13,7 +13,7 @@
 # Zero heap allocation for scalar queries after warmup.
 
 """
-    _constant_interp_nd_oneshot(grids, data, query, extraps_val, side_vals, searches, hints=nothing)
+    _constant_interp_nd_oneshot(grids, data, query, bcs, extraps_val, side_vals, searches, hints=nothing)
 
 Zero-allocation scalar one-shot ND constant evaluation.
 Evaluates directly from grids + data without constructing a ConstantInterpolantND.
@@ -41,7 +41,7 @@ function _constant_interp_nd_oneshot(
 end
 
 """
-    _constant_interp_nd_oneshot_batch!(output, grids, data, queries, extraps_val, side_vals, searches, hints=nothing)
+    _constant_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps_val, side_vals, policies, hints, mono)
 
 In-place batch one-shot ND constant evaluation.
 Uses query protocol (`_query_length`, `_query_extract`) — works with any query format.

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -35,8 +35,8 @@ function _constant_interp_nd_oneshot(
 
     extraps_eff = _resolve_extrap(extraps_val, bcs, grids, data, Val(N))
     q_eval = _handle_all_extraps(query, grids, extraps_eff)
-    indices_pairs, Ls, Rs = _search_all_intervals_lr(q_eval, grids, searches, hints, bcs)
-    return _constant_nd_kernel_lr(data, indices_pairs, Rs, side_vals, q_eval, Ls)
+    stencils, Ls, Rs = _search_all_intervals_stencil(q_eval, grids, searches, hints, bcs)
+    return _constant_nd_kernel_stencil(data, stencils, Rs, side_vals, q_eval, Ls)
 end
 
 """
@@ -70,8 +70,8 @@ function _constant_interp_nd_oneshot_batch!(
             output[k] = oob_val; continue
         end
         q_eval = _handle_all_extraps(query_k, grids, extraps_eff)
-        indices_pairs, Ls, Rs = _search_all_intervals_lr(q_eval, grids, policies, hints, bcs)
-        output[k] = _constant_nd_kernel_lr(data, indices_pairs, Rs, side_vals, q_eval, Ls)
+        stencils, Ls, Rs = _search_all_intervals_stencil(q_eval, grids, policies, hints, bcs)
+        output[k] = _constant_nd_kernel_stencil(data, stencils, Rs, side_vals, q_eval, Ls)
     end
     return output
 end

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -36,7 +36,8 @@ function _constant_interp_nd_oneshot(
     extraps_eff = _resolve_extrap(extraps_val, bcs, grids, data, Val(N))
     q_eval = _handle_all_extraps(query, grids, extraps_eff)
     stencils, Ls, Rs = _search_all_intervals_stencil(q_eval, grids, searches, hints, bcs)
-    return _constant_nd_kernel_stencil(data, stencils, Rs, side_vals, q_eval, Ls)
+    hs = map(_get_h, grids, Ls, Rs)
+    return _constant_nd_kernel(data, stencils, hs, side_vals, q_eval, Ls)
 end
 
 """
@@ -71,7 +72,8 @@ function _constant_interp_nd_oneshot_batch!(
         end
         q_eval = _handle_all_extraps(query_k, grids, extraps_eff)
         stencils, Ls, Rs = _search_all_intervals_stencil(q_eval, grids, policies, hints, bcs)
-        output[k] = _constant_nd_kernel_stencil(data, stencils, Rs, side_vals, q_eval, Ls)
+        hs = map(_get_h, grids, Ls, Rs)
+        output[k] = _constant_nd_kernel(data, stencils, hs, side_vals, q_eval, Ls)
     end
     return output
 end

--- a/src/core/cached_range.jl
+++ b/src/core/cached_range.jl
@@ -182,6 +182,7 @@ function _create_spacing(x::_CachedRange{T}) where {T}
 end
 
 # 3-arg grid-based accessors: _CachedRange has h/inv_h cached in the struct.
-# AbstractVector fallbacks are in grid_spacing.jl.
+# Args are (x, xL, xR) — natural L→R order, matching AbstractVector fallbacks
+# in grid_spacing.jl. The cached form ignores both endpoints (uniform step).
 @inline _get_h(x::_CachedRange, ::Real, ::Real) = x.h
 @inline _get_inv_h(x::_CachedRange, ::Real, ::Real) = x.inv_h

--- a/src/core/core.jl
+++ b/src/core/core.jl
@@ -10,6 +10,7 @@ include("polyfit_kernels.jl")       # 4. Boundary condition computation kernels 
 include("grid_spacing.jl")     # 5. ScalarSpacing, VectorSpacing
 include("cached_range.jl")     # 5b. _CachedRange struct + _to_float (Range → _CachedRange normalizer)
 include("search.jl")           # 6. Search policy + interval search
+include("idx_stencil.jl")      # 6a. _IdxStencil{K} — wrap-aware per-axis index stencil
 include("factory.jl")          # 6b. User-facing factory functions (Search, Extrap, Side)
 include("utils.jl")            # 7. Shared utilities (1D)
 include("periodic.jl")         # 8. Periodic BC helpers (wrapping, validation, exclusive endpoint)

--- a/src/core/grid_spacing.jl
+++ b/src/core/grid_spacing.jl
@@ -138,8 +138,8 @@ Uses `@propagate_inbounds` to enable bounds-check elision in hot loops.
 # _CachedRange overloads are in cached_range.jl (loaded after this file).
 # float(): scalar conversion (0 alloc, register op). Ensures Int grids produce
 # Float h/inv_h for kernel compatibility. No-op for AbstractFloat/Dual grids.
-@inline _get_h(::AbstractVector, xR::Real, xL::Real) = float(xR - xL)
-@inline _get_inv_h(::AbstractVector, xR::Real, xL::Real) = inv(float(xR - xL))
+@inline _get_h(::AbstractVector, xL::Real, xR::Real) = float(xR - xL)
+@inline _get_inv_h(::AbstractVector, xL::Real, xR::Real) = inv(float(xR - xL))
 
 # ========================================
 # Factory Functions

--- a/src/core/idx_stencil.jl
+++ b/src/core/idx_stencil.jl
@@ -37,7 +37,7 @@ Construction:
 s = _IdxStencil((5, 6))            # K inferred (=2)
 s = _IdxStencil{2}((5, 6))         # K specified
 s = _IdxStencil((5, 6, 7, 8))      # K=4 stencil
-s = _pair(5, 6)                    # K=2 convenience
+s = _IdxPair(5, 6)                 # K=2 convenience (2-arg constructor)
 const _IdxPair = _IdxStencil{2}    # alias
 ```
 
@@ -58,19 +58,23 @@ end
 #
 # The struct's auto-generated inner constructor
 #   `_IdxStencil{K}(t::NTuple{K, Int}) where K`
-# serves BOTH call shapes once K is reachable from the tuple length:
-#   _IdxStencil{2}((5, 6))   -- K specified, inner matches directly
-#   _IdxStencil((5, 6))      -- Julia's `where K` inference on the inner
-#                               resolves K=2 from the NTuple{2, Int} argument
-# No outer constructor needed — adding one here would overwrite the inner
-# (same normalized method signature at the Julia type system level) and
-# trigger a precompile-time method-overwriting error.
+# handles tuple-style construction for both `_IdxStencil((5, 6))` and
+# `_IdxStencil{2}((5, 6))`. We do NOT add an outer for the tuple form —
+# Julia normalizes any such outer to the same method signature as the
+# inner, triggering a precompile-time method-overwriting error.
+#
+# Below we add ONE positional-args outer (Vararg{Int, K}) so callers can
+# write `_IdxStencil{K}(i1, i2, …, iK)` without the explicit tuple
+# parentheses. This is purely cosmetic — body just forwards to the inner
+# with the captured Vararg tuple.
 
-# K=2 convenience alias (most common case: Linear/Constant 1D+ND, Cubic 1D)
+@inline _IdxStencil{K}(idxs::Vararg{Int, K}) where {K} = _IdxStencil{K}(idxs)
+
+# K=2 convenience alias (most common case: Linear/Constant 1D+ND, Cubic 1D).
+# Combined with the Vararg outer above, `_IdxPair(idxL, idxR)` works directly:
+# Julia resolves `_IdxPair === _IdxStencil{2}` then matches the Vararg method
+# with K=2. No separate `_IdxPair(...)` method needed.
 const _IdxPair = _IdxStencil{2}
-
-# Construct a pair stencil from left + right indices (Phase 6 style call sites).
-@inline _pair(idxL::Int, idxR::Int) = _IdxStencil((idxL, idxR))
 
 # ────────────────────────────────────────
 # Accessors — explicit, no AbstractVector inheritance

--- a/src/core/idx_stencil.jl
+++ b/src/core/idx_stencil.jl
@@ -1,0 +1,101 @@
+# ========================================
+# _IdxStencil{K} — wrap-aware per-axis index stencil
+# ========================================
+# Unified corner-addressing type used by all multi-point interpolation methods.
+# Wraps `NTuple{K, Int}` with a distinct type so:
+#
+#   * Non-periodic interior cells store `(idx, idx+1, …, idx+K-1)` (no wrap).
+#   * Periodic-exclusive seam cells store wrapped indices (e.g. `(n, 1)` for
+#     K=2, or `(n-1, n, 1, 2)` for K=4) without any grid/value copy.
+#
+# Design rationale:
+#   * K is a type parameter so one kernel function serves Linear/Constant K=2,
+#     (future) ND Hermite K=4, etc. via parametric dispatch.
+#   * Distinct struct identity avoids the N=0 dispatch ambiguity that
+#     `NTuple{N, NTuple{K, Int}}` would create against `NTuple{N, Int}`
+#     (both collapse to `Tuple{}` at N=0). The remedy is not the type wrap
+#     alone — it is having **one** unified function shape, so overload
+#     ambiguity never arises in the first place.
+#   * Memory layout is identical to a raw `NTuple{K, Int}` (inline, no
+#     boxing). All getters are `@inline` — compiler produces the same ASM as
+#     raw tuple indexing after inlining.
+#
+# Not exported — internal API.
+
+"""
+    _IdxStencil{K}
+
+Per-axis index stencil carrying `K` grid indices. Corners the query reads on
+one axis; the tuple may contain wrapped indices for periodic-exclusive seam
+cells.
+
+Fields:
+- `indices::NTuple{K, Int}`: the K grid indices
+
+Construction:
+```julia
+s = _IdxStencil((5, 6))            # K inferred (=2)
+s = _IdxStencil{2}((5, 6))         # K specified
+s = _IdxStencil((5, 6, 7, 8))      # K=4 stencil
+s = _pair(5, 6)                    # K=2 convenience
+const _IdxPair = _IdxStencil{2}    # alias
+```
+
+Access:
+```julia
+s[1]         # first corner (= idxL for K=2)
+s[2]         # second corner (= idxR for K=2)
+length(s)    # K
+```
+"""
+struct _IdxStencil{K}
+    indices::NTuple{K, Int}
+end
+
+# ────────────────────────────────────────
+# Constructors
+# ────────────────────────────────────────
+#
+# The struct's auto-generated inner constructor
+#   `_IdxStencil{K}(t::NTuple{K, Int}) where K`
+# serves BOTH call shapes once K is reachable from the tuple length:
+#   _IdxStencil{2}((5, 6))   -- K specified, inner matches directly
+#   _IdxStencil((5, 6))      -- Julia's `where K` inference on the inner
+#                               resolves K=2 from the NTuple{2, Int} argument
+# No outer constructor needed — adding one here would overwrite the inner
+# (same normalized method signature at the Julia type system level) and
+# trigger a precompile-time method-overwriting error.
+
+# K=2 convenience alias (most common case: Linear/Constant 1D+ND, Cubic 1D)
+const _IdxPair = _IdxStencil{2}
+
+# Construct a pair stencil from left + right indices (Phase 6 style call sites).
+@inline _pair(idxL::Int, idxR::Int) = _IdxStencil((idxL, idxR))
+
+# ────────────────────────────────────────
+# Accessors — explicit, no AbstractVector inheritance
+# ────────────────────────────────────────
+# We deliberately do NOT subtype AbstractVector:
+# - Inheriting iterate/show/broadcast fallbacks can force type instability or
+#   heap-allocating defaults in edge cases.
+# - The only operations needed inside hot kernels are `getindex(s, k)` and
+#   `length(s)` — both provided inline below.
+
+@inline Base.getindex(s::_IdxStencil, k::Int) = @inbounds s.indices[k]
+@inline Base.length(::_IdxStencil{K}) where {K} = K
+@inline Base.firstindex(::_IdxStencil) = 1
+@inline Base.lastindex(::_IdxStencil{K}) where {K} = K
+
+# `iterate` provided for `for i in stencil` ergonomics; still allocation-free
+# because it's a compile-time-known fixed-K loop.
+@inline function Base.iterate(s::_IdxStencil{K}, state::Int = 1) where {K}
+    state > K && return nothing
+    return (@inbounds s.indices[state], state + 1)
+end
+
+# ────────────────────────────────────────
+# Equality (for test assertions and debugging)
+# ────────────────────────────────────────
+
+@inline Base.:(==)(a::_IdxStencil{K}, b::_IdxStencil{K}) where {K} = a.indices == b.indices
+@inline Base.hash(s::_IdxStencil, h::UInt) = hash(s.indices, hash(:_IdxStencil, h))

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -590,31 +590,33 @@ avoiding ntuple-closure boxing on heterogeneous tuple inputs.
 @inline _search_axis_oneshot_hint(q, grid, spacing, search, hint) =
     @inbounds search_interval(_resolve_search(grid, q, search, hint), grid, spacing, q)
 @inline _getidx(r) = r[1]
-@inline _getidxR(r) = r[2]
 @inline _getL(r) = r[3]
 @inline _getR(r) = r[4]
 
 # BC-aware per-axis oneshot: threads per-axis bc into the Searcher so PeriodicBC{:exclusive}
 # dispatches in `search_interval` return (n, 1, x[n], x[1]+period) at seam cells.
 # The 4-tuple `(idx_L, idx_R, xL, xR)` per axis is destructured downstream via
-# `_getidx` + `_getidxR` for zero-copy corner addressing in ND kernels.
+# `_getstencil` (wrapping as `_IdxStencil{2}`) for zero-copy corner addressing.
 @inline _search_axis_oneshot_bc(q, grid, spacing, search, bc) =
     @inbounds search_interval(_resolve_search(grid, q, search, nothing, bc), grid, spacing, q)
 @inline _search_axis_oneshot_bc_hint(q, grid, spacing, search, hint, bc) =
     @inbounds search_interval(_resolve_search(grid, q, search, hint, bc), grid, spacing, q)
 
-# Pair-valued interval tuple per axis: `indices_pairs[d] = (idx_L_d, idx_R_d)`.
+# Stencil-valued interval tuple per axis: `stencils[d] = _IdxStencil{2}((idx_L_d, idx_R_d))`.
 # Consumers (periodic-aware ND kernels) read corner addresses via
-# `indices_pairs[d][bit_d + 1]` — `bit=0 → idx_L`, `bit=1 → idx_R`. For non-periodic
+# `stencils[d][bit_d + 1]` — `bit=0 → idx_L`, `bit=1 → idx_R`. For non-periodic
 # axes `idx_R == idx_L + 1`; for periodic-exclusive axes at the seam `idx_R == 1`
 # (wrap) so eval reads the periodic neighbor without data extension.
-@inline _getpair(r) = (r[1], r[2])
+# The `_IdxStencil{K}` wrapper (src/core/idx_stencil.jl) unifies this shape across
+# method families and carries K as a type parameter for future K > 2 variants
+# (ND Hermite bicubic, etc.).
+@inline _getstencil(r) = _IdxStencil((r[1], r[2]))
 
 # Shared projector for all `_search_all_intervals*` overloads. Every variant
 # boils down to "run `map(search_fn, ...)` then extract `(indices, Ls, Rs)`
 # from each result". Only the index extractor differs:
-#   - `_getidx`  → `NTuple{N, Int}`              (single corner per axis)
-#   - `_getpair` → `NTuple{N, NTuple{2, Int}}`   (left/right pair per axis)
+#   - `_getidx`     → `NTuple{N, Int}`             (single corner per axis)
+#   - `_getstencil` → `NTuple{N, _IdxStencil{2}}`  (left/right pair per axis)
 # Centralizing the `(map(_getL, ...), map(_getR, ...))` tail keeps all variants
 # in sync when the 4-tuple `search_interval` return shape evolves.
 @inline _project_search_results(results, proj::F) where {F} =
@@ -770,8 +772,8 @@ end
 # Parallel in purpose to `_search_all_intervals`, but threads per-axis `bcs`
 # into each `Searcher` so `PeriodicBC{:exclusive}` axes return
 # `(n, 1, x[n], x[1]+L)` at seam cells via the BC-aware `search_interval`
-# dispatch. Returns `(indices_pairs, Ls, Rs)` where
-# `indices_pairs[d] = (idx_L_d, idx_R_d)` — non-periodic axes have
+# dispatch. Returns `(stencils, Ls, Rs)` where
+# `stencils[d] = _IdxStencil{2}((idx_L_d, idx_R_d))` — non-periodic axes have
 # `idx_R == idx_L + 1`; periodic-exclusive axes at seam have `idx_R == 1` (wrap).
 #
 # Structurally mirrors persistent's `_search_all_intervals`: one `map` that
@@ -786,11 +788,11 @@ end
 # Per-axis inline: build Searcher + run search_interval in one body.
 # 3-arg `search_interval` (no spacing) — Range uses _search_direct's own step,
 # Vector uses _search_binary. Avoids VectorSpacing allocation entirely since
-# the pair-variant `_compute_linear_params_lr` derives `h` from `Rs[d] - Ls[d]`.
-@inline _search_axis_lr(grid, q, search, hint, bc) =
+# the stencil-variant `_compute_linear_params_stencil` derives `h` from `Rs[d] - Ls[d]`.
+@inline _search_axis_stencil(grid, q, search, hint, bc) =
     @inbounds search_interval(_resolve_search(grid, q, search, hint, bc), grid, q)
 
-@inline function _search_all_intervals_lr(
+@inline function _search_all_intervals_stencil(
         q_evals::Tuple{Vararg{Real, N}},
         grids::Tuple{Vararg{AbstractVector, N}},
         searches::Tuple{Vararg{AbstractSearchPolicy, N}},
@@ -798,8 +800,8 @@ end
         bcs::Tuple{Vararg{AbstractBC, N}},
     ) where {N}
     hints_eff = _ensure_hint_nd(hints, Val(N))
-    results = map(_search_axis_lr, grids, q_evals, searches, hints_eff, bcs)
-    return _project_search_results(results, _getpair)
+    results = map(_search_axis_stencil, grids, q_evals, searches, hints_eff, bcs)
+    return _project_search_results(results, _getstencil)
 end
 
 # Nothing hint + mono → delegate to stateless 4-arg (zero Ref alloc).

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -787,8 +787,9 @@ end
 
 # Per-axis inline: build Searcher + run search_interval in one body.
 # 3-arg `search_interval` (no spacing) — Range uses _search_direct's own step,
-# Vector uses _search_binary. Avoids VectorSpacing allocation entirely since
-# the stencil-variant `_compute_linear_params_stencil` derives `h` from `Rs[d] - Ls[d]`.
+# Vector uses _search_binary. Avoids VectorSpacing allocation entirely; the
+# stencil-using callers compute `h` from the search-returned `(xL, xR)` via
+# 3-arg `_get_h(grid, xL, xR)` dispatch.
 @inline _search_axis_stencil(grid, q, search, hint, bc) =
     @inbounds search_interval(_resolve_search(grid, q, search, hint, bc), grid, q)
 

--- a/src/cubic/cubic_anchor.jl
+++ b/src/cubic/cubic_anchor.jl
@@ -329,8 +329,8 @@ while preserving the full Dual value for weight computation.
     # Compute geometry (cubic-internal concern)
     # h and inv_h are Tg (grid type)
     # dL and dR preserve Dual type for AD (via loc.xq)
-    h = _get_h(x, loc.xR, loc.xL)
-    inv_h = _get_inv_h(x, loc.xR, loc.xL)
+    h = _get_h(x, loc.xL, loc.xR)
+    inv_h = _get_inv_h(x, loc.xL, loc.xR)
     dL = loc.xq - loc.xL
     dR = loc.xR - loc.xq
 

--- a/src/hermite/hermite_eval.jl
+++ b/src/hermite/hermite_eval.jl
@@ -25,8 +25,8 @@
     @boundscheck _check_domain(x, xq, extrap)
     idx, idx_R, xL, xR = search_interval(searcher, x, xq)
     dL = xq - xL
-    h = _get_h(x, xR, xL)
-    inv_h = _get_inv_h(x, xR, xL)
+    h = _get_h(x, xL, xR)
+    inv_h = _get_inv_h(x, xL, xR)
     @inbounds return _hermite_kernel_1d(op, y[idx], y[idx_R], dy[idx], dy[idx_R], h, inv_h, dL)
 end
 
@@ -48,8 +48,8 @@ end
     end
     idx, idx_R, xL, xR = search_interval(searcher, x, xq)
     dL = xq - xL
-    h = _get_h(x, xR, xL)
-    inv_h = _get_inv_h(x, xR, xL)
+    h = _get_h(x, xL, xR)
+    inv_h = _get_inv_h(x, xL, xR)
     @inbounds return _hermite_kernel_1d(op, y[idx], y[idx_R], dy[idx], dy[idx_R], h, inv_h, dL)
 end
 
@@ -66,8 +66,8 @@ end
     xq_wrapped = _wrap_to_domain(xq, extrap)
     idx, idx_R, xL, xR = search_interval(searcher, x, xq_wrapped)
     dL = xq_wrapped - xL
-    h = _get_h(x, xR, xL)
-    inv_h = _get_inv_h(x, xR, xL)
+    h = _get_h(x, xL, xR)
+    inv_h = _get_inv_h(x, xL, xR)
     @inbounds return _hermite_kernel_1d(op, y[idx], y[idx_R], dy[idx], dy[idx_R], h, inv_h, dL)
 end
 
@@ -256,8 +256,8 @@ end
     dyL = _local_slope(sm, x, y, idx, n)
     dyR = _local_slope(sm, x, y, idx_R, n)
     dL = xq - xL
-    h = _get_h(x, xR, xL)
-    inv_h = _get_inv_h(x, xR, xL)
+    h = _get_h(x, xL, xR)
+    inv_h = _get_inv_h(x, xL, xR)
     @inbounds return _hermite_kernel_1d(op, y[idx], y[idx_R], dyL, dyR, h, inv_h, dL)
 end
 
@@ -281,8 +281,8 @@ end
     dyL = _local_slope(sm, x, y, idx, n)
     dyR = _local_slope(sm, x, y, idx_R, n)
     dL = xq - xL
-    h = _get_h(x, xR, xL)
-    inv_h = _get_inv_h(x, xR, xL)
+    h = _get_h(x, xL, xR)
+    inv_h = _get_inv_h(x, xL, xR)
     @inbounds return _hermite_kernel_1d(op, y[idx], y[idx_R], dyL, dyR, h, inv_h, dL)
 end
 
@@ -301,8 +301,8 @@ end
     dyL = _local_slope(sm, x, y, idx, n)
     dyR = _local_slope(sm, x, y, idx_R, n)
     dL = xq_wrapped - xL
-    h = _get_h(x, xR, xL)
-    inv_h = _get_inv_h(x, xR, xL)
+    h = _get_h(x, xL, xR)
+    inv_h = _get_inv_h(x, xL, xR)
     @inbounds return _hermite_kernel_1d(op, y[idx], y[idx_R], dyL, dyR, h, inv_h, dL)
 end
 

--- a/src/linear/linear_adjoint.jl
+++ b/src/linear/linear_adjoint.jl
@@ -181,7 +181,7 @@ function _fixup_linear_anchor_state!(
         state = xq_i < x_lo ? OOB_LEFT : OOB_RIGHT
         aq = anchors[i]
         anchors[i] = typeof(aq)(
-            aq.idxL, aq.idxR, aq.xq, state, aq.xL, aq.h, aq.inv_h, aq.alpha
+            aq.stencil, aq.xq, state, aq.xL, aq.h, aq.inv_h, aq.alpha
         )
     end
     return nothing

--- a/src/linear/linear_anchor.jl
+++ b/src/linear/linear_anchor.jl
@@ -88,20 +88,13 @@ end
 @inline Base.propertynames(::_LinearAnchoredQuery) =
     (:stencil, :idxL, :idxR, :xq, :state, :xL, :h, :inv_h, :alpha)
 
-# Outer constructor (positional pair): infers Tq from alpha's arithmetic type
-# and promotes xq to match. Keeps the legacy 8-arg call shape used by every
-# existing caller (Series one-shot, adjoint fixup, `_anchor_query`).
+# Outer constructor: infers `Tq` from alpha's arithmetic type and promotes
+# `xq` to match. Callers pass an explicit `_IdxPair` (or any `_IdxStencil{2}`)
+# so seam-aware index handling is local to the call site.
 #
 # For Float grids:  alpha::Tq, xq::Tq — no conversion (identity).
 # For Dual grids + Float query:  alpha::Dual (from grid arithmetic),
 #   xq promoted to Dual via convert (zero partials = "query has no grid sensitivity").
-@inline function _LinearAnchoredQuery(idxL::Int, idxR::Int, xq, state::UInt8, xL::Tg, h::Tg, inv_h::Tg, alpha) where {Tg}
-    Ta = typeof(alpha)
-    xq_p = convert(Ta, xq)
-    return _LinearAnchoredQuery{Tg, Ta}(_pair(idxL, idxR), xq_p, state, xL, h, inv_h, alpha)
-end
-
-# Stencil-native outer constructor — preferred for new code.
 @inline function _LinearAnchoredQuery(stencil::_IdxStencil{2}, xq, state::UInt8, xL::Tg, h::Tg, inv_h::Tg, alpha) where {Tg}
     Ta = typeof(alpha)
     xq_p = convert(Ta, xq)
@@ -300,7 +293,7 @@ in `xq` and `alpha` fields. The interval search uses `_extract_primal(xq)` for c
     # on a fixed grid with at most wrap-to-domain remapping — so `idxR = idxL+1`
     # here. Periodic-exclusive seam anchors are constructed via `_LinearAnchoredQuery(...)`
     # directly in the exclusive periodic one-shot helpers (bypassing `_anchor_loc`).
-    return _LinearAnchoredQuery(loc.idx, loc.idx + 1, loc.xq, loc.state, loc.xL, h, inv_h, alpha)
+    return _LinearAnchoredQuery(_IdxPair(loc.idx, loc.idx + 1), loc.xq, loc.state, loc.xL, h, inv_h, alpha)
 end
 
 # ========================================

--- a/src/linear/linear_anchor.jl
+++ b/src/linear/linear_anchor.jl
@@ -285,8 +285,8 @@ in `xq` and `alpha` fields. The interval search uses `_extract_primal(xq)` for c
     loc = _anchor_loc(x, xq, wrap, policy)
 
     # Compute geometry (linear-internal concern)
-    h = _get_h(x, loc.xR, loc.xL)
-    inv_h = _get_inv_h(x, loc.xR, loc.xL)
+    h = _get_h(x, loc.xL, loc.xR)
+    inv_h = _get_inv_h(x, loc.xL, loc.xR)
     alpha = (loc.xq - loc.xL) * inv_h
 
     # `_anchor_loc` never returns a periodic-exclusive seam pair — it operates

--- a/src/linear/linear_anchor.jl
+++ b/src/linear/linear_anchor.jl
@@ -23,8 +23,9 @@ matches the interpolant grid.
 - `Tq`: Query type (widened to `promote_type(Tq, Tg)` by the outer constructor)
 
 # Fields
-- `idxL`: Left cell index (`1 ≤ idxL ≤ n-1` normally; equals `n` at periodic-exclusive seam)
-- `idxR`: Right cell index (`idxL + 1` normally; wraps to `1` at periodic-exclusive seam)
+- `stencil::_IdxStencil{2}`: Corner-index stencil; `stencil[1]` is the left index, `stencil[2]` the right
+  (legacy `aq.idxL` / `aq.idxR` virtual properties read through `getproperty` — see below).
+  For non-periodic cells `idxR == idxL + 1`; at periodic-exclusive seam `idxL == n`, `idxR == 1` (wrap).
 - `xq`: Original query point (or wrapped value for periodic), preserves original precision
 - `state`: Domain state (`IN_DOMAIN`, `OOB_LEFT`, or `OOB_RIGHT`)
 - `xL`: Left grid point of the interval (avoids re-indexing x[idxL] which triggers TwicePrecision on Range)

--- a/src/linear/linear_anchor.jl
+++ b/src/linear/linear_anchor.jl
@@ -53,8 +53,13 @@ as it eliminates O(log n) binary search.
 - `inv_h` for EvalDeriv1: `(yR - yL) * inv_h` (no division)
 """
 struct _LinearAnchoredQuery{Tg, Tq <: Real}
-    idxL::Int                  # left cell index
-    idxR::Int                  # right cell index (idxL+1 normally; 1 at periodic-exclusive seam)
+    # Corner-index stencil: `stencil[1]` is the left index (idxL), `stencil[2]`
+    # is the right index (idxR). For non-periodic cells `idxR == idxL + 1`; for
+    # periodic-exclusive seam cells `idxR == 1` (wrap). Unified across all
+    # wrap-aware methods via `_IdxStencil{K}` (src/core/idx_stencil.jl).
+    # Legacy `aq.idxL` / `aq.idxR` accessors are preserved via `getproperty`
+    # below — every existing call site reads through the virtual property.
+    stencil::_IdxStencil{2}
     xq::Tq                     # query point (possibly wrapped)
     state::UInt8               # IN_DOMAIN / OOB_LEFT / OOB_RIGHT
     xL::Tg                     # left grid point
@@ -63,9 +68,29 @@ struct _LinearAnchoredQuery{Tg, Tq <: Real}
     alpha::Tq                  # normalized position: (xq - xL) / h
 end
 
-# Outer constructor: infers Tq from alpha's arithmetic type and promotes xq to match.
-# Callers pass raw fields without worrying about type widening — the constructor
-# handles the Tg×Tq promotion automatically.
+# ──────────────────────────────────────────────────────────────
+# Virtual property accessors — legacy `aq.idxL` / `aq.idxR` ergonomics
+# ──────────────────────────────────────────────────────────────
+# Preserves every existing call site (kernel eval, adjoint scatter, Series
+# one-shot, tests) without a single source change downstream.
+#
+# Dispatch pattern: `getproperty(aq, s::Symbol)` delegates to `_get_lin_prop(aq, Val(s))`,
+# one method per property symbol. This forces compile-time specialization — each
+# property returns a concrete type and the call inlines to a single `getfield`
+# (+ tuple index for `:idxL` / `:idxR`). A single-method `getproperty` with
+# `s === :idxL && ...` branches is *not* reliably inlined inside hot loops:
+# the union of possible return types (Int, Tq, UInt8, Tg, _IdxStencil{2})
+# defeats return-type inference and causes boxing. Val-dispatch sidesteps this.
+@inline Base.getproperty(aq::_LinearAnchoredQuery, s::Symbol) = _get_lin_prop(aq, Val(s))
+@inline _get_lin_prop(aq::_LinearAnchoredQuery, ::Val{:idxL}) = getfield(aq, :stencil)[1]
+@inline _get_lin_prop(aq::_LinearAnchoredQuery, ::Val{:idxR}) = getfield(aq, :stencil)[2]
+@inline _get_lin_prop(aq::_LinearAnchoredQuery, ::Val{s}) where {s} = getfield(aq, s)
+@inline Base.propertynames(::_LinearAnchoredQuery) =
+    (:stencil, :idxL, :idxR, :xq, :state, :xL, :h, :inv_h, :alpha)
+
+# Outer constructor (positional pair): infers Tq from alpha's arithmetic type
+# and promotes xq to match. Keeps the legacy 8-arg call shape used by every
+# existing caller (Series one-shot, adjoint fixup, `_anchor_query`).
 #
 # For Float grids:  alpha::Tq, xq::Tq — no conversion (identity).
 # For Dual grids + Float query:  alpha::Dual (from grid arithmetic),
@@ -73,7 +98,14 @@ end
 @inline function _LinearAnchoredQuery(idxL::Int, idxR::Int, xq, state::UInt8, xL::Tg, h::Tg, inv_h::Tg, alpha) where {Tg}
     Ta = typeof(alpha)
     xq_p = convert(Ta, xq)
-    return _LinearAnchoredQuery{Tg, Ta}(idxL, idxR, xq_p, state, xL, h, inv_h, alpha)
+    return _LinearAnchoredQuery{Tg, Ta}(_pair(idxL, idxR), xq_p, state, xL, h, inv_h, alpha)
+end
+
+# Stencil-native outer constructor — preferred for new code.
+@inline function _LinearAnchoredQuery(stencil::_IdxStencil{2}, xq, state::UInt8, xL::Tg, h::Tg, inv_h::Tg, alpha) where {Tg}
+    Ta = typeof(alpha)
+    xq_p = convert(Ta, xq)
+    return _LinearAnchoredQuery{Tg, Ta}(stencil, xq_p, state, xL, h, inv_h, alpha)
 end
 
 # ========================================

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -215,7 +215,7 @@ For ForwardDiff compatibility, `xq` can be a Dual type:
 # ========================================
 # Core eval: extrap dispatch → search → kernel (no intermediate layers)
 # ========================================
-# _get_inv_h(x, xR, xL) dispatches to x.inv_h (_CachedRange) or inv(xR-xL) (Vector).
+# _get_inv_h(x, xL, xR) dispatches to x.inv_h (_CachedRange) or inv(xR-xL) (Vector).
 
 # NoExtrap / ExtendExtrap / other: direct search + kernel.
 # _check_domain(::NoExtrap) throws if OOB; all others are no-ops.
@@ -230,7 +230,7 @@ For ForwardDiff compatibility, `xq` can be a Dual type:
     @boundscheck _check_domain(x, xq, extrap)
     idx, idx_R, xL, xR = search_interval(searcher, x, xq)
     dL = xq - xL  # xq can be Dual here (preserves AD)
-    @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, xR, xL), dL)
+    @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, xL, xR), dL)
 end
 
 # ClampExtrap / FillExtrap: boundary check → extrap value or kernel.
@@ -250,7 +250,7 @@ end
     end
     idx, idx_R, xL, xR = search_interval(searcher, x, xq)
     dL = xq - xL
-    @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, xR, xL), dL)
+    @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, xL, xR), dL)
 end
 
 # WrapExtrap: wrap query to domain → search + kernel.
@@ -269,7 +269,7 @@ end
     xq_wrapped = _wrap_to_domain(xq, extrap)
     idx, idx_R, xL, xR = search_interval(searcher, x, xq_wrapped)
     dL = xq_wrapped - xL
-    @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, xR, xL), dL)
+    @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, xL, xR), dL)
 end
 
 # Public scalar one-shot API.

--- a/src/linear/linear_oneshot_series.jl
+++ b/src/linear/linear_oneshot_series.jl
@@ -57,7 +57,7 @@
     h = _get_h(x, xR, xL)
     inv_h = _get_inv_h(x, xR, xL)
     alpha = (xq_wrapped - xL) * inv_h
-    aq = _LinearAnchoredQuery(idxL, idxR, xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
+    aq = _LinearAnchoredQuery(_IdxPair(idxL, idxR), xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
 
     @inbounds for k in 1:K
         output[k] = _linear_eval_at_anchor(vecs[k], aq, op, extrap_p)
@@ -205,7 +205,7 @@ In-place one-shot linear interpolation at multiple query points.
             h = _get_h(x, xR, xL)
             inv_h = _get_inv_h(x, xR, xL)
             alpha = (xq_wrapped - xL) * inv_h
-            aq = _LinearAnchoredQuery(idxL, idxR, xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
+            aq = _LinearAnchoredQuery(_IdxPair(idxL, idxR), xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
             for k in 1:K
                 outputs[k][j] = _linear_eval_at_anchor(vecs[k], aq, deriv, extrap_p)
             end

--- a/src/linear/linear_oneshot_series.jl
+++ b/src/linear/linear_oneshot_series.jl
@@ -54,8 +54,8 @@
     idxL, idxR, xL, xR = search_interval(searcher, x, xq_wrapped)
     # Use _get_h/_get_inv_h so _CachedRange returns its exact cached step
     # instead of the cancellation-prone `xR - xL` on large-offset grids.
-    h = _get_h(x, xR, xL)
-    inv_h = _get_inv_h(x, xR, xL)
+    h = _get_h(x, xL, xR)
+    inv_h = _get_inv_h(x, xL, xR)
     alpha = (xq_wrapped - xL) * inv_h
     aq = _LinearAnchoredQuery(_IdxPair(idxL, idxR), xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
 
@@ -202,8 +202,8 @@ In-place one-shot linear interpolation at multiple query points.
             xq_wrapped = _wrap_to_domain(xqs[j], extrap_p)
             idxL, idxR, xL, xR = search_interval(searcher, x, xq_wrapped)
             # Cached-step-preserving dispatch (matches scalar/persistent paths).
-            h = _get_h(x, xR, xL)
-            inv_h = _get_inv_h(x, xR, xL)
+            h = _get_h(x, xL, xR)
+            inv_h = _get_inv_h(x, xL, xR)
             alpha = (xq_wrapped - xL) * inv_h
             aq = _LinearAnchoredQuery(_IdxPair(idxL, idxR), xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
             for k in 1:K

--- a/src/linear/linear_series_interp.jl
+++ b/src/linear/linear_series_interp.jl
@@ -209,7 +209,7 @@ end
 end
 
 # ExtendExtrap - extend linear polynomial using boundary interval.
-# _get_inv_h(x, xR, xL) dispatches to x.inv_h (_CachedRange) or inv(xR-xL) (Vector).
+# _get_inv_h(x, xL, xR) dispatches to x.inv_h (_CachedRange) or inv(xR-xL) (Vector).
 @inline function _eval_linear_series_point_extrap!(
         out::AbstractVector{Tv},
         y_point::Matrix{Tv},
@@ -228,7 +228,7 @@ end
         xL = x[idx]
         xR = x[idx1]
     end
-    inv_h = _get_inv_h(x, xR, xL)
+    inv_h = _get_inv_h(x, xL, xR)
     dL = aq.xq - xL
     @inbounds @simd for k in axes(out, 1)
         yL = y_point[k, idx]

--- a/src/linear/nd/linear_nd_eval.jl
+++ b/src/linear/nd/linear_nd_eval.jl
@@ -50,7 +50,10 @@ end
     ) where {Tg, Tv, N}
     q_eval = _handle_all_extraps(query, itp.grids, itp.extraps)
     indices, Ls, _ = _search_all_intervals(q_eval, itp.grids, itp.spacings, policies, hints, mono)
-    hs, αs = _compute_linear_params(q_eval, itp.spacings, indices, Ls, Val(N))
+    # Persistent fast lane: 2-arg `_get_h` reads precomputed `spacings[d].h`
+    # (or `.h[i]` for Vector). `map` dispatches per-axis with concrete types.
+    hs = map(_get_h, itp.spacings, indices)
+    αs = map(_alpha_of, q_eval, Ls, hs)
     return (itp.data, indices, hs, αs)
 end
 
@@ -156,54 +159,15 @@ end
 # of `ntuple(d -> q_eval[d], Val(N))` where runtime-indexed lookup collapses
 # to an abstract return type. See MEMORY.md "ND Constructor Inferrability
 # Pattern" for the canonical precedent.
+#
+# `_alpha_of` is the only surviving named helper from this region. The earlier
+# `_alphas_from_hs(q, Ls, hs)`, `_compute_linear_params(q, spacings, indices, Ls, …)`,
+# and `_compute_linear_params_stencil(q, Ls, Rs, …)` wrappers were single-line
+# `map`-forwarders that hid the actual arithmetic behind two extra layers; call
+# sites now do the `map(_get_h, …)` + `map(_alpha_of, q, Ls, hs)` directly.
+#   - persistent path: `map(_get_h, spacings, indices)` (2-arg cached fast lane)
+#   - BC oneshot path: `map(_get_h, grids, Ls, Rs)` (3-arg dispatch, seam-aware)
 @inline _alpha_of(q::Real, L::Real, h::Real) = (q - L) / h
-@inline _alphas_from_hs(q_eval, Ls, hs) = map(_alpha_of, q_eval, Ls, hs)
-
-"""
-    _compute_linear_params(q_eval, spacings, indices, Ls, Val(N)) -> (hs, αs)
-
-Cell widths and normalized coordinates for multilinear interpolation via
-spacing lookup. Used by persistent ND paths where `spacings` is precomputed.
-
-Shares the `αs` formula with `_compute_linear_params_stencil` via `_alphas_from_hs`;
-only the `hs` derivation (spacing lookup) is variant-specific. Uses `map` over
-the `(spacings, indices)` tuple pair to avoid Union boxing when the axes carry
-heterogeneous spacing concrete types (ScalarSpacing + VectorSpacing mix).
-"""
-@inline function _compute_linear_params(
-        q_eval::Tuple{Vararg{Real, N}},
-        spacings::Tuple{Vararg{AbstractGridSpacing, N}},
-        indices::NTuple{N, Int},
-        Ls::Tuple{Vararg{Real, N}},
-        ::Val{N}
-    ) where {N}
-    hs = map(_get_h, spacings, indices)
-    return (hs, _alphas_from_hs(q_eval, Ls, hs))
-end
-
-"""
-    _compute_linear_params_stencil(q_eval, Ls, Rs, Val(N)) -> (hs, αs)
-
-Stencil-variant — computes per-axis cell width directly from
-`Rs[d] - Ls[d]` to avoid the idx-based spacing lookup (which is out-of-bounds
-for the seam cell at `idx_L == n` on periodic-exclusive axes — there's no
-`spacing.widths[n]`). For uniform Range grids via ScalarSpacing the cost is
-unchanged (1 subtraction vs 1 field load). For Vector axes this matches what
-VectorSpacing would return for interior cells and Just Works for the seam cell.
-
-Shares the `αs` formula with `_compute_linear_params` via `_alphas_from_hs`.
-`map(-, Rs, Ls)` dispatches per-element with concrete types (no Union-box risk
-from heterogeneous `Rs` / `Ls` tuples; matches MEMORY.md's inferrability rules).
-"""
-@inline function _compute_linear_params_stencil(
-        q_eval::Tuple{Vararg{Real, N}},
-        Ls::Tuple{Vararg{Real, N}},
-        Rs::Tuple{Vararg{Real, N}},
-        ::Val{N}
-    ) where {N}
-    hs = map(-, Rs, Ls)
-    return (hs, _alphas_from_hs(q_eval, Ls, hs))
-end
 
 # ========================================
 # Multilinear Interpolation Kernel

--- a/src/linear/nd/linear_nd_eval.jl
+++ b/src/linear/nd/linear_nd_eval.jl
@@ -236,17 +236,6 @@ function _multilinear_sum_body(N::Int, make_idx_expr::Function)
         @inbounds $sum_expr
     end
 end
-@generated function _multilinear_sum_stencil(
-        data::AbstractArray{Tv, N},
-        stencils::NTuple{N, _IdxStencil{2}},
-        hs::NTuple{N},
-        αs::Tuple{Vararg{Real, N}},
-        ops::NTuple{N, AbstractEvalOp},
-        ::Val{N}
-    ) where {Tv, N}
-    return _multilinear_sum_body(N, (d, bit) -> :(stencils[$d][$(bit + 1)]))
-end
-
 # ========================================
 # Linear Weight Functions
 # ========================================

--- a/src/linear/nd/linear_nd_eval.jl
+++ b/src/linear/nd/linear_nd_eval.jl
@@ -165,7 +165,7 @@ end
 Cell widths and normalized coordinates for multilinear interpolation via
 spacing lookup. Used by persistent ND paths where `spacings` is precomputed.
 
-Shares the `αs` formula with `_compute_linear_params_lr` via `_alphas_from_hs`;
+Shares the `αs` formula with `_compute_linear_params_stencil` via `_alphas_from_hs`;
 only the `hs` derivation (spacing lookup) is variant-specific. Uses `map` over
 the `(spacings, indices)` tuple pair to avoid Union boxing when the axes carry
 heterogeneous spacing concrete types (ScalarSpacing + VectorSpacing mix).
@@ -182,9 +182,9 @@ heterogeneous spacing concrete types (ScalarSpacing + VectorSpacing mix).
 end
 
 """
-    _compute_linear_params_lr(q_eval, Ls, Rs, Val(N)) -> (hs, αs)
+    _compute_linear_params_stencil(q_eval, Ls, Rs, Val(N)) -> (hs, αs)
 
-Pair-variant (Phase 6) — computes per-axis cell width directly from
+Stencil-variant — computes per-axis cell width directly from
 `Rs[d] - Ls[d]` to avoid the idx-based spacing lookup (which is out-of-bounds
 for the seam cell at `idx_L == n` on periodic-exclusive axes — there's no
 `spacing.widths[n]`). For uniform Range grids via ScalarSpacing the cost is
@@ -195,7 +195,7 @@ Shares the `αs` formula with `_compute_linear_params` via `_alphas_from_hs`.
 `map(-, Rs, Ls)` dispatches per-element with concrete types (no Union-box risk
 from heterogeneous `Rs` / `Ls` tuples; matches MEMORY.md's inferrability rules).
 """
-@inline function _compute_linear_params_lr(
+@inline function _compute_linear_params_stencil(
         q_eval::Tuple{Vararg{Real, N}},
         Ls::Tuple{Vararg{Real, N}},
         Rs::Tuple{Vararg{Real, N}},
@@ -213,8 +213,8 @@ end
 # produce an identical flat 2^N straight-line unroll; only the per-axis corner
 # addressing differs. `make_idx_expr(d, bit)` returns the address expression
 # for axis `d` at corner bit `bit` ∈ {0, 1}:
-#   non-pair : (d, bit) -> :(indices[$d] + $bit)
-#   pair     : (d, bit) -> :(indices_pairs[$d][$(bit + 1)])
+#   single-idx : (d, bit) -> :(indices[$d] + $bit)
+#   stencil    : (d, bit) -> :(stencils[$d][$(bit + 1)])
 # Runs at compile time only (inside @generated); closure cost is free.
 function _multilinear_sum_body(N::Int, make_idx_expr::Function)
     num_corners = 1 << N  # 2^N
@@ -249,7 +249,7 @@ The weight function depends on the evaluation operation:
 - EvalValue: (1-α) if b=0, α if b=1
 - EvalDeriv1: -1/h if b=0, 1/h if b=1
 
-Shares body with `_multilinear_sum_lr` via `_multilinear_sum_body`.
+Shares body with `_multilinear_sum_stencil` via `_multilinear_sum_body`.
 """
 @generated function _multilinear_sum(
         data::AbstractArray{Tv, N},
@@ -263,32 +263,35 @@ Shares body with `_multilinear_sum_lr` via `_multilinear_sum_body`.
 end
 
 """
-    _multilinear_sum_lr(data, indices_pairs, hs, αs, ops, Val(N))
+    _multilinear_sum_stencil(data, stencils, hs, αs, ops, Val(N))
 
-Pair-valued indices variant for zero-copy periodic ND evaluation (Phase 6).
+Stencil-variant for zero-copy periodic ND evaluation.
 
-`indices_pairs[d] = (idx_L_d, idx_R_d)` — for each corner bit pattern
-`b ∈ {0,1}^N`, corner address on axis `d` is `indices_pairs[d][b_d + 1]`
-(bit 0 → left `idx_L_d`, bit 1 → right `idx_R_d`).
+`stencils[d]::_IdxStencil{2}` carries `(idx_L_d, idx_R_d)` — for each corner
+bit pattern `b ∈ {0,1}^N`, corner address on axis `d` is
+`stencils[d][b_d + 1]` (bit 0 → left `idx_L_d`, bit 1 → right `idx_R_d`).
+For non-periodic cells, `idx_R == idx_L + 1`; for periodic-exclusive seam
+cells, `idx_R == 1` (wrap) so the kernel reads the wrapped neighbor without
+any data extension.
 
 Distinct name (not an overload) because at `N=0` `NTuple{0, Int}` and
-`NTuple{0, NTuple{2, Int}}` both collapse to `Tuple{}`, making
+`NTuple{0, _IdxStencil{2}}` both collapse to `Tuple{}`, making
 overload-style dispatch ambiguous (caught by Aqua static analysis). Used
 only by periodic ND oneshot — non-periodic/persistent callers stay on
 `_multilinear_sum`.
 
 Shares body with `_multilinear_sum` via `_multilinear_sum_body`; only the
-corner-address expression differs — `indices[d] + bit` → `indices_pairs[d][bit + 1]`.
+corner-address expression differs — `indices[d] + bit` → `stencils[d][bit + 1]`.
 """
-@generated function _multilinear_sum_lr(
+@generated function _multilinear_sum_stencil(
         data::AbstractArray{Tv, N},
-        indices_pairs::NTuple{N, NTuple{2, Int}},
+        stencils::NTuple{N, _IdxStencil{2}},
         hs::NTuple{N},
         αs::Tuple{Vararg{Real, N}},
         ops::NTuple{N, AbstractEvalOp},
         ::Val{N}
     ) where {Tv, N}
-    return _multilinear_sum_body(N, (d, bit) -> :(indices_pairs[$d][$(bit + 1)]))
+    return _multilinear_sum_body(N, (d, bit) -> :(stencils[$d][$(bit + 1)]))
 end
 
 # ========================================

--- a/src/linear/nd/linear_nd_eval.jl
+++ b/src/linear/nd/linear_nd_eval.jl
@@ -54,7 +54,11 @@ end
     # (or `.h[i]` for Vector). `map` dispatches per-axis with concrete types.
     hs = map(_get_h, itp.spacings, indices)
     αs = map(_alpha_of, q_eval, Ls, hs)
-    return (itp.data, indices, hs, αs)
+    # Wrap raw indices into the unified stencil shape so `_multilinear_sum`
+    # has a single signature across persistent / BC oneshot callers.
+    # Non-periodic cells are always `(idx, idx+1)` — no seam wrap.
+    stencils = map(i -> _IdxPair(i, i + 1), indices)
+    return (itp.data, stencils, hs, αs)
 end
 
 # N=2 specialization: direct destructuring eliminates ntuple closure overhead
@@ -74,7 +78,9 @@ end
     αx = (x_eval - xL) / hx
     αy = (y_eval - yL) / hy
 
-    return (itp.data, (ix, iy), (hx, hy), (αx, αy))
+    # N=2 specialization wraps directly into the unified stencil shape — same
+    # `_multilinear_sum` signature as the generic-N persistent / BC oneshot paths.
+    return (itp.data, (_IdxPair(ix, ix + 1), _IdxPair(iy, iy + 1)), (hx, hy), (αx, αy))
 end
 
 # Evaluate kernel at a pre-located cell with given derivative ops
@@ -86,8 +92,8 @@ end
     if _has_second_or_higher_derivative(ops, Val(N))
         return 0 * first(itp.data)
     end
-    data, indices, hs, αs = cell
-    return _multilinear_sum(data, indices, hs, αs, ops, Val(N))
+    data, stencils, hs, αs = cell
+    return _multilinear_sum(data, stencils, hs, αs, ops, Val(N))
 end
 
 # ========================================
@@ -173,13 +179,44 @@ end
 # Multilinear Interpolation Kernel
 # ========================================
 
-# Shared Expr builder for the two multilinear generators below. Both variants
-# produce an identical flat 2^N straight-line unroll; only the per-axis corner
-# addressing differs. `make_idx_expr(d, bit)` returns the address expression
-# for axis `d` at corner bit `bit` ∈ {0, 1}:
-#   single-idx : (d, bit) -> :(indices[$d] + $bit)
-#   stencil    : (d, bit) -> :(stencils[$d][$(bit + 1)])
-# Runs at compile time only (inside @generated); closure cost is free.
+"""
+    _multilinear_sum(data, stencils, hs, αs, ops, Val(N))
+
+Compute the multilinear interpolation sum over 2^N corners.
+
+`stencils[d]::_IdxStencil{2}` carries `(idx_L_d, idx_R_d)` — for each corner
+bit pattern `b ∈ {0,1}^N`, the corner address on axis `d` is
+`stencils[d][b_d + 1]` (bit 0 → left `idx_L_d`, bit 1 → right `idx_R_d`).
+For non-periodic cells `idx_R == idx_L + 1`; for periodic-exclusive seam
+cells `idx_R == 1` (wrap), so the kernel reads the wrapped neighbor without
+any data extension.
+
+Per-corner weight: `∏ᵢ _linear_weight(ops[i], αs[i], hs[i], bᵢ)`. The weight
+function depends on the evaluation op — EvalValue: `(1-α)` for `b=0`, `α`
+for `b=1`; EvalDeriv1: `-1/h` for `b=0`, `+1/h` for `b=1`.
+
+Single-overload, stencil-only kernel. Persistent callers wrap their
+single-index `indices` via `map(i -> _IdxPair(i, i+1), indices)` at the
+call site before invoking; BC oneshot callers receive seam-aware stencils
+directly from `_search_all_intervals_stencil`.
+"""
+@generated function _multilinear_sum(
+        data::AbstractArray{Tv, N},
+        stencils::NTuple{N, _IdxStencil{2}},
+        hs::NTuple{N},
+        αs::Tuple{Vararg{Real, N}},
+        ops::NTuple{N, AbstractEvalOp},
+        ::Val{N}
+    ) where {Tv, N}
+    return _multilinear_sum_body(N, (d, bit) -> :(stencils[$d][$(bit + 1)]))
+end
+
+# Shared Expr builder for the multilinear @generated kernel above. Produces
+# the flat 2^N straight-line unroll. `make_idx_expr(d, bit)` returns the
+# address expression for axis `d` at corner bit `bit` ∈ {0, 1}; the kernel
+# above passes the stencil-style `(d, bit) -> :(stencils[$d][$(bit + 1)])`.
+# Body kept as a callback-driven helper so future K > 2 kernels (ND Hermite)
+# can reuse it without duplicating the corner-unroll skeleton.
 function _multilinear_sum_body(N::Int, make_idx_expr::Function)
     num_corners = 1 << N  # 2^N
     corner_exprs = []
@@ -199,54 +236,6 @@ function _multilinear_sum_body(N::Int, make_idx_expr::Function)
         @inbounds $sum_expr
     end
 end
-
-"""
-    _multilinear_sum(data, indices, hs, αs, ops, Val(N))
-
-Compute the multilinear interpolation sum over 2^N corners.
-
-For each corner indexed by bit pattern b ∈ {0,1}^N:
-- Corner index: (indices[1]+b₁, indices[2]+b₂, ..., indices[N]+bₙ)
-- Weight: ∏ᵢ _linear_weight(ops[i], αs[i], hs[i], bᵢ)
-
-The weight function depends on the evaluation operation:
-- EvalValue: (1-α) if b=0, α if b=1
-- EvalDeriv1: -1/h if b=0, 1/h if b=1
-
-Shares body with `_multilinear_sum_stencil` via `_multilinear_sum_body`.
-"""
-@generated function _multilinear_sum(
-        data::AbstractArray{Tv, N},
-        indices::NTuple{N, Int},
-        hs::NTuple{N},
-        αs::Tuple{Vararg{Real, N}},
-        ops::NTuple{N, AbstractEvalOp},
-        ::Val{N}
-    ) where {Tv, N}
-    return _multilinear_sum_body(N, (d, bit) -> :(indices[$d] + $bit))
-end
-
-"""
-    _multilinear_sum_stencil(data, stencils, hs, αs, ops, Val(N))
-
-Stencil-variant for zero-copy periodic ND evaluation.
-
-`stencils[d]::_IdxStencil{2}` carries `(idx_L_d, idx_R_d)` — for each corner
-bit pattern `b ∈ {0,1}^N`, corner address on axis `d` is
-`stencils[d][b_d + 1]` (bit 0 → left `idx_L_d`, bit 1 → right `idx_R_d`).
-For non-periodic cells, `idx_R == idx_L + 1`; for periodic-exclusive seam
-cells, `idx_R == 1` (wrap) so the kernel reads the wrapped neighbor without
-any data extension.
-
-Distinct name (not an overload) because at `N=0` `NTuple{0, Int}` and
-`NTuple{0, _IdxStencil{2}}` both collapse to `Tuple{}`, making
-overload-style dispatch ambiguous (caught by Aqua static analysis). Used
-only by periodic ND oneshot — non-periodic/persistent callers stay on
-`_multilinear_sum`.
-
-Shares body with `_multilinear_sum` via `_multilinear_sum_body`; only the
-corner-address expression differs — `indices[d] + bit` → `stencils[d][bit + 1]`.
-"""
 @generated function _multilinear_sum_stencil(
         data::AbstractArray{Tv, N},
         stencils::NTuple{N, _IdxStencil{2}},

--- a/src/linear/nd/linear_nd_oneshot.jl
+++ b/src/linear/nd/linear_nd_oneshot.jl
@@ -41,14 +41,16 @@ function _linear_interp_nd_oneshot(
 
     extraps_eff = _resolve_extrap(extraps_val, bcs, grids, data, Val(N))
     q_eval = _handle_all_extraps(query, grids, extraps_eff)
-    # BC-aware per-axis search — returns (indices_pairs, Ls, Rs) where
-    # indices_pairs[d] = (idx_L_d, idx_R_d); periodic seam axes have idx_R == 1.
-    # No spacings needed — pair-variant `_compute_linear_params_lr` uses Rs-Ls for h,
-    # avoiding VectorSpacing allocation for Vector grids.
-    indices_pairs, Ls, Rs = _search_all_intervals_lr(q_eval, grids, searches, hints, bcs)
-    hs, αs = _compute_linear_params_lr(q_eval, Ls, Rs, Val(N))
-    # Pair-dispatch `_multilinear_sum`: corner[d] = indices_pairs[d][bit_d + 1]
-    return _multilinear_sum_lr(data, indices_pairs, hs, αs, ops, Val(N))
+    # BC-aware per-axis search — returns (stencils, Ls, Rs) where
+    # stencils[d]::_IdxStencil{2} wraps (idx_L_d, idx_R_d); periodic seam
+    # axes have idx_R == 1 (wrap), so kernel reads the wrapped neighbor
+    # without data extension. No spacings needed —
+    # `_compute_linear_params_stencil` uses Rs-Ls for h, avoiding
+    # VectorSpacing allocation for Vector grids.
+    stencils, Ls, Rs = _search_all_intervals_stencil(q_eval, grids, searches, hints, bcs)
+    hs, αs = _compute_linear_params_stencil(q_eval, Ls, Rs, Val(N))
+    # Stencil dispatch: corner[d] = stencils[d][bit_d + 1]
+    return _multilinear_sum_stencil(data, stencils, hs, αs, ops, Val(N))
 end
 
 """
@@ -82,9 +84,9 @@ function _linear_interp_nd_oneshot_batch!(
             output[k] = oob_val; continue
         end
         q_eval = _handle_all_extraps(query_k, grids, extraps_eff)
-        indices_pairs, Ls, Rs = _search_all_intervals_lr(q_eval, grids, policies, hints, bcs)
-        hs, αs = _compute_linear_params_lr(q_eval, Ls, Rs, Val(N))
-        output[k] = _multilinear_sum_lr(data, indices_pairs, hs, αs, ops, Val(N))
+        stencils, Ls, Rs = _search_all_intervals_stencil(q_eval, grids, policies, hints, bcs)
+        hs, αs = _compute_linear_params_stencil(q_eval, Ls, Rs, Val(N))
+        output[k] = _multilinear_sum_stencil(data, stencils, hs, αs, ops, Val(N))
     end
     return output
 end

--- a/src/linear/nd/linear_nd_oneshot.jl
+++ b/src/linear/nd/linear_nd_oneshot.jl
@@ -44,12 +44,12 @@ function _linear_interp_nd_oneshot(
     # BC-aware per-axis search — returns (stencils, Ls, Rs) where
     # stencils[d]::_IdxStencil{2} wraps (idx_L_d, idx_R_d); periodic seam
     # axes have idx_R == 1 (wrap), so kernel reads the wrapped neighbor
-    # without data extension. No spacings needed —
-    # `_compute_linear_params_stencil` uses Rs-Ls for h, avoiding
-    # VectorSpacing allocation for Vector grids.
+    # without data extension. No spacings needed — 3-arg `_get_h(x, xL, xR)`
+    # dispatches to cached `x.h` for `_CachedRange` and `xR-xL` for Vector,
+    # giving seam-aware h without VectorSpacing allocation.
     stencils, Ls, Rs = _search_all_intervals_stencil(q_eval, grids, searches, hints, bcs)
-    hs, αs = _compute_linear_params_stencil(q_eval, Ls, Rs, Val(N))
-    # Stencil dispatch: corner[d] = stencils[d][bit_d + 1]
+    hs = map(_get_h, grids, Ls, Rs)
+    αs = map(_alpha_of, q_eval, Ls, hs)
     return _multilinear_sum_stencil(data, stencils, hs, αs, ops, Val(N))
 end
 
@@ -85,7 +85,8 @@ function _linear_interp_nd_oneshot_batch!(
         end
         q_eval = _handle_all_extraps(query_k, grids, extraps_eff)
         stencils, Ls, Rs = _search_all_intervals_stencil(q_eval, grids, policies, hints, bcs)
-        hs, αs = _compute_linear_params_stencil(q_eval, Ls, Rs, Val(N))
+        hs = map(_get_h, grids, Ls, Rs)
+        αs = map(_alpha_of, q_eval, Ls, hs)
         output[k] = _multilinear_sum_stencil(data, stencils, hs, αs, ops, Val(N))
     end
     return output

--- a/src/linear/nd/linear_nd_oneshot.jl
+++ b/src/linear/nd/linear_nd_oneshot.jl
@@ -14,7 +14,7 @@
 # Zero heap allocation for scalar queries after warmup.
 
 """
-    _linear_interp_nd_oneshot(grids, data, query, extraps_val, searches, ops, hints=nothing)
+    _linear_interp_nd_oneshot(grids, data, query, bcs, extraps_val, searches, ops, hints=nothing)
 
 Zero-allocation scalar one-shot ND multilinear evaluation.
 Evaluates directly from grids + data — no pool, no data extension even for
@@ -54,7 +54,7 @@ function _linear_interp_nd_oneshot(
 end
 
 """
-    _linear_interp_nd_oneshot_batch!(output, grids, data, queries, extraps_val, searches, ops, hints=nothing)
+    _linear_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps_val, policies, ops, hints, mono)
 
 In-place batch one-shot ND multilinear evaluation.
 Uses query protocol (`_query_length`, `_query_extract`) — works with any query format.

--- a/src/linear/nd/linear_nd_oneshot.jl
+++ b/src/linear/nd/linear_nd_oneshot.jl
@@ -50,7 +50,7 @@ function _linear_interp_nd_oneshot(
     stencils, Ls, Rs = _search_all_intervals_stencil(q_eval, grids, searches, hints, bcs)
     hs = map(_get_h, grids, Ls, Rs)
     αs = map(_alpha_of, q_eval, Ls, hs)
-    return _multilinear_sum_stencil(data, stencils, hs, αs, ops, Val(N))
+    return _multilinear_sum(data, stencils, hs, αs, ops, Val(N))
 end
 
 """
@@ -87,7 +87,7 @@ function _linear_interp_nd_oneshot_batch!(
         stencils, Ls, Rs = _search_all_intervals_stencil(q_eval, grids, policies, hints, bcs)
         hs = map(_get_h, grids, Ls, Rs)
         αs = map(_alpha_of, q_eval, Ls, hs)
-        output[k] = _multilinear_sum_stencil(data, stencils, hs, αs, ops, Val(N))
+        output[k] = _multilinear_sum(data, stencils, hs, αs, ops, Val(N))
     end
     return output
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,7 @@ else
     include("test_abstract_types.jl")
     include("test_grid_spacing.jl")
     include("test_search.jl")
+    include("test_idx_stencil.jl")
     include("test_anchor_common.jl")
     include("test_search_anchor_integration.jl")
     include("test_search_context_normalization.jl")

--- a/test/test_constant_anchor.jl
+++ b/test/test_constant_anchor.jl
@@ -37,6 +37,35 @@ using FastInterpolations
         @test aq.dL isa Float64
     end
 
+    @testset "virtual property type-stability + zero-alloc" begin
+        # Pins the Val-dispatched `getproperty` contract: every virtual access
+        # (idxL/idxR backed by stencil) and direct field access (h/dL) must
+        # infer to a concrete type and allocate zero bytes inside a function
+        # barrier. A regression to single-method `getproperty` with
+        # `s === :idxL && return ...` branches would defeat inference and
+        # silently slow hot consumers.
+        # `@inferred` requires a call expression — wrap each access in a
+        # 1-arg helper so the macro sees a function call.
+        _get_idxL(aq) = aq.idxL
+        _get_idxR(aq) = aq.idxR
+        _get_h(aq) = aq.h
+        _get_dL(aq) = aq.dL
+
+        x = collect(range(0.0, 1.0, 11))
+        aq = FastInterpolations._anchor_query(x, 0.35, Val(:constant))
+
+        @test @inferred(_get_idxL(aq)) isa Int
+        @test @inferred(_get_idxR(aq)) isa Int
+        @test @inferred(_get_h(aq)) isa Float64
+        @test @inferred(_get_dL(aq)) isa Float64
+
+        function _bench_idx(aq)
+            return aq.idxL + aq.idxR
+        end
+        _bench_idx(aq); _bench_idx(aq)  # warmup
+        @test (@allocated _bench_idx(aq)) == 0
+    end
+
     # ========================================
     # Scalar Construction Tests
     # ========================================

--- a/test/test_constant_anchor.jl
+++ b/test/test_constant_anchor.jl
@@ -17,8 +17,12 @@ using FastInterpolations
         aq = FastInterpolations._anchor_query(x, xq, Val(:constant))
 
         @test aq isa FastInterpolations._ConstantAnchoredQuery{Float64}
-        @test hasfield(typeof(aq), :idxL)
-        @test hasfield(typeof(aq), :idxR)
+        # `idxL` and `idxR` are virtual properties backed by `stencil::_IdxStencil{2}`
+        # since the _IdxStencil migration — `hasproperty` handles both real and
+        # virtual fields.
+        @test hasproperty(aq, :idxL)
+        @test hasproperty(aq, :idxR)
+        @test hasfield(typeof(aq), :stencil)
         @test hasfield(typeof(aq), :xq)
         @test hasfield(typeof(aq), :state)
         @test hasfield(typeof(aq), :h)

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -317,8 +317,10 @@ using FastInterpolations: _CachedRange
         x = collect(range(0.0, step = 1.0, length = 4))    # axis 1 periodic, period 4
         yy = collect(range(0.0, step = 1.0, length = 3))   # axis 2 NoBC
         zz = collect(range(0.0, step = 1.0, length = 3))   # axis 3 NoBC
-        data = [Float64(i - 1) + 10 * Float64(j - 1) + 100 * Float64(k - 1)
-                for i in 1:4, j in 1:3, k in 1:3]
+        data = [
+            Float64(i - 1) + 10 * Float64(j - 1) + 100 * Float64(k - 1)
+                for i in 1:4, j in 1:3, k in 1:3
+        ]
 
         bc = (PeriodicBC(endpoint = :exclusive, period = 4.0), NoBC(), NoBC())
         extrap = (NoExtrap(), NoExtrap(), NoExtrap())

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -269,7 +269,7 @@ using FastInterpolations: _CachedRange
         @test itp isa ConstantInterpolantND
     end
 
-    @testset "ND seam-cell — _constant_nd_kernel_lr exact wrap" begin
+    @testset "ND seam-cell — _constant_nd_kernel exact wrap" begin
         # 2D, axis 1 :exclusive (period=4), axis 2 NoBC. Constant uses one of
         # the (idx_L, idx_R) corners per axis according to `side`. Pinning down
         # LeftSide and RightSide along the seam axis is the strongest unit-level

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -308,6 +308,40 @@ using FastInterpolations: _CachedRange
         @test constant_interp((x, yy), data, q_pre; bc = bc, extrap = extrap, side = side_LL) == 2.0
     end
 
+    @testset "ND seam-cell — _constant_nd_kernel at N=3 with periodic axis-1 wrap" begin
+        # The unified `_constant_nd_kernel` is @generated and addresses one of
+        # 2^N corners per query via runtime offsets. Existing seam-cell tests
+        # are N=2 only; this exercises the N=3 unroll with axis-1 wrap, pinning
+        # the `ifelse(offset==0, stencils[d][1], stencils[d][2])` corner-pick
+        # for any N.
+        x = collect(range(0.0, step = 1.0, length = 4))    # axis 1 periodic, period 4
+        yy = collect(range(0.0, step = 1.0, length = 3))   # axis 2 NoBC
+        zz = collect(range(0.0, step = 1.0, length = 3))   # axis 3 NoBC
+        data = [Float64(i - 1) + 10 * Float64(j - 1) + 100 * Float64(k - 1)
+                for i in 1:4, j in 1:3, k in 1:3]
+
+        bc = (PeriodicBC(endpoint = :exclusive, period = 4.0), NoBC(), NoBC())
+        extrap = (NoExtrap(), NoExtrap(), NoExtrap())
+
+        # Seam cell axis 1 at q=(3.5, 0.5, 0.5): axis-1 corners are
+        # data[4, j, k] (left) and data[1, j, k] (right, wrapped).
+        q = (3.5, 0.5, 0.5)
+
+        # All-LeftSide ⇒ pick (4, 1, 1) ⇒ data[4, 1, 1] = 3.0
+        side_LLL = (LeftSide(), LeftSide(), LeftSide())
+        @test constant_interp((x, yy, zz), data, q; bc = bc, extrap = extrap, side = side_LLL) == 3.0
+        itp_LLL = constant_interp((x, yy, zz), data; bc = bc, extrap = extrap, side = side_LLL)
+        @test itp_LLL(q) == 3.0
+
+        # RightSide axis 1 ⇒ wraps to (1, 1, 1) ⇒ data[1, 1, 1] = 0.0
+        side_RLL = (RightSide(), LeftSide(), LeftSide())
+        @test constant_interp((x, yy, zz), data, q; bc = bc, extrap = extrap, side = side_RLL) == 0.0
+
+        # All-RightSide ⇒ (1, 2, 2) ⇒ data[1, 2, 2] = 0 + 10 + 100 = 110.0
+        side_RRR = (RightSide(), RightSide(), RightSide())
+        @test constant_interp((x, yy, zz), data, q; bc = bc, extrap = extrap, side = side_RRR) == 110.0
+    end
+
     # ============================================================
     # Edge cases
     # ============================================================

--- a/test/test_idx_stencil.jl
+++ b/test/test_idx_stencil.jl
@@ -1,0 +1,109 @@
+# Unit tests for `_IdxStencil{K}` — the wrap-aware per-axis corner-index type.
+# See src/core/idx_stencil.jl for design notes.
+
+using Test
+using FastInterpolations: _IdxStencil, _IdxPair, _pair
+
+@testset "_IdxStencil" begin
+
+    @testset "Construction" begin
+        # NTuple constructor
+        s2 = _IdxStencil((5, 6))
+        @test s2 isa _IdxStencil{2}
+        @test s2.indices === (5, 6)
+
+        # Explicit K
+        s2b = _IdxStencil{2}((5, 6))
+        @test s2b isa _IdxStencil{2}
+        @test s2b.indices === (5, 6)
+
+        # K=4 (future ND Hermite)
+        s4 = _IdxStencil((3, 4, 5, 6))
+        @test s4 isa _IdxStencil{4}
+        @test s4.indices === (3, 4, 5, 6)
+
+        # _pair convenience
+        sp = _pair(10, 1)               # periodic-exclusive seam shape
+        @test sp isa _IdxStencil{2}
+        @test sp.indices === (10, 1)
+
+        # Alias
+        @test _IdxPair === _IdxStencil{2}
+    end
+
+    @testset "Accessors" begin
+        s = _IdxStencil((7, 8, 9))
+        @test s[1] == 7
+        @test s[2] == 8
+        @test s[3] == 9
+        @test length(s) == 3
+        @test firstindex(s) == 1
+        @test lastindex(s) == 3
+    end
+
+    @testset "Iteration" begin
+        s = _IdxStencil((2, 3, 4, 5))
+        collected = Int[]
+        for v in s
+            push!(collected, v)
+        end
+        @test collected == [2, 3, 4, 5]
+
+        # collect() on iteration — may allocate, but values correct
+        @test collect(s) == [2, 3, 4, 5]
+    end
+
+    @testset "Equality & hash" begin
+        a = _IdxStencil((1, 2))
+        b = _IdxStencil((1, 2))
+        c = _IdxStencil((2, 1))
+        @test a == b
+        @test a != c
+        @test hash(a) == hash(b)
+        @test hash(a) != hash(c)
+    end
+
+    @testset "Memory layout — identical to raw NTuple" begin
+        s2 = _IdxStencil((5, 6))
+        @test sizeof(s2) == sizeof((5, 6))                  # 16 bytes on 64-bit
+
+        s4 = _IdxStencil((1, 2, 3, 4))
+        @test sizeof(s4) == sizeof((1, 2, 3, 4))            # 32 bytes
+    end
+
+    @testset "Zero-allocation on hot path" begin
+        # Function barrier for @allocated
+        function bench_construct()
+            s = _IdxStencil((5, 6))
+            return s[1] + s[2]
+        end
+
+        function bench_iterate()
+            s = _IdxStencil((1, 2, 3, 4))
+            acc = 0
+            for v in s
+                acc += v
+            end
+            return acc
+        end
+
+        # Warmup
+        bench_construct(); bench_construct()
+        bench_iterate(); bench_iterate()
+
+        @test (@allocated bench_construct()) == 0
+        @test (@allocated bench_iterate()) == 0
+    end
+
+    @testset "Type stability" begin
+        # Construction infers to concrete _IdxStencil{K, NTuple{K, Int}}
+        @test @inferred(_IdxStencil((1, 2))) isa _IdxStencil{2}
+        @test @inferred(_IdxStencil((1, 2, 3, 4))) isa _IdxStencil{4}
+        @test @inferred(_pair(1, 2)) isa _IdxStencil{2}
+
+        # Accessors preserve Int concrete
+        s = _IdxStencil((5, 6))
+        @test @inferred(s[1]) isa Int
+        @test @inferred(length(s)) == 2
+    end
+end

--- a/test/test_idx_stencil.jl
+++ b/test/test_idx_stencil.jl
@@ -2,7 +2,7 @@
 # See src/core/idx_stencil.jl for design notes.
 
 using Test
-using FastInterpolations: _IdxStencil, _IdxPair, _pair
+using FastInterpolations: _IdxStencil, _IdxPair
 
 @testset "_IdxStencil" begin
 
@@ -22,8 +22,8 @@ using FastInterpolations: _IdxStencil, _IdxPair, _pair
         @test s4 isa _IdxStencil{4}
         @test s4.indices === (3, 4, 5, 6)
 
-        # _pair convenience
-        sp = _pair(10, 1)               # periodic-exclusive seam shape
+        # _IdxPair 2-arg constructor — periodic-exclusive seam shape
+        sp = _IdxPair(10, 1)
         @test sp isa _IdxStencil{2}
         @test sp.indices === (10, 1)
 
@@ -99,7 +99,7 @@ using FastInterpolations: _IdxStencil, _IdxPair, _pair
         # Construction infers to concrete _IdxStencil{K, NTuple{K, Int}}
         @test @inferred(_IdxStencil((1, 2))) isa _IdxStencil{2}
         @test @inferred(_IdxStencil((1, 2, 3, 4))) isa _IdxStencil{4}
-        @test @inferred(_pair(1, 2)) isa _IdxStencil{2}
+        @test @inferred(_IdxPair(1, 2)) isa _IdxStencil{2}
 
         # Accessors preserve Int concrete
         s = _IdxStencil((5, 6))

--- a/test/test_idx_stencil.jl
+++ b/test/test_idx_stencil.jl
@@ -96,7 +96,7 @@ using FastInterpolations: _IdxStencil, _IdxPair
     end
 
     @testset "Type stability" begin
-        # Construction infers to concrete _IdxStencil{K, NTuple{K, Int}}
+        # Construction infers to concrete _IdxStencil{K}
         @test @inferred(_IdxStencil((1, 2))) isa _IdxStencil{2}
         @test @inferred(_IdxStencil((1, 2, 3, 4))) isa _IdxStencil{4}
         @test @inferred(_IdxPair(1, 2)) isa _IdxStencil{2}

--- a/test/test_linear_anchor.jl
+++ b/test/test_linear_anchor.jl
@@ -18,8 +18,12 @@ using FastInterpolations
         aq = FastInterpolations._anchor_query(x, xq, Val(:linear))
 
         @test aq isa FastInterpolations._LinearAnchoredQuery{Float64}
-        @test hasfield(typeof(aq), :idxL)
-        @test hasfield(typeof(aq), :idxR)
+        # `idxL` and `idxR` are virtual properties backed by `stencil::_IdxStencil{2}`
+        # since the _IdxStencil migration — `hasproperty` handles both real and
+        # virtual fields.
+        @test hasproperty(aq, :idxL)
+        @test hasproperty(aq, :idxR)
+        @test hasfield(typeof(aq), :stencil)
         @test hasfield(typeof(aq), :xq)
         @test hasfield(typeof(aq), :state)
         @test hasfield(typeof(aq), :h)

--- a/test/test_linear_anchor.jl
+++ b/test/test_linear_anchor.jl
@@ -40,6 +40,35 @@ using FastInterpolations
         @test aq.alpha isa Float64
     end
 
+    @testset "virtual property type-stability + zero-alloc" begin
+        # Pins the Val-dispatched `getproperty` contract: every virtual access
+        # (idxL/idxR backed by stencil) and direct field access (alpha/h)
+        # must infer to a concrete type and allocate zero bytes inside a
+        # function barrier. A regression to single-method `getproperty` with
+        # `s === :idxL && return ...` branches would defeat inference (union
+        # return) and silently slow hot consumers.
+        # `@inferred` requires a call expression — wrap each access in a
+        # 1-arg helper so the macro sees a function call.
+        _get_idxL(aq) = aq.idxL
+        _get_idxR(aq) = aq.idxR
+        _get_alpha(aq) = aq.alpha
+        _get_h(aq) = aq.h
+
+        x = collect(range(0.0, 1.0, 11))
+        aq = FastInterpolations._anchor_query(x, 0.35, Val(:linear))
+
+        @test @inferred(_get_idxL(aq)) isa Int
+        @test @inferred(_get_idxR(aq)) isa Int
+        @test @inferred(_get_alpha(aq)) isa Float64
+        @test @inferred(_get_h(aq)) isa Float64
+
+        function _bench_idx(aq)
+            return aq.idxL + aq.idxR
+        end
+        _bench_idx(aq); _bench_idx(aq)  # warmup
+        @test (@allocated _bench_idx(aq)) == 0
+    end
+
     # ========================================
     # Scalar Construction Tests
     # ========================================

--- a/test/test_linear_periodic.jl
+++ b/test/test_linear_periodic.jl
@@ -166,7 +166,7 @@ end
     end
 
     @testset "ND Exclusive — auto-infer period on ND oneshot (regression)" begin
-        # Same class of bug as above, via _search_all_intervals_lr → _resolve_search per axis.
+        # Same class of bug as above, via _search_all_intervals_stencil → _resolve_search per axis.
         x = range(0.5, step = 1.0, length = 3)         # axis-1 periodic-exclusive (period auto)
         y = range(0.0, 1.0, length = 4)                # axis-2 NoBC
         data = [10xi + yj for xi in x, yj in y]
@@ -533,6 +533,35 @@ end
         @test linear_interp((x, yy), data2, q3; bc = bc_both, extrap = extrap) ≈ 2.5 atol = 1.0e-12
         itp_both = linear_interp((x, yy), data2; bc = bc_both, extrap = extrap)
         @test itp_both(q3) ≈ 2.5 atol = 1.0e-12
+    end
+
+    @testset "ND seam-cell — _multilinear_sum at N=3 with periodic axis-1 wrap" begin
+        # The unified `_multilinear_sum` is @generated and unrolls to 2^N corners.
+        # Existing seam-cell tests are N=2 only; this exercises the N=3 unroll
+        # with a wrapped corner on axis 1, ensuring the @generated body addresses
+        # `stencils[1][2] == 1` (wrap) correctly for any N.
+        x = collect(range(0.0, step = 1.0, length = 4))    # axis 1 periodic, period 4
+        yy = collect(range(0.0, step = 1.0, length = 3))   # axis 2 NoBC
+        zz = collect(range(0.0, step = 1.0, length = 3))   # axis 3 NoBC
+        # Separable data: (i-1) + 10*(j-1) + 100*(k-1) — corner-recoverable.
+        data = [Float64(i - 1) + 10 * Float64(j - 1) + 100 * Float64(k - 1)
+                for i in 1:4, j in 1:3, k in 1:3]
+
+        bc = (PeriodicBC(endpoint = :exclusive, period = 4.0), NoBC(), NoBC())
+        extrap = (NoExtrap(), NoExtrap(), NoExtrap())
+
+        # Seam on axis 1 at q1=3.5: blend axis-1 corners 3 (data[4,j,k]) and 4≡0 (data[1,j,k])
+        # ⇒ axis-1 contribution = 1.5 + 10*(j-1) + 100*(k-1).
+        # Axis 2 at 0.5 between j=1 (1.5) and j=2 (11.5) ⇒ 6.5 + 100*(k-1).
+        # Axis 3 at 0.5 between k=1 (6.5) and k=2 (106.5) ⇒ 56.5.
+        q = (3.5, 0.5, 0.5)
+        @test linear_interp((x, yy, zz), data, q; bc = bc, extrap = extrap) ≈ 56.5 atol = 1.0e-12
+
+        itp = linear_interp((x, yy, zz), data; bc = bc, extrap = extrap)
+        @test itp(q) ≈ 56.5 atol = 1.0e-12
+
+        # Persistent must match oneshot exactly (zero-copy seam ↔ extended-data path).
+        @test itp(q) ≈ linear_interp((x, yy, zz), data, q; bc = bc, extrap = extrap) atol = 1.0e-12
     end
 
     # ============================================================

--- a/test/test_linear_periodic.jl
+++ b/test/test_linear_periodic.jl
@@ -485,7 +485,7 @@ end
         @test itp isa LinearInterpolantND
     end
 
-    @testset "ND seam-cell — _multilinear_sum_lr exact bilinear via wrap" begin
+    @testset "ND seam-cell — _multilinear_sum exact bilinear via wrap" begin
         # 2D, axis 1 :exclusive (period=4), axis 2 NoBC. Query lands in the seam
         # cell on axis 1, so the kernel must read corners (n, 1) on that axis
         # rather than (n, n+1). Picks data values that make the expected wrap-

--- a/test/test_linear_periodic.jl
+++ b/test/test_linear_periodic.jl
@@ -544,8 +544,10 @@ end
         yy = collect(range(0.0, step = 1.0, length = 3))   # axis 2 NoBC
         zz = collect(range(0.0, step = 1.0, length = 3))   # axis 3 NoBC
         # Separable data: (i-1) + 10*(j-1) + 100*(k-1) — corner-recoverable.
-        data = [Float64(i - 1) + 10 * Float64(j - 1) + 100 * Float64(k - 1)
-                for i in 1:4, j in 1:3, k in 1:3]
+        data = [
+            Float64(i - 1) + 10 * Float64(j - 1) + 100 * Float64(k - 1)
+                for i in 1:4, j in 1:3, k in 1:3
+        ]
 
         bc = (PeriodicBC(endpoint = :exclusive, period = 4.0), NoBC(), NoBC())
         extrap = (NoExtrap(), NoExtrap(), NoExtrap())


### PR DESCRIPTION
## Summary

- New `_IdxStencil{K}` primitive — unified corner addressing for multi-point methods.
- Linear/Constant K=2 today; ND Hermite K=4 ready.
- 4-stage layer cleanup: collapse wrapper layers, unify kernel overload pairs.
- **Pure refactor — zero behavior change, zero perf regression.**
- Pays down debt accreted through PRs #124/#126/#127 before extending to ND Hermite.

## Core changes

### 1. `_IdxStencil{K}` — wrap-aware index stencil
- New `src/core/idx_stencil.jl`. Thin wrapper around `NTuple{K, Int}`.
- Distinct struct identity → resolves the N=0 dispatch ambiguity that motivated the old `_lr` / `_stencil` suffixes.
- `_IdxPair = _IdxStencil{2}` alias + Vararg outer constructor.
- Memory layout = raw `NTuple{K, Int}`. All accessors `@inline`.

### 2. Anchor structs use `stencil::_IdxStencil{2}`
- `_LinearAnchoredQuery` / `_ConstantAnchoredQuery` replace `idxL::Int` + `idxR::Int` with one `stencil` field.
- Val-dispatched `getproperty` keeps `aq.idxL` / `aq.idxR` ergonomics.
- Zero source change at downstream call sites (kernel eval, adjoint, Series, tests).
- New `@inferred` + `@allocated` testsets pin the type-stability contract.

### 3. Single-overload kernels
- `_multilinear_sum` and `_constant_nd_kernel` collapse `(Int-indexed, _stencil-suffixed)` pairs into one shape each.
- Single signature: `stencils::NTuple{N, _IdxStencil{2}}`.
- Constant kernel lifts `h` out of the `@generated` body.
- Constant runtime-offset corner addressing uses `ifelse(offset==0, stencils[d][1], stencils[d][2])` → CSEL on x86/ARM, 0.7% better than master's integer-add path.

### 4. Layer cleanup
- Delete `_compute_linear_params*` + `_alphas_from_hs` wrappers.
- Inline as `hs = map(_get_h, …)` + `αs = map(_alpha_of, …)` at 3 call sites.
- Reorder 3-arg `_get_h(x, xR, xL)` → `_get_h(x, xL, xR)` for natural L→R reading.
- ~28 mechanical call-site swaps; body unchanged.
- `_alpha_of(q, L, h) = (q - L) / h` survives as the named formula.

## Behavior preservation

- **Logic**: every change mechanical or pure layer reduction. No formulas modified.
- **Precision**: BC oneshot now uses cached `x.h` for `_CachedRange` instead of recomputing `xR - xL`. Mirrors the 1D Series fix in `883c4cd5`. Vector grids unchanged.
- **Allocations**: zero regression. New alloc tests pin the virtual-property contract.

## Risk & migration

- Internal-only refactor. `_IdxStencil` and helpers are `_`-prefixed.
- No public API surface changes.
- `aq.idxL` / `aq.idxR` continue to work via virtual properties.