### PR TITLE
(perf): Linear — `inv_h` and α split for op-aware DCE

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"bfc7d736-6ec8-404c-85c2-44ff9315f6f5","pid":6250,"procStart":"Sun Apr 26 04:16:34 2026","acquiredAt":1777219578644}

--- a/src/hetero/hetero_precomputed_eval.jl
+++ b/src/hetero/hetero_precomputed_eval.jl
@@ -100,7 +100,10 @@ Non-derivative axes (Linear/Constant) produce fewer intermediates (no derivative
                 elseif method_type <: QuadraticInterp
                     :(_quadratic_kernel_nd($op, $fL, $fR, $dfL, $inv_h, $dL))
                 elseif method_type <: LinearInterp
-                    :(_linear_kernel($op, $fL, $fR, $inv_h, $dL))
+                    # New `_linear_kernel` signature takes α (= dL * inv_h)
+                    # instead of dL. Hetero path is fully cached, so the
+                    # extra mul is one register op — no DCE needed here.
+                    :(_linear_kernel($op, $fL, $fR, $inv_h, $dL * $inv_h))
                 elseif method_type <: ConstantInterp
                     side_inst = fieldtype(method_type, :side)()
                     :(_constant_kernel($op, $fL, $fR, $h, $dL, $side_inst))

--- a/src/linear/linear_interpolant.jl
+++ b/src/linear/linear_interpolant.jl
@@ -12,11 +12,11 @@
 # _itp_grid, _itp_extrap, _itp_search use defaults (itp.x, itp.extrap, itp.search_policy).
 
 @inline function _itp_eval_scalar(itp::LinearInterpolant, xq, extrap, op, searcher)
-    return _linear_eval_at_point(itp.x, itp.y, xq, extrap, op, searcher)
+    return _linear_eval_at_point(itp.x, itp.y, itp.spacing, xq, extrap, op, searcher)
 end
 
 @inline function _itp_vector_loop!(output, itp::LinearInterpolant, xq, extrap, op, searcher)
-    return _linear_vector_loop!(output, itp.x, itp.y, xq, extrap, op, searcher)
+    return _linear_vector_loop!(output, itp.x, itp.y, itp.spacing, xq, extrap, op, searcher)
 end
 
 # ========================================
@@ -26,6 +26,8 @@ end
 # overhead when adaptive AutoSearch resolves to BinarySearch or LinearBinarySearch.
 # CRITICAL: All arguments must be fully typed — untyped args prevent SROA
 # of RefHint's Ref, causing 16-byte heap allocation per call.
+# Oneshot variant (no spacing) and persistent variant (with spacing) coexist;
+# persistent calls reuse the spacing's cached `inv_h` array per query.
 @inline function _linear_vector_loop!(
         output::AbstractVector,
         x::AbstractVector{Tg},
@@ -38,6 +40,22 @@ end
     extrap = _check_domain(x, xq, extrap)
     return @inbounds for i in eachindex(xq, output)
         output[i] = _linear_eval_at_point(x, y, xq[i], extrap, deriv, searcher)
+    end
+end
+
+@inline function _linear_vector_loop!(
+        output::AbstractVector,
+        x::AbstractVector{Tg},
+        y::AbstractVector{Tv},
+        spacing::AbstractGridSpacing{Tg},
+        xq::AbstractVector{<:Real},
+        extrap::E,
+        deriv::O,
+        searcher::P
+    ) where {Tg, Tv, E <: AbstractExtrap, O <: AbstractEvalOp, P <: Searcher}
+    extrap = _check_domain(x, xq, extrap)
+    return @inbounds for i in eachindex(xq, output)
+        output[i] = _linear_eval_at_point(x, y, spacing, xq[i], extrap, deriv, searcher)
     end
 end
 

--- a/src/linear/linear_kernels.jl
+++ b/src/linear/linear_kernels.jl
@@ -21,14 +21,17 @@
 # - α: Unconstrained — can be Tg or Dual{Tg} for AD support
 
 # ========================================
-# Standard Kernel (inv_h, dL signature)
+# Standard Kernel (inv_h, α signature)
 # ========================================
 
 """
     _linear_kernel(::EvalValue, yL::Tv, yR::Tv, inv_h::Tg, α) where {Tg, Tv}
 
-Evaluate linear interpolation value at normalized cell coordinate α ∈ [0, 1].
-Returns: yL + α*(yR - yL). `inv_h` is unused for value eval — DCE'd by LLVM
+Evaluate linear interpolation value at normalized cell coordinate `α`.
+Returns: yL + α*(yR - yL). `α` is typically in [0, 1] for in-domain
+queries but may fall outside that range under linear extrapolation
+(`ExtendExtrap`/`WrapExtrap`) where callers intentionally evaluate
+outside the cell. `inv_h` is unused for value eval — DCE'd by LLVM
 when the caller's `inv_h` extraction has no other live use.
 """
 @inline function _linear_kernel(::EvalValue, yL::Tv, yR::Tv, inv_h::Tg, α) where {Tg, Tv}

--- a/src/linear/linear_kernels.jl
+++ b/src/linear/linear_kernels.jl
@@ -5,9 +5,11 @@
 # No dependencies - can be tested independently.
 #
 # Unified API with two signatures:
-# 1. Standard: _linear_kernel(op, yL, yR, inv_h, dL)
-#    - Used for oneshot and non-anchored evaluation
-#    - Computes α = dL * inv_h internally
+# 1. Standard: _linear_kernel(op, yL, yR, inv_h, α)
+#    - Caller computes α via grid-type-dispatched `_alpha_of(q, L, R, grid)`
+#      (cached `*inv_h` for `_CachedRange`, direct `(q-L)/(R-L)` for plain
+#      `AbstractVector`) and pulls `inv_h` separately. EvalValue uses α only;
+#      EvalDeriv1 uses inv_h only — LLVM DCE removes the unused side per op.
 #
 # 2. Anchored: _linear_kernel(op, yL, yR, aq::_LinearAnchoredQuery)
 #    - Defined in linear_anchor.jl (after anchor type)
@@ -16,44 +18,35 @@
 # TYPE PARAMETERS:
 # - Tg: Grid type (AbstractFloat) - for inv_h (inverse interval width)
 # - Tv: Value type - for yL, yR (can be Complex{Tg}, Tg, etc.)
-# - Td: Offset type - for dL (can be Tg or Dual{Tg} for AD support)
+# - α: Unconstrained — can be Tg or Dual{Tg} for AD support
 
 # ========================================
 # Standard Kernel (inv_h, dL signature)
 # ========================================
 
 """
-    _linear_kernel(::EvalValue, yL::Tv, yR::Tv, inv_h::Tg, dL) where {Tg, Tv}
+    _linear_kernel(::EvalValue, yL::Tv, yR::Tv, inv_h::Tg, α) where {Tg, Tv}
 
-Evaluate linear interpolation value at offset dL from left boundary.
-Returns: yL * (1 - α) + yR * α where α = dL * inv_h
-
-# Type Parameters
-- `Tg`: Grid type — normally `<:AbstractFloat`, but accepts any scalar type
-        supporting multiplication (duck-typed grids like `ForwardDiff.Dual`)
-- `Tv`: Value type (unconstrained)
-- `dL`: Unconstrained — can be Tg or Dual{Tg} for AD support
-
-# Return Type
-promote_type(Tv, typeof(α)) — handles Complex*Float and Dual*Float correctly
+Evaluate linear interpolation value at normalized cell coordinate α ∈ [0, 1].
+Returns: yL + α*(yR - yL). `inv_h` is unused for value eval — DCE'd by LLVM
+when the caller's `inv_h` extraction has no other live use.
 """
-@inline function _linear_kernel(::EvalValue, yL::Tv, yR::Tv, inv_h::Tg, dL) where {Tg, Tv}
-    α = dL * inv_h
+@inline function _linear_kernel(::EvalValue, yL::Tv, yR::Tv, inv_h::Tg, α) where {Tg, Tv}
     return muladd(α, yR - yL, yL)  # yL + α*(yR-yL)
 end
 
 """
-    _linear_kernel(::EvalDeriv1, yL::Tv, yR::Tv, inv_h::Tg, dL) where {Tg, Tv}
+    _linear_kernel(::EvalDeriv1, yL::Tv, yR::Tv, inv_h::Tg, α) where {Tg, Tv}
 
 Evaluate first derivative (slope) of linear interpolation.
-Returns constant slope: (yR - yL) * inv_h
+Returns constant slope: (yR - yL) * inv_h. `α` is unused — DCE'd.
 """
-@inline function _linear_kernel(::EvalDeriv1, yL::Tv, yR::Tv, inv_h::Tg, dL) where {Tg, Tv}
+@inline function _linear_kernel(::EvalDeriv1, yL::Tv, yR::Tv, inv_h::Tg, α) where {Tg, Tv}
     return (yR - yL) * inv_h
 end
 
 """
-    _linear_kernel(::EvalDeriv2, yL::Tv, yR::Tv, inv_h::Tg, dL) where {Tg, Tv}
+    _linear_kernel(::EvalDeriv2, yL::Tv, yR::Tv, inv_h::Tg, α) where {Tg, Tv}
 
 Evaluate second derivative of linear interpolation.
 Always returns zero (linear function has no curvature).
@@ -61,21 +54,21 @@ Always returns zero (linear function has no curvature).
 Note: Mathematically, the second derivative is a Dirac delta at knots,
 but we return zero everywhere as a practical approximation.
 """
-@inline function _linear_kernel(::EvalDeriv2, yL::Tv, ::Tv, inv_h::Tg, dL) where {Tg, Tv}
+@inline function _linear_kernel(::EvalDeriv2, yL::Tv, ::Tv, inv_h::Tg, α) where {Tg, Tv}
     return 0 * yL
 end
 
 """
-    _linear_kernel(::EvalDeriv3, yL::Tv, yR::Tv, inv_h::Tg, dL) where {Tg, Tv}
+    _linear_kernel(::EvalDeriv3, yL::Tv, yR::Tv, inv_h::Tg, α) where {Tg, Tv}
 
 Third derivative of linear interpolation is always zero.
 Linear functions have constant first derivative (slope), zero second and third derivatives.
 """
-@inline function _linear_kernel(::EvalDeriv3, yL::Tv, ::Tv, inv_h::Tg, dL) where {Tg, Tv}
+@inline function _linear_kernel(::EvalDeriv3, yL::Tv, ::Tv, inv_h::Tg, α) where {Tg, Tv}
     return 0 * yL
 end
 
 """Generic fallback: N-th derivative of degree-1 polynomial is zero for N ≥ 2."""
-@inline function _linear_kernel(::DerivOp{N}, yL::Tv, ::Tv, ::Tg, dL) where {N, Tg, Tv}
+@inline function _linear_kernel(::DerivOp{N}, yL::Tv, ::Tv, ::Tg, α) where {N, Tg, Tv}
     return 0 * yL
 end

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -217,6 +217,12 @@ For ForwardDiff compatibility, `xq` can be a Dual type:
 # ========================================
 # _get_inv_h(x, xL, xR) dispatches to x.inv_h (_CachedRange) or inv(xR-xL) (Vector).
 
+# Oneshot path (no spacing): α via direct (q-L)/(R-L) on plain Vector grid
+# (`_alpha_of(q, L, R, grid)`); inv_h recomputed per query.
+# Persistent path (with spacing): α via cached `inv_h * (q-L)`; mirrors the ND
+# `_locate_cell` design — exact at knots is sacrificed for query-time speed
+# (1 ULP off possible at right knots; oneshot path remains exact).
+
 # NoExtrap / ExtendExtrap / other: direct search + kernel.
 # _check_domain(::NoExtrap) throws if OOB; all others are no-ops.
 @inline function _linear_eval_at_point(
@@ -231,6 +237,22 @@ For ForwardDiff compatibility, `xq` can be a Dual type:
     idx, idx_R, xL, xR = search_interval(searcher, x, xq)
     α = _alpha_of(xq, xL, xR, x)
     @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, xL, xR), α)
+end
+
+@inline function _linear_eval_at_point(
+        x::AbstractVector{Tg},
+        y::AbstractVector{Tv},
+        spacing::AbstractGridSpacing{Tg},
+        xq::Tq,
+        extrap::AbstractExtrap,
+        op::O,
+        searcher::S
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    @boundscheck _check_domain(x, xq, extrap)
+    idx, idx_R, xL, _ = search_interval(searcher, x, xq)
+    inv_h = _get_inv_h(spacing, idx)
+    α = (xq - xL) * inv_h
+    @inbounds return _linear_kernel(op, y[idx], y[idx_R], inv_h, α)
 end
 
 # ClampExtrap / FillExtrap: boundary check → extrap value or kernel.
@@ -253,6 +275,27 @@ end
     @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, xL, xR), α)
 end
 
+@inline function _linear_eval_at_point(
+        x::AbstractVector{Tg},
+        y::AbstractVector{Tv},
+        spacing::AbstractGridSpacing{Tg},
+        xq::Tq,
+        extrap::_ClampOrFill,
+        op::O,
+        searcher::S
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    xq_primal = _extract_primal(xq)
+    if xq_primal < first(x)
+        return _eval_extrapolation(op, first(y), extrap, xq)
+    elseif xq_primal > last(x)
+        return _eval_extrapolation(op, last(y), extrap, xq)
+    end
+    idx, idx_R, xL, _ = search_interval(searcher, x, xq)
+    inv_h = _get_inv_h(spacing, idx)
+    α = (xq - xL) * inv_h
+    @inbounds return _linear_kernel(op, y[idx], y[idx_R], inv_h, α)
+end
+
 # WrapExtrap: wrap query to domain → search + kernel.
 # Pass original xq (may be Dual) to _wrap_to_domain to preserve AD derivatives.
 # The 2-arg `_wrap_to_domain(xq, extrap)` reads `extrap._x_min/._x_max` directly —
@@ -270,6 +313,22 @@ end
     idx, idx_R, xL, xR = search_interval(searcher, x, xq_wrapped)
     α = _alpha_of(xq_wrapped, xL, xR, x)
     @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, xL, xR), α)
+end
+
+@inline function _linear_eval_at_point(
+        x::AbstractVector{Tg},
+        y::AbstractVector{Tv},
+        spacing::AbstractGridSpacing{Tg},
+        xq::Tq,
+        extrap::WrapExtrap,
+        op::O,
+        searcher::S
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    xq_wrapped = _wrap_to_domain(xq, extrap)
+    idx, idx_R, xL, _ = search_interval(searcher, x, xq_wrapped)
+    inv_h = _get_inv_h(spacing, idx)
+    α = (xq_wrapped - xL) * inv_h
+    @inbounds return _linear_kernel(op, y[idx], y[idx_R], inv_h, α)
 end
 
 # Public scalar one-shot API.

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -229,8 +229,8 @@ For ForwardDiff compatibility, `xq` can be a Dual type:
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     @boundscheck _check_domain(x, xq, extrap)
     idx, idx_R, xL, xR = search_interval(searcher, x, xq)
-    dL = xq - xL  # xq can be Dual here (preserves AD)
-    @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, xL, xR), dL)
+    α = _alpha_of(xq, xL, xR, x)
+    @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, xL, xR), α)
 end
 
 # ClampExtrap / FillExtrap: boundary check → extrap value or kernel.
@@ -249,8 +249,8 @@ end
         return _eval_extrapolation(op, last(y), extrap, xq)
     end
     idx, idx_R, xL, xR = search_interval(searcher, x, xq)
-    dL = xq - xL
-    @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, xL, xR), dL)
+    α = _alpha_of(xq, xL, xR, x)
+    @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, xL, xR), α)
 end
 
 # WrapExtrap: wrap query to domain → search + kernel.
@@ -268,8 +268,8 @@ end
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq_wrapped = _wrap_to_domain(xq, extrap)
     idx, idx_R, xL, xR = search_interval(searcher, x, xq_wrapped)
-    dL = xq_wrapped - xL
-    @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, xL, xR), dL)
+    α = _alpha_of(xq_wrapped, xL, xR, x)
+    @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, xL, xR), α)
 end
 
 # Public scalar one-shot API.

--- a/src/linear/linear_series_interp.jl
+++ b/src/linear/linear_series_interp.jl
@@ -229,11 +229,11 @@ end
         xR = x[idx1]
     end
     inv_h = _get_inv_h(x, xL, xR)
-    dL = aq.xq - xL
+    α = _alpha_of(aq.xq, xL, xR, x)
     @inbounds @simd for k in axes(out, 1)
         yL = y_point[k, idx]
         yR = y_point[k, idx1]
-        out[k] = _linear_kernel(op, yL, yR, inv_h, dL)
+        out[k] = _linear_kernel(op, yL, yR, inv_h, α)
     end
     return out
 end
@@ -279,12 +279,12 @@ while `aq.xq` carries the Dual payload so `dL = aq.xq - aq.xL` preserves derivat
     idxR = aq.idxR
 
     inv_h = aq.inv_h
-    dL = aq.xq - aq.xL  # aq.xq carries Dual info (widened by outer constructor)
+    α = aq.alpha  # precomputed by anchor constructor
 
     @inbounds @simd for k in axes(output, 1)
         yL = y_point[k, idxL]
         yR = y_point[k, idxR]
-        output[k] = _linear_kernel(op, yL, yR, inv_h, dL)
+        output[k] = _linear_kernel(op, yL, yR, inv_h, α)
     end
     return output
 end

--- a/src/linear/linear_series_interp.jl
+++ b/src/linear/linear_series_interp.jl
@@ -248,19 +248,21 @@ end
 Core scalar evaluation for all series at a single query point.
 Uses SIMD-optimized point-contiguous layout for vectorization across series.
 
-Query information (`aq.xq`, `aq.xL`, `aq.inv_h`) is read from the anchor.
-For duck grids (Dual), `aq.xq` carries the widened query type (via the outer
-constructor), so `dL = aq.xq - aq.xL` correctly propagates grid-side partials.
+Anchor data (`aq.alpha`, `aq.inv_h`, `aq.idxL`, `aq.idxR`) is read directly
+— `α` is precomputed by the anchor constructor as `(xq - xL) * inv_h`,
+so the SIMD loop only does multiplies/muladds per series.
 
 # Arguments
 - `output`: Pre-allocated output vector (length = n_series)
 - `sitp`: LinearSeriesInterpolant
-- `aq`: Anchor with precomputed indices (`idxL`/`idxR`) and widened `xq`
+- `aq`: Anchor with precomputed indices (`idxL`/`idxR`), `alpha`, `inv_h`
 - `op`: Evaluation operation (value, derivative)
 
 # AD Support
-Supports ForwardDiff.Dual input: the anchor's indices come from the primal value,
-while `aq.xq` carries the Dual payload so `dL = aq.xq - aq.xL` preserves derivatives.
+Supports ForwardDiff.Dual input: the anchor's indices come from the primal
+value while `aq.alpha` carries the Dual payload (the outer
+`_LinearAnchoredQuery` constructor widens via `promote_type(Tq, Tg)`), so
+the SIMD loop preserves grid-side partials through `α`.
 """
 @inline function _eval_linear_series_point!(
         output::AbstractVector,

--- a/src/linear/nd/linear_nd_eval.jl
+++ b/src/linear/nd/linear_nd_eval.jl
@@ -50,15 +50,10 @@ end
     ) where {Tg, Tv, N}
     q_eval = _handle_all_extraps(query, itp.grids, itp.extraps)
     indices, Ls, _ = _search_all_intervals(q_eval, itp.grids, itp.spacings, policies, hints, mono)
-    # Persistent fast lane: 2-arg `_get_h` reads precomputed `spacings[d].h`
-    # (or `.h[i]` for Vector). `map` dispatches per-axis with concrete types.
-    hs = map(_get_h, itp.spacings, indices)
-    αs = map(_alpha_of, q_eval, Ls, hs)
-    # Wrap raw indices into the unified stencil shape so `_multilinear_sum`
-    # has a single signature across persistent / BC oneshot callers.
-    # Non-periodic cells are always `(idx, idx+1)` — no seam wrap.
+    inv_hs = map(_get_inv_h, itp.spacings, indices)
+    αs = map(_alpha_of, q_eval, Ls, inv_hs)
     stencils = map(i -> _IdxPair(i, i + 1), indices)
-    return (itp.data, stencils, hs, αs)
+    return (itp.data, stencils, inv_hs, αs)
 end
 
 # N=2 specialization: direct destructuring eliminates ntuple closure overhead
@@ -73,14 +68,11 @@ end
         query, itp.grids, itp.spacings, itp.extraps, policies, hints, mono
     )
 
-    hx = _get_h(itp.spacings[1], ix)
-    hy = _get_h(itp.spacings[2], iy)
-    αx = (x_eval - xL) / hx
-    αy = (y_eval - yL) / hy
-
-    # N=2 specialization wraps directly into the unified stencil shape — same
-    # `_multilinear_sum` signature as the generic-N persistent / BC oneshot paths.
-    return (itp.data, (_IdxPair(ix, ix + 1), _IdxPair(iy, iy + 1)), (hx, hy), (αx, αy))
+    inv_hx = _get_inv_h(itp.spacings[1], ix)
+    inv_hy = _get_inv_h(itp.spacings[2], iy)
+    αx = (x_eval - xL) * inv_hx
+    αy = (y_eval - yL) * inv_hy
+    return (itp.data, (_IdxPair(ix, ix + 1), _IdxPair(iy, iy + 1)), (inv_hx, inv_hy), (αx, αy))
 end
 
 # Evaluate kernel at a pre-located cell with given derivative ops
@@ -92,8 +84,8 @@ end
     if _has_second_or_higher_derivative(ops, Val(N))
         return 0 * first(itp.data)
     end
-    data, stencils, hs, αs = cell
-    return _multilinear_sum(data, stencils, hs, αs, ops, Val(N))
+    data, stencils, inv_hs, αs = cell
+    return _multilinear_sum(data, stencils, inv_hs, αs, ops, Val(N))
 end
 
 # ========================================
@@ -155,32 +147,20 @@ end
     return false
 end
 
-# ========================================
-# Local Parameter Computation
-# ========================================
-
-# Shared `αs` formula for both variants. `map` on NTuples dispatches
-# per-element with concrete types — safe for heterogeneous `hs` / `Ls` /
-# `q_eval` tuples (e.g., Real + Float64 mixes), avoiding the Union-box risk
-# of `ntuple(d -> q_eval[d], Val(N))` where runtime-indexed lookup collapses
-# to an abstract return type. See MEMORY.md "ND Constructor Inferrability
-# Pattern" for the canonical precedent.
-#
-# `_alpha_of` is the only surviving named helper from this region. The earlier
-# `_alphas_from_hs(q, Ls, hs)`, `_compute_linear_params(q, spacings, indices, Ls, …)`,
-# and `_compute_linear_params_stencil(q, Ls, Rs, …)` wrappers were single-line
-# `map`-forwarders that hid the actual arithmetic behind two extra layers; call
-# sites now do the `map(_get_h, …)` + `map(_alpha_of, q, Ls, hs)` directly.
-#   - persistent path: `map(_get_h, spacings, indices)` (2-arg cached fast lane)
-#   - BC oneshot path: `map(_get_h, grids, Ls, Rs)` (3-arg dispatch, seam-aware)
-@inline _alpha_of(q::Real, L::Real, h::Real) = (q - L) / h
+# 3-arg form: caller supplies cached `inv_h` (persistent path).
+# 4-arg form: dispatch on grid type (oneshot path) — plain `AbstractVector`
+# uses direct division so EvalValue queries can DCE the separately-extracted
+# `inv_hs` (only needed by EvalDeriv1 kernel weights).
+@inline _alpha_of(q::Real, L::Real, inv_h::Real) = (q - L) * inv_h
+@inline _alpha_of(q::Real, L::Real, R::Real, x::_CachedRange)  = (q - L) * x.inv_h
+@inline _alpha_of(q::Real, L::Real, R::Real, ::AbstractVector) = (q - L) / float(R - L)
 
 # ========================================
 # Multilinear Interpolation Kernel
 # ========================================
 
 """
-    _multilinear_sum(data, stencils, hs, αs, ops, Val(N))
+    _multilinear_sum(data, stencils, inv_hs, αs, ops, Val(N))
 
 Compute the multilinear interpolation sum over 2^N corners.
 
@@ -191,9 +171,10 @@ For non-periodic cells `idx_R == idx_L + 1`; for periodic-exclusive seam
 cells `idx_R == 1` (wrap), so the kernel reads the wrapped neighbor without
 any data extension.
 
-Per-corner weight: `∏ᵢ _linear_weight(ops[i], αs[i], hs[i], bᵢ)`. The weight
-function depends on the evaluation op — EvalValue: `(1-α)` for `b=0`, `α`
-for `b=1`; EvalDeriv1: `-1/h` for `b=0`, `+1/h` for `b=1`.
+Per-corner weight: `∏ᵢ _linear_weight(ops[i], αs[i], inv_hs[i], bᵢ)`. The
+weight function depends on the evaluation op — EvalValue: `(1-α)` for `b=0`,
+`α` for `b=1` (inv_h unused); EvalDeriv1: `-inv_h` for `b=0`, `+inv_h` for
+`b=1` (precomputed reciprocal — no `inv()` at the kernel).
 
 Single-overload, stencil-only kernel. Persistent callers wrap their
 single-index `indices` via `map(i -> _IdxPair(i, i+1), indices)` at the
@@ -203,28 +184,18 @@ directly from `_search_all_intervals_stencil`.
 @generated function _multilinear_sum(
         data::AbstractArray{Tv, N},
         stencils::NTuple{N, _IdxStencil{2}},
-        hs::NTuple{N},
+        inv_hs::NTuple{N},
         αs::Tuple{Vararg{Real, N}},
         ops::NTuple{N, AbstractEvalOp},
         ::Val{N}
     ) where {Tv, N}
-    return _multilinear_sum_body(N, (d, bit) -> :(stencils[$d][$(bit + 1)]))
-end
-
-# Shared Expr builder for the multilinear @generated kernel above. Produces
-# the flat 2^N straight-line unroll. `make_idx_expr(d, bit)` returns the
-# address expression for axis `d` at corner bit `bit` ∈ {0, 1}; the kernel
-# above passes the stencil-style `(d, bit) -> :(stencils[$d][$(bit + 1)])`.
-# Body kept as a callback-driven helper so future K > 2 kernels (ND Hermite)
-# can reuse it without duplicating the corner-unroll skeleton.
-function _multilinear_sum_body(N::Int, make_idx_expr::Function)
     num_corners = 1 << N  # 2^N
     corner_exprs = []
     for corner in 0:(num_corners - 1)
         bits = ntuple(d -> (corner >> (d - 1)) & 1, N)
-        idx_expr = Expr(:tuple, [make_idx_expr(d, bits[d]) for d in 1:N]...)
+        idx_expr = Expr(:tuple, [:(stencils[$d][$(bits[d] + 1)]) for d in 1:N]...)
         weight_exprs = [
-            :(_linear_weight(ops[$d], αs[$d], hs[$d], Val($(bits[d]))))
+            :(_linear_weight(ops[$d], αs[$d], inv_hs[$d], Val($(bits[d]))))
                 for d in 1:N
         ]
         weight_expr = foldl((a, b) -> :($a * $b), weight_exprs)
@@ -240,18 +211,18 @@ end
 # Linear Weight Functions
 # ========================================
 
-# For value evaluation: (1-α) for bit=0, α for bit=1
-@inline _linear_weight(::EvalValue, α, h, ::Val{0}) = one(α) - α
-@inline _linear_weight(::EvalValue, α, h, ::Val{1}) = α
+# For value evaluation: (1-α) for bit=0, α for bit=1 (inv_h unused)
+@inline _linear_weight(::EvalValue, α, inv_h, ::Val{0}) = one(α) - α
+@inline _linear_weight(::EvalValue, α, inv_h, ::Val{1}) = α
 
-# For first derivative: -1/h for bit=0, 1/h for bit=1
-@inline _linear_weight(::EvalDeriv1, α, h, ::Val{0}) = -inv(h)
-@inline _linear_weight(::EvalDeriv1, α, h, ::Val{1}) = inv(h)
+# For first derivative: -inv_h for bit=0, +inv_h for bit=1
+@inline _linear_weight(::EvalDeriv1, α, inv_h, ::Val{0}) = -inv_h
+@inline _linear_weight(::EvalDeriv1, α, inv_h, ::Val{1}) = inv_h
 
 # Second and higher derivatives are zero (handled by early return in _eval_linear_nd)
 # But define them for completeness if somehow called
-@inline _linear_weight(::EvalDeriv2, α, h, ::Val{B}) where {B} = zero(α)
-@inline _linear_weight(::EvalDeriv3, α, h, ::Val{B}) where {B} = zero(α)
+@inline _linear_weight(::EvalDeriv2, α, inv_h, ::Val{B}) where {B} = zero(α)
+@inline _linear_weight(::EvalDeriv3, α, inv_h, ::Val{B}) where {B} = zero(α)
 
 # Generic fallback: N-th derivative weight is zero for N ≥ 2
-@inline _linear_weight(::DerivOp{N}, α, h, ::Val{B}) where {N, B} = zero(α)
+@inline _linear_weight(::DerivOp{N}, α, inv_h, ::Val{B}) where {N, B} = zero(α)

--- a/src/linear/nd/linear_nd_eval.jl
+++ b/src/linear/nd/linear_nd_eval.jl
@@ -152,7 +152,7 @@ end
 # uses direct division so EvalValue queries can DCE the separately-extracted
 # `inv_hs` (only needed by EvalDeriv1 kernel weights).
 @inline _alpha_of(q::Real, L::Real, inv_h::Real) = (q - L) * inv_h
-@inline _alpha_of(q::Real, L::Real, R::Real, x::_CachedRange)  = (q - L) * x.inv_h
+@inline _alpha_of(q::Real, L::Real, R::Real, x::_CachedRange) = (q - L) * x.inv_h
 @inline _alpha_of(q::Real, L::Real, R::Real, ::AbstractVector) = (q - L) / float(R - L)
 
 # ========================================

--- a/src/linear/nd/linear_nd_oneshot.jl
+++ b/src/linear/nd/linear_nd_oneshot.jl
@@ -41,16 +41,13 @@ function _linear_interp_nd_oneshot(
 
     extraps_eff = _resolve_extrap(extraps_val, bcs, grids, data, Val(N))
     q_eval = _handle_all_extraps(query, grids, extraps_eff)
-    # BC-aware per-axis search — returns (stencils, Ls, Rs) where
-    # stencils[d]::_IdxStencil{2} wraps (idx_L_d, idx_R_d); periodic seam
-    # axes have idx_R == 1 (wrap), so kernel reads the wrapped neighbor
-    # without data extension. No spacings needed — 3-arg `_get_h(x, xL, xR)`
-    # dispatches to cached `x.h` for `_CachedRange` and `xR-xL` for Vector,
-    # giving seam-aware h without VectorSpacing allocation.
+    # Periodic seam: stencils[d] carries (idx_L, idx_R) with idx_R==1 at wrap.
+    # `_alpha_of` keeps α independent of `inv_hs` so EvalValue queries DCE
+    # the inv_h computation on the plain `AbstractVector` path.
     stencils, Ls, Rs = _search_all_intervals_stencil(q_eval, grids, searches, hints, bcs)
-    hs = map(_get_h, grids, Ls, Rs)
-    αs = map(_alpha_of, q_eval, Ls, hs)
-    return _multilinear_sum(data, stencils, hs, αs, ops, Val(N))
+    αs = map(_alpha_of, q_eval, Ls, Rs, grids)
+    inv_hs = map(_get_inv_h, grids, Ls, Rs)
+    return _multilinear_sum(data, stencils, inv_hs, αs, ops, Val(N))
 end
 
 """
@@ -85,9 +82,9 @@ function _linear_interp_nd_oneshot_batch!(
         end
         q_eval = _handle_all_extraps(query_k, grids, extraps_eff)
         stencils, Ls, Rs = _search_all_intervals_stencil(q_eval, grids, policies, hints, bcs)
-        hs = map(_get_h, grids, Ls, Rs)
-        αs = map(_alpha_of, q_eval, Ls, hs)
-        output[k] = _multilinear_sum(data, stencils, hs, αs, ops, Val(N))
+        αs = map(_alpha_of, q_eval, Ls, Rs, grids)
+        inv_hs = map(_get_inv_h, grids, Ls, Rs)
+        output[k] = _multilinear_sum(data, stencils, inv_hs, αs, ops, Val(N))
     end
     return output
 end

--- a/test/test_linear.jl
+++ b/test/test_linear.jl
@@ -380,8 +380,11 @@ end
         itp = linear_interp(x, y)
         result = itp.(x_targets)
 
+        # Persistent uses cached `inv_h * α`; oneshot uses direct
+        # `(q-L)/(R-L)`. Both within 1 ULP — tolerance allows the
+        # documented design difference.
         expected_3arg = linear_interp(x, y, x_targets)
-        @test result == expected_3arg
+        @test result ≈ expected_3arg rtol = 4 * eps(Float64)
     end
 
     @testset "Type stability" begin

--- a/test/test_linear.jl
+++ b/test/test_linear.jl
@@ -384,8 +384,9 @@ end
         result = itp.(x_targets)
 
         # Persistent uses cached `inv_h * α`; oneshot uses direct
-        # `(q-L)/(R-L)`. Both within 1 ULP — tolerance allows the
-        # documented design difference.
+        # `(q-L)/(R-L)`. They can differ by a few ULPs at right knots
+        # — tolerance permits this documented design difference
+        # (rtol = 4*eps) while still catching real correctness regressions.
         expected_3arg = linear_interp(x, y, x_targets)
         @test result ≈ expected_3arg rtol = 4 * eps(Float64)
     end

--- a/test/test_linear.jl
+++ b/test/test_linear.jl
@@ -337,9 +337,12 @@ end
         result2 = itp.(rho2)
         result3 = itp(rho3)
 
-        @test result1 == linear_interp(x, y, rho1; extrap = ExtendExtrap())
-        @test result2 == linear_interp(x, y, rho2; extrap = ExtendExtrap())
-        @test result3 == linear_interp(x, y, rho3; extrap = ExtendExtrap())
+        # Persistent (cached `inv_h * α`) vs oneshot (direct division) may
+        # differ by 1 ULP at right knots — same documented trade-off as
+        # the Non-uniform grid test.
+        @test result1 ≈ linear_interp(x, y, rho1; extrap = ExtendExtrap()) rtol = 4 * eps(Float64)
+        @test result2 ≈ linear_interp(x, y, rho2; extrap = ExtendExtrap()) rtol = 4 * eps(Float64)
+        @test result3 ≈ linear_interp(x, y, rho3; extrap = ExtendExtrap()) rtol = 4 * eps(Float64)
     end
 
     @testset "Extrapolation :extension" begin

--- a/test/test_random_grid.jl
+++ b/test/test_random_grid.jl
@@ -67,10 +67,12 @@
             @test val isa Float64
             @test isfinite(val)
 
-            # Broadcast
+            # Broadcast — persistent (cached `inv_h * α`) vs oneshot
+            # (direct `(q-L)/(R-L)`) may differ by 1 ULP at right knots;
+            # same trade-off as `test_linear.jl` Non-uniform grid case.
             x_query = [x_min + 0.5, (x_min + x_max) / 2, x_max - 0.5]
             result = itp.(x_query)
-            @test result == linear_interp(x_random, y, x_query)
+            @test result ≈ linear_interp(x_random, y, x_query) rtol = 4 * eps(Float64)
         end
 
         @testset "Zero-allocation (scalar)" begin


### PR DESCRIPTION
## Summary

- Reshape Linear interpolation kernels (1D + ND) so α and `inv_h` are
  computed as independent expressions at call sites.
- LLVM dead-code-eliminates the unused side per evaluation op:
  EvalValue uses α only (inv_h DCE'd); EvalDeriv1 uses inv_h only (α DCE'd).
- Plain `AbstractVector` oneshot grids: direct `(q-L)/(R-L)` to avoid
  the `inv()*α` round-trip; cached grids reuse precomputed `inv_h`.
- 1D persistent path now wires `LinearInterpolant.spacing` (was unused) so
  it benefits from cached `inv_h * α` like the ND persistent path —
  consistent oneshot/persistent split across 1D and ND.

## Core changes

### 1. ND multilinear (`linear_nd_eval.jl` / `linear_nd_oneshot.jl`)
- Kernel `_multilinear_sum(data, stencils, inv_hs, αs, ops, Val(N))`: takes
  `inv_hs` directly. EvalDeriv1 weights become `±inv_h` (one less `inv()`
  per derivative axis).
- `_alpha_of` reshape: 3-arg `(q, L, inv_h)` for persistent path (caller
  pulls cached `inv_h`); 4-arg `(q, L, R, grid)` overloads on `_CachedRange`
  (cached × mul) and plain `AbstractVector` (direct division).
- Inlined `_multilinear_sum_body` helper into the @generated body
  (single caller, no value in indirection).

### 2. 1D linear (`linear_kernels.jl` + 3 call-site files)
- Kernel signature: `(op, yL, yR, inv_h, dL)` → `(op, yL, yR, inv_h, α)`.
  EvalValue body simplifies to `muladd(α, yR-yL, yL)` (drops internal
  `α = dL * inv_h`).
- Callers (`linear_oneshot.jl` × 3, `linear_series_interp.jl` × 2,
  `hetero_precomputed_eval.jl` × 1) compute α independently:
  - oneshot: `α = _alpha_of(xq, xL, xR, x)` (grid-type dispatch)
  - series SIMD loop: reads precomputed `aq.alpha` from anchor
  - hetero ND linear branch: `$dL * $inv_h` inline (cached path)

### 3. 1D persistent path wires `LinearInterpolant.spacing`
- `LinearInterpolant.spacing` was already populated at build time but
  `_itp_eval_scalar` / `_itp_vector_loop!` ignored it — persistent calls
  recomputed `R-L` from search results every query.
- New 6-arg `_linear_eval_at_point(x, y, spacing, xq, …)` overloads (3
  extrap variants) read cached `_get_inv_h(spacing, idx)` and use
  `inv_h * α`. New `_linear_vector_loop!` overload threads spacing
  through the batch loop.
- `_itp_eval_scalar` / `_itp_vector_loop!` now pass `itp.spacing` →
  persistent path uses cached reciprocal × multiply (mirrors ND).
- Oneshot 5-arg path is untouched; `linear_interp(x, y, xq)` continues
  to compute `α` via direct `(q-L)/(R-L)` for plain Vector grids
  (exact at knots).

### Numerical contract (intended split)

- **Oneshot path**: exact at every knot — direct division consumes the
  same `(R-L)` from search results.
- **Persistent path** (1D and ND): cached `inv(h)` × `(q-L)` may differ
  by 1 ULP at right knots since `h * inv(h)` ≠ `1.0` exactly in
  floating point. Documented trade-off — perf wins outweigh the ULP
  drift, oneshot remains the exact-knot reference. The Non-uniform
  grid persistent-vs-oneshot equality test now uses `≈ rtol=4*eps`.

## Performance

### ND (3-run mean, master vs HEAD)

| Path | master | HEAD | Δ |
|---|---:|---:|--:|
| 2D persistent Range batch (1k) | 4.738 μs | 4.510 μs | **−4.8%** |
| 2D oneshot Range scalar | 14.860 ns | 14.237 ns | **−4.2%** |
| 2D oneshot Range batch (1k) | 4.270 μs | 4.106 μs | **−3.8%** |
| 3D persistent Range scalar | 8.335 ns | 7.917 ns | **−5.0%** |
| 3D persistent Range batch (1k) | 8.000 μs | 7.524 μs | **−5.9%** |
| 3D oneshot Range batch (1k) | 7.917 μs | 7.339 μs | **−7.3%** |
| Vector grid + scalar (other) | — | — | within ±1% noise band |

### 1D (3-run best-of-mins, master vs HEAD)

| Path | master min | HEAD min | Δ |
|---|---:|---:|--:|
| 1D persistent Vector batch (1k) | 7.125 μs | 6.800 μs | **−4.6%** |
| 1D persistent Vector scalar | 9.17 ns | 9.08 ns | **−1.0%** |
| 1D oneshot Vector scalar | 9.17 ns | 9.00 ns | **−1.9%** |
| 1D oneshot Vector batch (1k) | 7.135 μs | 7.000 μs | **−1.9%** |
| 1D persistent Range scalar/batch | 2.67 ns / 1.062 μs | unchanged | 0 (cached either way) |
| 1D oneshot Range scalar/batch | 5.25 ns / 1.062 μs | unchanged / +0.5% | within noise |