### PR TITLE
(refac+perf): Cubic `PeriodicBC(:exclusive)` — zero-copy oneshot + sibling-method alignment

### DIFF
--- a/src/core/bc_types.jl
+++ b/src/core/bc_types.jl
@@ -697,18 +697,6 @@ end
     )
 end
 
-@noinline function _throw_periodic_exclusive_cache()
-    throw(
-        ArgumentError(
-            "CubicSplineCache does not support PeriodicBC(endpoint=:exclusive) because " *
-                "the cache is grid-only and cannot extend data values. " *
-                "Use cubic_interp(x, y, xq; bc=PeriodicBC(endpoint=:exclusive)) or " *
-                "CubicInterpolant(x, y; bc=PeriodicBC(endpoint=:exclusive)) instead."
-        )
-    )
-end
-
-
 # ========================================
 # Cubic BC Type Alias
 # ========================================

--- a/src/core/bc_types.jl
+++ b/src/core/bc_types.jl
@@ -697,6 +697,15 @@ end
     )
 end
 
+@noinline _throw_periodic_exclusive_cache() = throw(
+    ArgumentError(
+        "CubicSplineCache(x; bc=PeriodicBC(endpoint=:exclusive)) direct construction is " *
+            "not supported. Use the public oneshot/persistent APIs " *
+            "(`cubic_interp(x, y, xq; bc=PeriodicBC(endpoint=:exclusive))` or " *
+            "`cubic_interp(x, y; bc=PeriodicBC(endpoint=:exclusive))`) instead."
+    )
+)
+
 # ========================================
 # Cubic BC Type Alias
 # ========================================

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -731,7 +731,7 @@ letting user-facing oneshot entry points use a single, non-misleading call.
 end
 
 """
-    _prepare_periodic_nd(grids, data, bcs) -> (grids_ext, data_ext, bcs_resolved)
+    _prepare_periodic_nd(grids, data, bcs) -> (grids_ext, data_ext, bcs_post_extend)
 
 Prepare N-dimensional grids and data for periodic interpolation.
 
@@ -744,7 +744,12 @@ Called once at build time before `_build_nd_coeffs`.
 # Returns
 - `grids_ext`: Grids with exclusive axes extended (Range type preserved when possible)
 - `data_ext`: Data with first slice appended along each exclusive axis
-- `bcs_resolved`: BCs with resolved period for exclusive axes (for display/introspection)
+- `bcs_post_extend`: Per-axis BCs after extension. Exclusive periodic axes are
+  normalized to `PeriodicBC(:inclusive, check=false)` (period dropped — the
+  extended grid carries the period implicitly as `last(grid_ext) - first(grid_ext)`).
+  Callers that need the period for storage/introspection re-materialize via
+  `_with_resolved_period(bc, last(grid_ext) - first(grid_ext))`. Other axes pass
+  through unchanged.
 """
 function _prepare_periodic_nd(
         grids::NTuple{N, AbstractVector{Tg}},

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -99,11 +99,17 @@ Four-tier dispatch based on element type:
 
 Throws `ArgumentError` if endpoints differ.
 """
-@inline function _check_periodic_endpoints(bc::PeriodicBC, y::AbstractVector)
+@inline function _check_periodic_endpoints(bc::PeriodicBC{:inclusive}, y::AbstractVector)
     periodic_check(bc) || return nothing
     _check_periodic_endpoints(y)
     return nothing
 end
+
+# `:exclusive` form has no endpoint-matching constraint: the user provides n
+# distinct samples and the seam is virtual (constructed from `bc.period`).
+# Calling `_check_periodic_endpoints(y)` on raw exclusive y would falsely
+# reject valid data (e.g., `y = sin.(2π .* x_excl)` where `y[1] ≠ y[n]`).
+@inline _check_periodic_endpoints(::PeriodicBC{:exclusive}, ::AbstractVector) = nothing
 
 @inline function _check_periodic_endpoints(y::AbstractVector{T}) where {T <: AbstractFloat}
     isapprox(first(y), last(y); atol = 8 * eps(T), rtol = sqrt(eps(T))) ||
@@ -797,7 +803,12 @@ end
         grid_ext = grid_d isa AbstractRange ?
             _to_float_adding_endpoint(grid_d, Tg) :
             extend_vector_grid(grid_d, x_end, Tg)
-        return (grid_ext, _with_resolved_period(bc_d, period))
+        # Normalize bc to `:inclusive` post-extension: the extended grid IS a
+        # closed-cycle inclusive form (length n+1, last point at x[1]+period),
+        # so downstream solvers/cache builders should treat it as inclusive.
+        # Without this normalization, BC-aware solvers (e.g. cubic) would
+        # interpret `:exclusive` as "raw n-grid" and miscount the cycle.
+        return (grid_ext, _bc_after_extend(bc_d))
     end
     grids_out = map(first, processed)
     bcs_out = map(last, processed)

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -448,13 +448,15 @@ _extend_values(y::AbstractVector) = vcat(y, first(y))
 
 @inline function WrapExtrap(x::AbstractVector, bc::PeriodicBC{:exclusive, <:Real})
     x_min = first(x)
-    # Route through `_resolve_exclusive_period` so Range grids get the same
-    # `period ≈ step(x) * length(x)` cross-check that persistent paths rely on.
-    # Without this, `linear_interp(range(0,step=0.1,length=10), y, q;
-    # bc=PeriodicBC(:exclusive, period=2.0))` would silently accept a period
-    # that disagrees with the grid's implied period — persistent throws on the
-    # same input, so oneshot must too.
-    period = _resolve_exclusive_period(x, bc)
+    # `_resolve_exclusive_period` returns the user's period as-is; cast to
+    # grid float to keep wrap arithmetic in grid precision. Without this a
+    # `Float64` literal period on a `Float32` grid silently produces a
+    # `WrapExtrap{Float64}`, polluting downstream anchors/weights (codex P2 #1).
+    # Mirrors `_resolve_seam_period` in hermite_periodic_slopes.jl.
+    period_raw = _resolve_exclusive_period(x, bc)
+    Tg_raw = eltype(x)
+    Tg = Tg_raw <: _PromotableValue ? float(Tg_raw) : Tg_raw
+    period = Tg(period_raw)
     x_max = x_min + period
     # Virtual endpoint must lie strictly beyond the last grid point so the seam
     # cell [x[end], x_min+period] is non-empty and the grid covers at most one

--- a/src/cubic/cubic_adjoint.jl
+++ b/src/cubic/cubic_adjoint.jl
@@ -177,10 +177,12 @@ Dispatches on `DerivOp{N}` to select the appropriate weight field from `_CubicAn
         aq = anchors[q]
         yb = y_bar[q]
         wyL, wyR, wzL, wzR = aq.w0
-        f_bar[aq.idx] += wyL * yb
-        f_bar[aq.idx + 1] += wyR * yb
-        z_bar[aq.idx] += wzL * yb
-        z_bar[aq.idx + 1] += wzR * yb
+        idxL = aq.idxL
+        idxR = aq.idxR
+        f_bar[idxL] += wyL * yb
+        f_bar[idxR] += wyR * yb
+        z_bar[idxL] += wzL * yb
+        z_bar[idxR] += wzR * yb
     end
     return nothing
 end
@@ -194,10 +196,12 @@ end
         aq = anchors[q]
         yb = y_bar[q]
         wyL, wyR, wzL, wzR = aq.w1
-        f_bar[aq.idx] += wyL * yb
-        f_bar[aq.idx + 1] += wyR * yb
-        z_bar[aq.idx] += wzL * yb
-        z_bar[aq.idx + 1] += wzR * yb
+        idxL = aq.idxL
+        idxR = aq.idxR
+        f_bar[idxL] += wyL * yb
+        f_bar[idxR] += wyR * yb
+        z_bar[idxL] += wzL * yb
+        z_bar[idxR] += wzR * yb
     end
     return nothing
 end
@@ -211,8 +215,8 @@ end
         aq = anchors[q]
         yb = y_bar[q]
         wzL, wzR = aq.w2
-        z_bar[aq.idx] += wzL * yb
-        z_bar[aq.idx + 1] += wzR * yb
+        z_bar[aq.idxL] += wzL * yb
+        z_bar[aq.idxR] += wzR * yb
     end
     return nothing
 end
@@ -226,8 +230,8 @@ end
         aq = anchors[q]
         yb = y_bar[q]
         wzL, wzR = aq.w3
-        z_bar[aq.idx] += wzL * yb
-        z_bar[aq.idx + 1] += wzR * yb
+        z_bar[aq.idxL] += wzL * yb
+        z_bar[aq.idxR] += wzR * yb
     end
     return nothing
 end
@@ -377,7 +381,7 @@ function _fixup_clampfill_anchors!(
         aq = anchors[i]
         w0_new = keep_w0 ? aq.w0 : (z, z, z, z)
         anchors[i] = _CubicAnchoredQuery{Tg, Tg}(
-            aq.idx, aq.xq, IN_DOMAIN,
+            getfield(aq, :stencil), aq.xq, IN_DOMAIN,
             w0_new, (z, z, z, z), (z, z), (z, z)
         )
     end

--- a/src/cubic/cubic_adjoint.jl
+++ b/src/cubic/cubic_adjoint.jl
@@ -568,7 +568,7 @@ Operates in-place on `z_bar[1:n]`; `z_bar[n+1]` is not touched.
 """
 function _adjoint_periodic_solve!(
         z_bar::AbstractVector{Tv},
-        cache::CubicSplineCache{Tg, X, F, PeriodicData{Tg}, S},
+        cache::CubicSplineCache{Tg, X, F, <:PeriodicData{Tg}, S},
         q_t::AbstractVector,
         n::Int
     ) where {Tv, Tg, X, F, S <: AbstractGridSpacing{Tg}}

--- a/src/cubic/cubic_anchor.jl
+++ b/src/cubic/cubic_anchor.jl
@@ -23,7 +23,10 @@ matches the interpolant grid.
 - `Tq`: Query type (Float or ForwardDiff.Dual for AD support)
 
 # Fields
-- `idx`: Interval index where xq falls
+- `stencil`: `_IdxStencil{2}` carrying the corner pair `(idxL, idxR)`.
+  `idxR == idxL + 1` for non-seam cells; `idxR == 1` at periodic-exclusive
+  seam cells (wrap). Virtual properties `aq.idx` (= `idxL`), `aq.idxL`,
+  and `aq.idxR` are exposed via `getproperty` for ergonomics.
 - `xq`: Original query point (or wrapped value for periodic)
 - `state`: Domain state (`IN_DOMAIN`, `OOB_LEFT`, or `OOB_RIGHT`)
 - `w0`: Precomputed weights for value (wyL, wyR, wzL, wzR)

--- a/src/cubic/cubic_anchor.jl
+++ b/src/cubic/cubic_anchor.jl
@@ -357,9 +357,18 @@ while preserving the full Dual value for weight computation.
     w2 = _compute_anchor_weights(EvalDeriv2(), h, inv_h, dL, dR)
     w3 = _compute_anchor_weights(EvalDeriv3(), h, inv_h, dL, dR)
 
-    # Non-periodic / WrapExtrap path: corner pair is always `(idx, idx+1)` —
-    # no seam wrap. Series oneshot exclusive constructs the anchor directly
-    # with a possibly-wrapped `_IdxPair` (see `_cubic_oneshot_series_periodic!`).
+    # `_anchor_loc` discards `idx_R` from `search_interval`'s 4-tuple, so this
+    # path always assumes `idxR = idxL + 1`. Valid only for:
+    #   - non-periodic queries (no seam dispatch in the searcher),
+    #   - `WrapExtrap` queries (wrap maps into `[first(x), last(x))`, no seam),
+    #   - periodic queries on a *post-extension* (n+1) grid (idxL+1 ≤ n+1).
+    # Periodic-exclusive callers on a raw n-size grid MUST bypass this path
+    # and build the anchor from `search_interval`'s 4-tuple to preserve the
+    # seam pair `(n, 1)` (see `_cubic_oneshot_series_periodic!` /
+    # `_cubic_oneshot_series_periodic_vec!`). The proper long-term fix is the
+    # `_anchor_loc` 4-tuple refactor tracked as MEMORY.md "search_interval
+    # 4-value refactor (PR A)", which would let this path read `idx_R`
+    # directly and eliminate the bypass.
     return _CubicAnchoredQuery(_IdxPair(loc.idx, loc.idx + 1), loc.xq, loc.state, w0, w1, w2, w3, Tg)
 end
 

--- a/src/cubic/cubic_anchor.jl
+++ b/src/cubic/cubic_anchor.jl
@@ -58,7 +58,11 @@ in both `xq` and weight fields, enabling automatic differentiation through
 series interpolant evaluation.
 """
 struct _CubicAnchoredQuery{Tg, Tq <: Real}
-    idx::Int                   # interval index
+    # Corner-index stencil: `stencil[1]` is the left index (idxL), `stencil[2]`
+    # is the right index (idxR). For non-periodic cells `idxR == idxL + 1`; for
+    # periodic-exclusive seam cells `idxR == 1` (wrap). Mirrors `_LinearAnchoredQuery`.
+    # Legacy `aq.idx` accessor is preserved via `getproperty` (= idxL).
+    stencil::_IdxStencil{2}
     xq::Tq                     # query point (possibly wrapped), Float or Dual
     state::UInt8               # IN_DOMAIN / OOB_LEFT / OOB_RIGHT
     w0::NTuple{4, Tq}           # (wyL, wyR, wzL, wzR) for value
@@ -67,12 +71,25 @@ struct _CubicAnchoredQuery{Tg, Tq <: Real}
     w3::NTuple{2, Tq}           # (wzL, wzR) for third deriv - optimized
 end
 
+# Virtual property accessors — legacy `aq.idx` ergonomics + new `aq.idxL`/`aq.idxR`.
+# Val-dispatch (rather than a single `getproperty` with `===` branches) forces
+# per-property compile-time specialization so each lookup inlines to a single
+# `getfield` (+ tuple index for the stencil paths). Avoids the union-typed
+# return that would otherwise box weights/state in hot loops.
+@inline Base.getproperty(aq::_CubicAnchoredQuery, s::Symbol) = _get_cub_prop(aq, Val(s))
+@inline _get_cub_prop(aq::_CubicAnchoredQuery, ::Val{:idx}) = getfield(aq, :stencil)[1]
+@inline _get_cub_prop(aq::_CubicAnchoredQuery, ::Val{:idxL}) = getfield(aq, :stencil)[1]
+@inline _get_cub_prop(aq::_CubicAnchoredQuery, ::Val{:idxR}) = getfield(aq, :stencil)[2]
+@inline _get_cub_prop(aq::_CubicAnchoredQuery, ::Val{s}) where {s} = getfield(aq, s)
+@inline Base.propertynames(::_CubicAnchoredQuery) =
+    (:stencil, :idx, :idxL, :idxR, :xq, :state, :w0, :w1, :w2, :w3)
+
 # Outer constructor: infer Tq from weight element type (not from input xq).
 # When grid is Dual, weights are Dual even if xq is Float64.
 # Widens xq to match weight type for struct consistency.
-@inline function _CubicAnchoredQuery(idx::Int, xq, state::UInt8, w0::NTuple{4, Tw}, w1::NTuple{4, Tw}, w2::NTuple{2, Tw}, w3::NTuple{2, Tw}, ::Type{Tg}) where {Tg, Tw}
+@inline function _CubicAnchoredQuery(stencil::_IdxStencil{2}, xq, state::UInt8, w0::NTuple{4, Tw}, w1::NTuple{4, Tw}, w2::NTuple{2, Tw}, w3::NTuple{2, Tw}, ::Type{Tg}) where {Tg, Tw}
     xq_p = convert(Tw, xq)
-    return _CubicAnchoredQuery{Tg, Tw}(idx, xq_p, state, w0, w1, w2, w3)
+    return _CubicAnchoredQuery{Tg, Tw}(stencil, xq_p, state, w0, w1, w2, w3)
 end
 
 # ========================================
@@ -340,7 +357,10 @@ while preserving the full Dual value for weight computation.
     w2 = _compute_anchor_weights(EvalDeriv2(), h, inv_h, dL, dR)
     w3 = _compute_anchor_weights(EvalDeriv3(), h, inv_h, dL, dR)
 
-    return _CubicAnchoredQuery(loc.idx, loc.xq, loc.state, w0, w1, w2, w3, Tg)
+    # Non-periodic / WrapExtrap path: corner pair is always `(idx, idx+1)` —
+    # no seam wrap. Series oneshot exclusive constructs the anchor directly
+    # with a possibly-wrapped `_IdxPair` (see `_cubic_oneshot_series_periodic!`).
+    return _CubicAnchoredQuery(_IdxPair(loc.idx, loc.idx + 1), loc.xq, loc.state, w0, w1, w2, w3, Tg)
 end
 
 # ========================================
@@ -351,16 +371,19 @@ end
 
 # ─── Kernel: dispatches on DerivOp, returns scalar ───────────────────────────
 
-# EvalValue: Full 4-term dot product
+# EvalValue: Full 4-term dot product. `aq.idxR` carries seam wrap (== 1 at the
+# periodic-exclusive seam, otherwise == idxL + 1) — kernels are oblivious.
 @inline function _cubic_eval_kernel(
         y::AbstractVector, z::AbstractVector,
         aq::_CubicAnchoredQuery, ::EvalValue
     )
     wyL, wyR, wzL, wzR = aq.w0
+    idxL = aq.idxL
+    idxR = aq.idxR
     @inbounds return muladd(
-        wyR, y[aq.idx + 1], muladd(
-            wyL, y[aq.idx],
-            muladd(wzR, z[aq.idx + 1], wzL * z[aq.idx])
+        wyR, y[idxR], muladd(
+            wyL, y[idxL],
+            muladd(wzR, z[idxR], wzL * z[idxL])
         )
     )
 end
@@ -371,10 +394,12 @@ end
         aq::_CubicAnchoredQuery, ::EvalDeriv1
     )
     wyL, wyR, wzL, wzR = aq.w1
+    idxL = aq.idxL
+    idxR = aq.idxR
     @inbounds return muladd(
-        wyR, y[aq.idx + 1], muladd(
-            wyL, y[aq.idx],
-            muladd(wzR, z[aq.idx + 1], wzL * z[aq.idx])
+        wyR, y[idxR], muladd(
+            wyL, y[idxL],
+            muladd(wzR, z[idxR], wzL * z[idxL])
         )
     )
 end
@@ -385,7 +410,7 @@ end
         aq::_CubicAnchoredQuery, ::EvalDeriv2
     )
     wzL, wzR = aq.w2
-    @inbounds return muladd(wzR, z[aq.idx + 1], wzL * z[aq.idx])
+    @inbounds return muladd(wzR, z[aq.idxR], wzL * z[aq.idxL])
 end
 
 # EvalDeriv3: Optimized 2-term (z-only, no y-loads)
@@ -394,7 +419,7 @@ end
         aq::_CubicAnchoredQuery, ::EvalDeriv3
     )
     wzL, wzR = aq.w3
-    @inbounds return muladd(wzR, z[aq.idx + 1], wzL * z[aq.idx])
+    @inbounds return muladd(wzR, z[aq.idxR], wzL * z[aq.idxL])
 end
 
 # DerivOp{N≥4}: zero (N-th derivative of cubic is zero for N ≥ 4)
@@ -402,7 +427,7 @@ end
         y::AbstractVector, ::AbstractVector,
         aq::_CubicAnchoredQuery, ::DerivOp{N}
     ) where {N}
-    return 0 * (@inbounds y[aq.idx])
+    return 0 * (@inbounds y[aq.idxL])
 end
 
 # ─── Extrap dispatch: handles OOB logic ──────────────────────────────────────

--- a/src/cubic/cubic_cache.jl
+++ b/src/cubic/cubic_cache.jl
@@ -45,10 +45,12 @@ function CubicSplineCache(x::AbstractVector{T}; bc::AbstractBC = CubicFit()) whe
     # Normalize early: Range → _CachedRange, Vector → identity.
     x = _to_float(x, T)
 
-    # Periodic BC
+    # Periodic BC. Both `:inclusive` and `:exclusive` are accepted: the cache
+    # builder is BC-aware (see `_build_periodic_cache`) and resolves the cycle
+    # length + seam-cell width per endpoint variant. Exclusive form lets the
+    # oneshot path consume the user's n-size grid without a (n+1) extension copy.
     if _is_periodic_bc(bc)
-        bc isa PeriodicBC{:exclusive} && _throw_periodic_exclusive_cache()
-        return _build_periodic_cache(x)
+        return _build_periodic_cache(x, bc)
     end
 
     # Normalize BC to BCPair (ZeroCurvBC/ZeroSlopeBC → BCPair, PointBC → symmetric BCPair)

--- a/src/cubic/cubic_cache.jl
+++ b/src/cubic/cubic_cache.jl
@@ -45,11 +45,14 @@ function CubicSplineCache(x::AbstractVector{T}; bc::AbstractBC = CubicFit()) whe
     # Normalize early: Range → _CachedRange, Vector → identity.
     x = _to_float(x, T)
 
-    # Periodic BC. Both `:inclusive` and `:exclusive` are accepted: the cache
-    # builder is BC-aware (see `_build_periodic_cache`) and resolves the cycle
-    # length + seam-cell width per endpoint variant. Exclusive form lets the
-    # oneshot path consume the user's n-size grid without a (n+1) extension copy.
+    # Periodic BC. Direct construction with `:exclusive` is rejected at the
+    # public surface — the eval kernel for cache-direct usage
+    # (`cubic_interp!(out, cache, y, xq)`) does not thread BC into the searcher,
+    # so seam-cell queries would silently mis-evaluate. The internal cache pool
+    # (`_get_cubic_cache(x, bc, ...)`) handles `:exclusive` correctly when used
+    # via the public `cubic_interp(x, y, ...; bc=...)` oneshot/persistent APIs.
     if _is_periodic_bc(bc)
+        bc isa PeriodicBC{:exclusive} && _throw_periodic_exclusive_cache()
         return _build_periodic_cache(x, bc)
     end
 

--- a/src/cubic/cubic_cache_pool.jl
+++ b/src/cubic/cubic_cache_pool.jl
@@ -72,7 +72,7 @@ mutable struct CacheEntry{T <: AbstractFloat, L <: PointBC, R <: PointBC, X <: A
 end
 
 """
-    PeriodicCacheEntry{T, X, S}
+    PeriodicCacheEntry{T, X, S, E}
 
 Cache entry for periodic BC (uses PeriodicData).
 
@@ -80,6 +80,10 @@ Cache entry for periodic BC (uses PeriodicData).
 - `T`: Float type (Float32 or Float64)
 - `X`: Grid type (Vector{T} or StepRangeLen)
 - `S`: Grid spacing type (ScalarSpacing{T} or VectorSpacing{T})
+- `E`: Endpoint variant (`:inclusive` or `:exclusive`) — encoded so the bank
+  registry holds *separate* banks per variant. The cache content (Sherman-
+  Morrison `q`, period, seam-cell width) differs between variants on the same
+  grid object, so cache lookup must be partitioned to avoid mixing them.
 
 # Fields
 - `id::UInt`: objectid of the ORIGINAL input x (hint for fast lookup)
@@ -89,10 +93,10 @@ Cache entry for periodic BC (uses PeriodicData).
 # Mutation Safety
 See `CacheEntry` documentation for details on mutation safety pattern.
 """
-mutable struct PeriodicCacheEntry{T <: AbstractFloat, X <: AbstractVector{T}, S <: AbstractGridSpacing{T}} <: AbstractCacheEntry{T, X}
+mutable struct PeriodicCacheEntry{T <: AbstractFloat, X <: AbstractVector{T}, S <: AbstractGridSpacing{T}, E} <: AbstractCacheEntry{T, X}
     id::UInt
     x::X
-    cache::CubicSplineCache{T, X, ThomasFactorization{T, Vector{T}}, PeriodicData{T}, S}
+    cache::CubicSplineCache{T, X, ThomasFactorization{T, Vector{T}}, PeriodicData{T, E}, S}
 end
 
 # ===============================================================
@@ -351,16 +355,21 @@ end
 @inline _get_derivative_bank(x::AbstractVector, bc::BCPair) = _get_derivative_bank(typeof(x), bc)
 
 """
-Get or create a periodic BC cache bank for the given (T, X, S) combination.
+Get or create a periodic BC cache bank for the given (T, X, S, E) combination.
 Accepts Type{X} to avoid needing an instance (eliminates collect() for views).
+
+`E` (`:inclusive`/`:exclusive`) is encoded in the entry type so inclusive and
+exclusive caches for the same grid object live in *different* banks — their
+cache contents (cycle length, seam-cell width, Sherman-Morrison `q`) differ.
 """
-@inline function _get_periodic_bank(::Type{X}) where {T <: AbstractFloat, X <: AbstractVector{T}}
+@inline function _get_periodic_bank(::Type{X}, ::Val{E}) where {T <: AbstractFloat, X <: AbstractVector{T}, E}
     S = _spacing_type(X)
-    EntryType = PeriodicCacheEntry{T, X, S}
+    EntryType = PeriodicCacheEntry{T, X, S, E}
     return _get_bank(_PERIODIC_REGISTRY, CacheBank{EntryType})
 end
 # Instance convenience: forward to Type dispatch
-@inline _get_periodic_bank(x::AbstractVector) = _get_periodic_bank(typeof(x))
+@inline _get_periodic_bank(::Type{X}, ::PeriodicBC{E}) where {X, E} = _get_periodic_bank(X, Val(E))
+@inline _get_periodic_bank(x::AbstractVector, bc::PeriodicBC) = _get_periodic_bank(typeof(x), bc)
 
 # ===============================================================
 # Internal: RCU Lookup (Lock-Free Read Path)
@@ -431,14 +440,17 @@ end
     return _build_derivative_bc_cache(_to_float(x, T), bc.left, bc.right)
 end
 
-# Build cache for periodic BC entry
-@inline function _build_cache(::Type{<:PeriodicCacheEntry{T}}, x::AbstractVector{T}, ::Nothing) where {T <: AbstractFloat}
-    return _build_periodic_cache(x)
+# Build cache for periodic BC entry. The `bc::PeriodicBC{E}` argument is required
+# (not optional `Nothing`) because cache content is BC-form-dependent: cycle
+# length, period, and seam-cell width all differ between `:inclusive` and
+# `:exclusive`. The entry's E type-param matches `bc`'s E by dispatch.
+@inline function _build_cache(::Type{<:PeriodicCacheEntry{T, X, S, E}}, x::AbstractVector{T}, bc::PeriodicBC{E}) where {T <: AbstractFloat, X, S, E}
+    return _build_periodic_cache(x, bc)
 end
 
 # Non-AbstractFloat Real input: convert to float for periodic cache.
-@inline function _build_cache(::Type{<:PeriodicCacheEntry{T}}, x::AbstractVector, ::Nothing) where {T <: AbstractFloat}
-    return _build_periodic_cache(_to_float(x, T))
+@inline function _build_cache(::Type{<:PeriodicCacheEntry{T, X, S, E}}, x::AbstractVector, bc::PeriodicBC{E}) where {T <: AbstractFloat, X, S, E}
+    return _build_periodic_cache(_to_float(x, T), bc)
 end
 
 # ---------------------------------------------------------------
@@ -529,9 +541,10 @@ not RHS values (y-data + BC values).
 """
 @inline function _get_cubic_cache(x; bc::AbstractBC = CubicFit())
     xp = _prepare_grid(x)
-    # Handle periodic BC
-    if _is_periodic_bc(bc)
-        return _get_periodic_cache_impl(xp)
+    # Handle periodic BC. `bc` carries the endpoint variant (E type-param) which
+    # the periodic pool uses to partition inclusive/exclusive caches.
+    if bc isa PeriodicBC
+        return _get_periodic_cache_impl(xp, bc)
     end
 
     # Normalize BC to BCPair and route to cache
@@ -560,8 +573,8 @@ end
     return _get_derivative_cache_impl(_prepare_grid(x), BCPair(Deriv1(zero(FT)), Deriv1(zero(FT))))
 end
 
-@inline function _get_cubic_cache(x, ::PeriodicBC)
-    return _get_periodic_cache_impl(_prepare_grid(x))
+@inline function _get_cubic_cache(x, bc::PeriodicBC)
+    return _get_periodic_cache_impl(_prepare_grid(x), bc)
 end
 
 # BCPair: convert to cache-compatible form, route to cache impl.
@@ -662,37 +675,39 @@ end
 end
 
 """
-Internal implementation for periodic BC cache lookup.
+Internal implementation for periodic BC cache lookup. `bc` is threaded through
+so `_get_periodic_bank` selects the right E-variant bank (inclusive/exclusive
+caches partition into separate banks — see `PeriodicCacheEntry`).
 """
-@inline function _get_periodic_cache_impl(x::AbstractVector{T}) where {T <: AbstractFloat}
-    bank = _get_periodic_bank(Vector{T})
-    return _lookup_or_insert!(bank, x, nothing)
+@inline function _get_periodic_cache_impl(x::AbstractVector{T}, bc::PeriodicBC) where {T <: AbstractFloat}
+    bank = _get_periodic_bank(Vector{T}, bc)
+    return _lookup_or_insert!(bank, x, bc)
 end
 
 # _CachedRange: bank keyed on _CachedRange{T}.
-@inline function _get_periodic_cache_impl(x::_CachedRange{T}) where {T <: AbstractFloat}
-    bank = _get_periodic_bank(_CachedRange{T})
-    return _lookup_or_insert!(bank, x, nothing)
+@inline function _get_periodic_cache_impl(x::_CachedRange{T}, bc::PeriodicBC) where {T <: AbstractFloat}
+    bank = _get_periodic_bank(_CachedRange{T}, bc)
+    return _lookup_or_insert!(bank, x, bc)
 end
 
 # AbstractRange fallback: normalize via _to_float → _CachedRange dispatch above.
-@inline function _get_periodic_cache_impl(x::AbstractRange{T}) where {T <: AbstractFloat}
-    return _get_periodic_cache_impl(_to_float(x, T))
+@inline function _get_periodic_cache_impl(x::AbstractRange{T}, bc::PeriodicBC) where {T <: AbstractFloat}
+    return _get_periodic_cache_impl(_to_float(x, T), bc)
 end
 
 # Integer grids: look up in the Float64 bank directly.
-@inline function _get_periodic_cache_impl(x::AbstractVector{T}) where {T <: Integer}
-    bank = _get_periodic_bank(Vector{float(T)})
-    return _lookup_or_insert!(bank, x, nothing)
+@inline function _get_periodic_cache_impl(x::AbstractVector{T}, bc::PeriodicBC) where {T <: Integer}
+    bank = _get_periodic_bank(Vector{float(T)}, bc)
+    return _lookup_or_insert!(bank, x, bc)
 end
 
 # Rational grids: same pattern.
-@inline function _get_periodic_cache_impl(x::AbstractVector{T}) where {T <: Rational}
-    bank = _get_periodic_bank(Vector{float(T)})
-    return _lookup_or_insert!(bank, x, nothing)
+@inline function _get_periodic_cache_impl(x::AbstractVector{T}, bc::PeriodicBC) where {T <: Rational}
+    bank = _get_periodic_bank(Vector{float(T)}, bc)
+    return _lookup_or_insert!(bank, x, bc)
 end
 
 # Duck-typed grids (Dual, etc.): build fresh, no caching.
-@inline function _get_periodic_cache_impl(x::AbstractVector)
-    return _build_periodic_cache(_to_float(x, _cache_float_type(eltype(x))))
+@inline function _get_periodic_cache_impl(x::AbstractVector, bc::PeriodicBC)
+    return _build_periodic_cache(_to_float(x, _cache_float_type(eltype(x))), bc)
 end

--- a/src/cubic/cubic_cache_pool.jl
+++ b/src/cubic/cubic_cache_pool.jl
@@ -430,8 +430,17 @@ end
 # configuration and must produce two distinct caches.
 @inline _verify_cache_match(::Any, ::Any) = true
 @inline function _verify_cache_match(cache::CubicSplineCache, bc::PeriodicBC{:exclusive, P}) where {P}
-    P === Nothing && return true   # Range-inferred period — derived from grid, no mismatch possible
-    return cache.bc_config.period == bc.period
+    # `bc.period === Nothing` means "auto-infer from grid"; the requested
+    # period is `step(x) * length(x)` for Range grids (the only shape allowed
+    # to omit it). Comparing to `cache.bc_config.period` here prevents reusing
+    # a stale cache built with an explicit period that passed the Range
+    # tolerance but does not match the inferred value.
+    requested = if P === Nothing
+        step(cache.x) * length(cache.x)
+    else
+        bc.period
+    end
+    return cache.bc_config.period == requested
 end
 
 # ---------------------------------------------------------------

--- a/src/cubic/cubic_cache_pool.jl
+++ b/src/cubic/cubic_cache_pool.jl
@@ -376,12 +376,20 @@ end
 # ===============================================================
 
 """
-    _rcu_lookup(snap, id, x) -> cache or nothing
+    _rcu_lookup(snap, id, x, bc_config) -> cache or nothing
 
 Lock-free cache lookup on an immutable snapshot.
 Uses 2-pass algorithm with verification:
-- Pass 1: objectid hint match → verify with isequal (catches in-place mutation)
-- Pass 2: isequal fallback (different object, same content)
+- Pass 1: objectid hint match → verify with isequal + `_verify_cache_match`
+  (catches in-place mutation AND BC mismatch)
+- Pass 2: isequal + `_verify_cache_match` fallback (different object, same content)
+
+The `bc_config` argument is the user-supplied BC for the lookup. It is passed to
+`_verify_cache_match` so exclusive periodic caches can additionally check that
+the cached `bc_config.period` matches the requested period — same `x` with two
+distinct explicit periods (or auto-inferred vs explicit) must yield distinct
+caches. For non-periodic / inclusive caches `_verify_cache_match` falls through
+to `true`, so this argument is a no-op in those banks.
 
 # Thread Safety
 - This function is called on an immutable snapshot

--- a/src/cubic/cubic_cache_pool.jl
+++ b/src/cubic/cubic_cache_pool.jl
@@ -392,22 +392,22 @@ Uses 2-pass algorithm with verification:
 Entry stores a snapshot of x (copy for Vector, same for Range).
 Pass 1 verifies content even on objectid match to detect in-place mutation.
 """
-@inline function _rcu_lookup(snap::BankSnapshot{E}, id::UInt, x::X) where {E, X}
+@inline function _rcu_lookup(snap::BankSnapshot{E}, id::UInt, x::X, bc_config) where {E, X}
     store = snap.store
     count = snap.count
 
     # [Pass 1] Identity hint check with verification
     # objectid match is a HINT that this might be the right entry.
     # We MUST verify content because user may have mutated x in-place.
+    # Periodic exclusive caches additionally verify the user-supplied period
+    # against the cached `bc_config.period` (codex P1) — same `x` with two
+    # different explicit periods must yield distinct caches.
     @inbounds for i in 1:count
         entry = store[i]
         if entry.id === id
-            # Verify content matches snapshot (catches in-place mutation)
-            if isequal(entry.x, x)
+            if isequal(entry.x, x) && _verify_cache_match(entry.cache, bc_config)
                 return entry.cache
             end
-            # objectid matched but content differs → mutation detected!
-            # Continue to Pass 2 (might find another entry with matching content)
         end
     end
 
@@ -415,12 +415,23 @@ Pass 1 verifies content even on objectid match to detect in-place mutation.
     # This handles: different object with same content (cache hit)
     @inbounds for i in 1:count
         entry = store[i]
-        if isequal(entry.x, x)
+        if isequal(entry.x, x) && _verify_cache_match(entry.cache, bc_config)
             return entry.cache
         end
     end
 
     return nothing
+end
+
+# BC-aware cache match verification. Default is `true` (objectid + isequal
+# already adequate for non-periodic and inclusive caches). Exclusive periodic
+# caches must additionally check that the user-supplied period matches the
+# cached period — same `x` with two distinct explicit periods is a valid
+# configuration and must produce two distinct caches.
+@inline _verify_cache_match(::Any, ::Any) = true
+@inline function _verify_cache_match(cache::CubicSplineCache, bc::PeriodicBC{:exclusive, P}) where {P}
+    P === Nothing && return true   # Range-inferred period — derived from grid, no mismatch possible
+    return cache.bc_config.period == bc.period
 end
 
 # ---------------------------------------------------------------
@@ -473,7 +484,7 @@ Core lookup/insert logic for CacheBank{E} using RCU pattern.
 
     # === RCU Read Path (Lock-Free) ===
     snap = @atomic :acquire bank.snapshot
-    found = _rcu_lookup(snap, id, x)
+    found = _rcu_lookup(snap, id, x, bc_config)
     found !== nothing && return found
 
     # === RCU Write Path (Lock + Copy-on-Write) ===
@@ -481,7 +492,7 @@ Core lookup/insert logic for CacheBank{E} using RCU pattern.
     try
         # Double-check after acquiring lock
         snap = @atomic :monotonic bank.snapshot
-        found = _rcu_lookup(snap, id, x)
+        found = _rcu_lookup(snap, id, x, bc_config)
         found !== nothing && return found
 
         # Build cache — CubicSplineCache inner constructor handles copy(x)
@@ -618,8 +629,18 @@ end
     if autocache
         return _get_cubic_cache(x_norm, bc)
     else
+        # Bypass the public `CubicSplineCache(x; bc=bc)` outer constructor —
+        # it rejects `:exclusive` PeriodicBC for direct user use, but the
+        # internal `autocache=false` path is safe (oneshot / persistent
+        # callers thread `bc` into the searcher via `_resolve_search`).
         FT = _cache_float_type(eltype(x))
-        return CubicSplineCache(_to_float(x_norm, FT); bc = bc)
+        x_typed = _to_float(x_norm, FT)
+        if _is_periodic_bc(bc)
+            return _build_periodic_cache(x_typed, bc)
+        else
+            bc_normalized = _normalize_bc(bc)
+            return _build_derivative_bc_cache(x_typed, bc_normalized.left, bc_normalized.right)
+        end
     end
 end
 

--- a/src/cubic/cubic_eval.jl
+++ b/src/cubic/cubic_eval.jl
@@ -109,28 +109,19 @@ end
 #
 # Inclusive form: spacing carries all n cells (length(x) - 1 = n), so any
 #   `idx in 1..n` resolves through the standard accessor.
-# Exclusive form: spacing carries only n-1 interior cells; the seam cell
-#   (`idx == length(z)` where `length(z) == n`) reads `h_n` from `bc_config`.
-#   `idx_R == 1` at the seam from the searcher dispatch confirms this is
-#   the wrapped cell, but indexing on `idx > length(spacing entries)` is
-#   simpler and uniform across ScalarSpacing/VectorSpacing.
+# Exclusive form: the cycle length is `n_cells = length(bc.q)` and the seam
+#   cell (`idx == n_cells`) is virtual — its width is `bc.h_n` (computed at
+#   cache build from `period - (last(x) - first(x))`). For ScalarSpacing this
+#   may differ from `step` if the user-supplied period was within the Range
+#   tolerance but not bit-equal to `step * length`.
 @inline _periodic_cell_h(spacing, idx::Int, ::PeriodicData{Tg, :inclusive}) where {Tg} =
     (_get_h(spacing, idx), _get_inv_h(spacing, idx))
 
 @inline function _periodic_cell_h(spacing::AbstractGridSpacing{Tg}, idx::Int, bc::PeriodicData{Tg, :exclusive}) where {Tg}
-    # ScalarSpacing (uniform Range): all cells share `step`; seam_h equals step
-    # for valid exclusive Range input. Return the spacing accessor — uniform.
-    # VectorSpacing: spacing.h has n-1 entries; idx == n is OOB → seam.
-    return idx > _periodic_n_real_cells(spacing) ?
+    return idx == length(bc.q) ?
         (bc.h_n, inv(bc.h_n)) :
         (_get_h(spacing, idx), _get_inv_h(spacing, idx))
 end
-
-# Number of real (spacing-resident) cell widths. For VectorSpacing this is
-# `length(spacing.h)`; for ScalarSpacing (uniform), every index is "real" since
-# the constant step is well-defined for any idx.
-@inline _periodic_n_real_cells(s::ScalarSpacing) = typemax(Int)   # always real (uniform step)
-@inline _periodic_n_real_cells(s::VectorSpacing) = length(s.h)
 
 # ========================================
 # Extrapolation-aware Evaluation

--- a/src/cubic/cubic_eval.jl
+++ b/src/cubic/cubic_eval.jl
@@ -65,18 +65,27 @@ end
     return _cubic_kernel(op, zL, zR, yL, yR, h, inv_h, dL, dR)
 end
 
-"Evaluate periodic cubic spline at a single point with operation dispatch and search policy."
+"""
+Evaluate periodic cubic spline at a single point with operation dispatch and search policy.
+
+`bc_config::PeriodicData{Tg, E}` provides:
+- `period` for query wrap (`_wrap_to_domain`).
+- `h_n` (seam-cell width) — for `:exclusive` form, the spacing object only
+  carries n-1 interior cell widths; the seam cell (`idx == n`) reads from
+  `bc_config.h_n` instead. Inclusive form is unaffected (spacing has the
+  full n cells); the BC-aware accessor below dispatches on `E`.
+"""
 @inline function _eval_cubic_at_point_periodic(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         spacing::AbstractGridSpacing{Tg},
         z::AbstractVector,
         xq::Tq,
-        period::Tg,
+        bc_config::PeriodicData{Tg},
         op::O,
         searcher::S
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
-    xq_wrapped = _wrap_to_domain(xq, first(x), first(x) + period)
+    xq_wrapped = _wrap_to_domain(xq, first(x), first(x) + bc_config.period)
     idx, idx_R, xL, xR = search_interval(searcher, x, spacing, xq_wrapped)
 
     # Compute offset from original xq to preserve AD (adjust for wrapping)
@@ -84,8 +93,7 @@ end
     # wrapping is a discrete operation that AD shouldn't track
     dL = xq_wrapped - xL   # distance from Left endpoint
     dR = xR - xq_wrapped   # distance from Right endpoint
-    h = _get_h(spacing, idx)
-    inv_h = _get_inv_h(spacing, idx)
+    h, inv_h = _periodic_cell_h(spacing, idx, bc_config)
 
     @inbounds begin
         zL = z[idx]
@@ -96,6 +104,33 @@ end
 
     return _cubic_kernel(op, zL, zR, yL, yR, h, inv_h, dL, dR)
 end
+
+# Periodic cell-width accessor — BC-aware via `PeriodicData{Tg, E}` type-param.
+#
+# Inclusive form: spacing carries all n cells (length(x) - 1 = n), so any
+#   `idx in 1..n` resolves through the standard accessor.
+# Exclusive form: spacing carries only n-1 interior cells; the seam cell
+#   (`idx == length(z)` where `length(z) == n`) reads `h_n` from `bc_config`.
+#   `idx_R == 1` at the seam from the searcher dispatch confirms this is
+#   the wrapped cell, but indexing on `idx > length(spacing entries)` is
+#   simpler and uniform across ScalarSpacing/VectorSpacing.
+@inline _periodic_cell_h(spacing, idx::Int, ::PeriodicData{Tg, :inclusive}) where {Tg} =
+    (_get_h(spacing, idx), _get_inv_h(spacing, idx))
+
+@inline function _periodic_cell_h(spacing::AbstractGridSpacing{Tg}, idx::Int, bc::PeriodicData{Tg, :exclusive}) where {Tg}
+    # ScalarSpacing (uniform Range): all cells share `step`; seam_h equals step
+    # for valid exclusive Range input. Return the spacing accessor — uniform.
+    # VectorSpacing: spacing.h has n-1 entries; idx == n is OOB → seam.
+    return idx > _periodic_n_real_cells(spacing) ?
+        (bc.h_n, inv(bc.h_n)) :
+        (_get_h(spacing, idx), _get_inv_h(spacing, idx))
+end
+
+# Number of real (spacing-resident) cell widths. For VectorSpacing this is
+# `length(spacing.h)`; for ScalarSpacing (uniform), every index is "real" since
+# the constant step is well-defined for any idx.
+@inline _periodic_n_real_cells(s::ScalarSpacing) = typemax(Int)   # always real (uniform step)
+@inline _periodic_n_real_cells(s::VectorSpacing) = length(s.h)
 
 # ========================================
 # Extrapolation-aware Evaluation
@@ -193,7 +228,7 @@ end
 
 "Evaluate with BC-aware dispatch (Periodic BC) with search policy."
 @inline function _eval_with_bc(
-        cache::CubicSplineCache{Tg, X, F, PeriodicData{Tg}, S},
+        cache::CubicSplineCache{Tg, X, F, <:PeriodicData{Tg}, S},
         y::AbstractVector{Tv},
         z::AbstractVector,
         xq::Tq,
@@ -201,7 +236,7 @@ end
         op::O,
         searcher::P
     ) where {Tg, Tv, Tq, X, F, S <: AbstractGridSpacing{Tg}, O <: AbstractEvalOp, P <: Searcher}
-    return _eval_cubic_at_point_periodic(cache.x, y, cache.spacing, z, xq, cache.bc_config.period, op, searcher)
+    return _eval_cubic_at_point_periodic(cache.x, y, cache.spacing, z, xq, cache.bc_config, op, searcher)
 end
 
 "Evaluate with BC-aware dispatch (Generic Derivative BC) with search policy."
@@ -239,10 +274,10 @@ end
     end
 end
 
-"Vector loop for Periodic BC with 2-stage optimization. Accepts any Real query type."
+"Vector loop for Periodic BC. Accepts any Real query type."
 @inline function _cubic_vector_loop!(
         output::AbstractVector,
-        cache::CubicSplineCache{Tg, X, F, PeriodicData{Tg}, S},
+        cache::CubicSplineCache{Tg, X, F, <:PeriodicData{Tg}, S},
         y::AbstractVector{Tv},
         z::AbstractVector,
         x_query::AbstractVector{<:Real},
@@ -250,21 +285,16 @@ end
         op::O,
         searcher::P
     ) where {Tg, Tv, X, F, S <: AbstractGridSpacing{Tg}, O <: AbstractEvalOp, P <: Searcher}
-    x_min = first(cache.x)
-    x_max = x_min + cache.bc_config.period
-    qmin, qmax = minimum(x_query), maximum(x_query)
-
-    return if qmin >= x_min && qmax < x_max
-        # Fast path: all queries inside domain
-        @inbounds for k in eachindex(x_query, output)
-            output[k] = _eval_cubic_at_point(cache.x, y, cache.spacing, z, x_query[k], op, searcher)
-        end
-    else
-        # Slow path: per-element wrap
-        period = cache.bc_config.period
-        @inbounds for k in eachindex(x_query, output)
-            output[k] = _eval_cubic_at_point_periodic(cache.x, y, cache.spacing, z, x_query[k], period, op, searcher)
-        end
+    # Use the periodic kernel uniformly: it handles BC-aware seam cell widths
+    # via `bc_config` (essential for `:exclusive` Vector grids where the spacing
+    # only carries n-1 cells and the seam cell width is in `bc_config.h_n`).
+    # `_wrap_to_domain` is a no-op when queries are already in-domain, so the
+    # previous "fast path" optimization (skipping wrap for in-domain queries)
+    # had no measurable benefit and is removed to keep the seam-cell handling
+    # in one place.
+    bc_config = cache.bc_config
+    return @inbounds for k in eachindex(x_query, output)
+        output[k] = _eval_cubic_at_point_periodic(cache.x, y, cache.spacing, z, x_query[k], bc_config, op, searcher)
     end
 end
 

--- a/src/cubic/cubic_interpolant.jl
+++ b/src/cubic/cubic_interpolant.jl
@@ -246,10 +246,13 @@ so the pool memory can be safely reused after this function returns.
     Tz = _output_eltype(eltype(y), eltype(cache.x))
     tmp_z = acquire!(pool, Tz, length(y))
     _solve_system!(tmp_z, cache, y, cache.bc_config)
-    bc_display = _with_resolved_period(bc, cache.bc_config.period)
+    # Normalize stored bc to `:inclusive` (matching cache state) with period
+    # materialized for introspection. Prevents re-extension when this
+    # interpolant is later passed to `cubic_adjoint(itp.cache.x; bc=itp.bc)`.
+    bc_normalized = _with_resolved_period(_bc_after_extend(bc), cache.bc_config.period)
     # Materialize WrapExtrap with the extended grid's span so the struct stores
     # the typed form; kernels never see WrapExtrap{Nothing}.
-    return CubicInterpolant(cache, y, tmp_z, bc_display, WrapExtrap(cache.x), search)
+    return CubicInterpolant(cache, y, tmp_z, bc_normalized, WrapExtrap(cache.x), search)
 end
 
 # ========================================

--- a/src/cubic/cubic_oneshot.jl
+++ b/src/cubic/cubic_oneshot.jl
@@ -131,11 +131,21 @@ AD-compatible: xq is unconstrained to support ForwardDiff.Dual types.
 end
 
 """
-    _cubic_periodic_solve!(pool, x, y, bc, autocache) -> (cache, y_p, z)
+    _cubic_periodic_solve!(pool, x, y, bc, autocache) -> (cache, y_eff, z)
 
-Shared periodic setup: extend exclusive→inclusive grid, then solve tridiagonal system.
-Pool buffers (x_p, y_p, z) are acquired from `pool` — caller's @with_pool scope
-manages their lifetime. Follows the `_create_spacing_pooled(pool, ...)` pattern.
+Shared periodic setup: build BC-aware cache and solve the periodic tridiagonal
+system on the user's grid as-is.
+
+- `:inclusive` input (`length(x) = n+1`, `y[1] ≈ y[end]`): solver consumes the
+  full closed-cycle grid; eval kernel may read `z[n+1]` (mirrored to `z[1]`).
+- `:exclusive` input (`length(x) = n`, virtual seam): solver uses the n-cell
+  cycle directly; the seam-cell width is held in `cache.bc_config.h_n`. No
+  grid extension or memcpy — `_resolve_search`'s seam dispatch handles
+  eval-time wrap (`q ≥ x[n] → idx_R = 1, xR = x[1] + period`).
+
+Pool buffer `z` is acquired from `pool` (caller's `@with_pool` scope manages
+lifetime). `y_eff` returned for caller convenience — same object as `y`
+(caller may bind a separate variable for clarity in the existing API shape).
 """
 @inline function _cubic_periodic_solve!(
         pool::AbstractArrayPool,
@@ -146,21 +156,21 @@ manages their lifetime. Follows the `_create_spacing_pooled(pool, ...)` pattern.
     ) where {Tg, Tv}
     @assert length(x) == length(y) "x and y must have the same length"
 
-    # ── Extend exclusive → inclusive (pool-based, zero-alloc after warmup) ──
-    # Shared helper also calls _check_periodic_endpoints on y_p. `extrap` slot is
-    # vestigial for cubic — the periodic `_eval_with_bc`/`_cubic_vector_loop!`
-    # dispatch ignores the extrap arg — so we pass `WrapExtrap()` and discard
-    # the helper's materialized return to keep this path's stack frame lean
-    # (no 16-byte WrapExtrap{T} bumping LTS allocation measurements).
-    x_p, y_p, _ = _periodic_extend_1d_pooled!(pool, x, y, bc, WrapExtrap())
+    # Inclusive form requires `y[1] ≈ y[end]` (closed-cycle data). Previously
+    # this validation was performed inside `_periodic_extend_1d_pooled!`; with
+    # the zero-copy path skipping that helper, we invoke the check explicitly
+    # here. The dispatch is a no-op for `:exclusive` (which has no endpoint
+    # constraint — virtual seam is constructed from `bc.period`).
+    _check_periodic_endpoints(bc, y)
 
-    # ── Solve periodic tridiagonal system ──
-    cache = _get_cubic_cache(x_p, PeriodicBC(), _effective_autocache(autocache, Tg))
+    # Build cache on the user's grid (BC-aware: `:inclusive` length n+1 OR
+    # `:exclusive` length n). Zero-copy — no `_periodic_extend_1d_pooled!`.
+    cache = _get_cubic_cache(x, bc, _effective_autocache(autocache, Tg))
     Tz = _output_eltype(Tv, eltype(cache.x))
-    z = acquire!(pool, Tz, length(y_p))
-    _solve_system!(z, cache, y_p, cache.bc_config)
+    z = acquire!(pool, Tz, length(y))
+    _solve_system!(z, cache, y, cache.bc_config)
 
-    return cache, y_p, z
+    return cache, y, z
 end
 
 """
@@ -227,7 +237,9 @@ In-place cubic spline interpolation with optional automatic caching.
         search::AbstractSearchPolicy = AutoSearch()
     ) where {Tg, Tv}
     x = _prepare_grid(x)
-    searcher = _resolve_search(x, x_query, search, nothing)
+    # Thread `bc` so PeriodicBC{:exclusive} routes to the seam-aware Searcher
+    # (`search.jl:928`). Non-periodic bc is a no-op via the NoBC default.
+    searcher = _resolve_search(x, x_query, search, nothing, bc)
     # Periodic BC
     if _is_periodic_bc(bc)
         return _cubic_interp_periodic!(output, x, y, x_query, bc, autocache, deriv, searcher)
@@ -373,7 +385,9 @@ function cubic_interp(
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, Tq <: Real}
     x = _prepare_grid(x)
-    searcher = _resolve_search(x, xq, search, hint)
+    # Thread `bc` so PeriodicBC{:exclusive} routes to the seam-aware Searcher
+    # (`search.jl:928`). Non-periodic bc is a no-op via the NoBC default.
+    searcher = _resolve_search(x, xq, search, hint, bc)
     if _is_periodic_bc(bc)
         return _cubic_interp_periodic_scalar(x, y, xq, bc, autocache, deriv, searcher)
     end

--- a/src/cubic/cubic_oneshot_series.jl
+++ b/src/cubic/cubic_oneshot_series.jl
@@ -72,22 +72,13 @@ end
     output[1] = _cubic_eval_kernel(y_p_first, z, aq, op)
 
     # ── Phase 2: Reuse z buffer for remaining series (no grid re-extension) ──
-    # For exclusive BC: y_p_first is a pool buffer of length n+1, safe to overwrite
-    # For inclusive BC: y_p_first IS the user's vector, must NOT mutate it
-    is_exclusive = bc isa PeriodicBC{:exclusive}
-    y_p = if is_exclusive
-        y_p_first  # pool buffer, safe to reuse
-    else
-        acquire!(pool, Tv_out, n_p)  # separate buffer for inclusive BC
-    end
+    # `y_p_first === y1_promoted` (a pool buffer copied from user series 1).
+    # Zero-copy oneshot keeps `length(y_p_first) = n_p` (= n for `:exclusive`,
+    # n+1 for `:inclusive`). Reuse y_p_first as the per-series scratch buffer.
+    y_p = y_p_first
 
     for k in 2:length(output)
-        if is_exclusive
-            @inbounds copyto!(y_p, 1, vecs[k], 1, n)
-            @inbounds y_p[n + 1] = vecs[k][1]
-        else
-            @inbounds copyto!(y_p, 1, vecs[k], 1, n_p)
-        end
+        @inbounds copyto!(y_p, 1, vecs[k], 1, n_p)
         _check_periodic_endpoints(bc, y_p)
         _solve_system!(z, cache, y_p, cache.bc_config)
         @inbounds output[k] = _cubic_eval_kernel(y_p, z, aq, op)
@@ -132,21 +123,16 @@ end
         outputs[1][j] = _cubic_eval_kernel(y_p_first, z, aq_vec[j], op)
     end
 
-    # Phase 2: Reuse z buffer for remaining series
-    is_exclusive = bc isa PeriodicBC{:exclusive}
-    y_p = if is_exclusive
-        y_p_first  # pool buffer, safe to reuse
-    else
-        acquire!(pool, Tv_out, n_p)  # separate buffer for inclusive BC
-    end
+    # Phase 2: Reuse `y1_promoted` (pool buffer of length `n_p`) + z for the
+    # remaining series. `y_p_first === y1_promoted` (zero-copy oneshot returns
+    # the user-typed buffer that was passed in), so it's safe to overwrite.
+    # No `y_p[n+1] = ...` closure write needed: zero-copy `:exclusive` cycle
+    # is `length(y) = n_p = n` (raw), and `:inclusive` already has y[1]≈y[n+1]
+    # in the user-supplied data so copying the full n_p length suffices.
+    y_p = y_p_first
 
     for k in 2:K
-        if is_exclusive
-            @inbounds copyto!(y_p, 1, vecs[k], 1, n)
-            @inbounds y_p[n + 1] = vecs[k][1]
-        else
-            @inbounds copyto!(y_p, 1, vecs[k], 1, n_p)
-        end
+        @inbounds copyto!(y_p, 1, vecs[k], 1, n_p)
         _check_periodic_endpoints(bc, y_p)
         _solve_system!(z, cache, y_p, cache.bc_config)
         @inbounds for j in eachindex(xqs)

--- a/src/cubic/cubic_oneshot_series.jl
+++ b/src/cubic/cubic_oneshot_series.jl
@@ -42,9 +42,17 @@
     return output
 end
 
-# Periodic: extend grid ONCE, then solve+eval per y-vector reusing buffers.
-# Phase 1: _cubic_periodic_solve! for first series → establishes cache, x_p, y_p, z
-# Phase 2: reuse y_p + z for remaining series (only y-data changes, no grid re-extension)
+# Periodic scalar: zero-copy. One search → seam-aware `_IdxPair` anchor → loop
+# solve+eval per series. No grid extension, no `y_p` rebuild.
+#
+# The anchor stores the corner pair `(idxL, idxR)` directly. For inclusive,
+# search returns `(idx, idx+1)`. For exclusive at the seam (xq ≥ x[n]),
+# `search_interval` dispatches to `(n, 1, x[n], x[1] + period)` so the kernel
+# reads `y[1]`/`z[1]` for the wrapped corner — no extension needed.
+#
+# Mirrors `_linear_oneshot_series_periodic!`: wrap query, search once, anchor
+# carries seam pair, K-loop solves and evaluates. Caller passes a bc-threaded
+# `searcher` so the seam dispatch fires for `:exclusive`.
 @inline @with_pool pool function _cubic_oneshot_series_periodic!(
         output::AbstractVector,
         x::AbstractVector{Tg},
@@ -57,36 +65,49 @@ end
     ) where {Tg}
     vecs = _series_vectors(s)
     n = length(x)
-    Tv_out = _value_type(_series_eltype(s), Tg)
+    K = length(output)
 
-    # Promote first series to Tv_out so z/y_p buffers match all series (mixed-type safety)
-    y1_promoted = acquire!(pool, Tv_out, n)
-    copyto!(y1_promoted, 1, first(vecs), 1, n)
+    # `:inclusive` requires `y[1] ≈ y[end]` per series; `:exclusive` is no-op.
+    if bc isa PeriodicBC{:inclusive}
+        @inbounds for k in 1:K
+            _check_periodic_endpoints(bc, vecs[k])
+        end
+    end
 
-    # ── Phase 1: Extend grid + solve first series (establishes cache + x_p) ──
-    cache, y_p_first, z = _cubic_periodic_solve!(pool, x, y1_promoted, bc, autocache)
-    n_p = length(y_p_first)  # inclusive length (n or n+1 depending on BC mode)
+    # Build cache on the user's grid (BC-aware: `_build_periodic_cache`).
+    cache = _get_cubic_cache(x, bc, _effective_autocache(autocache, Tg))
 
-    # Build anchor on the extended (inclusive) grid — once for all series
-    aq = _anchor_query(cache.x, xq, Val(:cubic), true, searcher)
-    output[1] = _cubic_eval_kernel(y_p_first, z, aq, op)
+    # Wrap query + seam-aware search → corner pair (possibly seam-wrapped).
+    extrap_p = _resolve_extrap(NoExtrap(), bc, cache.x, first(vecs))
+    xq_wrapped = _wrap_to_domain(xq, extrap_p)
+    idxL, idxR, xL, xR = search_interval(searcher, cache.x, xq_wrapped)
 
-    # ── Phase 2: Reuse z buffer for remaining series (no grid re-extension) ──
-    # `y_p_first === y1_promoted` (a pool buffer copied from user series 1).
-    # Zero-copy oneshot keeps `length(y_p_first) = n_p` (= n for `:exclusive`,
-    # n+1 for `:inclusive`). Reuse y_p_first as the per-series scratch buffer.
-    y_p = y_p_first
+    # Geometry: `_get_h(::AbstractVector, xL, xR) = xR - xL` works directly
+    # for the seam cell since `xR = x[1] + period` is the period-shifted node.
+    h = _get_h(cache.x, xL, xR)
+    inv_h = _get_inv_h(cache.x, xL, xR)
+    dL = xq_wrapped - xL
+    dR = xR - xq_wrapped
+    w0 = _compute_anchor_weights(EvalValue(), h, inv_h, dL, dR)
+    w1 = _compute_anchor_weights(EvalDeriv1(), h, inv_h, dL, dR)
+    w2 = _compute_anchor_weights(EvalDeriv2(), h, inv_h, dL, dR)
+    w3 = _compute_anchor_weights(EvalDeriv3(), h, inv_h, dL, dR)
+    aq = _CubicAnchoredQuery(_IdxPair(idxL, idxR), xq_wrapped, IN_DOMAIN, w0, w1, w2, w3, eltype(cache.x))
 
-    for k in 2:length(output)
-        @inbounds copyto!(y_p, 1, vecs[k], 1, n_p)
-        _check_periodic_endpoints(bc, y_p)
-        _solve_system!(z, cache, y_p, cache.bc_config)
-        @inbounds output[k] = _cubic_eval_kernel(y_p, z, aq, op)
+    # Solve + eval per series. Both `_solve_system!` and the kernel read `y`
+    # read-only (the periodic solver acquires its own scratch internally),
+    # so we feed `vecs[k]` directly — no per-series copy needed.
+    Tz = _output_eltype(_series_eltype(s), eltype(cache.x))
+    z = acquire!(pool, Tz, n)
+    @inbounds for k in 1:K
+        _solve_system!(z, cache, vecs[k], cache.bc_config)
+        output[k] = _cubic_eval_kernel(vecs[k], z, aq, op)
     end
     return output
 end
 
-# Periodic vector: extend grid once, pre-compute anchors, then solve+eval per series.
+# Periodic vector: zero-copy. Build cache once, pre-fill seam-aware anchors
+# for all queries, then solve+eval per series. No grid extension.
 @inline function _cubic_oneshot_series_periodic_vec!(
         pool::AbstractArrayPool,
         outputs::AbstractVector{<:AbstractVector},
@@ -101,42 +122,49 @@ end
     vecs = _series_vectors(s)
     n = length(x)
     K = n_series(s)
-    Tv_out = _value_type(_series_eltype(s), Tg)
 
-    # Promote first series to Tv_out so z/y_p buffers match all series (mixed-type safety)
-    y1_promoted = acquire!(pool, Tv_out, n)
-    copyto!(y1_promoted, 1, first(vecs), 1, n)
-
-    # Phase 1: Extend grid + solve first series (establishes cache + x_p)
-    cache, y_p_first, z = _cubic_periodic_solve!(pool, x, y1_promoted, bc, autocache)
-    n_p = length(y_p_first)
-
-    # Pre-compute anchors on the extended (inclusive) grid — once for all series
-    # Tq widens when grid is Dual: promote_type(Float64, Dual) = Dual
-    Tq_w = promote_type(Tq, eltype(cache.x))
-    aq_vec = acquire!(pool, _CubicAnchoredQuery{eltype(cache.x), Tq_w}, length(xqs))
-    searcher = _resolve_search(cache.x, xqs, search, nothing)
-    _fill_anchors!(aq_vec, cache.x, xqs, Val(:cubic), true, searcher)
-
-    # Eval first series (already solved)
-    @inbounds for j in eachindex(xqs)
-        outputs[1][j] = _cubic_eval_kernel(y_p_first, z, aq_vec[j], op)
+    # `:inclusive` validation per-series (`:exclusive` no-op).
+    if bc isa PeriodicBC{:inclusive}
+        @inbounds for k in 1:K
+            _check_periodic_endpoints(bc, vecs[k])
+        end
     end
 
-    # Phase 2: Reuse `y1_promoted` (pool buffer of length `n_p`) + z for the
-    # remaining series. `y_p_first === y1_promoted` (zero-copy oneshot returns
-    # the user-typed buffer that was passed in), so it's safe to overwrite.
-    # No `y_p[n+1] = ...` closure write needed: zero-copy `:exclusive` cycle
-    # is `length(y) = n_p = n` (raw), and `:inclusive` already has y[1]≈y[n+1]
-    # in the user-supplied data so copying the full n_p length suffices.
-    y_p = y_p_first
+    cache = _get_cubic_cache(x, bc, _effective_autocache(autocache, Tg))
+    extrap_p = _resolve_extrap(NoExtrap(), bc, cache.x, first(vecs))
 
-    for k in 2:K
-        @inbounds copyto!(y_p, 1, vecs[k], 1, n_p)
-        _check_periodic_endpoints(bc, y_p)
-        _solve_system!(z, cache, y_p, cache.bc_config)
-        @inbounds for j in eachindex(xqs)
-            outputs[k][j] = _cubic_eval_kernel(y_p, z, aq_vec[j], op)
+    # Pre-fill seam-aware anchors. We bypass `_fill_anchors!` (which discards
+    # `idx_R` via `_anchor_loc`) and construct each anchor from the 4-tuple
+    # returned by `search_interval` — `_IdxPair(idxL, idxR)` carries the seam
+    # wrap directly. Searcher is bc-threaded so `:exclusive` dispatches the
+    # `(n, 1, x[n], x[1] + period)` seam tuple.
+    Tg_c = eltype(cache.x)
+    Tq_w = promote_type(Tq, Tg_c)
+    aq_vec = acquire!(pool, _CubicAnchoredQuery{Tg_c, Tq_w}, length(xqs))
+    searcher = _resolve_search(cache.x, xqs, search, nothing, bc)
+    @inbounds for j in eachindex(xqs)
+        xq_wrapped = _wrap_to_domain(xqs[j], extrap_p)
+        idxL, idxR, xL, xR = search_interval(searcher, cache.x, xq_wrapped)
+        h = _get_h(cache.x, xL, xR)
+        inv_h = _get_inv_h(cache.x, xL, xR)
+        dL = xq_wrapped - xL
+        dR = xR - xq_wrapped
+        w0 = _compute_anchor_weights(EvalValue(), h, inv_h, dL, dR)
+        w1 = _compute_anchor_weights(EvalDeriv1(), h, inv_h, dL, dR)
+        w2 = _compute_anchor_weights(EvalDeriv2(), h, inv_h, dL, dR)
+        w3 = _compute_anchor_weights(EvalDeriv3(), h, inv_h, dL, dR)
+        aq_vec[j] = _CubicAnchoredQuery(_IdxPair(idxL, idxR), xq_wrapped, IN_DOMAIN, w0, w1, w2, w3, Tg_c)
+    end
+
+    # Solve per series, eval at all queries. `_solve_system!` reads `y`
+    # read-only (periodic solver acquires its own scratch); kernel reads
+    # `y[idxL]`/`y[idxR]` — both can come straight from `vecs[k]`.
+    Tz = _output_eltype(_series_eltype(s), Tg_c)
+    z = acquire!(pool, Tz, n)
+    @inbounds for k in 1:K
+        _solve_system!(z, cache, vecs[k], cache.bc_config)
+        for j in eachindex(xqs)
+            outputs[k][j] = _cubic_eval_kernel(vecs[k], z, aq_vec[j], op)
         end
     end
     return outputs
@@ -175,7 +203,10 @@ Build cache once → anchor once → solve+eval per y-vector with z-buffer reuse
     K = n_series(s)
     Tg_actual = eltype(x)
     output = Vector{_series_output_type(_output_eltype(_series_eltype(s), Tg_actual), Tq)}(undef, K)
-    searcher = _resolve_search(x, xq, search, hint)
+    # Thread `bc` so PeriodicBC{:exclusive} routes to the seam-aware Searcher
+    # (`search.jl:939`) — required for the zero-copy seam pair in the periodic
+    # series helper. NoBC default keeps non-periodic paths unchanged.
+    searcher = _resolve_search(x, xq, search, hint, bc)
     if _is_periodic_bc(bc)
         _cubic_oneshot_series_periodic!(output, x, s, xq, bc, deriv, autocache, searcher)
         return output
@@ -203,7 +234,8 @@ end
     length(output) == n_series(s) || _throw_series_dim_mismatch(length(output), n_series(s))
     x = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
     _is_periodic_bc(bc) || _check_domain(x, xq, extrap)
-    searcher = _resolve_search(x, xq, search, hint)
+    # Thread `bc` so PeriodicBC{:exclusive} routes to the seam-aware Searcher.
+    searcher = _resolve_search(x, xq, search, hint, bc)
     if _is_periodic_bc(bc)
         _cubic_oneshot_series_periodic!(output, x, s, xq, bc, deriv, autocache, searcher)
         return output

--- a/src/cubic/cubic_oneshot_series.jl
+++ b/src/cubic/cubic_oneshot_series.jl
@@ -82,10 +82,11 @@ end
     xq_wrapped = _wrap_to_domain(xq, extrap_p)
     idxL, idxR, xL, xR = search_interval(searcher, cache.x, xq_wrapped)
 
-    # Geometry: `_get_h(::AbstractVector, xL, xR) = xR - xL` works directly
-    # for the seam cell since `xR = x[1] + period` is the period-shifted node.
-    h = _get_h(cache.x, xL, xR)
-    inv_h = _get_inv_h(cache.x, xL, xR)
+    # `_periodic_cell_h` returns `bc.h_n` at the seam cell (where solver and
+    # eval must agree on width) and the spacing accessor elsewhere. Going
+    # through `_get_h(cache.x, xL, xR)` would skip the seam fixup for
+    # `_CachedRange` since that overload returns the cached `step`.
+    h, inv_h = _periodic_cell_h(cache.spacing, idxL, cache.bc_config)
     dL = xq_wrapped - xL
     dR = xR - xq_wrapped
     w0 = _compute_anchor_weights(EvalValue(), h, inv_h, dL, dR)
@@ -145,8 +146,7 @@ end
     @inbounds for j in eachindex(xqs)
         xq_wrapped = _wrap_to_domain(xqs[j], extrap_p)
         idxL, idxR, xL, xR = search_interval(searcher, cache.x, xq_wrapped)
-        h = _get_h(cache.x, xL, xR)
-        inv_h = _get_inv_h(cache.x, xL, xR)
+        h, inv_h = _periodic_cell_h(cache.spacing, idxL, cache.bc_config)
         dL = xq_wrapped - xL
         dR = xR - xq_wrapped
         w0 = _compute_anchor_weights(EvalValue(), h, inv_h, dL, dR)

--- a/src/cubic/cubic_oneshot_series.jl
+++ b/src/cubic/cubic_oneshot_series.jl
@@ -42,13 +42,32 @@
     return output
 end
 
+# Build a seam-aware cubic anchor for one query against a (possibly raw
+# n-size) periodic cache. Bypasses `_anchor_query_impl` because that helper's
+# `_anchor_loc` discards `idx_R`, so it cannot represent the periodic-exclusive
+# seam pair `(n, 1)`. Search returns the 4-tuple directly; `_periodic_cell_h`
+# supplies the seam-aware width (`bc.h_n` at the seam, spacing accessor
+# elsewhere). Used by both scalar and vector periodic series helpers.
+@inline function _build_periodic_cubic_anchor(
+        cache::CubicSplineCache,
+        xq,
+        extrap_p::AbstractExtrap,
+        searcher::Searcher,
+    )
+    xq_wrapped = _wrap_to_domain(xq, extrap_p)
+    idxL, idxR, xL, xR = search_interval(searcher, cache.x, xq_wrapped)
+    h, inv_h = _periodic_cell_h(cache.spacing, idxL, cache.bc_config)
+    dL = xq_wrapped - xL
+    dR = xR - xq_wrapped
+    w0 = _compute_anchor_weights(EvalValue(), h, inv_h, dL, dR)
+    w1 = _compute_anchor_weights(EvalDeriv1(), h, inv_h, dL, dR)
+    w2 = _compute_anchor_weights(EvalDeriv2(), h, inv_h, dL, dR)
+    w3 = _compute_anchor_weights(EvalDeriv3(), h, inv_h, dL, dR)
+    return _CubicAnchoredQuery(_IdxPair(idxL, idxR), xq_wrapped, IN_DOMAIN, w0, w1, w2, w3, eltype(cache.x))
+end
+
 # Periodic scalar: zero-copy. One search → seam-aware `_IdxPair` anchor → loop
 # solve+eval per series. No grid extension, no `y_p` rebuild.
-#
-# The anchor stores the corner pair `(idxL, idxR)` directly. For inclusive,
-# search returns `(idx, idx+1)`. For exclusive at the seam (xq ≥ x[n]),
-# `search_interval` dispatches to `(n, 1, x[n], x[1] + period)` so the kernel
-# reads `y[1]`/`z[1]` for the wrapped corner — no extension needed.
 #
 # Mirrors `_linear_oneshot_series_periodic!`: wrap query, search once, anchor
 # carries seam pair, K-loop solves and evaluates. Caller passes a bc-threaded
@@ -76,24 +95,8 @@ end
 
     # Build cache on the user's grid (BC-aware: `_build_periodic_cache`).
     cache = _get_cubic_cache(x, bc, _effective_autocache(autocache, Tg))
-
-    # Wrap query + seam-aware search → corner pair (possibly seam-wrapped).
     extrap_p = _resolve_extrap(NoExtrap(), bc, cache.x, first(vecs))
-    xq_wrapped = _wrap_to_domain(xq, extrap_p)
-    idxL, idxR, xL, xR = search_interval(searcher, cache.x, xq_wrapped)
-
-    # `_periodic_cell_h` returns `bc.h_n` at the seam cell (where solver and
-    # eval must agree on width) and the spacing accessor elsewhere. Going
-    # through `_get_h(cache.x, xL, xR)` would skip the seam fixup for
-    # `_CachedRange` since that overload returns the cached `step`.
-    h, inv_h = _periodic_cell_h(cache.spacing, idxL, cache.bc_config)
-    dL = xq_wrapped - xL
-    dR = xR - xq_wrapped
-    w0 = _compute_anchor_weights(EvalValue(), h, inv_h, dL, dR)
-    w1 = _compute_anchor_weights(EvalDeriv1(), h, inv_h, dL, dR)
-    w2 = _compute_anchor_weights(EvalDeriv2(), h, inv_h, dL, dR)
-    w3 = _compute_anchor_weights(EvalDeriv3(), h, inv_h, dL, dR)
-    aq = _CubicAnchoredQuery(_IdxPair(idxL, idxR), xq_wrapped, IN_DOMAIN, w0, w1, w2, w3, eltype(cache.x))
+    aq = _build_periodic_cubic_anchor(cache, xq, extrap_p, searcher)
 
     # Solve + eval per series. Both `_solve_system!` and the kernel read `y`
     # read-only (the periodic solver acquires its own scratch internally),
@@ -134,26 +137,13 @@ end
     cache = _get_cubic_cache(x, bc, _effective_autocache(autocache, Tg))
     extrap_p = _resolve_extrap(NoExtrap(), bc, cache.x, first(vecs))
 
-    # Pre-fill seam-aware anchors. We bypass `_fill_anchors!` (which discards
-    # `idx_R` via `_anchor_loc`) and construct each anchor from the 4-tuple
-    # returned by `search_interval` — `_IdxPair(idxL, idxR)` carries the seam
-    # wrap directly. Searcher is bc-threaded so `:exclusive` dispatches the
-    # `(n, 1, x[n], x[1] + period)` seam tuple.
+    # Pre-fill seam-aware anchors via `_build_periodic_cubic_anchor`.
     Tg_c = eltype(cache.x)
     Tq_w = promote_type(Tq, Tg_c)
     aq_vec = acquire!(pool, _CubicAnchoredQuery{Tg_c, Tq_w}, length(xqs))
     searcher = _resolve_search(cache.x, xqs, search, nothing, bc)
     @inbounds for j in eachindex(xqs)
-        xq_wrapped = _wrap_to_domain(xqs[j], extrap_p)
-        idxL, idxR, xL, xR = search_interval(searcher, cache.x, xq_wrapped)
-        h, inv_h = _periodic_cell_h(cache.spacing, idxL, cache.bc_config)
-        dL = xq_wrapped - xL
-        dR = xR - xq_wrapped
-        w0 = _compute_anchor_weights(EvalValue(), h, inv_h, dL, dR)
-        w1 = _compute_anchor_weights(EvalDeriv1(), h, inv_h, dL, dR)
-        w2 = _compute_anchor_weights(EvalDeriv2(), h, inv_h, dL, dR)
-        w3 = _compute_anchor_weights(EvalDeriv3(), h, inv_h, dL, dR)
-        aq_vec[j] = _CubicAnchoredQuery(_IdxPair(idxL, idxR), xq_wrapped, IN_DOMAIN, w0, w1, w2, w3, Tg_c)
+        aq_vec[j] = _build_periodic_cubic_anchor(cache, xqs[j], extrap_p, searcher)
     end
 
     # Solve per series, eval at all queries. `_solve_system!` reads `y`

--- a/src/cubic/cubic_solver.jl
+++ b/src/cubic/cubic_solver.jl
@@ -99,25 +99,54 @@ end
 # Cache Builders
 # ========================================
 
-"Build cache for periodic cubic spline using Sherman-Morrison formula."
-function _build_periodic_cache(x::AbstractVector{T}) where {T}
-    n = length(x) - 1  # Number of intervals
+"""
+Build cache for periodic cubic spline using Sherman-Morrison formula.
 
-    n >= 3 || throw(ArgumentError("Periodic spline requires at least 4 points"))
+BC-aware: handles both `:inclusive` (length(x) = n+1, y[1] ≈ y[n+1]) and
+`:exclusive` (length(x) = n, virtual seam between x[n] and x[1]+period).
 
-    period = last(x) - first(x)
+For `:exclusive`, the spacing object only carries the n-1 interior cell widths
+— the seam cell width `h_n = period - (last(x) - first(x))` is computed here
+and stored in `PeriodicData.h_n` for solve-time access (see `α` in
+`_solve_cubic_system_periodic!`).
+"""
+function _build_periodic_cache(x::AbstractVector{T}, bc::PeriodicBC) where {T}
+    # Cycle length (number of cells) and seam-cell width depend on the endpoint variant.
+    # Inclusive:  length(x) == n + 1, last cell width is on the spacing object.
+    # Exclusive:  length(x) == n,     seam cell is virtual — width derived from period.
+    if bc isa PeriodicBC{:exclusive}
+        n = length(x)
+        period = _resolve_seam_period(x, bc)
+        h_n = period - (last(x) - first(x))
+        E = :exclusive
+    else
+        n = length(x) - 1
+        period = last(x) - first(x)
+        # spacing built below has cell index 1..n; h_n = last spacing entry.
+        E = :inclusive
+        h_n = zero(T)  # placeholder — assigned after spacing is built
+    end
 
-    # Create spacing object (ScalarSpacing for Range, VectorSpacing for Vector)
+    n >= 3 || throw(ArgumentError("Periodic spline requires at least 3 cells (length(x) >= 4 for inclusive, >= 3 for exclusive)"))
+
+    # Create spacing object (ScalarSpacing for Range, VectorSpacing for Vector).
+    # For exclusive, spacing has n-1 interior cell widths (from x[1..n] differences);
+    # the seam cell width is held in `h_n` separately.
     spacing = _create_spacing(x)
 
-    # Build modified tridiagonal matrix A' for Sherman-Morrison
+    # Inclusive form fills `h_n` from the spacing (last real cell).
+    # Exclusive form already computed `h_n = seam_h` above.
+    if !(bc isa PeriodicBC{:exclusive})
+        h_n = _get_h(spacing, n)
+    end
+
+    # Build modified tridiagonal matrix A' for Sherman-Morrison.
     # CRITICAL: Use Vector allocation (NOT pool!) for persistent arrays
     # These arrays are stored in CubicSplineCache which outlives the function.
     dl = Vector{T}(undef, n - 1)
     d_diag = Vector{T}(undef, n)  # Will become inv_d after factorization
     du = Vector{T}(undef, n - 1)
 
-    h_n = _get_h(spacing, n)
     h_1 = _get_h(spacing, 1)
     d_diag[1] = h_n + 2 * h_1
 
@@ -148,8 +177,9 @@ function _build_periodic_cache(x::AbstractVector{T}) where {T}
     q[n] = one(T)
     _ldiv_tridiagonal_nopiv!(q, thomas)
 
-    # Workspaces (z, y_temp) are allocated from task-local pools at solve time
-    bc_config = PeriodicData(q, period)
+    # Workspaces (z, y_temp) are allocated from task-local pools at solve time.
+    # `E` (Symbol type-param) baked into PeriodicData so RHS dispatch is zero-cost.
+    bc_config = PeriodicData{T, E}(q, period, h_n)
 
     return CubicSplineCache(x, spacing, thomas, bc_config)
 end
@@ -326,11 +356,26 @@ end
 # Periodic RHS function
 # ----------------------------------------
 
-"Compute RHS vector d for periodic cubic spline system in-place."
-@inline function compute_rhs_periodic!(d::AbstractVector, y::AbstractVector, spacing::AbstractGridSpacing{Tg}) where {Tg}
-    n = length(y) - 1
+"""
+    compute_rhs_periodic!(d, y, spacing, bc_config) -> nothing
 
-    # Use spacing accessors
+Compute the n_cells-length RHS vector for the periodic cubic spline system.
+
+BC-aware via `bc_config` type-param dispatch (zero-cost):
+- `PeriodicData{T, :inclusive}`: `length(y) == n_cells + 1` with `y[1] ≈ y[n+1]`.
+  Last cell width comes from the spacing object.
+- `PeriodicData{T, :exclusive}`: `length(y) == n_cells`. Seam-cell width
+  (`bc_config.h_n`) bridges `y[n]` and the cyclic-wrapped `y[1]`.
+
+Interior rows (`2:n_cells-1`) are identical between forms — they reference only
+real (non-seam) cell widths.
+"""
+@inline function compute_rhs_periodic!(
+        d::AbstractVector, y::AbstractVector,
+        spacing::AbstractGridSpacing{Tg}, ::PeriodicData{Tg, :inclusive}
+    ) where {Tg}
+    n = length(y) - 1   # n_cells
+
     @inbounds d[1] = 6 * (y[2] - y[1]) * _get_inv_h(spacing, 1) - 6 * (y[1] - y[end - 1]) * _get_inv_h(spacing, n)
 
     @inbounds for i in 2:(n - 1)
@@ -342,26 +387,53 @@ end
     return nothing
 end
 
+@inline function compute_rhs_periodic!(
+        d::AbstractVector, y::AbstractVector,
+        spacing::AbstractGridSpacing{Tg}, bc_config::PeriodicData{Tg, :exclusive}
+    ) where {Tg}
+    n = length(y)         # n_cells (raw exclusive form)
+    inv_h_n = inv(bc_config.h_n)   # seam-cell width inverse
+
+    # Cyclic indexing at the seam: previous-of-y[1] is y[n]; next-of-y[n] is y[1].
+    @inbounds d[1] = 6 * (y[2] - y[1]) * _get_inv_h(spacing, 1) - 6 * (y[1] - y[n]) * inv_h_n
+
+    @inbounds for i in 2:(n - 1)
+        d[i] = 6 * (y[i + 1] - y[i]) * _get_inv_h(spacing, i) - 6 * (y[i] - y[i - 1]) * _get_inv_h(spacing, i - 1)
+    end
+
+    @inbounds d[n] = 6 * (y[1] - y[n]) * inv_h_n - 6 * (y[n] - y[n - 1]) * _get_inv_h(spacing, n - 1)
+
+    return nothing
+end
+
 # ========================================
 # System Solvers
 # ========================================
 # Scalar Thomas solver moved to: core/thomas_lu_solver.jl
 # - _ldiv_tridiagonal_nopiv!
 
-"Solve periodic cyclic tridiagonal system using Sherman-Morrison formula."
+"""
+Solve periodic cyclic tridiagonal system using Sherman-Morrison formula.
+
+BC-aware: cycle length, seam-cell width, and final z-extension all read from
+`cache.bc_config` (`PeriodicData{Tg, E}`), so this body works uniformly for
+both `:inclusive` (length(y) = n+1) and `:exclusive` (length(y) = n).
+"""
 @inline function _solve_cubic_system_periodic!(
         z_workspace::AbstractVector,
         y_temp::AbstractVector,
-        cache::CubicSplineCache{Tg, X, F, PeriodicData{Tg}, S},
+        cache::CubicSplineCache{Tg, X, F, <:PeriodicData{Tg}, S},
         y::AbstractVector
     ) where {Tg, X, F, S <: AbstractGridSpacing{Tg}}
-    n = length(y) - 1
+    bc_config = cache.bc_config
+    q = bc_config.q
+    n = length(q)   # n_cells (BC-form-agnostic: q is allocated to cycle length in builder)
 
-    compute_rhs_periodic!(y_temp, y, cache.spacing)
+    # RHS: BC-aware via `bc_config` type-param dispatch (compute_rhs_periodic!).
+    compute_rhs_periodic!(y_temp, y, cache.spacing, bc_config)
     _ldiv_tridiagonal_nopiv!(y_temp, cache.thomas)
 
-    α = _get_h(cache.spacing, n)
-    q = cache.bc_config.q
+    α = bc_config.h_n   # seam-cell width baked at cache-build time
 
     vTy = α * (y_temp[1] + y_temp[n])
     vTq = α * (q[1] + q[n])
@@ -387,10 +459,18 @@ end
         z_workspace[i] = y_temp[i] - factor * q[i]
     end
 
-    z_workspace[n + 1] = z_workspace[1]
+    # Inclusive form: eval may read z[n+1] (idx_R can reach n+1 on the inclusive
+    # closed-cycle grid) → mirror z[1] into the trailing slot.
+    # Exclusive form: search seam dispatch returns idx_R = 1 directly (no n+1 access)
+    # and `z_workspace` was allocated to length n, so leave as-is.
+    _finalize_z_periodic_seam!(z_workspace, bc_config)
 
     return z_workspace
 end
+
+@inline _finalize_z_periodic_seam!(z::AbstractVector, ::PeriodicData{Tg, :inclusive}) where {Tg} =
+    (@inbounds z[end] = z[1]; nothing)
+@inline _finalize_z_periodic_seam!(::AbstractVector, ::PeriodicData{Tg, :exclusive}) where {Tg} = nothing
 
 # ========================================
 # Unified System Solver Entry Point
@@ -428,11 +508,13 @@ Tg = grid type, Tv = value type (can be Complex)
 """
 @inline @with_pool pool function _solve_system!(
         out_z::AbstractVector{Tz},
-        cache::CubicSplineCache{Tg, X, F, PeriodicData{Tg}, S},
+        cache::CubicSplineCache{Tg, X, F, <:PeriodicData{Tg}, S},
         y::AbstractVector,
-        ::PeriodicData{Tg}  # Unused, for API consistency with BCPair version
+        ::PeriodicData  # Unused, for API consistency with BCPair version
     ) where {Tz, Tg, X, F, S <: AbstractGridSpacing{Tg}}
-    n = length(y) - 1
+    # Cycle length (number of cells) is BC-form-agnostic: q is allocated to that
+    # length in the cache builder regardless of inclusive/exclusive input form.
+    n = length(cache.bc_config.q)
 
     # Periodic workspaces need n elements (NOT length(y)!)
     # Use pool allocation for zero-allocation hot path

--- a/src/cubic/cubic_solver.jl
+++ b/src/cubic/cubic_solver.jl
@@ -121,11 +121,13 @@ function _build_periodic_cache(x::AbstractVector{T}, bc::PeriodicBC) where {T}
         # Seam cell width must be strictly positive — `period <= last(x) - first(x)`
         # places the virtual endpoint at or before the last grid point, which
         # is geometrically invalid (codex P2.1).
-        h_n > 0 || throw(ArgumentError(
-            "PeriodicBC(endpoint=:exclusive) requires period > (last(x) - first(x)). " *
-                "Got period=$period, grid span=$(last(x) - first(x)), " *
-                "yielding seam cell width h_n=$h_n (must be > 0)."
-        ))
+        h_n > 0 || throw(
+            ArgumentError(
+                "PeriodicBC(endpoint=:exclusive) requires period > (last(x) - first(x)). " *
+                    "Got period=$period, grid span=$(last(x) - first(x)), " *
+                    "yielding seam cell width h_n=$h_n (must be > 0)."
+            )
+        )
         E = :exclusive
     else
         n = length(x) - 1

--- a/src/cubic/cubic_solver.jl
+++ b/src/cubic/cubic_solver.jl
@@ -118,6 +118,14 @@ function _build_periodic_cache(x::AbstractVector{T}, bc::PeriodicBC) where {T}
         n = length(x)
         period = _resolve_seam_period(x, bc)
         h_n = period - (last(x) - first(x))
+        # Seam cell width must be strictly positive — `period <= last(x) - first(x)`
+        # places the virtual endpoint at or before the last grid point, which
+        # is geometrically invalid (codex P2.1).
+        h_n > 0 || throw(ArgumentError(
+            "PeriodicBC(endpoint=:exclusive) requires period > (last(x) - first(x)). " *
+                "Got period=$period, grid span=$(last(x) - first(x)), " *
+                "yielding seam cell width h_n=$h_n (must be > 0)."
+        ))
         E = :exclusive
     else
         n = length(x) - 1

--- a/src/cubic/cubic_types.jl
+++ b/src/cubic/cubic_types.jl
@@ -8,13 +8,28 @@
 # Boundary condition types (AbstractBC, PointBC, Deriv1, Deriv2, BCPair, PeriodicBC) are defined in bc_types.jl
 
 """
-    PeriodicData{T}
+    PeriodicData{T, E}
 
 Pre-computed data for Sherman-Morrison periodic spline solver.
 
+# Type parameters
+- `T`: Element type (Float64, Float32, etc.)
+- `E`: Endpoint variant — `:inclusive` (`length(x) = n+1`, `y[1] ≈ y[n+1]`) or
+  `:exclusive` (`length(x) = n`, virtual seam at `x[1] + period`). Encoded in
+  the type for zero-cost dispatch in `compute_rhs_periodic!` (the only place
+  the formula differs between forms).
+
 # Fields
-- `q::Vector{T}`: Pre-computed A'^{-1} * u vector for Sherman-Morrison formula
-- `period::T`: Period T = x[end] - x[1]
+- `q::Vector{T}`: Pre-computed A'^{-1} * u vector for Sherman-Morrison formula.
+  Length = number of cells in the closed cycle (n_cells).
+- `period::T`: Full cycle length (resolved from grid for `:inclusive`,
+  from `bc.period` for `:exclusive`).
+- `h_n::T`: Width of the seam cell (last cell in the closed cycle).
+  - Inclusive: `h_n = x[n+1] - x[n]`.
+  - Exclusive: `h_n = period - (x[n] - x[1])` (virtual seam between `x[n]` and `x[1]+period`).
+  Stored explicitly so the Sherman-Morrison Schur factor `α = h_n` is available
+  at solve-time without re-deriving it from the spacing object (spacing only
+  carries the n-1 interior cell widths in exclusive form).
 
 # Notes
 For cyclic tridiagonal system A_cyclic = A' + u * v^T, Sherman-Morrison gives:
@@ -25,9 +40,10 @@ where q = A'^{-1} * u is pre-computed and reused for different y vectors.
 Workspaces for the periodic solver are allocated from task-local pools via `@with_pool`,
 not stored in this struct. This eliminates shared mutable state.
 """
-struct PeriodicData{T}
-    q::Vector{T}  # Pre-computed A'^{-1} * u
-    period::T     # x[end] - x[1]
+struct PeriodicData{T, E}
+    q::Vector{T}  # Pre-computed A'^{-1} * u (length = n_cells)
+    period::T     # full cycle length
+    h_n::T        # seam-cell width: x[n+1]-x[n] inclusive, period-(x[n]-x[1]) exclusive
 end
 
 """

--- a/src/cubic/nd/cubic_nd_interpolant.jl
+++ b/src/cubic/nd/cubic_nd_interpolant.jl
@@ -106,14 +106,8 @@ function _build_nd_interpolant(
         searches::NTuple{N, AbstractSearchPolicy},
         ::PreCompute
     ) where {Tg, Tv, N}
-    # Save user's original bcs for storage (pre-extension) — preserves user's
-    # `:exclusive` endpoint for introspection. Solver consumes post-extension
-    # form via the bcs returned below.
-    bcs_orig = bcs
-
-    # Extend grids/data for exclusive periodic axes (build-time only).
-    # After this, all periodic axes are in inclusive-form (length n+1, closed
-    # cycle), and `bcs` is normalized to `:inclusive` accordingly.
+    # Extend grids/data for exclusive periodic axes; bcs are normalized to
+    # `:inclusive` per axis (via `_bc_after_extend` inside the helper).
     grids, data, bcs = _prepare_periodic_nd(grids, data, bcs)
 
     # Per-axis materialization via 2-arg primitive — post-extension, `last(grid) -
@@ -127,16 +121,12 @@ function _build_nd_interpolant(
     # Create spacings (uses @generated to avoid closure boxing for heterogeneous grids)
     spacings = _create_spacings_typed(grids)
 
-    # Normalize BCs for storage — preserve user's original endpoint
-    # (`:exclusive`/`:inclusive`) and bake the resolved period in. Periodic axes
-    # use the post-extension grid span (which equals the resolved period) so
-    # `bc.period` is concrete in the stored interpolant for introspection.
-    # Uses map instead of ntuple so each bc element gets its concrete type
-    # (ntuple indexes with Int → Union return; map dispatches per-element → compile-time branch)
-    bcs_store = map(bcs_orig, grids) do bc, grid
+    # Periodic bcs are already `:inclusive`; materialize period from the
+    # extended grid span for introspection. Non-periodic axes go through
+    # `_normalize_bc` for BCPair/PointBC handling.
+    bcs_store = map(bcs, grids) do bc, grid
         if _is_periodic_bc(bc)
-            period = last(grid) - first(grid)
-            _with_resolved_period(bc, period)
+            _with_resolved_period(bc, last(grid) - first(grid))
         else
             _normalize_bc(bc, first(data))
         end

--- a/src/cubic/nd/cubic_nd_interpolant.jl
+++ b/src/cubic/nd/cubic_nd_interpolant.jl
@@ -106,8 +106,14 @@ function _build_nd_interpolant(
         searches::NTuple{N, AbstractSearchPolicy},
         ::PreCompute
     ) where {Tg, Tv, N}
-    # Extend grids/data for exclusive periodic axes (build-time only)
-    # After this, all periodic axes have inclusive-form data.
+    # Save user's original bcs for storage (pre-extension) — preserves user's
+    # `:exclusive` endpoint for introspection. Solver consumes post-extension
+    # form via the bcs returned below.
+    bcs_orig = bcs
+
+    # Extend grids/data for exclusive periodic axes (build-time only).
+    # After this, all periodic axes are in inclusive-form (length n+1, closed
+    # cycle), and `bcs` is normalized to `:inclusive` accordingly.
     grids, data, bcs = _prepare_periodic_nd(grids, data, bcs)
 
     # Per-axis materialization via 2-arg primitive — post-extension, `last(grid) -
@@ -121,10 +127,13 @@ function _build_nd_interpolant(
     # Create spacings (uses @generated to avoid closure boxing for heterogeneous grids)
     spacings = _create_spacings_typed(grids)
 
-    # Normalize BCs for storage — preserve endpoint and resolved period for periodic axes
+    # Normalize BCs for storage — preserve user's original endpoint
+    # (`:exclusive`/`:inclusive`) and bake the resolved period in. Periodic axes
+    # use the post-extension grid span (which equals the resolved period) so
+    # `bc.period` is concrete in the stored interpolant for introspection.
     # Uses map instead of ntuple so each bc element gets its concrete type
     # (ntuple indexes with Int → Union return; map dispatches per-element → compile-time branch)
-    bcs_store = map(bcs, grids) do bc, grid
+    bcs_store = map(bcs_orig, grids) do bc, grid
         if _is_periodic_bc(bc)
             period = last(grid) - first(grid)
             _with_resolved_period(bc, period)

--- a/src/cubic/nd/cubic_nd_math.jl
+++ b/src/cubic/nd/cubic_nd_math.jl
@@ -281,7 +281,7 @@ function _apply_derivative_bc!(dydx::AbstractVector{Tv}, bc::BCPair, args...) wh
     return nothing
 end
 
-function _apply_derivative_bc!(dydx::AbstractVector{Tv}, bc::PeriodicData{Tg}, args...) where {Tv, Tg}
+function _apply_derivative_bc!(dydx::AbstractVector{Tv}, bc::PeriodicData{Tg, E}, args...) where {Tv, Tg, E}
     # Enforce periodic: dydx[1] == dydx[end]
     avg = inv(Tg(2)) * (dydx[1] + dydx[end])
     @inbounds dydx[1] = avg

--- a/src/hetero/hetero_build.jl
+++ b/src/hetero/hetero_build.jl
@@ -89,6 +89,7 @@ end
         partials::AbstractArray{Tv, NP1},
         grids,
         methods::Tuple{Vararg{AbstractInterpMethod, N}},
+        bcs::Tuple{Vararg{AbstractBC, N}},
         sizes::NTuple{N, Int},
         ::Val{D},
         ::Val{N},
@@ -97,7 +98,7 @@ end
         # Derivative axis: differentiate using compact stride
         stride_d = D == 1 ? 1 : prod(sizes[1:(D - 1)])
         method_d = methods[D]
-        bc_d = _extract_bc(method_d)
+        bc_d = bcs[D]
         @inbounds for p_src_offset in 0:(stride_d - 1)
             p_src = p_src_offset + 1
             p_dst = p_src_offset + stride_d + 1
@@ -110,7 +111,7 @@ end
     # Non-derivative axis (sizes[D]=1): skip — no entries to compute
 
     if D < N
-        _build_nd_partials_dim_hetero!(partials, grids, methods, sizes, Val(D + 1), Val(N))
+        _build_nd_partials_dim_hetero!(partials, grids, methods, bcs, sizes, Val(D + 1), Val(N))
     end
     return partials
 end
@@ -120,19 +121,21 @@ end
 # ========================================
 
 """
-    _compute_nd_partials_hetero!(partials, grids, data, methods, sizes)
+    _compute_nd_partials_hetero!(partials, grids, data, methods, bcs, sizes)
 
 Compute compact partial derivatives for heterogeneous ND interpolation.
 
 Uses mixed-radix indexing: `sizes[d] = 2` for derivative axes, `1` for others.
 Total entries = `prod(sizes)` ≤ 2^N. Non-derivative axes are skipped entirely.
-BCs are extracted from method types only for derivative axes (Cubic/Quadratic).
+
+`bcs` is the per-axis BC tuple from `_prepare_periodic_nd[_pooled]` (post-extension form).
 """
 function _compute_nd_partials_hetero!(
         partials::AbstractArray{Tv, NP1},
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{<:Any, N},
         methods::Tuple{Vararg{AbstractInterpMethod, N}},
+        bcs::Tuple{Vararg{AbstractBC, N}},
         sizes::NTuple{N, Int},
     ) where {Tv, Tg, N, NP1}
     @boundscheck begin
@@ -150,13 +153,13 @@ function _compute_nd_partials_hetero!(
     copyto!(f_partial, data)
 
     # Build up higher-order partials stage by stage
-    _build_nd_partials_dim_hetero!(partials, grids, methods, sizes, Val(1), Val(N))
+    _build_nd_partials_dim_hetero!(partials, grids, methods, bcs, sizes, Val(1), Val(N))
 
     return partials
 end
 
 """
-    _build_nd_coeffs_hetero(grids, Tv, data, methods) -> _HeteroPartials
+    _build_nd_coeffs_hetero(grids, Tv, data, methods, bcs) -> _HeteroPartials
 
 Allocate and compute compact heterogeneous partial derivatives.
 Data is copied into `partials[1, ...]` via `copyto!` which handles type promotion —
@@ -168,6 +171,7 @@ function _build_nd_coeffs_hetero(
         ::Type{Tv},
         data::AbstractArray{<:Any, N},
         methods::Tuple{Vararg{AbstractInterpMethod, N}},
+        bcs::Tuple{Vararg{AbstractBC, N}},
     ) where {Tg, Tv, N}
     sizes = map(_deriv_size, methods)
 
@@ -178,7 +182,7 @@ function _build_nd_coeffs_hetero(
     partials = Array{Tz, N + 1}(undef, n_partials, size(data)...)
 
     # copyto! in _compute_nd_partials_hetero! handles data → Tz promotion
-    _compute_nd_partials_hetero!(partials, grids, data, methods, sizes)
+    _compute_nd_partials_hetero!(partials, grids, data, methods, bcs, sizes)
 
     return _HeteroPartials{Tz, N, N + 1}(partials)
 end

--- a/src/hetero/hetero_interpolant.jl
+++ b/src/hetero/hetero_interpolant.jl
@@ -323,13 +323,13 @@ function _build_hetero_precomputed(
 
     # Extend exclusive periodic axes to inclusive form (same as CubicInterpolantND).
     # Must happen before spacings + partials so the stored grid matches the data.
-    grids_typed, data_ext, _ = _prepare_periodic_nd(grids_typed, data, bcs_periodic)
+    grids_typed, data_ext, bcs_resolved = _prepare_periodic_nd(grids_typed, data, bcs_periodic)
     # Per-axis materialize via 2-arg primitive (post-extension grid-span).
     extraps = map(_resolve_extrap, extraps, grids_typed)
     spacings = _create_spacings_typed(grids_typed)
 
     # Build partials on the (possibly extended) data
-    hetero_partials = _build_nd_coeffs_hetero(grids_typed, Tv, data_ext, methods)
+    hetero_partials = _build_nd_coeffs_hetero(grids_typed, Tv, data_ext, methods, bcs_resolved)
 
     return HeteroInterpolantND{
         Tg, Tv, N,

--- a/src/hetero/hetero_oneshot.jl
+++ b/src/hetero/hetero_oneshot.jl
@@ -28,9 +28,10 @@
     oob_result = _try_fill_oob(query, grids, extraps_val, ops, @inbounds first(data))
     oob_result !== nothing && return oob_result
 
-    # 1. Extend exclusive periodic axes (pool-based)
+    # 1. Extend exclusive periodic axes (pool-based). `bcs_p` is the
+    # post-extension bc tuple, threaded into the build below.
     bcs_periodic = map(_bc_for_periodic_check, methods)
-    grids_p, data_p, _ = _prepare_periodic_nd_pooled(pool, grids, data, bcs_periodic)
+    grids_p, data_p, bcs_p = _prepare_periodic_nd_pooled(pool, grids, data, bcs_periodic)
 
     # 1a. Per-axis materialization: upgrade WrapExtrap{Nothing} → WrapExtrap{T} against
     # the post-extension grid so the downstream eval pipeline never sees the singleton.
@@ -45,7 +46,7 @@
     partials = acquire!(pool, Tz, (n_partials, size(data_p)...))
 
     # 3. Compute heterogeneous partials in-place (reuses build.jl core)
-    _compute_nd_partials_hetero!(partials, grids_p, data_p, methods, sizes)
+    _compute_nd_partials_hetero!(partials, grids_p, data_p, methods, bcs_p, sizes)
 
     # 4. Pool-based spacings
     spacings = _create_spacings_pooled(pool, grids_p)
@@ -82,7 +83,7 @@ end
 
     # Build phase (ONE-TIME)
     bcs_periodic = map(_bc_for_periodic_check, methods)
-    grids_p, data_p, _ = _prepare_periodic_nd_pooled(pool, grids, data, bcs_periodic)
+    grids_p, data_p, bcs_p = _prepare_periodic_nd_pooled(pool, grids, data, bcs_periodic)
 
     # Per-axis materialization against the (possibly extended) grid.
     # Post-extension: grid-span IS the wrap domain → 2-arg primitive per-axis.
@@ -93,7 +94,7 @@ end
     sizes = map(_deriv_size, methods)
     n_partials = prod(sizes)
     partials = acquire!(pool, Tz, (n_partials, size(data_p)...))
-    _compute_nd_partials_hetero!(partials, grids_p, data_p, methods, sizes)
+    _compute_nd_partials_hetero!(partials, grids_p, data_p, methods, bcs_p, sizes)
     spacings = _create_spacings_pooled(pool, grids_p)
 
     # Eval loop (per query)

--- a/test/test_cubic_oneshot_series.jl
+++ b/test/test_cubic_oneshot_series.jl
@@ -156,6 +156,59 @@
         end
     end
 
+    # AD through exclusive PeriodicBC: WrapExtrap's period-cast path and the
+    # seam-aware anchor must preserve `ForwardDiff.Dual` end-to-end. Pin AD
+    # against the analytic derivative reference (single-y `cubic_interp` with
+    # `DerivOp(1)`).
+    @testset "ForwardDiff AD through exclusive PeriodicBC" begin
+        using ForwardDiff
+        x_exc = collect(range(0.0, step = 0.01, length = 100))
+        y1_exc = sin.(2π .* x_exc)
+        y2_exc = cos.(2π .* x_exc)
+        bc_exc = PeriodicBC(endpoint = :exclusive, period = 1.0)
+        f_ad(t) = sum(cubic_interp(x_exc, Series(y1_exc, y2_exc), t; bc = bc_exc))
+
+        for xq in (0.37, 0.95)   # interior + seam
+            grad_ad = ForwardDiff.derivative(f_ad, xq)
+            ref = cubic_interp(x_exc, y1_exc, xq; bc = bc_exc, deriv = DerivOp(1)) +
+                  cubic_interp(x_exc, y2_exc, xq; bc = bc_exc, deriv = DerivOp(1))
+            @test grad_ad ≈ ref atol = 1e-10
+        end
+    end
+
+    # DerivOp through exclusive PeriodicBC at the seam: the seam-aware anchor
+    # carries (idxL=n, idxR=1); each derivative kernel selects different weight
+    # tuples (w1/w2/w3), so a weight-mismatch bug would only surface here.
+    @testset "DerivOp × Series exclusive — seam region" begin
+        x_exc = collect(range(0.0, step = 0.01, length = 100))
+        y1_exc = sin.(2π .* x_exc)
+        y2_exc = cos.(2π .* x_exc)
+        bc_exc = PeriodicBC(endpoint = :exclusive, period = 1.0)
+        for d in (1, 2, 3), xq in (0.991, 0.995, 0.999)
+            op = DerivOp(d)
+            vals = cubic_interp(x_exc, Series(y1_exc, y2_exc), xq; bc = bc_exc, deriv = op)
+            ref1 = cubic_interp(x_exc, y1_exc, xq; bc = bc_exc, deriv = op)
+            ref2 = cubic_interp(x_exc, y2_exc, xq; bc = bc_exc, deriv = op)
+            @test vals[1] ≈ ref1 atol = 1e-9
+            @test vals[2] ≈ ref2 atol = 1e-9
+        end
+    end
+
+    @testset "Zero allocation (in-place vector, exclusive PeriodicBC)" begin
+        function measure(x_exc, y1_exc, y2_exc)
+            s = Series(y1_exc, y2_exc)
+            xqs = [0.05, 0.37, 0.75, 0.95]
+            outputs = [zeros(length(xqs)) for _ in 1:2]
+            bc_exc = PeriodicBC(endpoint = :exclusive, period = 1.0)
+            cubic_interp!(outputs, x_exc, s, xqs; bc = bc_exc)  # warmup
+            return @allocated cubic_interp!(outputs, x_exc, s, xqs; bc = bc_exc)
+        end
+        x_exc = collect(range(0.0, step = 0.01, length = 100))
+        y1_exc = sin.(2π .* x_exc)
+        y2_exc = cos.(2π .* x_exc)
+        @test measure(x_exc, y1_exc, y2_exc) <= ALLOC_THRESHOLD
+    end
+
     # NOTE: Allocation tests use the function-barrier pattern with arguments
     # (rather than closure capture or @testset-local vars) because Test.jl wraps
     # @testset bodies in try/catch, which weakens type inference under @testitem

--- a/test/test_cubic_oneshot_series.jl
+++ b/test/test_cubic_oneshot_series.jl
@@ -89,13 +89,10 @@
         end
     end
 
-    # codex P2.3: The anchor path used by Series oneshot stores only `idx::Int`
-    # and reads `y[aq.idx + 1]`/`z[aq.idx + 1]` in the kernel. With zero-copy
-    # exclusive (n-size data) the seam cell needs `idxR = 1`, but `aq.idx + 1
-    # = n + 1` is OOB / wraps to garbage. These tests pin the seam region for
-    # both scalar and vector Series oneshot. Reference is the single-vector
-    # 1D path which already handles the seam via `search_interval`'s 4-tuple.
-    @testset "PeriodicBC scalar (exclusive) — seam region (codex P2.3)" begin
+    # Pin the seam region for both scalar and vector Series oneshot under
+    # zero-copy exclusive periodic. Reference is the single-vector 1D path,
+    # which routes the seam pair `(n, 1)` through `search_interval`.
+    @testset "PeriodicBC scalar (exclusive) — seam region" begin
         x_exc = collect(range(0.0, step = 0.01, length = 100))
         y1_exc = sin.(2π .* x_exc)
         y2_exc = cos.(2π .* x_exc)
@@ -109,7 +106,31 @@
         end
     end
 
-    @testset "PeriodicBC vector (exclusive) — seam region (codex P2.3)" begin
+    # Float32 grid + Float64 period: `WrapExtrap(x, bc)` must cast the period to
+    # the grid's float type, otherwise OOB-wrapped queries widen to Float64 and
+    # break the preallocated `_CubicAnchoredQuery{Float32, Float32}` buffer.
+    @testset "Float32 grid + Float64 period vector series" begin
+        x32 = collect(range(0.0f0, step = 0.1f0, length = 10))   # Float32, span 0.9
+        # Keep y in Float32 (default `2π` is Float64 → broadcast widens).
+        two_pi = Float32(2π)
+        y1 = sin.(two_pi .* x32)
+        y2 = cos.(two_pi .* x32)
+        @assert eltype(y1) === Float32
+        bc = PeriodicBC(endpoint = :exclusive, period = 1.0)     # Float64 literal
+        # 1.05 is OOB, wraps via the seam-aware WrapExtrap.
+        xqs = Float32[0.05, 1.05]
+        outs = cubic_interp(x32, Series(y1, y2), xqs; bc = bc)
+        @test length(outs) == 2
+        @test eltype(outs[1]) === Float32
+        for j in eachindex(xqs)
+            ref1 = cubic_interp(x32, y1, xqs[j]; bc = bc)
+            ref2 = cubic_interp(x32, y2, xqs[j]; bc = bc)
+            @test outs[1][j] ≈ ref1
+            @test outs[2][j] ≈ ref2
+        end
+    end
+
+    @testset "PeriodicBC vector (exclusive) — seam region" begin
         x_exc = collect(range(0.0, step = 0.01, length = 100))
         y1_exc = sin.(2π .* x_exc)
         y2_exc = cos.(2π .* x_exc)

--- a/test/test_cubic_oneshot_series.jl
+++ b/test/test_cubic_oneshot_series.jl
@@ -101,8 +101,8 @@
             vals = cubic_interp(x_exc, Series(y1_exc, y2_exc), xq; bc = bc_exc)
             ref1 = cubic_interp(x_exc, y1_exc, xq; bc = bc_exc)
             ref2 = cubic_interp(x_exc, y2_exc, xq; bc = bc_exc)
-            @test vals[1] ≈ ref1 atol = 1e-12
-            @test vals[2] ≈ ref2 atol = 1e-12
+            @test vals[1] ≈ ref1 atol = 1.0e-12
+            @test vals[2] ≈ ref2 atol = 1.0e-12
         end
     end
 
@@ -140,8 +140,8 @@
         for j in eachindex(xqs_seam)
             ref1 = cubic_interp(x_exc, y1_exc, xqs_seam[j]; bc = bc_exc)
             ref2 = cubic_interp(x_exc, y2_exc, xqs_seam[j]; bc = bc_exc)
-            @test outs[1][j] ≈ ref1 atol = 1e-12
-            @test outs[2][j] ≈ ref2 atol = 1e-12
+            @test outs[1][j] ≈ ref1 atol = 1.0e-12
+            @test outs[2][j] ≈ ref2 atol = 1.0e-12
         end
     end
 
@@ -171,8 +171,8 @@
         for xq in (0.37, 0.95)   # interior + seam
             grad_ad = ForwardDiff.derivative(f_ad, xq)
             ref = cubic_interp(x_exc, y1_exc, xq; bc = bc_exc, deriv = DerivOp(1)) +
-                  cubic_interp(x_exc, y2_exc, xq; bc = bc_exc, deriv = DerivOp(1))
-            @test grad_ad ≈ ref atol = 1e-10
+                cubic_interp(x_exc, y2_exc, xq; bc = bc_exc, deriv = DerivOp(1))
+            @test grad_ad ≈ ref atol = 1.0e-10
         end
     end
 
@@ -189,8 +189,8 @@
             vals = cubic_interp(x_exc, Series(y1_exc, y2_exc), xq; bc = bc_exc, deriv = op)
             ref1 = cubic_interp(x_exc, y1_exc, xq; bc = bc_exc, deriv = op)
             ref2 = cubic_interp(x_exc, y2_exc, xq; bc = bc_exc, deriv = op)
-            @test vals[1] ≈ ref1 atol = 1e-9
-            @test vals[2] ≈ ref2 atol = 1e-9
+            @test vals[1] ≈ ref1 atol = 1.0e-9
+            @test vals[2] ≈ ref2 atol = 1.0e-9
         end
     end
 

--- a/test/test_cubic_oneshot_series.jl
+++ b/test/test_cubic_oneshot_series.jl
@@ -89,6 +89,41 @@
         end
     end
 
+    # codex P2.3: The anchor path used by Series oneshot stores only `idx::Int`
+    # and reads `y[aq.idx + 1]`/`z[aq.idx + 1]` in the kernel. With zero-copy
+    # exclusive (n-size data) the seam cell needs `idxR = 1`, but `aq.idx + 1
+    # = n + 1` is OOB / wraps to garbage. These tests pin the seam region for
+    # both scalar and vector Series oneshot. Reference is the single-vector
+    # 1D path which already handles the seam via `search_interval`'s 4-tuple.
+    @testset "PeriodicBC scalar (exclusive) — seam region (codex P2.3)" begin
+        x_exc = collect(range(0.0, step = 0.01, length = 100))
+        y1_exc = sin.(2π .* x_exc)
+        y2_exc = cos.(2π .* x_exc)
+        bc_exc = PeriodicBC(endpoint = :exclusive, period = 1.0)
+        for xq in (0.991, 0.995, 0.999)
+            vals = cubic_interp(x_exc, Series(y1_exc, y2_exc), xq; bc = bc_exc)
+            ref1 = cubic_interp(x_exc, y1_exc, xq; bc = bc_exc)
+            ref2 = cubic_interp(x_exc, y2_exc, xq; bc = bc_exc)
+            @test vals[1] ≈ ref1 atol = 1e-12
+            @test vals[2] ≈ ref2 atol = 1e-12
+        end
+    end
+
+    @testset "PeriodicBC vector (exclusive) — seam region (codex P2.3)" begin
+        x_exc = collect(range(0.0, step = 0.01, length = 100))
+        y1_exc = sin.(2π .* x_exc)
+        y2_exc = cos.(2π .* x_exc)
+        bc_exc = PeriodicBC(endpoint = :exclusive, period = 1.0)
+        xqs_seam = [0.991, 0.995, 0.999]  # all in [x[n], x[1]+period) seam cell
+        outs = cubic_interp(x_exc, Series(y1_exc, y2_exc), xqs_seam; bc = bc_exc)
+        for j in eachindex(xqs_seam)
+            ref1 = cubic_interp(x_exc, y1_exc, xqs_seam[j]; bc = bc_exc)
+            ref2 = cubic_interp(x_exc, y2_exc, xqs_seam[j]; bc = bc_exc)
+            @test outs[1][j] ≈ ref1 atol = 1e-12
+            @test outs[2][j] ≈ ref2 atol = 1e-12
+        end
+    end
+
     @testset "PeriodicBC vector in-place" begin
         xqs = [0.1, 0.37, 0.5, 0.9]
         outputs = [zeros(length(xqs)) for _ in 1:2]

--- a/test/test_periodic_exclusive.jl
+++ b/test/test_periodic_exclusive.jl
@@ -552,6 +552,63 @@
             x = range(0.0, step = 0.1, length = 10)
             @test_throws ArgumentError CubicSplineCache(x; bc = PeriodicBC(endpoint = :exclusive))
         end
+
+        @testset "Cache key includes bc.period — distinct periods on same x (codex P1)" begin
+            # Same Vector x called twice with different explicit periods: each
+            # must build/lookup a distinct cache. Pre-fix: bank partitioned by
+            # `(T, X, S, E)` only and `_rcu_lookup` compared `x` only, so the
+            # second call silently hit the first cache and used the stale
+            # period in its bc_config (wrong seam_h, wrong q vector).
+            x = collect([0.0, 0.3, 0.6, 0.85, 1.05, 1.4, 1.85])    # non-uniform
+            y = [0.0, 1.0, 0.5, -0.5, 0.3, 0.8, -0.2]
+            xq = 1.95   # in seam region — sensitive to seam_h
+
+            v1 = cubic_interp(x, y, xq; bc = PeriodicBC(endpoint = :exclusive, period = 2.5))
+            v2 = cubic_interp(x, y, xq; bc = PeriodicBC(endpoint = :exclusive, period = 2.2))
+            v3 = cubic_interp(x, y, xq; bc = PeriodicBC(endpoint = :exclusive, period = 2.5))
+
+            # v1 and v3 should match (same period). v1 vs v2 should differ
+            # (different seam geometry → different result).
+            @test v1 ≈ v3
+            @test !isapprox(v1, v2; atol = 1.0e-6)
+
+            # Direct cache pool inspection — distinct cache objects for distinct periods.
+            c1 = FastInterpolations._get_cubic_cache(x, PeriodicBC(endpoint = :exclusive, period = 2.5))
+            c2 = FastInterpolations._get_cubic_cache(x, PeriodicBC(endpoint = :exclusive, period = 2.2))
+            @test c1.bc_config.period ≈ 2.5
+            @test c2.bc_config.period ≈ 2.2
+            @test c1.bc_config.h_n ≈ 0.65
+            @test c2.bc_config.h_n ≈ 0.35
+        end
+
+        @testset "Reject non-positive seam width (codex P2.1)" begin
+            # Pre-fix: `_build_periodic_cache(x, bc::PeriodicBC{:exclusive})`
+            # computed `h_n = period - (last(x) - first(x))` without checking
+            # `h_n > 0`. Master path threw via `_extend_exclusive`'s
+            # `last(x) < x_end` validation; zero-copy bypass lost that.
+            x = collect([0.0, 0.3, 0.6, 0.85, 1.05, 1.4, 1.85])    # span = 1.85
+            y = sin.(2π .* x ./ 2.0)
+
+            # period == grid span → h_n == 0 → divide by zero in solver
+            @test_throws ArgumentError cubic_interp(x, y, 0.5; bc = PeriodicBC(endpoint = :exclusive, period = 1.85))
+
+            # period < grid span → h_n < 0 → invalid seam geometry
+            @test_throws ArgumentError cubic_interp(x, y, 0.5; bc = PeriodicBC(endpoint = :exclusive, period = 1.5))
+        end
+
+        @testset "autocache=false routes through internal builder (codex P2.2)" begin
+            # Pre-fix: `_get_cubic_cache(x, bc, autocache=false)` routed to
+            # `CubicSplineCache(...; bc=bc)` outer constructor, which (post
+            # commit 7d9b125e) rejects `:exclusive` direct construction. So
+            # the public oneshot API silently broke for `autocache=false`.
+            x = collect(range(0.0, 1.0, length = 11))[1:10]
+            y = sin.(2π .* x)
+            bc = PeriodicBC(endpoint = :exclusive, period = 1.0)
+
+            v_true = cubic_interp(x, y, 0.5; bc = bc, autocache = true)
+            v_false = cubic_interp(x, y, 0.5; bc = bc, autocache = false)
+            @test v_true ≈ v_false
+        end
     end
 
 end

--- a/test/test_periodic_exclusive.jl
+++ b/test/test_periodic_exclusive.jl
@@ -610,7 +610,7 @@
             # Single-y oneshot at interior + seam queries.
             for xq in (0.05, 0.95)
                 @test cubic_interp(r, y, xq; bc = bc) ≈
-                      cubic_interp(v, y, xq; bc = bc) atol = 1.0e-13
+                    cubic_interp(v, y, xq; bc = bc) atol = 1.0e-13
             end
 
             # Series oneshot — scalar.

--- a/test/test_periodic_exclusive.jl
+++ b/test/test_periodic_exclusive.jl
@@ -553,12 +553,10 @@
             @test_throws ArgumentError CubicSplineCache(x; bc = PeriodicBC(endpoint = :exclusive))
         end
 
-        @testset "Cache key includes bc.period — distinct periods on same x (codex P1)" begin
-            # Same Vector x called twice with different explicit periods: each
-            # must build/lookup a distinct cache. Pre-fix: bank partitioned by
-            # `(T, X, S, E)` only and `_rcu_lookup` compared `x` only, so the
-            # second call silently hit the first cache and used the stale
-            # period in its bc_config (wrong seam_h, wrong q vector).
+        @testset "Cache key includes bc.period — distinct periods on same x" begin
+            # Same Vector x with two different explicit periods must produce
+            # two distinct caches: their bc_config.period and seam_h differ,
+            # and a stale cache hit would silently miscompute at the seam.
             x = collect([0.0, 0.3, 0.6, 0.85, 1.05, 1.4, 1.85])    # non-uniform
             y = [0.0, 1.0, 0.5, -0.5, 0.3, 0.8, -0.2]
             xq = 1.95   # in seam region — sensitive to seam_h
@@ -581,11 +579,9 @@
             @test c2.bc_config.h_n ≈ 0.35
         end
 
-        @testset "Reject non-positive seam width (codex P2.1)" begin
-            # Pre-fix: `_build_periodic_cache(x, bc::PeriodicBC{:exclusive})`
-            # computed `h_n = period - (last(x) - first(x))` without checking
-            # `h_n > 0`. Master path threw via `_extend_exclusive`'s
-            # `last(x) < x_end` validation; zero-copy bypass lost that.
+        @testset "Reject non-positive seam width" begin
+            # `period <= last(x) - first(x)` places the virtual endpoint at or
+            # before the last grid point — geometrically invalid. Must throw.
             x = collect([0.0, 0.3, 0.6, 0.85, 1.05, 1.4, 1.85])    # span = 1.85
             y = sin.(2π .* x ./ 2.0)
 
@@ -596,11 +592,74 @@
             @test_throws ArgumentError cubic_interp(x, y, 0.5; bc = PeriodicBC(endpoint = :exclusive, period = 1.5))
         end
 
-        @testset "autocache=false routes through internal builder (codex P2.2)" begin
-            # Pre-fix: `_get_cubic_cache(x, bc, autocache=false)` routed to
-            # `CubicSplineCache(...; bc=bc)` outer constructor, which (post
-            # commit 7d9b125e) rejects `:exclusive` direct construction. So
-            # the public oneshot API silently broke for `autocache=false`.
+        @testset "Range and Vector grids agree at seam with off-bit-equal period" begin
+            # An explicit period that passes the Range tolerance but is not
+            # exactly `step(x) * length(x)` makes `bc.h_n` differ from `step`.
+            # The cubic solver bakes `bc.h_n` into the periodic system; eval
+            # must use the same width at the seam cell. Vector grids already
+            # do (VectorSpacing has only n-1 interior cells, so the seam idx
+            # falls through to `bc.h_n`); Range grids store a uniform
+            # `ScalarSpacing` and previously returned `step` at every idx,
+            # producing a width mismatch with the solver. Pin Range vs Vector
+            # equivalence at seam queries.
+            r = range(0.0, step = 0.1, length = 10)
+            v = collect(r)                        # same grid, Vector form
+            y = sin.(2π .* v)
+            bc = PeriodicBC(endpoint = :exclusive, period = 1.0 + 1.0e-9)
+
+            # Single-y oneshot at interior + seam queries.
+            for xq in (0.05, 0.95)
+                @test cubic_interp(r, y, xq; bc = bc) ≈
+                      cubic_interp(v, y, xq; bc = bc) atol = 1.0e-13
+            end
+
+            # Series oneshot — scalar.
+            for xq in (0.05, 0.95)
+                vals_r = cubic_interp(r, Series(y, y), xq; bc = bc)
+                vals_v = cubic_interp(v, Series(y, y), xq; bc = bc)
+                @test vals_r[1] ≈ vals_v[1] atol = 1.0e-13
+            end
+
+            # Series oneshot — vector queries (covers seam region).
+            xqs = [0.05, 0.5, 0.95]
+            outs_r = cubic_interp(r, Series(y, y), xqs; bc = bc)
+            outs_v = cubic_interp(v, Series(y, y), xqs; bc = bc)
+            for j in eachindex(xqs)
+                @test outs_r[1][j] ≈ outs_v[1][j] atol = 1.0e-13
+            end
+        end
+
+        @testset "Cache key resolves Nothing period for Range grids" begin
+            # `bc.period === Nothing` means "auto-infer from grid"
+            # (`step(x)*length(x)`). The lookup must compare that inferred
+            # value to the cached period — otherwise a previous explicit-period
+            # cache that fell within the Range tolerance is reused incorrectly.
+            FastInterpolations.clear_cubic_cache!()
+            r = range(0.0, step = 0.1, length = 10)   # inferred period = 1.0
+            y = sin.(2π .* collect(r))
+
+            # 1e-9 is within `sqrt(eps(Float64)) ≈ 1.49e-8`, so the explicit
+            # period passes `_resolve_exclusive_period`'s tolerance.
+            period_offset = 1.0e-9
+            bc_explicit = PeriodicBC(endpoint = :exclusive, period = 1.0 + period_offset)
+            bc_inferred = PeriodicBC(endpoint = :exclusive)
+
+            # Seed the bank with the explicit-period cache.
+            cubic_interp(r, y, 0.5; bc = bc_explicit)
+
+            # Auto-infer must produce a cache with the inferred period (1.0),
+            # not the off-by-1e-9 explicit one already in the bank.
+            c_inferred = FastInterpolations._get_cubic_cache(r, bc_inferred)
+            c_explicit = FastInterpolations._get_cubic_cache(r, bc_explicit)
+            @test c_inferred.bc_config.period == 1.0
+            @test c_explicit.bc_config.period == 1.0 + period_offset
+            @test c_inferred !== c_explicit
+        end
+
+        @testset "autocache=false routes through internal builder" begin
+            # `autocache=false` must build an exclusive cache directly. The
+            # public outer `CubicSplineCache` rejects `:exclusive`, so the
+            # autocache=false branch must bypass it.
             x = collect(range(0.0, 1.0, length = 11))[1:10]
             y = sin.(2π .* x)
             bc = PeriodicBC(endpoint = :exclusive, period = 1.0)

--- a/test/test_periodic_exclusive.jl
+++ b/test/test_periodic_exclusive.jl
@@ -543,17 +543,14 @@
             @test itp(1.0f0) isa Float32
         end
 
-        @testset "CubicSplineCache accepts exclusive PeriodicBC (zero-copy)" begin
-            # Previously the cache builder threw ArgumentError because the cache
-            # was grid-only and could not extend data values. With the BC-aware
-            # `_build_periodic_cache(x, bc)`, exclusive form is consumed
-            # directly: cycle length = length(x), seam-cell width derived from
-            # `bc.period`. No data extension required.
+        @testset "CubicSplineCache rejects exclusive PeriodicBC (direct construction)" begin
+            # The internal cache pool handles `:exclusive` correctly via the
+            # public oneshot/persistent APIs. Direct cache construction is
+            # rejected because the cache-direct eval path
+            # (`cubic_interp!(out, cache, y, xq)`) does not thread BC into the
+            # searcher, so seam-cell queries would silently mis-evaluate.
             x = range(0.0, step = 0.1, length = 10)
-            cache = CubicSplineCache(x; bc = PeriodicBC(endpoint = :exclusive))
-            @test cache.bc_config isa FastInterpolations.PeriodicData
-            @test cache.bc_config.period ≈ 1.0
-            @test cache.bc_config.h_n ≈ 0.1                  # seam-cell width = period - (last - first)
+            @test_throws ArgumentError CubicSplineCache(x; bc = PeriodicBC(endpoint = :exclusive))
         end
     end
 

--- a/test/test_periodic_exclusive.jl
+++ b/test/test_periodic_exclusive.jl
@@ -425,42 +425,39 @@
         show(buf, MIME"text/plain"(), sitp)
         @test occursin("Periodic", String(take!(buf)))
 
-        # itp.bc preserves original user-specified BC with resolved period
-        @testset "itp.bc preserves endpoint and resolves period" begin
+        # `itp.bc` is normalized to `:inclusive` post-extension, with period
+        # materialized from the cache for introspection.
+        @testset "itp.bc reflects post-extension `:inclusive` form (period preserved)" begin
             N_bc = 16
             dx_bc = 2π / N_bc
 
-            # Exclusive with explicit period
+            # Exclusive input → normalized to `:inclusive`, period preserved
             x_bc = range(0.0, step = dx_bc, length = N_bc)
             y_bc = sin.(x_bc)
             itp_excl = cubic_interp(collect(x_bc), y_bc; bc = PeriodicBC(endpoint = :exclusive, period = 2π))
-            @test itp_excl.bc isa PeriodicBC{:exclusive}
+            @test itp_excl.bc isa PeriodicBC{:inclusive}
             @test itp_excl.bc.period ≈ 2π
 
-            # Exclusive without period (auto-inferred from Range) — period should still be resolved
+            # Exclusive without period (auto-inferred from Range)
             itp_excl_auto = cubic_interp(x_bc, y_bc; bc = PeriodicBC(endpoint = :exclusive))
-            @test itp_excl_auto.bc isa PeriodicBC{:exclusive}
+            @test itp_excl_auto.bc isa PeriodicBC{:inclusive}
             @test itp_excl_auto.bc.period ≈ 2π
 
-            # show output should reflect exclusive with period
             buf_bc = IOBuffer()
             show(buf_bc, MIME"text/plain"(), itp_excl_auto)
             s = String(take!(buf_bc))
-            @test occursin("exclusive", s)
+            @test occursin("Periodic", s)
             @test occursin("period≈", s)
 
-            # Inclusive — period should also be resolved from grid
+            # Inclusive input — passthrough; period materialized too
             x_incl_bc = range(0.0, step = dx_bc, length = N_bc + 1)
-            y_incl_bc = sin.(x_incl_bc)
-            y_incl_bc[end] = y_incl_bc[1]
+            y_incl_bc = sin.(x_incl_bc); y_incl_bc[end] = y_incl_bc[1]
             itp_incl = cubic_interp(collect(x_incl_bc), y_incl_bc; bc = PeriodicBC())
             @test itp_incl.bc isa PeriodicBC{:inclusive}
             @test itp_incl.bc.period ≈ 2π
 
-            # show output should show period for inclusive too
             show(buf_bc, MIME"text/plain"(), itp_incl)
-            s_incl = String(take!(buf_bc))
-            @test occursin("period≈", s_incl)
+            @test occursin("period≈", String(take!(buf_bc)))
         end
 
         # Also test exclusive series interpolant show
@@ -794,7 +791,7 @@ end
     # ========================================
     # bcs_store preserves endpoint info
     # ========================================
-    @testset "bcs_store preserves endpoint and period" begin
+    @testset "bcs_store reflects post-extension `:inclusive` form" begin
         Nx = 16
         x = range(0.0, step = 2π / Nx, length = Nx)
         y = range(0.0, 1.0, 8)
@@ -805,9 +802,9 @@ end
             bc = (PeriodicBC(endpoint = :exclusive), ZeroCurvBC())
         )
 
-        # Exclusive axis preserves endpoint symbol and resolved period
-        @test itp.bcs[1] isa PeriodicBC{:exclusive}
-        @test itp.bcs[1].period ≈ 2π
+        @test itp.bcs[1] isa PeriodicBC{:inclusive}                   # normalized
+        @test itp.bcs[1].period ≈ 2π                                  # materialized from grid span
+        @test itp.bcs[2] isa BCPair                                    # ZeroCurvBC → BCPair{Deriv2, Deriv2}
     end
 
     # ========================================

--- a/test/test_periodic_exclusive.jl
+++ b/test/test_periodic_exclusive.jl
@@ -546,9 +546,17 @@
             @test itp(1.0f0) isa Float32
         end
 
-        @testset "CubicSplineCache rejects exclusive PeriodicBC" begin
+        @testset "CubicSplineCache accepts exclusive PeriodicBC (zero-copy)" begin
+            # Previously the cache builder threw ArgumentError because the cache
+            # was grid-only and could not extend data values. With the BC-aware
+            # `_build_periodic_cache(x, bc)`, exclusive form is consumed
+            # directly: cycle length = length(x), seam-cell width derived from
+            # `bc.period`. No data extension required.
             x = range(0.0, step = 0.1, length = 10)
-            @test_throws ArgumentError CubicSplineCache(x; bc = PeriodicBC(endpoint = :exclusive))
+            cache = CubicSplineCache(x; bc = PeriodicBC(endpoint = :exclusive))
+            @test cache.bc_config isa FastInterpolations.PeriodicData
+            @test cache.bc_config.period ≈ 1.0
+            @test cache.bc_config.h_n ≈ 0.1                  # seam-cell width = period - (last - first)
         end
     end
 
@@ -593,8 +601,11 @@ end
             @test size(data_out) == (N + 1, 5)
             @test data_out[end, :] ≈ data_out[1, :]      # first slice copied
             @test grids_out[2] === y                      # unchanged reference
-            @test bcs_out[1] isa PeriodicBC{:exclusive}   # preserved endpoint
-            @test bcs_out[1].period ≈ 2π                  # resolved period
+            # Post-extension: bc is normalized to `:inclusive` (grid is now in
+            # closed-cycle inclusive form, so the seam cell is the last real cell).
+            # The resolved period is recoverable as `last(grid) - first(grid)`.
+            @test bcs_out[1] isa PeriodicBC{:inclusive}
+            @test last(grids_out[1]) - first(grids_out[1]) ≈ 2π
             @test bcs_out[2] === ZeroCurvBC()              # unchanged
         end
 
@@ -611,8 +622,9 @@ end
             @test data_out[end, :] ≈ data_out[1, :]       # dim 1 wrap
             @test data_out[:, end] ≈ data_out[:, 1]        # dim 2 wrap
             @test data_out[end, end] ≈ data_out[1, 1]      # corner
-            @test bcs_out[1].period ≈ 2π
-            @test bcs_out[2].period ≈ π
+            # Post-extension period is encoded in the grid span (not bc.period).
+            @test last(grids_out[1]) - first(grids_out[1]) ≈ 2π
+            @test last(grids_out[2]) - first(grids_out[2]) ≈ π
         end
 
         @testset "Range preserved after extension" begin

--- a/test/test_rcu.jl
+++ b/test/test_rcu.jl
@@ -82,7 +82,10 @@ Tests for the thread-safe autocache implementation:
             bank = FI._get_derivative_bank(x, bc)
 
             snap = @atomic :acquire bank.snapshot
-            result = FI._rcu_lookup(snap, objectid(x2), x2)
+            # `_rcu_lookup` 4th arg verifies the cache's BC against the looked-up
+            # one (codex P1). Derivative banks fall through `_verify_cache_match
+            # (::Any, ::Any) = true`, so any sentinel works here.
+            result = FI._rcu_lookup(snap, objectid(x2), x2, bc)
             @test result === nothing
         end
 
@@ -97,7 +100,7 @@ Tests for the thread-safe autocache implementation:
             bank = FI._get_derivative_bank(x, bc)
 
             snap = @atomic :acquire bank.snapshot
-            result = FI._rcu_lookup(snap, objectid(x), x)
+            result = FI._rcu_lookup(snap, objectid(x), x, bc)
             @test result !== nothing
         end
 
@@ -116,7 +119,7 @@ Tests for the thread-safe autocache implementation:
             bank = FI._get_derivative_bank(x, bc)
 
             snap = @atomic :acquire bank.snapshot
-            result = FI._rcu_lookup(snap, objectid(x_copy), x_copy)
+            result = FI._rcu_lookup(snap, objectid(x_copy), x_copy, bc)
             @test result !== nothing
         end
     end
@@ -268,7 +271,7 @@ Tests for the thread-safe autocache implementation:
             y[end] = y[1]
             FI.cubic_interp(x, y, π; bc = FI.PeriodicBC(), autocache = true)
 
-            bank = FI._get_periodic_bank(x)
+            bank = FI._get_periodic_bank(x, FI.PeriodicBC())
             snap = @atomic :acquire bank.snapshot
             @test snap.count == 1
         end

--- a/test/test_thomas_lu_solver.jl
+++ b/test/test_thomas_lu_solver.jl
@@ -174,7 +174,17 @@
 
                 y = rand(T, length(x))
                 rhs = Vector{T}(undef, size(Aprime, 1))
-                FI.compute_rhs_periodic!(rhs, y, spacing)
+                # Inclusive form: y has n+1 nodes; bc_config carries period
+                # and seam-cell width (last-cell h, since the spacing already
+                # holds it for inclusive). `q` is unused by `compute_rhs_periodic!`
+                # but the struct field is non-optional.
+                n_cells = length(x) - 1
+                bc_config = FI.PeriodicData{T, :inclusive}(
+                    Vector{T}(undef, n_cells),
+                    x[end] - x[1],
+                    x[end] - x[end - 1],
+                )
+                FI.compute_rhs_periodic!(rhs, y, spacing, bc_config)
 
                 # Baseline: stdlib LU + ldiv!
                 x_base = copy(rhs)


### PR DESCRIPTION
## Summary

After PR #126/#127 (Linear/Constant) and PR #131 (PCHIP/Cardinal/Akima), cubic
was the last 1D method still extending `:exclusive` → `:inclusive` on every
oneshot call. This PR pulls cubic onto the same zero-copy contract — single-y
and Series oneshots consume the user's raw n-grid, with the seam cell
`(idxL=n, idxR=1)` flowing through the existing 4-tuple `search_interval`.

The bigger value than the perf gain is **architectural consistency**: cubic
now uses the same `_IdxStencil{2}` anchor shape, BC-aware solver pattern, and
`bcs_resolved` ND threading as the sibling methods. One cross-cutting
correctness fix surfaced along the way (`WrapExtrap` period precision —
affects Linear/Constant/Hermite too).

## Performance — master vs this branch (cubic exclusive PeriodicBC)

`@benchmark` minimum, ns/call, in-place where applicable. Same machine, same session.

### N=21

| Path | master (ns) | branch (ns) | Δ |
|---|---:|---:|---:|
| single-y scalar (Range) | 290.3 | 272.5 | **−6.1%** |
| single-y scalar (Vector) | 314.2 | 281.0 | **−10.6%** |
| single-y vector (Vector) | 346.6 | 323.6 | **−6.6%** |
| series scalar (Range) | 516.9 | 479.2 | **−7.3%** |
| series scalar (Vector) | 533.7 | 480.6 | **−10.0%** |
| series vector (Vector) | 604.1 | 562.3 | **−6.9%** |

### N=101

| Path | master (ns) | branch (ns) | Δ |
|---|---:|---:|---:|
| single-y scalar (Range) | 649.0 | 618.1 | **−4.8%** |
| single-y scalar (Vector) | 748.3 | 692.7 | **−7.4%** |
| single-y vector (Vector) | 869.0 | 837.9 | −3.6% |
| series scalar (Range) | 1237.5 | 1154.1 | **−6.7%** |
| series scalar (Vector) | 1333.4 | 1225.0 | **−8.1%** |
| series vector (Vector) | 1504.1 | 1395.9 | **−7.2%** |

### N=501

| Path | master (ns) | branch (ns) | Δ |
|---|---:|---:|---:|
| single-y scalar (Range) | 2333.3 | 2254.6 | −3.4% |
| single-y scalar (Vector) | 2754.6 | 2643.6 | −4.0% |
| series scalar (Range) | 4654.7 | 4434.4 | **−4.7%** |
| series scalar (Vector) | 5118.0 | 4851.1 | **−5.2%** |
| series vector (Range) | 4702.3 | 4500.0 | **−4.3%** |
| series vector (Vector) | 5312.5 | 5069.3 | **−4.6%** |

Gains are most visible at small N + Vector grid + Series scalar (where
extension memcpy dominated). At large N the per-eval solve cost dominates and
zero-copy savings are diluted. Absolute savings are ~30 ns at N=21, ~60-100 ns
at N=101, ~200-250 ns at N=501.

**Note**: cubic has been cache-pool-amortized since day 1 (Thomas + Sherman-
Morrison are too expensive to redo per call), so its zero-copy ceiling is
much lower than Linear/Constant's was pre-#126 (where every oneshot rebuilt
spacing). The `−5~−10%` here is close to the algorithmic floor for
already-amortized cubic.

## Core changes

### BC-aware periodic solver

`PeriodicData{T, E}` gains an endpoint type-param `E ∈ {:inclusive,
:exclusive}` and a seam-cell width `h_n::T`. The cache builder, RHS, and
solver fork on `E`; Sherman-Morrison machinery is unchanged (cycle length
is `length(bc.q)`, BC-form-agnostic). Cache pool is partitioned by `E`.

### Anchor refactor — `_CubicAnchoredQuery` carries `_IdxStencil{2}`

`idx::Int` → `stencil::_IdxStencil{2}` (mirrors `_LinearAnchoredQuery` since
PR #128). Series oneshot helpers feed the seam-aware `(n, 1)` pair directly
from `search_interval` so seam queries read `y[1]` / `z[1]` for the wrapped
corner with no extension. Legacy `aq.idx` preserved as a virtual property.

### Hetero ND build threads post-extension bcs

`_prepare_periodic_nd[_pooled]` already returned BCs normalized to
`:inclusive` for extended axes; the hetero build chain was discarding that
and re-extracting raw bcs from methods. With BC-aware cubic now inside
`_compute_nd_partials_hetero!`, the asymmetry would have caused
`h_n = 0` miscomputation. `bcs_resolved` is threaded through so cubic
always sees the consistent (grid, bc) pair.

### `WrapExtrap(x, bc)` casts period to grid float — cross-cutting

`_resolve_exclusive_period` returned the user's raw `bc.period`; a Float64
literal on a Float32 grid silently produced `WrapExtrap{Float64}`,
polluting downstream anchors and (in cubic series vector) tripping a
`MethodError` on the preallocated `_CubicAnchoredQuery{Float32, Float32}`
buffer. Cast through the `_PromotableValue`-aware float promotion. **This
fix is cross-cutting — Linear/Constant/Hermite series also benefit.**

### Edge cases fixed within the refactor

`_verify_cache_match` resolves `bc.period === Nothing` against the inferred
period (was unconditionally accepting any same-grid cache). `_periodic_cell_h`
exclusive seam uses `idx == length(bc.q)` so ScalarSpacing returns `bc.h_n`
at the seam (was returning the cached `step` even when `bc.h_n ≠ step` for
tolerance-accepted Range periods). `_build_periodic_cache` validates
`h_n > 0`. `autocache=false` bypasses the public outer constructor.

## Public API

| Surface | Change |
|---|---|
| `cubic_interp(x, y, xq; bc=PeriodicBC(:exclusive, period=...))` | unchanged behavior, faster |
| `cubic_interp(x, Series(...), xq; bc=...)` | zero-copy for `:exclusive`; type-stable across precision mixes |
| Persistent `itp.bc` | normalized to `:inclusive` with resolved period (post-extension form) |
| `CubicSplineCache(x; bc=PeriodicBC(:exclusive))` | **breaking** — `ArgumentError`; cache-direct eval can't thread BC |
| `interp((x,y), data, q; method=(CubicInterp(bc=PeriodicBC(:exclusive)), …))` | unchanged behavior; previously also correct (cubic solver was BC-agnostic), now consistent with the BC-aware solver |

## Tests

`test_periodic_exclusive.jl` (+168) gains an edge-case block — distinct
caches per period, seam-width validation, `autocache=false`, Range vs
Vector seam equivalence at off-bit-equal periods, Nothing-period cache
resolution. `test_cubic_oneshot_series.jl` (+109) adds seam-region (scalar
+ vector), Float32 grid + Float64 period, ForwardDiff AD through
`:exclusive`, DerivOp(1/2/3) × Series × seam, and a zero-alloc gate for the
exclusive vector path. `test_thomas_lu_solver.jl` / `test_rcu.jl` synced to
the new `PeriodicData` / `_rcu_lookup` / `_get_periodic_bank` signatures.

## Out of scope (tracked TODOs)

- **`_AnchorLoc` 4-tuple refactor** — `_anchor_loc` discards `idx_R`, so each
  method's `_*_anchor_query_impl` rebuilds `_IdxPair(idx, idx + 1)`. Series
  oneshot exclusive bypasses this by calling `search_interval` directly.
  Plumbing `idx_R` through `_AnchorLoc` would remove the bypass for cubic /
  linear / constant / quadratic uniformly. Cross-method refactor, separate PR.
- **Q-outer × K-inner refactor for cubic series vector** — Linear/Constant
  switched in PR #127 (anchor on stack, K-inner register-resident, no anchor
  pool). Cubic still K-outer × Q-inner because the per-series z solve makes
  the trade-off different: applying Q×K would require K pre-solved z's
  (K×n storage) instead of one reused z. Potential further `−5~−10%` gain
  but is a separate perf-driven PR.
- **Cubic adjoint zero-copy** — adjoint constructor still extends the grid;
  symmetric work to this PR's forward path, separate release.