### PR TITLE
(refac): PeriodicBC on all 1D / Hetero ND adjoint paths + NoBC unification

### DIFF
--- a/ext/FastInterpolationsChainRulesCoreExt.jl
+++ b/ext/FastInterpolationsChainRulesCoreExt.jl
@@ -188,7 +188,10 @@ function ChainRulesCore.rrule(
         kwargs...
     ) where {Tv}
     y = func(x, f, xq; deriv = deriv, kwargs...)
-    adj = _adjoint_func(func)(x, xq; deriv = deriv, kwargs...)
+    # Adjoint constructor does not consume `deriv` (deriv is an apply-time argument).
+    # Previously slurped by `_extra...` on adjoint constructors; now the 5 non-cubic
+    # adjoints have explicit kwargs only, so passing `deriv` would be a `MethodError`.
+    adj = _adjoint_func(func)(x, xq; kwargs...)
     eval_value = deriv isa DerivOp{0}
     d = eval_value ? func(x, f, xq; deriv = DerivOp(1), kwargs...) : nothing
     function _interp1d_pb(Δy)
@@ -230,7 +233,8 @@ function ChainRulesCore.rrule(
         y = func(grids, data, queries; deriv = deriv, kwargs...)
         ds = nothing
     end
-    adj = _adjoint_func(func)(grids, queries; deriv = deriv, kwargs...)
+    # Adjoint constructor does not consume `deriv` (apply-time arg only).
+    adj = _adjoint_func(func)(grids, queries; kwargs...)
     function _interp_nd_scalar_pb(Δy)
         Δy isa AbstractZero && return NoTangent(), NoTangent(), ZeroTangent(), ZeroTangent()
         Δu = unthunk(Δy)
@@ -313,6 +317,68 @@ function ChainRulesCore.rrule(
     end
 
     return itp, _interp_unified_ctor_pb
+end
+
+# One-shot rrules for `interp(grids, data, query/queries; method=..., ...)`.
+# Without these, the call falls through to the in-place batch path which
+# Zygote rejects ("Mutating arrays is not supported"). Routes ∂/∂data
+# through `hetero_adjoint(...)` — the unified adjoint that accepts any
+# method tuple (homogeneous or heterogeneous).
+@inline _expand_method_tuple(method::AbstractInterpMethod, ::Val{N}) where {N} =
+    ntuple(_ -> method, Val(N))
+@inline _expand_method_tuple(method::Tuple{Vararg{AbstractInterpMethod, N}}, ::Val{N}) where {N} =
+    method
+
+# Single-point query: `value_gradient` returns both eval and ∂/∂queries
+# in one cell-locate, mirroring the `_InterpMethod` ND scalar rrule above.
+function ChainRulesCore.rrule(
+        ::typeof(FastInterpolations.interp),
+        grids::NTuple{N, AbstractVector},
+        data::AbstractArray{Tv, N},
+        queries::Tuple{Vararg{Real, N}};
+        method::Union{AbstractInterpMethod, Tuple{Vararg{AbstractInterpMethod, N}}},
+        deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
+        kwargs...
+    ) where {Tv, N}
+    method_tuple = _expand_method_tuple(method, Val(N))
+    eval_value = deriv isa DerivOp{0} || (deriv isa Tuple && all(d -> d isa DerivOp{0}, deriv))
+    if eval_value
+        itp = FastInterpolations.interp(grids, data; method = method, kwargs...)
+        y, ds = value_gradient(itp, queries)
+    else
+        y = FastInterpolations.interp(grids, data, queries; method = method, deriv = deriv, kwargs...)
+        ds = nothing
+    end
+    adj = FastInterpolations.hetero_adjoint(grids, queries; methods = method_tuple, kwargs...)
+    function _interp_unified_scalar_pb(Δy)
+        Δy isa AbstractZero && return NoTangent(), NoTangent(), ZeroTangent(), ZeroTangent()
+        Δu = unthunk(Δy)
+        f_bar = adj(Δu; deriv = deriv)
+        ∂queries = eval_value ? ntuple(i -> real(conj(Δu) * ds[i]), Val(N)) : NoTangent()
+        return NoTangent(), NoTangent(), f_bar, ∂queries
+    end
+    return y, _interp_unified_scalar_pb
+end
+
+# Batch queries: ∂/∂data only (per-query gradients in batch mode are not
+# supported by the existing one-shot adjoint contract).
+function ChainRulesCore.rrule(
+        ::typeof(FastInterpolations.interp),
+        grids::NTuple{N, AbstractVector},
+        data::AbstractArray{Tv, N},
+        queries;
+        method::Union{AbstractInterpMethod, Tuple{Vararg{AbstractInterpMethod, N}}},
+        kwargs...
+    ) where {Tv, N}
+    method_tuple = _expand_method_tuple(method, Val(N))
+    y = FastInterpolations.interp(grids, data, queries; method = method, kwargs...)
+    adj = FastInterpolations.hetero_adjoint(grids, queries; methods = method_tuple, kwargs...)
+    function _interp_unified_batch_pb(Δy)
+        Δy isa AbstractZero && return NoTangent(), NoTangent(), ZeroTangent(), ZeroTangent()
+        f_bar = adj(unthunk(Δy); kwargs...)
+        return NoTangent(), NoTangent(), f_bar, NoTangent()
+    end
+    return y, _interp_unified_batch_pb
 end
 
 # ════════════════════════════════════════

--- a/ext/FastInterpolationsChainRulesCoreExt.jl
+++ b/ext/FastInterpolationsChainRulesCoreExt.jl
@@ -188,9 +188,9 @@ function ChainRulesCore.rrule(
         kwargs...
     ) where {Tv}
     y = func(x, f, xq; deriv = deriv, kwargs...)
-    # Adjoint constructor does not consume `deriv` (deriv is an apply-time argument).
-    # Previously slurped by `_extra...` on adjoint constructors; now the 5 non-cubic
-    # adjoints have explicit kwargs only, so passing `deriv` would be a `MethodError`.
+    # Adjoint constructor does not consume `deriv` (deriv is an apply-time argument);
+    # do NOT forward `deriv` here — Linear/Constant/PCHIP/Cardinal/Akima constructors
+    # have explicit kwargs only and would raise `MethodError`.
     adj = _adjoint_func(func)(x, xq; kwargs...)
     eval_value = deriv isa DerivOp{0}
     d = eval_value ? func(x, f, xq; deriv = DerivOp(1), kwargs...) : nothing
@@ -361,21 +361,26 @@ function ChainRulesCore.rrule(
 end
 
 # Batch queries: ∂/∂data only (per-query gradients in batch mode are not
-# supported by the existing one-shot adjoint contract).
+# supported by the existing one-shot adjoint contract). `deriv` is extracted
+# explicitly so the pullback callable receives only apply-time kwargs —
+# mirroring the scalar sibling's `f_bar = adj(Δu; deriv = deriv)`. Slurping
+# raw `kwargs...` here would leak construction-time args (`extrap`, `search`)
+# into the adjoint apply path.
 function ChainRulesCore.rrule(
         ::typeof(FastInterpolations.interp),
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         queries;
         method::Union{AbstractInterpMethod, Tuple{Vararg{AbstractInterpMethod, N}}},
+        deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
         kwargs...
     ) where {Tv, N}
     method_tuple = _expand_method_tuple(method, Val(N))
-    y = FastInterpolations.interp(grids, data, queries; method = method, kwargs...)
+    y = FastInterpolations.interp(grids, data, queries; method = method, deriv = deriv, kwargs...)
     adj = FastInterpolations.hetero_adjoint(grids, queries; methods = method_tuple, kwargs...)
     function _interp_unified_batch_pb(Δy)
         Δy isa AbstractZero && return NoTangent(), NoTangent(), ZeroTangent(), ZeroTangent()
-        f_bar = adj(unthunk(Δy); kwargs...)
+        f_bar = adj(unthunk(Δy); deriv = deriv)
         return NoTangent(), NoTangent(), f_bar, NoTangent()
     end
     return y, _interp_unified_batch_pb

--- a/src/akima/akima_adjoint.jl
+++ b/src/akima/akima_adjoint.jl
@@ -57,20 +57,39 @@ f_bar = adj(y_bar; deriv=DerivOp(1))    # derivative adjoint
 adj(f_bar, y_bar)                       # in-place
 ```
 """
-struct AkimaAdjoint1D{Tg, Tv <: Real, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
+struct AkimaAdjoint1D{Tg, Tv <: Real, BC <: AbstractBC, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
     anchors::Vector{_HermiteAdjointAnchor1D{Tg}}
-    grid::Vector{Tg}       # Grid points (needed for slope adjoint secant computation)
-    data::Vector{Tv}       # y values (needed for slope weight conditions)
-    grid_size::Int
+    grid::Vector{Tg}       # Extended grid (length n+1 for `:exclusive`, n otherwise)
+    data::Vector{Tv}       # Extended y values (length matches grid)
+    grid_size::Int         # Internal length: n+1 for `:exclusive`, n otherwise
+    bc::BC
     extrap::EP
 end
 
 # ========================================
 # 1D Adjoint Protocol Accessors
 # ========================================
+# Callables, Base.size, Base.Matrix, exclusive-periodic in-place seam fold
+# inherited from AbstractAdjoint1D via src/core/adjoint_protocol.jl.
 
 @inline _n_queries(adj::AkimaAdjoint1D) = length(adj.anchors)
-@inline _adjoint_output_length(adj::AkimaAdjoint1D) = adj.grid_size
+
+@inline _adjoint_output_length(adj::AkimaAdjoint1D) =
+    adj.bc isa PeriodicBC{:exclusive} ? adj.grid_size - 1 : adj.grid_size
+
+@inline _adjoint_internal_length(adj::AkimaAdjoint1D) = adj.grid_size
+
+@inline _adjoint_1d_has_exclusive_periodic(adj::AkimaAdjoint1D) =
+    adj.bc isa PeriodicBC{:exclusive}
+
+function _adjoint_1d_finalize(f_bar::AbstractVector, adj::AkimaAdjoint1D)
+    if adj.bc isa PeriodicBC{:exclusive}
+        n_internal = adj.grid_size
+        @inbounds f_bar[1] += f_bar[n_internal]
+        return f_bar[1:(n_internal - 1)]
+    end
+    return f_bar
+end
 
 # ========================================
 # Akima Slope Adjoint: J^T * dy_bar -> f_bar update
@@ -388,6 +407,83 @@ end
 end
 
 # ========================================
+# Closed-Cycle Akima Slope Adjoint (PeriodicBC)
+# ========================================
+#
+# After `_periodic_extend_1d`-style extension, the grid is closed-cycle
+# (`:exclusive` extended to n+1 with y_ext[n+1]=y[1]; `:inclusive` already
+# closed). The forward Akima slope at every k uses the SAME 4-secant
+# weighted formula with cyclic secant indices via mod1 over m_cyc = n-1.
+# No virtual secants — wrap delivers real grid secants instead.
+#
+# The adjoint mirrors `_akima_slope_adjoint!` interior body, but with a
+# `_akima_scatter_secant_adjoint_periodic!` cyclic scatter helper that
+# wraps `m_idx` via mod1 to a real secant index in `[1, m_cyc]`.
+
+@inline function _akima_scatter_secant_adjoint_periodic!(
+        f_bar::AbstractVector, coeff, m_idx::Int,
+        x::AbstractVector{Tg}, m_cyc::Int
+    ) where {Tg}
+    # Cyclic secant: m[j_cyc] = (y[j_cyc+1] - y[j_cyc]) / h[j_cyc]
+    j_cyc = mod1(m_idx, m_cyc)
+    @inbounds begin
+        inv_h = one(Tg) / (x[j_cyc + 1] - x[j_cyc])
+        c = coeff * inv_h
+        f_bar[j_cyc]     -= c
+        f_bar[j_cyc + 1] += c
+    end
+    return nothing
+end
+
+@inline function _akima_slope_adjoint_periodic!(
+        f_bar::AbstractVector, dy_bar::AbstractVector,
+        x::AbstractVector{Tg}, y::AbstractVector{Tv}
+    ) where {Tg, Tv}
+    n = length(x)
+    n >= 2 || return nothing
+    m_cyc = n - 1  # cycle length (real secants on the closed cycle)
+
+    # Cyclic secant access — handles the seam-cell secant transparently for
+    # `:exclusive` (after extension `(y[n+1] - y[n]) / h_seam` is just the
+    # secant of cell n in the extended grid) and the wrap-around for
+    # `:inclusive` (mod1 keeps j ∈ [1, n-1]).
+    @inline _msec(j) = let
+        jw = mod1(j, m_cyc)
+        @inbounds (y[jw + 1] - y[jw]) / (x[jw + 1] - x[jw])
+    end
+
+    @inbounds for k in 1:n
+        m_km2 = _msec(k - 2)
+        m_km1 = _msec(k - 1)
+        m_k   = _msec(k)
+        m_kp1 = _msec(k + 1)
+
+        w1 = abs(m_kp1 - m_k)
+        w2 = abs(m_km1 - m_km2)
+        wsum = w1 + w2
+
+        db = dy_bar[k]
+        if wsum == zero(wsum)
+            # Equal-weight fallback: dy[k] = (m_km1 + m_k)/2
+            _akima_scatter_secant_adjoint_periodic!(f_bar, db / 2, k - 1, x, m_cyc)
+            _akima_scatter_secant_adjoint_periodic!(f_bar, db / 2, k,     x, m_cyc)
+        else
+            dy_k = (w1 * m_km1 + w2 * m_k) / wsum
+            s1 = sign(m_kp1 - m_k)
+            s2 = sign(m_km1 - m_km2)
+            d_km2, d_km1, d_k, d_kp1 = _akima_slope_adjoint_weighted(
+                dy_k, m_km1, m_k, w1, w2, wsum, s1, s2
+            )
+            _akima_scatter_secant_adjoint_periodic!(f_bar, d_km2 * db, k - 2, x, m_cyc)
+            _akima_scatter_secant_adjoint_periodic!(f_bar, d_km1 * db, k - 1, x, m_cyc)
+            _akima_scatter_secant_adjoint_periodic!(f_bar, d_k   * db, k,     x, m_cyc)
+            _akima_scatter_secant_adjoint_periodic!(f_bar, d_kp1 * db, k + 1, x, m_cyc)
+        end
+    end
+    return nothing
+end
+
+# ========================================
 # Core Apply Function
 # ========================================
 
@@ -406,8 +502,13 @@ end
     # Step 1: Hermite scatter -> (f_bar, dy_bar)
     _scatter_hermite_adjoint!(f_bar, dy_bar, adj.anchors, y_bar, deriv)
 
-    # Step 2: Akima slope J^T * dy_bar -> f_bar update
-    _akima_slope_adjoint!(f_bar, dy_bar, adj.grid, adj.data)
+    # Step 2: Akima slope J^T * dy_bar -> f_bar update.
+    # PeriodicBC (closed-cycle internal grid) → wrap-aware path.
+    if adj.bc isa PeriodicBC
+        _akima_slope_adjoint_periodic!(f_bar, dy_bar, adj.grid, adj.data)
+    else
+        _akima_slope_adjoint!(f_bar, dy_bar, adj.grid, adj.data)
+    end
 
     return nothing
 end
@@ -456,6 +557,7 @@ function akima_adjoint(
         x::AbstractVector,
         y::AbstractVector,
         x_query::AbstractVector;
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         _extra...
     )
@@ -463,9 +565,21 @@ function akima_adjoint(
 
     length(x_p) >= 2 || _throw_adjoint_grid_too_small(length(x_p))
 
-    # NoExtrap: validate all queries in-domain
-    if extrap isa NoExtrap
-        x_lo, x_hi = first(x_p), last(x_p)
+    # Promote y to float (slope adjoint computes fractional derivatives).
+    _, y_p = _promote_itp_inputs(x, y)
+
+    # Closed-cycle extension for periodic BCs — mirrors the forward
+    # `akima_interp_precompute` path. `:exclusive` gets vcat-extended to n+1;
+    # `:inclusive` is already closed at n. After this, the slope adjoint
+    # runs over the extended grid via the unified periodic 4-secant
+    # weighted formula (`_akima_slope_adjoint_periodic!`). For `:exclusive`
+    # the protocol's exclusive in-place callable folds f_work[1] +=
+    # f_work[n+1] and trims.
+    x_ext, y_ext, extrap_eff = _periodic_extend_1d(x_p, y_p, bc, extrap)
+
+    # NoExtrap: validate queries against extended domain.
+    if extrap_eff isa NoExtrap
+        x_lo, x_hi = first(x_ext), last(x_ext)
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
             (_extract_primal(x_lo) <= xq_i <= _extract_primal(x_hi)) || throw(
@@ -474,15 +588,14 @@ function akima_adjoint(
         end
     end
 
-    # Wrap axis (axis-as-truth) and bake anchors
-    x_axis = _cache_axis(x_p, NoBC())
-    anchors = _bake_hermite_adjoint_anchors(x_axis, xq_p, extrap)
+    # Bake anchors against the extended axis.
+    x_axis = _cache_axis(x_ext, NoBC())
+    anchors = _bake_hermite_adjoint_anchors(x_axis, xq_p, extrap_eff)
 
-    # Promote y to float: slope adjoint computes fractional derivatives (Int division loses precision)
-    _, y_p = _promote_itp_inputs(x, y)
-    Tv = eltype(y_p)
-    return AkimaAdjoint1D{Tg, Tv, typeof(extrap)}(
-        anchors, collect(x_p), collect(Tv, y_p), length(x_p), extrap
+    Tv = eltype(y_ext)
+    return AkimaAdjoint1D{Tg, Tv, typeof(bc), typeof(extrap_eff)}(
+        anchors, collect(x_ext), collect(Tv, y_ext), length(x_ext),
+        bc, extrap_eff
     )
 end
 
@@ -491,8 +604,9 @@ function akima_adjoint(
         x::AbstractVector,
         y::AbstractVector,
         x_query::Real;
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         _extra...
     )
-    return akima_adjoint(x, y, [x_query]; extrap = extrap)
+    return akima_adjoint(x, y, [x_query]; bc = bc, extrap = extrap)
 end

--- a/src/akima/akima_adjoint.jl
+++ b/src/akima/akima_adjoint.jl
@@ -416,11 +416,11 @@ end
     @inbounds begin
         h_km2 = x[j_km2 + 1] - x[j_km2]
         h_km1 = x[j_km1 + 1] - x[j_km1]
-        h_k   = x[j_k   + 1] - x[j_k]
+        h_k = x[j_k + 1] - x[j_k]
         h_kp1 = x[j_kp1 + 1] - x[j_kp1]
         m_km2 = (y[j_km2 + 1] - y[j_km2]) / h_km2
         m_km1 = (y[j_km1 + 1] - y[j_km1]) / h_km1
-        m_k   = (y[j_k   + 1] - y[j_k])   / h_k
+        m_k = (y[j_k + 1] - y[j_k]) / h_k
         m_kp1 = (y[j_kp1 + 1] - y[j_kp1]) / h_kp1
     end
 
@@ -433,12 +433,12 @@ end
         # Equal-weight fallback: dy[k] = (m_km1 + m_k)/2 →
         # ∂dy/∂m_km1 = 1/2, ∂dy/∂m_k = 1/2.
         c_km1 = (db / 2) / h_km1
-        c_k   = (db / 2) / h_k
+        c_k = (db / 2) / h_k
         @inbounds begin
-            f_bar[j_km1]     -= c_km1
+            f_bar[j_km1] -= c_km1
             f_bar[j_km1 + 1] += c_km1
-            f_bar[j_k]       -= c_k
-            f_bar[j_k + 1]   += c_k
+            f_bar[j_k] -= c_k
+            f_bar[j_k + 1] += c_k
         end
     else
         dy_k = (w1 * m_km1 + w2 * m_k) / wsum
@@ -449,16 +449,16 @@ end
         )
         c_km2 = (d_km2 * db) / h_km2
         c_km1 = (d_km1 * db) / h_km1
-        c_k   = (d_k   * db) / h_k
+        c_k = (d_k * db) / h_k
         c_kp1 = (d_kp1 * db) / h_kp1
         @inbounds begin
-            f_bar[j_km2]     -= c_km2
+            f_bar[j_km2] -= c_km2
             f_bar[j_km2 + 1] += c_km2
-            f_bar[j_km1]     -= c_km1
+            f_bar[j_km1] -= c_km1
             f_bar[j_km1 + 1] += c_km1
-            f_bar[j_k]       -= c_k
-            f_bar[j_k + 1]   += c_k
-            f_bar[j_kp1]     -= c_kp1
+            f_bar[j_k] -= c_k
+            f_bar[j_k + 1] += c_k
+            f_bar[j_kp1] -= c_kp1
             f_bar[j_kp1 + 1] += c_kp1
         end
     end
@@ -483,7 +483,7 @@ end
             _akima_periodic_kernel!(
                 f_bar, dy_bar, x, y, k,
                 mod1(k - 2, m_cyc), mod1(k - 1, m_cyc),
-                mod1(k,     m_cyc), mod1(k + 1, m_cyc),
+                mod1(k, m_cyc), mod1(k + 1, m_cyc),
             )
         end
         return nothing

--- a/src/akima/akima_adjoint.jl
+++ b/src/akima/akima_adjoint.jl
@@ -74,23 +74,6 @@ end
 
 @inline _n_queries(adj::AkimaAdjoint1D) = length(adj.anchors)
 
-@inline _adjoint_output_length(adj::AkimaAdjoint1D) =
-    adj.bc isa PeriodicBC{:exclusive} ? adj.grid_size - 1 : adj.grid_size
-
-@inline _adjoint_internal_length(adj::AkimaAdjoint1D) = adj.grid_size
-
-@inline _adjoint_1d_has_exclusive_periodic(adj::AkimaAdjoint1D) =
-    adj.bc isa PeriodicBC{:exclusive}
-
-function _adjoint_1d_finalize(f_bar::AbstractVector, adj::AkimaAdjoint1D)
-    if adj.bc isa PeriodicBC{:exclusive}
-        n_internal = adj.grid_size
-        @inbounds f_bar[1] += f_bar[n_internal]
-        return f_bar[1:(n_internal - 1)]
-    end
-    return f_bar
-end
-
 # ========================================
 # Akima Slope Adjoint: J^T * dy_bar -> f_bar update
 # ========================================
@@ -610,7 +593,6 @@ function akima_adjoint(
         x_query::AbstractVector;
         bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
-        _extra...
     )
     x_p, xq_p, Tg = _promote_adjoint_inputs(x, x_query)
 
@@ -657,7 +639,6 @@ function akima_adjoint(
         x_query::Real;
         bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
-        _extra...
     )
     return akima_adjoint(x, y, [x_query]; bc = bc, extrap = extrap)
 end

--- a/src/akima/akima_adjoint.jl
+++ b/src/akima/akima_adjoint.jl
@@ -193,6 +193,7 @@ Virtual secants for j=0,-1,n,n+1 are linear combinations of real secants.
 end
 
 @inline function _akima_slope_adjoint!(
+        ::NoBC,
         f_bar::AbstractVector, dy_bar::AbstractVector,
         x::AbstractVector{Tg}, y::AbstractVector{Tv}
     ) where {Tg, Tv}
@@ -464,7 +465,8 @@ end
     return nothing
 end
 
-@inline function _akima_slope_adjoint_periodic!(
+@inline function _akima_slope_adjoint!(
+        ::PeriodicBC,
         f_bar::AbstractVector, dy_bar::AbstractVector,
         x::AbstractVector{Tg}, y::AbstractVector{Tv}
     ) where {Tg, Tv}
@@ -526,23 +528,20 @@ end
 
 @with_pool pool function _akima_adjoint_apply!(
         f_bar::AbstractVector{Tv},
-        adj::AkimaAdjoint1D{Tg},
+        adj::AkimaAdjoint1D{Tg, Tv2, BC},
         y_bar,
         deriv::DerivOp = EvalValue()
-    ) where {Tv, Tg}
+    ) where {Tv, Tg, Tv2, BC}
     n = adj.grid_size
     dy_bar = zeros!(pool, Tv, n)
 
     # Step 1: Hermite scatter -> (f_bar, dy_bar)
     _scatter_hermite_adjoint!(f_bar, dy_bar, adj.anchors, y_bar, deriv)
 
-    # Step 2: Akima slope J^T * dy_bar -> f_bar update.
-    # PeriodicBC (closed-cycle internal grid) → wrap-aware path.
-    if adj.bc isa PeriodicBC
-        _akima_slope_adjoint_periodic!(f_bar, dy_bar, adj.grid, adj.data)
-    else
-        _akima_slope_adjoint!(f_bar, dy_bar, adj.grid, adj.data)
-    end
+    # Step 2: Akima slope J^T * dy_bar -> f_bar update. BC dispatched at compile
+    # time via `BC` parameter bound in where clause (two methods of the slope
+    # adjoint cover `::PeriodicBC` and `::NoBC` — see definitions above).
+    _akima_slope_adjoint!(adj.bc, f_bar, dy_bar, adj.grid, adj.data)
 
     return nothing
 end

--- a/src/akima/akima_adjoint.jl
+++ b/src/akima/akima_adjoint.jl
@@ -414,23 +414,69 @@ end
 # (`:exclusive` extended to n+1 with y_ext[n+1]=y[1]; `:inclusive` already
 # closed). The forward Akima slope at every k uses the SAME 4-secant
 # weighted formula with cyclic secant indices via mod1 over m_cyc = n-1.
-# No virtual secants — wrap delivers real grid secants instead.
 #
-# The adjoint mirrors `_akima_slope_adjoint!` interior body, but with a
-# `_akima_scatter_secant_adjoint_periodic!` cyclic scatter helper that
-# wraps `m_idx` via mod1 to a real secant index in `[1, m_cyc]`.
+# Akima slope stencil radius = 2 (uses 4 secants m[k-2..k+1] / 5 grid
+# points y[k-2..k+2]). Boundary indices where mod1 actually wraps:
+# k ∈ {1, 2, n-1, n}. For interior k ∈ [3, n-2], all 4 secant indices
+# stay in `[1, m_cyc]` and we read grid/data directly — no mod1 cost.
+# Split the loop accordingly.
 
-@inline function _akima_scatter_secant_adjoint_periodic!(
-        f_bar::AbstractVector, coeff, m_idx::Int,
-        x::AbstractVector{Tg}, m_cyc::Int
+# Per-k kernel — given pre-resolved secant indices (j_km2, j_km1, j_k,
+# j_kp1), apply the Akima weighted-secant formula's transpose. `@inline`
+# folds it into both boundary (mod1) and interior (direct) call sites.
+@inline function _akima_periodic_kernel!(
+        f_bar::AbstractVector, dy_bar::AbstractVector,
+        x::AbstractVector{Tg}, y::AbstractVector,
+        k::Int, j_km2::Int, j_km1::Int, j_k::Int, j_kp1::Int
     ) where {Tg}
-    # Cyclic secant: m[j_cyc] = (y[j_cyc+1] - y[j_cyc]) / h[j_cyc]
-    j_cyc = mod1(m_idx, m_cyc)
     @inbounds begin
-        inv_h = one(Tg) / (x[j_cyc + 1] - x[j_cyc])
-        c = coeff * inv_h
-        f_bar[j_cyc]     -= c
-        f_bar[j_cyc + 1] += c
+        h_km2 = x[j_km2 + 1] - x[j_km2]
+        h_km1 = x[j_km1 + 1] - x[j_km1]
+        h_k   = x[j_k   + 1] - x[j_k]
+        h_kp1 = x[j_kp1 + 1] - x[j_kp1]
+        m_km2 = (y[j_km2 + 1] - y[j_km2]) / h_km2
+        m_km1 = (y[j_km1 + 1] - y[j_km1]) / h_km1
+        m_k   = (y[j_k   + 1] - y[j_k])   / h_k
+        m_kp1 = (y[j_kp1 + 1] - y[j_kp1]) / h_kp1
+    end
+
+    w1 = abs(m_kp1 - m_k)
+    w2 = abs(m_km1 - m_km2)
+    wsum = w1 + w2
+    db = dy_bar[k]
+
+    if wsum == zero(wsum)
+        # Equal-weight fallback: dy[k] = (m_km1 + m_k)/2 →
+        # ∂dy/∂m_km1 = 1/2, ∂dy/∂m_k = 1/2.
+        c_km1 = (db / 2) / h_km1
+        c_k   = (db / 2) / h_k
+        @inbounds begin
+            f_bar[j_km1]     -= c_km1
+            f_bar[j_km1 + 1] += c_km1
+            f_bar[j_k]       -= c_k
+            f_bar[j_k + 1]   += c_k
+        end
+    else
+        dy_k = (w1 * m_km1 + w2 * m_k) / wsum
+        s1 = sign(m_kp1 - m_k)
+        s2 = sign(m_km1 - m_km2)
+        d_km2, d_km1, d_k, d_kp1 = _akima_slope_adjoint_weighted(
+            dy_k, m_km1, m_k, w1, w2, wsum, s1, s2
+        )
+        c_km2 = (d_km2 * db) / h_km2
+        c_km1 = (d_km1 * db) / h_km1
+        c_k   = (d_k   * db) / h_k
+        c_kp1 = (d_kp1 * db) / h_kp1
+        @inbounds begin
+            f_bar[j_km2]     -= c_km2
+            f_bar[j_km2 + 1] += c_km2
+            f_bar[j_km1]     -= c_km1
+            f_bar[j_km1 + 1] += c_km1
+            f_bar[j_k]       -= c_k
+            f_bar[j_k + 1]   += c_k
+            f_bar[j_kp1]     -= c_kp1
+            f_bar[j_kp1 + 1] += c_kp1
+        end
     end
     return nothing
 end
@@ -441,45 +487,50 @@ end
     ) where {Tg, Tv}
     n = length(x)
     n >= 2 || return nothing
-    m_cyc = n - 1  # cycle length (real secants on the closed cycle)
+    m_cyc = n - 1
 
-    # Cyclic secant access — handles the seam-cell secant transparently for
-    # `:exclusive` (after extension `(y[n+1] - y[n]) / h_seam` is just the
-    # secant of cell n in the extended grid) and the wrap-around for
-    # `:inclusive` (mod1 keeps j ∈ [1, n-1]).
-    @inline _msec(j) = let
-        jw = mod1(j, m_cyc)
-        @inbounds (y[jw + 1] - y[jw]) / (x[jw + 1] - x[jw])
-    end
-
-    @inbounds for k in 1:n
-        m_km2 = _msec(k - 2)
-        m_km1 = _msec(k - 1)
-        m_k   = _msec(k)
-        m_kp1 = _msec(k + 1)
-
-        w1 = abs(m_kp1 - m_k)
-        w2 = abs(m_km1 - m_km2)
-        wsum = w1 + w2
-
-        db = dy_bar[k]
-        if wsum == zero(wsum)
-            # Equal-weight fallback: dy[k] = (m_km1 + m_k)/2
-            _akima_scatter_secant_adjoint_periodic!(f_bar, db / 2, k - 1, x, m_cyc)
-            _akima_scatter_secant_adjoint_periodic!(f_bar, db / 2, k,     x, m_cyc)
-        else
-            dy_k = (w1 * m_km1 + w2 * m_k) / wsum
-            s1 = sign(m_kp1 - m_k)
-            s2 = sign(m_km1 - m_km2)
-            d_km2, d_km1, d_k, d_kp1 = _akima_slope_adjoint_weighted(
-                dy_k, m_km1, m_k, w1, w2, wsum, s1, s2
+    # Tiny grids: n ∈ {2, 3} have no interior — boundary set covers all k.
+    # Use unified mod1 path. For n=2, m_cyc=1 collapses every secant to the
+    # single cell; for n=3, m_cyc=2 has only two real secants. Both cases
+    # are handled correctly by the kernel via fully-wrapped indices.
+    if n < 4
+        @inbounds for k in 1:n
+            _akima_periodic_kernel!(
+                f_bar, dy_bar, x, y, k,
+                mod1(k - 2, m_cyc), mod1(k - 1, m_cyc),
+                mod1(k,     m_cyc), mod1(k + 1, m_cyc),
             )
-            _akima_scatter_secant_adjoint_periodic!(f_bar, d_km2 * db, k - 2, x, m_cyc)
-            _akima_scatter_secant_adjoint_periodic!(f_bar, d_km1 * db, k - 1, x, m_cyc)
-            _akima_scatter_secant_adjoint_periodic!(f_bar, d_k   * db, k,     x, m_cyc)
-            _akima_scatter_secant_adjoint_periodic!(f_bar, d_kp1 * db, k + 1, x, m_cyc)
         end
+        return nothing
     end
+
+    # ── Boundary k=1: j_km2 = m_cyc-1, j_km1 = m_cyc (both wrap) ────────
+    @inbounds _akima_periodic_kernel!(
+        f_bar, dy_bar, x, y, 1,
+        m_cyc - 1, m_cyc, 1, 2,
+    )
+    # ── Boundary k=2: j_km2 = m_cyc (wraps) ─────────────────────────────
+    @inbounds _akima_periodic_kernel!(
+        f_bar, dy_bar, x, y, 2,
+        m_cyc, 1, 2, 3,
+    )
+
+    # ── Interior k = 3..n-2: no wrap, direct grid access ────────────────
+    @inbounds for k in 3:(n - 2)
+        _akima_periodic_kernel!(f_bar, dy_bar, x, y, k, k - 2, k - 1, k, k + 1)
+    end
+
+    # ── Boundary k=n-1: j_kp1 = mod1(n, m_cyc) = 1 (wraps) ──────────────
+    @inbounds _akima_periodic_kernel!(
+        f_bar, dy_bar, x, y, n - 1,
+        n - 3, n - 2, n - 1, 1,
+    )
+    # ── Boundary k=n: j_k = 1, j_kp1 = 2 (both wrap) ────────────────────
+    @inbounds _akima_periodic_kernel!(
+        f_bar, dy_bar, x, y, n,
+        n - 2, n - 1, 1, 2,
+    )
+
     return nothing
 end
 

--- a/src/cardinal/cardinal_adjoint.jl
+++ b/src/cardinal/cardinal_adjoint.jl
@@ -241,19 +241,21 @@ function cardinal_adjoint(
 
     length(x_p) >= 2 || _throw_adjoint_grid_too_small(length(x_p))
 
-    # BC-aware axis wrap. For `:exclusive`, `_cache_axis` returns
-    # `_ExclusivePeriodicAxis` of logical length n+1; `collect` materializes
-    # to a length-(n+1) Vector with the virtual seam endpoint at index n+1.
-    # For `:inclusive` / NoBC, length unchanged. The slope adjoint then
-    # runs over the materialized closed-cycle grid via the periodic path.
-    x_axis = _cache_axis(x_p, bc, Tg)
-    extrap_eff = _resolve_extrap(extrap, bc, x_axis)
+    # Closed-cycle extension for periodic BCs — mirrors the forward
+    # `cardinal_interpolant` persistent path. Cardinal adjoint is data-free
+    # (slopes linear in y), so we extend the x grid only via the x-only
+    # sibling `_prepare_periodic_grid`. `:exclusive` becomes length-(n+1)
+    # with the seam endpoint as a real grid point; `:inclusive` is already
+    # closed at n. After this, the slope adjoint runs over the extended
+    # grid via the unified periodic 4-corner formula
+    # (`_cardinal_slope_adjoint_periodic!`).
+    x_ext = _prepare_periodic_grid(x_p, bc)
+    extrap_eff = _resolve_extrap(extrap, bc, x_ext)
+    bc_eff = _bc_after_extend(bc)
 
-    # NoExtrap: validate queries against the axis's domain (covers the seam
-    # endpoint for `:exclusive`; non-periodic NoExtrap still validates here
-    # since periodic auto-promotes to WrapExtrap above).
+    # NoExtrap: validate queries against extended domain.
     if extrap_eff isa NoExtrap
-        x_lo, x_hi = _extract_primal(first(x_axis)), _extract_primal(last(x_axis))
+        x_lo, x_hi = _extract_primal(first(x_ext)), _extract_primal(last(x_ext))
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
             (x_lo <= xq_i <= x_hi) || throw(
@@ -262,10 +264,17 @@ function cardinal_adjoint(
         end
     end
 
+    # Wrap the extended grid for cached `h`/`inv_h` (matches forward
+    # Cardinal persistent's storage type). After `bc_eff` normalization
+    # any periodic input becomes `:inclusive` over the closed-cycle grid,
+    # so `_cache_axis` here returns `_CachedRange` / `_CachedVector` of
+    # length n+1 (NOT `_ExclusivePeriodicAxis` — the seam is now a real
+    # grid point in `x_ext`).
+    x_axis = _cache_axis(x_ext, bc_eff, Tg)
     anchors = _bake_hermite_adjoint_anchors(x_axis, xq_p, extrap_eff)
 
     return CardinalAdjoint1D{Tg, typeof(bc), typeof(extrap_eff)}(
-        anchors, collect(Tg, x_axis), length(x_axis), Tg(tension), bc, extrap_eff
+        anchors, collect(Tg, x_ext), length(x_ext), Tg(tension), bc, extrap_eff
     )
 end
 

--- a/src/cardinal/cardinal_adjoint.jl
+++ b/src/cardinal/cardinal_adjoint.jl
@@ -52,20 +52,39 @@ f_bar = adj(y_bar; deriv=DerivOp(1))    # derivative adjoint
 adj(f_bar, y_bar)                       # in-place
 ```
 """
-struct CardinalAdjoint1D{Tg, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
+struct CardinalAdjoint1D{Tg, BC <: AbstractBC, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
     anchors::Vector{_HermiteAdjointAnchor1D{Tg}}
-    grid::Vector{Tg}       # Grid points (needed for slope adjoint stencil widths)
-    grid_size::Int
+    grid::Vector{Tg}       # Grid points (extended to length n+1 for `:exclusive`)
+    grid_size::Int         # Internal length: n+1 for `:exclusive`, n otherwise
     tension::Tg
+    bc::BC
     extrap::EP
 end
 
 # ========================================
 # 1D Adjoint Protocol Accessors
 # ========================================
+# Callables, Base.size, Base.Matrix, exclusive-periodic in-place seam fold
+# inherited from AbstractAdjoint1D via src/core/adjoint_protocol.jl.
 
 @inline _n_queries(adj::CardinalAdjoint1D) = length(adj.anchors)
-@inline _adjoint_output_length(adj::CardinalAdjoint1D) = adj.grid_size
+
+@inline _adjoint_output_length(adj::CardinalAdjoint1D) =
+    adj.bc isa PeriodicBC{:exclusive} ? adj.grid_size - 1 : adj.grid_size
+
+@inline _adjoint_internal_length(adj::CardinalAdjoint1D) = adj.grid_size
+
+@inline _adjoint_1d_has_exclusive_periodic(adj::CardinalAdjoint1D) =
+    adj.bc isa PeriodicBC{:exclusive}
+
+function _adjoint_1d_finalize(f_bar::AbstractVector, adj::CardinalAdjoint1D)
+    if adj.bc isa PeriodicBC{:exclusive}
+        n_internal = adj.grid_size
+        @inbounds f_bar[1] += f_bar[n_internal]
+        return f_bar[1:(n_internal - 1)]
+    end
+    return f_bar
+end
 
 # ========================================
 # Slope Adjoint: J^T * dy_bar -> f_bar update
@@ -109,6 +128,43 @@ end
     return nothing
 end
 
+# Closed-cycle Cardinal slope adjoint (after `_periodic_extend_1d`-style extension).
+# Forward:  dy[k] = scale * (m_prev*h_prev + m_curr*h_curr) / (h_prev + h_curr)
+#   where  m_prev = (y[j_prev+1] - y[j_prev]) / h_prev,
+#          m_curr = (y[j_curr+1] - y[j_curr]) / h_curr,
+#          j_prev = mod1(k-1, m_cyc),  j_curr = mod1(k, m_cyc),  m_cyc = n-1.
+#
+# Adjoint scatters dy_bar[k] to FOUR f_bar entries (j_prev, j_prev+1, j_curr,
+# j_curr+1). For interior k (where j_prev+1 == j_curr), two of those writes
+# fall on the same index with opposite signs and cancel — equivalent to the
+# legacy 2-write central FD adjoint. For boundary k ∈ {1, n} in closed cycle,
+# the 4 indices are DISTINCT (the join wraps so j_prev+1 ≠ j_curr), and all
+# four writes contribute. Unified across both interior and boundary.
+@inline function _cardinal_slope_adjoint_periodic!(
+        f_bar::AbstractVector, dy_bar::AbstractVector,
+        x::AbstractVector{Tg}, tension::Tg
+    ) where {Tg}
+    n = length(x)
+    n >= 2 || return nothing
+    m_cyc = n - 1
+    scale = one(Tg) - tension
+
+    @inbounds for k in 1:n
+        j_prev = mod1(k - 1, m_cyc)
+        j_curr = mod1(k, m_cyc)
+        h_prev = x[j_prev + 1] - x[j_prev]
+        h_curr = x[j_curr + 1] - x[j_curr]
+        c = scale * dy_bar[k] / (h_prev + h_curr)
+        # Chain rule for both secants (`m_prev` and `m_curr`) — at interior
+        # the +c at j_prev+1 and -c at j_curr cancel naturally.
+        f_bar[j_prev]     -= c
+        f_bar[j_prev + 1] += c
+        f_bar[j_curr]     -= c
+        f_bar[j_curr + 1] += c
+    end
+    return nothing
+end
+
 # ========================================
 # Core Apply Function
 # ========================================
@@ -128,8 +184,13 @@ end
     # Step 1: Hermite scatter -> (f_bar, dy_bar)
     _scatter_hermite_adjoint!(f_bar, dy_bar, adj.anchors, y_bar, deriv)
 
-    # Step 2: Slope J^T * dy_bar -> f_bar update
-    _cardinal_slope_adjoint!(f_bar, dy_bar, adj.grid, adj.tension)
+    # Step 2: Slope J^T * dy_bar -> f_bar update.
+    # PeriodicBC (closed-cycle internal grid) → wrap-aware path.
+    if adj.bc isa PeriodicBC
+        _cardinal_slope_adjoint_periodic!(f_bar, dy_bar, adj.grid, adj.tension)
+    else
+        _cardinal_slope_adjoint!(f_bar, dy_bar, adj.grid, adj.tension)
+    end
 
     return nothing
 end
@@ -171,6 +232,7 @@ f_bar = adj(y_bar)
 function cardinal_adjoint(
         x::AbstractVector,
         x_query::AbstractVector;
+        bc::AbstractBC = NoBC(),
         tension::Real = 0.0,
         extrap::AbstractExtrap = NoExtrap(),
         _extra...
@@ -179,23 +241,31 @@ function cardinal_adjoint(
 
     length(x_p) >= 2 || _throw_adjoint_grid_too_small(length(x_p))
 
-    # NoExtrap: validate all queries in-domain
-    if extrap isa NoExtrap
-        x_lo, x_hi = first(x_p), last(x_p)
+    # BC-aware axis wrap. For `:exclusive`, `_cache_axis` returns
+    # `_ExclusivePeriodicAxis` of logical length n+1; `collect` materializes
+    # to a length-(n+1) Vector with the virtual seam endpoint at index n+1.
+    # For `:inclusive` / NoBC, length unchanged. The slope adjoint then
+    # runs over the materialized closed-cycle grid via the periodic path.
+    x_axis = _cache_axis(x_p, bc, Tg)
+    extrap_eff = _resolve_extrap(extrap, bc, x_axis)
+
+    # NoExtrap: validate queries against the axis's domain (covers the seam
+    # endpoint for `:exclusive`; non-periodic NoExtrap still validates here
+    # since periodic auto-promotes to WrapExtrap above).
+    if extrap_eff isa NoExtrap
+        x_lo, x_hi = _extract_primal(first(x_axis)), _extract_primal(last(x_axis))
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
-            (_extract_primal(x_lo) <= xq_i <= _extract_primal(x_hi)) || throw(
-                DomainError(xq_i, "query point outside domain [$(_extract_primal(x_lo)), $(_extract_primal(x_hi))]")
+            (x_lo <= xq_i <= x_hi) || throw(
+                DomainError(xq_i, "query point outside domain [$x_lo, $x_hi]")
             )
         end
     end
 
-    # Wrap axis (axis-as-truth) and bake anchors
-    x_axis = _cache_axis(x_p, NoBC())
-    anchors = _bake_hermite_adjoint_anchors(x_axis, xq_p, extrap)
+    anchors = _bake_hermite_adjoint_anchors(x_axis, xq_p, extrap_eff)
 
-    return CardinalAdjoint1D{Tg, typeof(extrap)}(
-        anchors, collect(x_p), length(x_p), Tg(tension), extrap
+    return CardinalAdjoint1D{Tg, typeof(bc), typeof(extrap_eff)}(
+        anchors, collect(Tg, x_axis), length(x_axis), Tg(tension), bc, extrap_eff
     )
 end
 
@@ -203,9 +273,10 @@ end
 function cardinal_adjoint(
         x::AbstractVector,
         x_query::Real;
+        bc::AbstractBC = NoBC(),
         tension::Real = 0.0,
         extrap::AbstractExtrap = NoExtrap(),
         _extra...
     )
-    return cardinal_adjoint(x, [x_query]; tension = tension, extrap = extrap)
+    return cardinal_adjoint(x, [x_query]; bc = bc, tension = tension, extrap = extrap)
 end

--- a/src/cardinal/cardinal_adjoint.jl
+++ b/src/cardinal/cardinal_adjoint.jl
@@ -81,6 +81,7 @@ end
 # Transpose: for each k, dy_bar[k] scatters to 2 f_bar entries.
 
 @inline function _cardinal_slope_adjoint!(
+        ::NoBC,
         f_bar::AbstractVector, dy_bar::AbstractVector,
         x::AbstractVector{Tg}, tension::Tg
     ) where {Tg}
@@ -127,7 +128,8 @@ end
 # boundary k=1 / k=n iterations use the 4-write closed-cycle formula
 # (the join wraps so j_prev+1 ≠ j_curr — all 4 writes are distinct),
 # while interior reuses the NoBC fast path.
-@inline function _cardinal_slope_adjoint_periodic!(
+@inline function _cardinal_slope_adjoint!(
+        ::PeriodicBC,
         f_bar::AbstractVector, dy_bar::AbstractVector,
         x::AbstractVector{Tg}, tension::Tg
     ) where {Tg}
@@ -200,23 +202,20 @@ end
 
 @with_pool pool function _cardinal_adjoint_apply!(
         f_bar::AbstractVector{Tv},
-        adj::CardinalAdjoint1D{Tg},
+        adj::CardinalAdjoint1D{Tg, BC},
         y_bar,
         deriv::DerivOp = EvalValue()
-    ) where {Tv, Tg}
+    ) where {Tv, Tg, BC}
     n = adj.grid_size
     dy_bar = zeros!(pool, Tv, n)
 
     # Step 1: Hermite scatter -> (f_bar, dy_bar)
     _scatter_hermite_adjoint!(f_bar, dy_bar, adj.anchors, y_bar, deriv)
 
-    # Step 2: Slope J^T * dy_bar -> f_bar update.
-    # PeriodicBC (closed-cycle internal grid) → wrap-aware path.
-    if adj.bc isa PeriodicBC
-        _cardinal_slope_adjoint_periodic!(f_bar, dy_bar, adj.grid, adj.tension)
-    else
-        _cardinal_slope_adjoint!(f_bar, dy_bar, adj.grid, adj.tension)
-    end
+    # Step 2: Slope J^T * dy_bar -> f_bar update. BC dispatched at compile time
+    # via `BC` parameter bound in where clause (two methods of the slope adjoint
+    # cover `::PeriodicBC` and `::NoBC` — see definitions above).
+    _cardinal_slope_adjoint!(adj.bc, f_bar, dy_bar, adj.grid, adj.tension)
 
     return nothing
 end

--- a/src/cardinal/cardinal_adjoint.jl
+++ b/src/cardinal/cardinal_adjoint.jl
@@ -69,23 +69,6 @@ end
 
 @inline _n_queries(adj::CardinalAdjoint1D) = length(adj.anchors)
 
-@inline _adjoint_output_length(adj::CardinalAdjoint1D) =
-    adj.bc isa PeriodicBC{:exclusive} ? adj.grid_size - 1 : adj.grid_size
-
-@inline _adjoint_internal_length(adj::CardinalAdjoint1D) = adj.grid_size
-
-@inline _adjoint_1d_has_exclusive_periodic(adj::CardinalAdjoint1D) =
-    adj.bc isa PeriodicBC{:exclusive}
-
-function _adjoint_1d_finalize(f_bar::AbstractVector, adj::CardinalAdjoint1D)
-    if adj.bc isa PeriodicBC{:exclusive}
-        n_internal = adj.grid_size
-        @inbounds f_bar[1] += f_bar[n_internal]
-        return f_bar[1:(n_internal - 1)]
-    end
-    return f_bar
-end
-
 # ========================================
 # Slope Adjoint: J^T * dy_bar -> f_bar update
 # ========================================
@@ -278,7 +261,6 @@ function cardinal_adjoint(
         bc::AbstractBC = NoBC(),
         tension::Real = 0.0,
         extrap::AbstractExtrap = NoExtrap(),
-        _extra...
     )
     x_p, xq_p, Tg = _promote_adjoint_inputs(x, x_query)
 
@@ -328,7 +310,6 @@ function cardinal_adjoint(
         bc::AbstractBC = NoBC(),
         tension::Real = 0.0,
         extrap::AbstractExtrap = NoExtrap(),
-        _extra...
     )
     return cardinal_adjoint(x, [x_query]; bc = bc, tension = tension, extrap = extrap)
 end

--- a/src/cardinal/cardinal_adjoint.jl
+++ b/src/cardinal/cardinal_adjoint.jl
@@ -134,34 +134,77 @@ end
 #          m_curr = (y[j_curr+1] - y[j_curr]) / h_curr,
 #          j_prev = mod1(k-1, m_cyc),  j_curr = mod1(k, m_cyc),  m_cyc = n-1.
 #
-# Adjoint scatters dy_bar[k] to FOUR f_bar entries (j_prev, j_prev+1, j_curr,
-# j_curr+1). For interior k (where j_prev+1 == j_curr), two of those writes
-# fall on the same index with opposite signs and cancel — equivalent to the
-# legacy 2-write central FD adjoint. For boundary k ∈ {1, n} in closed cycle,
-# the 4 indices are DISTINCT (the join wraps so j_prev+1 ≠ j_curr), and all
-# four writes contribute. Unified across both interior and boundary.
+# Cardinal slope stencil radius = 1 (uses y[k-1], y[k], y[k+1]). Boundary
+# indices where mod1 actually wraps: k=1 (j_prev → m_cyc) and k=n (j_curr
+# → 1). For interior k ∈ [2, n-1], j_prev = k-1 and j_curr = k stay in
+# `[1, m_cyc]` without wrapping, AND j_prev+1 == j_curr — so the two
+# inner-write pairs (`f_bar[j_prev+1] += c` and `f_bar[j_curr] -= c`)
+# cancel naturally and the body collapses to the 2-write central-FD
+# adjoint identical to NoBC interior. We split the loop accordingly: the
+# boundary k=1 / k=n iterations use the 4-write closed-cycle formula
+# (the join wraps so j_prev+1 ≠ j_curr — all 4 writes are distinct),
+# while interior reuses the NoBC fast path.
 @inline function _cardinal_slope_adjoint_periodic!(
         f_bar::AbstractVector, dy_bar::AbstractVector,
         x::AbstractVector{Tg}, tension::Tg
     ) where {Tg}
     n = length(x)
     n >= 2 || return nothing
-    m_cyc = n - 1
     scale = one(Tg) - tension
 
-    @inbounds for k in 1:n
-        j_prev = mod1(k - 1, m_cyc)
-        j_curr = mod1(k, m_cyc)
+    # Tiny grid (n == 2): the 1-secant cycle makes BOTH k=1 and k=2 wrap to
+    # the same secant. The interior range `2:n-1` is empty; bypass it.
+    if n == 2
+        m_cyc = 1
+        @inbounds for k in 1:2
+            j_prev = mod1(k - 1, m_cyc)
+            j_curr = mod1(k, m_cyc)
+            h_prev = x[j_prev + 1] - x[j_prev]
+            h_curr = x[j_curr + 1] - x[j_curr]
+            c = scale * dy_bar[k] / (h_prev + h_curr)
+            f_bar[j_prev]     -= c
+            f_bar[j_prev + 1] += c
+            f_bar[j_curr]     -= c
+            f_bar[j_curr + 1] += c
+        end
+        return nothing
+    end
+
+    m_cyc = n - 1
+
+    # ── Boundary k=1: j_prev wraps to m_cyc (= n-1) ─────────────────────
+    @inbounds begin
+        j_prev = m_cyc
+        j_curr = 1
         h_prev = x[j_prev + 1] - x[j_prev]
         h_curr = x[j_curr + 1] - x[j_curr]
-        c = scale * dy_bar[k] / (h_prev + h_curr)
-        # Chain rule for both secants (`m_prev` and `m_curr`) — at interior
-        # the +c at j_prev+1 and -c at j_curr cancel naturally.
-        f_bar[j_prev]     -= c
-        f_bar[j_prev + 1] += c
-        f_bar[j_curr]     -= c
-        f_bar[j_curr + 1] += c
+        c = scale * dy_bar[1] / (h_prev + h_curr)
+        f_bar[j_prev]     -= c       # f_bar[n-1]
+        f_bar[j_prev + 1] += c       # f_bar[n]
+        f_bar[j_curr]     -= c       # f_bar[1]
+        f_bar[j_curr + 1] += c       # f_bar[2]
     end
+
+    # ── Interior k = 2..n-1: no wrap; collapses to 2-write central FD ───
+    @inbounds for k in 2:(n - 1)
+        c = scale * dy_bar[k] / (x[k + 1] - x[k - 1])
+        f_bar[k - 1] -= c
+        f_bar[k + 1] += c
+    end
+
+    # ── Boundary k=n: j_curr wraps to 1 ─────────────────────────────────
+    @inbounds begin
+        j_prev = m_cyc           # n-1
+        j_curr = 1
+        h_prev = x[j_prev + 1] - x[j_prev]   # x[n] - x[n-1]
+        h_curr = x[j_curr + 1] - x[j_curr]   # x[2] - x[1]
+        c = scale * dy_bar[n] / (h_prev + h_curr)
+        f_bar[j_prev]     -= c       # f_bar[n-1]
+        f_bar[j_prev + 1] += c       # f_bar[n]
+        f_bar[j_curr]     -= c       # f_bar[1]
+        f_bar[j_curr + 1] += c       # f_bar[2]
+    end
+
     return nothing
 end
 

--- a/src/cardinal/cardinal_adjoint.jl
+++ b/src/cardinal/cardinal_adjoint.jl
@@ -147,9 +147,9 @@ end
             h_prev = x[j_prev + 1] - x[j_prev]
             h_curr = x[j_curr + 1] - x[j_curr]
             c = scale * dy_bar[k] / (h_prev + h_curr)
-            f_bar[j_prev]     -= c
+            f_bar[j_prev] -= c
             f_bar[j_prev + 1] += c
-            f_bar[j_curr]     -= c
+            f_bar[j_curr] -= c
             f_bar[j_curr + 1] += c
         end
         return nothing
@@ -164,9 +164,9 @@ end
         h_prev = x[j_prev + 1] - x[j_prev]
         h_curr = x[j_curr + 1] - x[j_curr]
         c = scale * dy_bar[1] / (h_prev + h_curr)
-        f_bar[j_prev]     -= c       # f_bar[n-1]
+        f_bar[j_prev] -= c       # f_bar[n-1]
         f_bar[j_prev + 1] += c       # f_bar[n]
-        f_bar[j_curr]     -= c       # f_bar[1]
+        f_bar[j_curr] -= c       # f_bar[1]
         f_bar[j_curr + 1] += c       # f_bar[2]
     end
 
@@ -184,9 +184,9 @@ end
         h_prev = x[j_prev + 1] - x[j_prev]   # x[n] - x[n-1]
         h_curr = x[j_curr + 1] - x[j_curr]   # x[2] - x[1]
         c = scale * dy_bar[n] / (h_prev + h_curr)
-        f_bar[j_prev]     -= c       # f_bar[n-1]
+        f_bar[j_prev] -= c       # f_bar[n-1]
         f_bar[j_prev + 1] += c       # f_bar[n]
-        f_bar[j_curr]     -= c       # f_bar[1]
+        f_bar[j_curr] -= c       # f_bar[1]
         f_bar[j_curr + 1] += c       # f_bar[2]
     end
 

--- a/src/constant/constant_adjoint.jl
+++ b/src/constant/constant_adjoint.jl
@@ -74,23 +74,6 @@ end
 
 @inline _n_queries(adj::ConstantAdjoint) = length(adj.anchors)
 
-@inline _adjoint_output_length(adj::ConstantAdjoint) =
-    adj.bc isa PeriodicBC{:exclusive} ? adj.grid_size - 1 : adj.grid_size
-
-@inline _adjoint_internal_length(adj::ConstantAdjoint) = adj.grid_size
-
-@inline _adjoint_1d_has_exclusive_periodic(adj::ConstantAdjoint) =
-    adj.bc isa PeriodicBC{:exclusive}
-
-function _adjoint_1d_finalize(f_bar::AbstractVector, adj::ConstantAdjoint)
-    if adj.bc isa PeriodicBC{:exclusive}
-        n_internal = adj.grid_size
-        @inbounds f_bar[1] += f_bar[n_internal]
-        return f_bar[1:(n_internal - 1)]
-    end
-    return f_bar
-end
-
 @inline _adjoint_1d_apply!(f_bar, adj::ConstantAdjoint, y_bar, deriv) =
     _constant_adjoint_apply!(f_bar, adj, y_bar, deriv)
 
@@ -243,7 +226,6 @@ function constant_adjoint(
         bc::AbstractBC = NoBC(),
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
-        _extra...
     )
     x_p, xq_p, Tg = _promote_adjoint_inputs(x, x_query)
 
@@ -298,7 +280,6 @@ function constant_adjoint(
         bc::AbstractBC = NoBC(),
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
-        _extra...
     )
     return constant_adjoint(x, [x_query]; bc = bc, side = side, extrap = extrap)
 end

--- a/src/constant/constant_adjoint.jl
+++ b/src/constant/constant_adjoint.jl
@@ -56,10 +56,11 @@ itp = constant_interp(x, f; side=NearestSide())
 @assert dot(itp.(xq), y_bar) ≈ dot(f, adj(y_bar))
 ```
 """
-struct ConstantAdjoint{Tg, SD <: AbstractSide, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
+struct ConstantAdjoint{Tg, BC <: AbstractBC, SD <: AbstractSide, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
     anchors::Vector{_ConstantAnchoredQuery{Tg, Tg}}
-    grid_size::Int
+    grid_size::Int  # internal length: n+1 for PeriodicBC{:exclusive}, n otherwise
     x_hi::Tg
+    bc::BC
     side::SD
     extrap::EP
 end
@@ -67,11 +68,28 @@ end
 # ========================================
 # 1D Adjoint Protocol Accessors
 # ========================================
-# Callables (6 overloads), Base.size, and Base.Matrix are inherited
-# from AbstractAdjoint via src/core/adjoint_protocol.jl.
+# Callables (6 overloads), Base.size, Base.Matrix, and exclusive-periodic
+# in-place seam fold are inherited from AbstractAdjoint1D via
+# src/core/adjoint_protocol.jl.
 
 @inline _n_queries(adj::ConstantAdjoint) = length(adj.anchors)
-@inline _adjoint_output_length(adj::ConstantAdjoint) = adj.grid_size
+
+@inline _adjoint_output_length(adj::ConstantAdjoint) =
+    adj.bc isa PeriodicBC{:exclusive} ? adj.grid_size - 1 : adj.grid_size
+
+@inline _adjoint_internal_length(adj::ConstantAdjoint) = adj.grid_size
+
+@inline _adjoint_1d_has_exclusive_periodic(adj::ConstantAdjoint) =
+    adj.bc isa PeriodicBC{:exclusive}
+
+function _adjoint_1d_finalize(f_bar::AbstractVector, adj::ConstantAdjoint)
+    if adj.bc isa PeriodicBC{:exclusive}
+        n_internal = adj.grid_size
+        @inbounds f_bar[1] += f_bar[n_internal]
+        return f_bar[1:(n_internal - 1)]
+    end
+    return f_bar
+end
 
 @inline _adjoint_1d_apply!(f_bar, adj::ConstantAdjoint, y_bar, deriv) =
     _constant_adjoint_apply!(f_bar, adj, y_bar, deriv)
@@ -222,6 +240,7 @@ f_bar = adj(y_bar)
 function constant_adjoint(
         x::AbstractVector,
         x_query::AbstractVector;
+        bc::AbstractBC = NoBC(),
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
         _extra...
@@ -230,11 +249,19 @@ function constant_adjoint(
 
     length(x_p) >= 2 || _throw_adjoint_grid_too_small(length(x_p))
 
-    x_hi = last(x_p)
+    # BC-aware axis wrap: `:exclusive` periodic → `_ExclusivePeriodicAxis` with
+    # logical length n+1. Anchors at the seam cell store stencil = (n, n+1);
+    # the protocol's exclusive-periodic in-place callable folds f_work[1] +=
+    # f_work[n+1] before trim. Right-boundary special case `xq == x_hi` also
+    # writes to f_bar[n+1] (the virtual seam endpoint), so it folds correctly.
+    x_axis = _cache_axis(x_p, bc, Tg)
+    extrap_eff = _resolve_extrap(extrap, bc, x_axis)
+    x_hi = last(x_axis)
 
-    # NoExtrap: validate all queries in-domain (use primal for Dual grid boundaries)
-    if extrap isa NoExtrap
-        x_lo_p, x_hi_p = _extract_primal(first(x_p)), _extract_primal(last(x_p))
+    # NoExtrap: validate all queries in-domain (uses x_axis bounds, which include
+    # the virtual seam endpoint for `:exclusive`).
+    if extrap_eff isa NoExtrap
+        x_lo_p, x_hi_p = _extract_primal(first(x_axis)), _extract_primal(last(x_axis))
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
             (x_lo_p <= xq_i <= x_hi_p) || throw(
@@ -244,33 +271,36 @@ function constant_adjoint(
     end
 
     # Build anchored queries with extrap-specific preprocessing
-    wrap = extrap isa WrapExtrap
-    if extrap isa _ClampOrFill || extrap isa ExtendExtrap
+    wrap = extrap_eff isa WrapExtrap
+    if extrap_eff isa _ClampOrFill || extrap_eff isa ExtendExtrap
         # For constant interp, ExtendExtrap == ClampExtrap (slope=0).
         # Clamp OOB queries to boundary for correct anchor geometry.
         # Then restore side flags so scatter can skip OOB contributions.
-        x_lo_p, x_hi_p = _extract_primal(first(x_p)), _extract_primal(last(x_p))
+        x_lo_p, x_hi_p = _extract_primal(first(x_axis)), _extract_primal(last(x_axis))
         xq_clamped = clamp.(xq_p, x_lo_p, x_hi_p)
-        anchors = _anchor_query(x_p, xq_clamped, Val(:constant), false)
+        anchors = _anchor_query(x_axis, xq_clamped, Val(:constant), false)
         _fixup_constant_anchor_state!(anchors, xq_p, x_lo_p, x_hi_p)
     else
-        # WrapExtrap: wraps to domain (correct)
-        # NoExtrap: already validated in-domain above
-        anchors = _anchor_query(x_p, xq_p, Val(:constant), wrap)
+        # WrapExtrap: wraps to domain (covers periodic auto-promotion).
+        # NoExtrap: already validated in-domain above.
+        anchors = _anchor_query(x_axis, xq_p, Val(:constant), wrap)
     end
 
-    return ConstantAdjoint{Tg, typeof(side), typeof(extrap)}(anchors, length(x_p), x_hi, side, extrap)
+    return ConstantAdjoint{Tg, typeof(bc), typeof(side), typeof(extrap_eff)}(
+        anchors, length(x_axis), x_hi, bc, side, extrap_eff
+    )
 end
 
 # Scalar query convenience
 function constant_adjoint(
         x::AbstractVector,
         x_query::Real;
+        bc::AbstractBC = NoBC(),
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
         _extra...
     )
-    return constant_adjoint(x, [x_query]; side = side, extrap = extrap)
+    return constant_adjoint(x, [x_query]; bc = bc, side = side, extrap = extrap)
 end
 
 # Matrix materialization inherited from AbstractAdjoint (adjoint_protocol.jl)

--- a/src/core/adjoint_protocol.jl
+++ b/src/core/adjoint_protocol.jl
@@ -72,12 +72,20 @@
 @inline _adjoint_1d_has_exclusive_periodic(adj::AbstractAdjoint1D) =
     adj.bc isa PeriodicBC{:exclusive}
 
-function _adjoint_1d_finalize(f_bar::AbstractVector, adj::AbstractAdjoint1D)
-    if adj.bc isa PeriodicBC{:exclusive}
-        n_internal = adj.grid_size
-        @inbounds f_bar[1] += f_bar[n_internal]
-        return f_bar[1:(n_internal - 1)]
-    end
+# Dispatches on `adj.bc`. Subtypes without `.bc` (`HermiteAdjoint1D`) override directly.
+@inline _adjoint_1d_finalize(f_bar::AbstractVector, adj::AbstractAdjoint1D) =
+    _adjoint_1d_finalize(adj.bc, f_bar, adj)
+
+@inline _adjoint_1d_finalize(::AbstractBC, f_bar::AbstractVector, ::AbstractAdjoint1D) = f_bar
+
+# Seam-fold + in-place shrink. `resize!` on `Vector` is O(1) (no copy);
+# slicing `f_bar[1:n-1]` would heap-allocate a copy on every call.
+@inline function _adjoint_1d_finalize(
+        ::PeriodicBC{:exclusive}, f_bar::Vector, adj::AbstractAdjoint1D,
+    )
+    n_internal = _adjoint_internal_length(adj)
+    @inbounds f_bar[1] += f_bar[n_internal]
+    resize!(f_bar, n_internal - 1)
     return f_bar
 end
 

--- a/src/core/adjoint_protocol.jl
+++ b/src/core/adjoint_protocol.jl
@@ -263,14 +263,11 @@ end
 @inline _seam_fold_axis!(f_work, ::Val{d}, gs_d::Int, ::PeriodicBC{:exclusive}) where {d} =
     (selectdim(f_work, d, 1) .+= selectdim(f_work, d, gs_d); nothing)
 @inline _seam_fold_axis!(f_work, ::Val{d}, ::Int, ::AbstractBC) where {d} = nothing
-# `HeteroAdjointND` stores `nothing` for non-derivative (Linear/Constant) axes,
-# which can never be `PeriodicBC{:exclusive}` — treat as no-op.
-@inline _seam_fold_axis!(f_work, ::Val{d}, ::Int, ::Nothing) where {d} = nothing
 
 # Compile-time-unrolled seam-fold loop (one branch per axis, all literal `d`).
 @generated function _apply_seam_fold!(
         f_work::AbstractArray{T, N},
-        bcs::NTuple{N, Union{AbstractBC, Nothing}},
+        bcs::NTuple{N, AbstractBC},
         gs::NTuple{N, Int}
     ) where {T, N}
     body = [:(_seam_fold_axis!(f_work, Val($d), gs[$d], bcs[$d])) for d in 1:N]

--- a/src/core/adjoint_protocol.jl
+++ b/src/core/adjoint_protocol.jl
@@ -7,13 +7,15 @@
 #
 # ── 1D Subtypes must implement:
 #   _n_queries(adj)::Int
-#   _adjoint_output_length(adj)::Int
 #   _adjoint_1d_apply!(f_bar, adj, y_bar, deriv)
 #
-# ── 1D Subtypes may override (for periodic BC):
+# ── 1D Subtypes inherit (assuming `adj.bc::AbstractBC` and `adj.grid_size::Int`):
+#   _adjoint_output_length(adj)::Int
 #   _adjoint_internal_length(adj)::Int
 #   _adjoint_1d_has_exclusive_periodic(adj)::Bool
 #   _adjoint_1d_finalize(f_bar, adj)
+# Override these only if the subtype lacks the assumed fields (e.g.,
+# `CubicAdjoint` reads `length(adj.cache.x)` instead of `adj.grid_size`).
 #
 # ── ND Subtypes must implement:
 #   _n_queries(adj)::Int
@@ -58,11 +60,26 @@
 # ║           1D Adjoint Protocol        ║
 # ╚══════════════════════════════════════╝
 
-# ── 1D Defaults (non-periodic types inherit these as-is) ──
+# ── 1D Defaults ──
+# Assume `adj.bc::AbstractBC` and `adj.grid_size::Int` fields. Concrete subtypes
+# without those fields (e.g., `CubicAdjoint` uses `length(adj.cache.x)`) override.
 
-@inline _adjoint_internal_length(adj::AbstractAdjoint1D) = _adjoint_output_length(adj)
-@inline _adjoint_1d_has_exclusive_periodic(::AbstractAdjoint1D) = false
-@inline _adjoint_1d_finalize(f_bar::AbstractVector, ::AbstractAdjoint1D) = f_bar
+@inline _adjoint_output_length(adj::AbstractAdjoint1D) =
+    adj.bc isa PeriodicBC{:exclusive} ? adj.grid_size - 1 : adj.grid_size
+
+@inline _adjoint_internal_length(adj::AbstractAdjoint1D) = adj.grid_size
+
+@inline _adjoint_1d_has_exclusive_periodic(adj::AbstractAdjoint1D) =
+    adj.bc isa PeriodicBC{:exclusive}
+
+function _adjoint_1d_finalize(f_bar::AbstractVector, adj::AbstractAdjoint1D)
+    if adj.bc isa PeriodicBC{:exclusive}
+        n_internal = adj.grid_size
+        @inbounds f_bar[1] += f_bar[n_internal]
+        return f_bar[1:(n_internal - 1)]
+    end
+    return f_bar
+end
 
 # ── Size / Introspection ──
 

--- a/src/core/bc_types.jl
+++ b/src/core/bc_types.jl
@@ -59,13 +59,11 @@ abstract type AbstractBC end
     NoBC <: AbstractBC
 
 Sentinel boundary-condition value meaning "no BC requested; use the method's
-built-in endpoint rule". Currently the default `bc` kwarg for **Constant and
-Linear** interpolation (the only non-cubic methods wired for `bc` in this
-release). PCHIP / Cardinal / Akima will adopt the same default when their
-`bc` kwarg is added (planned next phase).
+built-in endpoint rule". Default `bc` for all five 1D non-cubic method families
+(Linear, Constant, PCHIP, Cardinal, Akima).
 
-For supported methods, `bc=NoBC()` preserves existing behavior, and
-`bc=PeriodicBC(...)` engages the periodic build path.
+`bc=NoBC()` preserves the built-in endpoint behavior; `bc=PeriodicBC(...)`
+engages the periodic build path.
 
 Cubic and Quadratic do not use `NoBC` because their coefficient systems are
 under-determined without a concrete closure condition (they default to

--- a/src/core/bc_types.jl
+++ b/src/core/bc_types.jl
@@ -546,6 +546,7 @@ Note: PeriodicBC is handled separately via `_is_periodic_bc()` check before
 @inline _normalize_bc(::ZeroSlopeBC, sample) = (z = 0 * sample; BCPair(Deriv1(z), Deriv1(z)))
 @inline _normalize_bc(bc::BCPair) = bc
 @inline _normalize_bc(bc::PointBC) = BCPair(bc, bc)
+@inline _normalize_bc(bc::NoBC) = bc
 # Fallback: ignore second arg for all other BC types (only ZeroCurv/ZeroSlope need it)
 @inline _normalize_bc(bc::AbstractBC, _sample) = _normalize_bc(bc)
 

--- a/src/core/interp_method_types.jl
+++ b/src/core/interp_method_types.jl
@@ -93,6 +93,11 @@ end
 ConstantInterp(; side::AbstractSide = NearestSide(), bc::AbstractBC = NoBC()) =
     ConstantInterp(side, bc)
 
+# Positional 1-arg compat: pre-`bc`-field code used `ConstantInterp(LeftSide())`.
+# The default 2-field struct constructor `ConstantInterp(side, bc)` shadows that
+# call form; this outer ctor restores it with `bc=NoBC()` default.
+ConstantInterp(side::AbstractSide) = ConstantInterp(side, NoBC())
+
 """
     NoInterp()
 

--- a/src/core/interp_method_types.jl
+++ b/src/core/interp_method_types.jl
@@ -44,12 +44,21 @@ end
 CubicInterp(; bc::AbstractBC = CubicFit()) = CubicInterp(bc)
 
 """
-    LinearInterp()
+    LinearInterp(; bc::AbstractBC = NoBC())
 
 Linear interpolation method for one axis.
 Requires ≥2 grid points.
+
+# Arguments
+- `bc`: Boundary condition. Defaults to [`NoBC`](@ref) (use built-in endpoint
+  rule). Pass `PeriodicBC(...)` to engage periodic semantics — supported in
+  both homogeneous (e.g. `interp(grids, data; method=(LinearInterp(bc=PeriodicBC()), ...))`)
+  and heterogeneous (mixed with Cubic / Quadratic / Hermite axes) ND calls.
 """
-struct LinearInterp <: AbstractInterpMethod end
+struct LinearInterp{BC <: AbstractBC} <: AbstractInterpMethod
+    bc::BC
+end
+LinearInterp(; bc::AbstractBC = NoBC()) = LinearInterp(bc)
 
 """
     QuadraticInterp(; bc::AbstractBC = Left(QuadraticFit()))
@@ -67,18 +76,22 @@ end
 QuadraticInterp(; bc::AbstractBC = Left(QuadraticFit())) = QuadraticInterp(bc)
 
 """
-    ConstantInterp(; side::AbstractSide = NearestSide())
+    ConstantInterp(; side::AbstractSide = NearestSide(), bc::AbstractBC = NoBC())
 
 Constant (nearest-neighbor) interpolation method for one axis.
 Requires ≥2 grid points.
 
 # Arguments
 - `side`: Side selection — `NearestSide()`, `LeftSide()`, `RightSide()`.
+- `bc`: Boundary condition. Defaults to [`NoBC`](@ref). Pass `PeriodicBC(...)`
+  to engage periodic semantics in homogeneous or heterogeneous ND calls.
 """
-struct ConstantInterp{SD <: AbstractSide} <: AbstractInterpMethod
+struct ConstantInterp{SD <: AbstractSide, BC <: AbstractBC} <: AbstractInterpMethod
     side::SD
+    bc::BC
 end
-ConstantInterp(; side::AbstractSide = NearestSide()) = ConstantInterp(side)
+ConstantInterp(; side::AbstractSide = NearestSide(), bc::AbstractBC = NoBC()) =
+    ConstantInterp(side, bc)
 
 """
     NoInterp()

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -298,6 +298,28 @@ Uses dispatch on PeriodicBC{E} type parameter for type stability.
 @inline _prepare_periodic(x, y, bc::PeriodicBC{:exclusive}) = _extend_exclusive(x, y, bc)
 
 """
+    _prepare_periodic_grid(x, bc) -> x_ext
+
+x-only sibling of `_prepare_periodic` for data-free callers (adjoint
+operators that don't carry per-grid data). Mirrors the extension policy
+on the x side exactly:
+- `PeriodicBC{:inclusive}`  → passthrough (already closed-cycle).
+- `PeriodicBC{:exclusive}`  → length-(n+1) extension via `_extend_exclusive`'s
+                              x-side validation + `vcat` / Range endpoint append.
+"""
+@inline _prepare_periodic_grid(x, ::AbstractBC) = x          # NoBC / non-periodic — passthrough
+@inline _prepare_periodic_grid(x, ::PeriodicBC{:inclusive}) = x
+
+@inline function _prepare_periodic_grid(x::AbstractVector, bc::PeriodicBC{:exclusive})
+    period = _resolve_exclusive_period(x, bc)
+    _validate_exclusive_period(x, period)
+    Tg_real = eltype(x) <: _PromotableValue ? float(eltype(x)) : eltype(x)
+    x_end = first(x) + Tg_real(period)
+    last(x) < x_end || _throw_excl_endpoint_too_small(period, x_end, last(x))
+    return x isa AbstractRange ? _to_float_adding_endpoint(x, Tg_real) : vcat(x, x_end)
+end
+
+"""
     _can_infer_period(x) -> Bool
 
 Check if the period can be inferred from the grid (true for AbstractRange).

--- a/src/core/periodic_axis.jl
+++ b/src/core/periodic_axis.jl
@@ -36,9 +36,6 @@
 # at the wrapper level (single branch, predicted not-seam).
 #
 # Include order: search.jl → periodic.jl → periodic_axis.jl → periodic_data.jl → ...
-#
-# See `claudedocs/TODO/periodic_grid_wrapper_design.md` for the full design
-# rationale, PoC perf data (Vector hot loop = 0.99×), and migration plan.
 
 """
     _ExclusivePeriodicAxis{Tg, X<:AbstractVector{Tg}, Tp} <: AbstractVector{Tg}

--- a/src/cubic/cubic_adjoint.jl
+++ b/src/cubic/cubic_adjoint.jl
@@ -121,14 +121,9 @@ end
 @inline _adjoint_1d_apply!(f_bar, adj::CubicAdjoint, y_bar, deriv) =
     _cubic_adjoint_apply!(f_bar, adj, y_bar, deriv)
 
-function _adjoint_1d_finalize(f_bar::AbstractVector, adj::CubicAdjoint)
-    n_internal = length(adj.cache.x)
-    if adj.bc isa PeriodicBC{:exclusive}
-        @inbounds f_bar[1] += f_bar[n_internal]
-        return f_bar[1:(n_internal - 1)]
-    end
-    return f_bar
-end
+# `_adjoint_1d_finalize` falls through to the protocol default, which dispatches
+# on `adj.bc` and uses `_adjoint_internal_length(adj)` — CubicAdjoint's override
+# of `_adjoint_internal_length` (`length(adj.cache.x)`) supplies the right size.
 
 # ========================================
 # Core Apply Function

--- a/src/cubic/cubic_adjoint.jl
+++ b/src/cubic/cubic_adjoint.jl
@@ -437,7 +437,6 @@ function cubic_adjoint(
         bc::AbstractBC = CubicFit(),
         extrap::AbstractExtrap = NoExtrap(),
         autocache::Bool = true,
-        _extra...
     )
     x_p, xq_p, Tg = _promote_adjoint_inputs(x, x_query)
 
@@ -474,7 +473,6 @@ function cubic_adjoint(
         bc::AbstractBC = CubicFit(),
         extrap::AbstractExtrap = NoExtrap(),
         autocache::Bool = true,
-        _extra...
     )
     return cubic_adjoint(x, [x_query]; bc = bc, extrap = extrap, autocache = autocache)
 end

--- a/src/hermite/hermite_adjoint.jl
+++ b/src/hermite/hermite_adjoint.jl
@@ -426,7 +426,6 @@ function hermite_adjoint(
         x::AbstractVector,
         x_query::AbstractVector;
         extrap::AbstractExtrap = NoExtrap(),
-        _extra...
     )
     x_p, xq_p, Tg = _promote_adjoint_inputs(x, x_query)
 
@@ -457,7 +456,6 @@ function hermite_adjoint(
         x::AbstractVector,
         x_query::Real;
         extrap::AbstractExtrap = NoExtrap(),
-        _extra...
     )
     return hermite_adjoint(x, [x_query]; extrap = extrap)
 end

--- a/src/hermite/hermite_adjoint.jl
+++ b/src/hermite/hermite_adjoint.jl
@@ -364,6 +364,12 @@ end
 @inline _n_queries(adj::HermiteAdjoint1D) = length(adj.anchors)
 @inline _adjoint_output_length(adj::HermiteAdjoint1D) = adj.grid_size
 
+# HermiteAdjoint1D has no `bc` field (user-supplied slopes; periodic BC is
+# meaningless without slope handling). Override the protocol defaults that
+# read `adj.bc` to avoid a FieldError on the allocating callable's finalize.
+@inline _adjoint_1d_has_exclusive_periodic(::HermiteAdjoint1D) = false
+@inline _adjoint_1d_finalize(f_bar::AbstractVector, ::HermiteAdjoint1D) = f_bar
+
 @inline function _adjoint_1d_apply!(f_bar, adj::HermiteAdjoint1D, y_bar, deriv)
     _scatter_hermite_adjoint_y_only!(f_bar, adj.anchors, y_bar, deriv)
     return nothing

--- a/src/hetero/hetero_adjoint.jl
+++ b/src/hetero/hetero_adjoint.jl
@@ -449,8 +449,11 @@ function hetero_adjoint(
     Tg = _promote_grid_eltype(grids)
     Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
-    # 5-arg `_resolve_extrap` (no BC): expand + promote + per-axis 2-arg materialize.
-    extraps = _resolve_extrap(extrap, nothing, grids_typed, Val(N), Tg)
+    # 5-arg `_resolve_extrap` (BC-aware): periodic axes auto-promote to WrapExtrap
+    # so off-span queries (e.g. xq=1.05 with period=1.0) wrap rather than raising
+    # DomainError — matches the forward `interp(...)` resolution at the same call site.
+    bcs = map(_bc_for_periodic_check, methods)
+    extraps = _resolve_extrap(extrap, bcs, grids_typed, Val(N), Tg)
     return _build_hetero_nd_adjoint(grids_typed, queries, methods, extraps)
 end
 
@@ -490,8 +493,9 @@ function hetero_adjoint(
     Tg = _promote_grid_eltype(grids)
     Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
-    # 5-arg `_resolve_extrap` (no BC): expand + promote + per-axis 2-arg materialize.
-    extraps = _resolve_extrap(extrap, nothing, grids_typed, Val(N), Tg)
+    # BC-aware extrap resolution — same as the AbstractVector-queries overload above.
+    bcs = map(_bc_for_periodic_check, methods)
+    extraps = _resolve_extrap(extrap, bcs, grids_typed, Val(N), Tg)
     return _build_hetero_nd_adjoint(grids_typed, queries, methods, extraps)
 end
 
@@ -585,13 +589,16 @@ end
 # they never reach this dispatch — no method needed for those.
 
 # ── CubicInterp: physical extension + dual cache (user-bc + mixed-bc) ──
+# The `_is_already_extended` guard handles the rrule-replay path where stored
+# grids are already length `n+1` (see helper below).
 @inline function _build_hetero_axis_package(
         method::CubicInterp,
         grid::AbstractVector{Tg},
         ac
     ) where {Tg}
     bc_user  = method.bc
-    grid_ext = _prepare_periodic_grid(grid, bc_user)        # vcat for `:exclusive`, passthrough otherwise
+    grid_ext = bc_user isa PeriodicBC{:exclusive} && _is_already_extended(grid, bc_user) ?
+        grid : _prepare_periodic_grid(grid, bc_user)
     bc       = _is_periodic_bc(bc_user) ? bc_user : _normalize_bc(bc_user)
     mbc_raw  = _get_effective_bc(bc_user, 2, grid_ext)      # depends on grid_ext
     mixed_bc = _is_periodic_bc(mbc_raw) ? mbc_raw : _normalize_bc(mbc_raw)
@@ -631,9 +638,24 @@ end
         ac
     ) where {Tg}
     bc_user  = method.bc
-    grid_ext = bc_user isa PeriodicBC{:exclusive} ? _cache_axis(grid, bc_user) : grid
+    grid_ext = if bc_user isa PeriodicBC{:exclusive} && !_is_already_extended(grid, bc_user)
+        _cache_axis(grid, bc_user)
+    else
+        grid
+    end
     return (; grid_ext, bc = bc_user, mixed_bc = bc_user,
               cache = nothing, mixed_cache = nothing, mincurv_C = zero(Tg))
+end
+
+# rrule-replay safety: persistent forward stores extended (length-`n+1`) grids
+# but `methods[d].bc` retains `PeriodicBC{:exclusive}`. When ChainRules replays
+# adjoint construction with `hetero_adjoint(itp.grids, ...; methods=itp.methods)`
+# we must NOT re-extend an already-extended grid (would push virtual seam to
+# `n+2` and trip `_validate_exclusive_period`).
+@inline function _is_already_extended(grid::AbstractVector{Tg}, bc::PeriodicBC{:exclusive}) where {Tg}
+    length(grid) >= 2 || return false
+    p = Tg(_resolve_exclusive_period(grid, bc))
+    return isapprox(last(grid) - first(grid), p; atol = 8 * eps(p))
 end
 
 # ────────────────────────────────────────────────────────────────────────

--- a/src/hetero/hetero_adjoint.jl
+++ b/src/hetero/hetero_adjoint.jl
@@ -536,15 +536,15 @@ function _build_hetero_nd_adjoint(
     ac = _effective_autocache(true, Tg)
     axes = map((m, g) -> _build_hetero_axis_package(m, g, ac), methods, grids)
 
-    grids_ext    = map(a -> a.grid_ext,    axes)
-    bcs          = map(a -> a.bc,          axes)
-    mixed_bcs    = map(a -> a.mixed_bc,    axes)
-    caches       = map(a -> a.cache,       axes)
+    grids_ext = map(a -> a.grid_ext, axes)
+    bcs = map(a -> a.bc, axes)
+    mixed_bcs = map(a -> a.mixed_bc, axes)
+    caches = map(a -> a.cache, axes)
     mixed_caches = map(a -> a.mixed_cache, axes)
-    mincurv_Cs   = map(a -> a.mincurv_C,   axes)
+    mincurv_Cs = map(a -> a.mincurv_C, axes)
 
     # Bake per-query anchors against the (now per-axis-resolved) grids_ext.
-    anchors   = _bake_hetero_nd_anchors(grids_ext, queries, extraps, methods)
+    anchors = _bake_hetero_nd_anchors(grids_ext, queries, extraps, methods)
     grid_size = ntuple(d -> length(grids_ext[d]), Val(N))
 
     return HeteroAdjointND{
@@ -595,13 +595,13 @@ end
         grid::AbstractVector{Tg},
         ac
     ) where {Tg}
-    bc_user  = method.bc
+    bc_user = method.bc
     grid_ext = bc_user isa PeriodicBC{:exclusive} && _is_already_extended(grid, bc_user) ?
         grid : _prepare_periodic_grid(grid, bc_user)
-    bc       = _is_periodic_bc(bc_user) ? bc_user : _normalize_bc(bc_user)
-    mbc_raw  = _get_effective_bc(bc_user, 2, grid_ext)      # depends on grid_ext
+    bc = _is_periodic_bc(bc_user) ? bc_user : _normalize_bc(bc_user)
+    mbc_raw = _get_effective_bc(bc_user, 2, grid_ext)      # depends on grid_ext
     mixed_bc = _is_periodic_bc(mbc_raw) ? mbc_raw : _normalize_bc(mbc_raw)
-    cache       = _get_cubic_cache(grid_ext, _is_periodic_bc(bc) ? PeriodicBC() : bc, ac)
+    cache = _get_cubic_cache(grid_ext, _is_periodic_bc(bc) ? PeriodicBC() : bc, ac)
     mixed_cache = _get_cubic_cache(grid_ext, _is_periodic_bc(mixed_bc) ? PeriodicBC() : mixed_bc, ac)
     return (; grid_ext, bc, mixed_bc, cache, mixed_cache, mincurv_C = zero(Tg))
 end
@@ -612,9 +612,9 @@ end
         grid::AbstractVector{Tg},
         ac
     ) where {Tg}
-    bc_user   = method.bc
-    bc        = _normalize_bc(bc_user)
-    mixed_bc  = _normalize_bc(_get_effective_bc_quadratic(bc_user, 2, grid))
+    bc_user = method.bc
+    bc = _normalize_bc(bc_user)
+    mixed_bc = _normalize_bc(_get_effective_bc_quadratic(bc_user, 2, grid))
     mincurv_C = _mincurv_C_for_bc(bc_user, grid, length(grid))
     return (; grid_ext = grid, bc, mixed_bc, cache = nothing, mixed_cache = nothing, mincurv_C)
 end
@@ -625,8 +625,10 @@ end
         grid::AbstractVector{Tg},
         ac
     ) where {Tg}
-    return (; grid_ext = grid, bc = NoBC(), mixed_bc = NoBC(),
-              cache = nothing, mixed_cache = nothing, mincurv_C = zero(Tg))
+    return (;
+        grid_ext = grid, bc = NoBC(), mixed_bc = NoBC(),
+        cache = nothing, mixed_cache = nothing, mincurv_C = zero(Tg),
+    )
 end
 
 # ── Linear / Constant: zero-copy wrapper for `:exclusive`, passthrough else ──
@@ -636,14 +638,16 @@ end
         grid::AbstractVector{Tg},
         ac
     ) where {Tg}
-    bc_user  = method.bc
+    bc_user = method.bc
     grid_ext = if bc_user isa PeriodicBC{:exclusive} && !_is_already_extended(grid, bc_user)
         _cache_axis(grid, bc_user)
     else
         grid
     end
-    return (; grid_ext, bc = bc_user, mixed_bc = bc_user,
-              cache = nothing, mixed_cache = nothing, mincurv_C = zero(Tg))
+    return (;
+        grid_ext, bc = bc_user, mixed_bc = bc_user,
+        cache = nothing, mixed_cache = nothing, mincurv_C = zero(Tg),
+    )
 end
 
 # rrule-replay safety: persistent forward stores extended (length-`n+1`) grids

--- a/src/hetero/hetero_adjoint.jl
+++ b/src/hetero/hetero_adjoint.jl
@@ -400,7 +400,6 @@ end
                 "Hermite family methods (found $(join(unique(local_names), ", "))). " *
                 "This also affects `Zygote.gradient` / `ChainRulesCore.rrule` on " *
                 "`HeteroInterpolantND` built with PCHIP / Cardinal / Akima axes. " *
-                "Tracking: claudedocs/TODO/hermite_onthefly_integrate_and_nd_adjoint.md (Task 2). " *
                 "Workarounds: (1) switch Hermite axes to `CubicInterp` for AD support; " *
                 "(2) use `ForwardDiff.gradient` on a scalar-query closure, which works " *
                 "through the forward OnTheFly path without needing an adjoint; " *

--- a/src/hetero/hetero_adjoint.jl
+++ b/src/hetero/hetero_adjoint.jl
@@ -509,7 +509,11 @@ Internal builder for `HeteroAdjointND`. Separated from the public API so that
 Per-axis cache construction:
 - CubicInterp: CubicSplineCache (user BC) + CubicSplineCache (mixed-partial BC)
 - QuadraticInterp: compute MinCurvFit constant, no cache needed
-- LinearInterp/ConstantInterp: nothing (no build step)
+- LinearInterp / ConstantInterp / local-Hermite: no cache (`nothing` in `caches`).
+  These axes are handled by scatter alone — when `bc` is `PeriodicBC{:exclusive}`
+  the axis is wrapped via `_cache_axis` in `grids_ext` so that anchors and the
+  generic seam-fold post-apply hook see a length-`n+1` extended axis, then
+  `_adjoint_output_size` trims back to user-`n`.
 """
 function _build_hetero_nd_adjoint(
         grids::NTuple{N, AbstractVector{Tg}},
@@ -517,113 +521,28 @@ function _build_hetero_nd_adjoint(
         methods::Tuple{Vararg{AbstractInterpMethod, N}},
         extraps::Tuple{Vararg{AbstractExtrap, N}}
     ) where {N, Tg}
-    # Reject Hermite family methods upfront with a clear message. Without this
-    # guard, the scatter path below would fail deep in the per-axis weight
-    # computation with an obscure MethodError. Single point of entry for both
-    # direct `hetero_adjoint(...)` calls and the Zygote/ChainRules rrule
-    # (see `_adjoint_func_from_itp(::HeteroInterpolantND) = hetero_adjoint`).
+    # Reject Hermite family methods upfront with a clear message. Single point
+    # of entry for both direct `hetero_adjoint(...)` calls and the Zygote /
+    # ChainRules rrule (`_adjoint_func_from_itp(::HeteroInterpolantND) = hetero_adjoint`).
     _has_any_local_method(methods) && _throw_hetero_adjoint_hermite_unsupported(methods)
-    # Validate grid size and cubic PolyFit BC support requirements
-    @inbounds for d in 1:N
-        len_d = length(grids[d])
-        len_d >= 2 || _throw_adjoint_grid_too_small(d, len_d)
-        if methods[d] isa CubicInterp
-            bc_d = methods[d].bc
-            if !(bc_d isa PeriodicBC)
-                deg = get_polyfit_degree(bc_d)
-                if deg > 0 && len_d < deg + 1
-                    throw(
-                        ArgumentError(
-                            "PolyFit BC on dimension $d requires at least $(deg + 1) grid points, got $len_d"
-                        )
-                    )
-                end
-            end
-        end
-    end
+    _validate_hetero_axes(grids, methods, Val(N))
 
-    # Extend exclusive periodic grids → inclusive form (cubic axes only)
-    grids_ext = map(grids, methods) do grid_d, method_d
-        method_d isa CubicInterp || return grid_d
-        bc_d = method_d.bc
-        bc_d isa PeriodicBC{:exclusive} || return grid_d
-        period = _resolve_exclusive_period(grid_d, bc_d)
-        x_end = first(grid_d) + Tg(period)
-        if grid_d isa AbstractRange
-            _to_float_adding_endpoint(grid_d, Tg)
-        else
-            vcat(grid_d, x_end)
-        end
-    end
-
-    # Per-axis adjoint BC.
-    # Cubic/Quadratic axes go through normalization (BCPair / quadratic-BC form)
-    # — these drive the per-axis adjoint solver and the periodic seam fold.
-    # All other axes (Linear / Constant / local Hermite / NoInterp) store
-    # `NoBC()` — Hetero adjoint does not yet wrap/extend non-derivative axes
-    # for `PeriodicBC` (forward does, via `_cache_axis_for_method`, but the
-    # adjoint constructor extends only Cubic axes — see `grids_ext` above).
-    # Until that asymmetry is closed in a follow-up, storing PeriodicBC here
-    # would mis-size the trimmed adjoint output.
-    bcs = map(methods) do method_d
-        if method_d isa CubicInterp
-            bc_d = method_d.bc
-            _is_periodic_bc(bc_d) ? bc_d : _normalize_bc(bc_d)
-        elseif method_d isa QuadraticInterp
-            _normalize_bc(method_d.bc)
-        else
-            NoBC()
-        end
-    end
-
-    # Mixed-partial BCs (consumed only by Cubic/Quadratic per-axis adjoint
-    # solver; other axes' entries are inert).
-    mixed_bcs = map(methods, grids_ext) do method_d, grid_d
-        if method_d isa CubicInterp
-            mixed_bc = _get_effective_bc(method_d.bc, 2, grid_d)
-            _is_periodic_bc(mixed_bc) ? mixed_bc : _normalize_bc(mixed_bc)
-        elseif method_d isa QuadraticInterp
-            _normalize_bc(_get_effective_bc_quadratic(method_d.bc, 2, grid_d))
-        else
-            NoBC()
-        end
-    end
-
-    # Per-axis caches (cubic only)
-    # _effective_autocache: bypass cache pool for Dual grids (ephemeral, hit rate ≈ 0%)
+    # Per-axis "package" via method-typed dispatch — see `_build_hetero_axis_package`
+    # below. Each package is a NamedTuple with the 6 fields the builder threads
+    # into `HeteroAdjointND`. Replaces the previous 5 if-cascade `map`s; the
+    # per-method axis policy lives in ONE place per method type.
     ac = _effective_autocache(true, Tg)
-    caches = map(methods, grids_ext, bcs) do method_d, grid_d, bp_d
-        method_d isa CubicInterp || return nothing
-        if _is_periodic_bc(bp_d)
-            _get_cubic_cache(grid_d, PeriodicBC(), ac)
-        else
-            _get_cubic_cache(grid_d, bp_d, ac)
-        end
-    end
+    axes = map((m, g) -> _build_hetero_axis_package(m, g, ac), methods, grids)
 
-    mixed_caches = map(methods, grids_ext, mixed_bcs) do method_d, grid_d, mbp_d
-        method_d isa CubicInterp || return nothing
-        if _is_periodic_bc(mbp_d)
-            _get_cubic_cache(grid_d, PeriodicBC(), ac)
-        else
-            _get_cubic_cache(grid_d, mbp_d, ac)
-        end
-    end
+    grids_ext    = map(a -> a.grid_ext,    axes)
+    bcs          = map(a -> a.bc,          axes)
+    mixed_bcs    = map(a -> a.mixed_bc,    axes)
+    caches       = map(a -> a.cache,       axes)
+    mixed_caches = map(a -> a.mixed_cache, axes)
+    mincurv_Cs   = map(a -> a.mincurv_C,   axes)
 
-    # Per-axis MinCurvFit constants (quadratic only) — axis-based form
-    # reads `_get_inv_h(grid_d, i)` from wrapped or raw axes uniformly.
-    mincurv_Cs = map(methods, grids_ext) do method_d, grid_d
-        if method_d isa QuadraticInterp
-            bc_d = method_d.bc
-            _mincurv_C_for_bc(bc_d, grid_d, length(grid_d))
-        else
-            zero(Tg)
-        end
-    end
-
-    # Bake per-query anchors
-    anchors = _bake_hetero_nd_anchors(grids_ext, queries, extraps, methods)
-
+    # Bake per-query anchors against the (now per-axis-resolved) grids_ext.
+    anchors   = _bake_hetero_nd_anchors(grids_ext, queries, extraps, methods)
     grid_size = ntuple(d -> length(grids_ext[d]), Val(N))
 
     return HeteroAdjointND{
@@ -636,4 +555,109 @@ function _build_hetero_nd_adjoint(
         caches, mixed_caches, bcs, mixed_bcs,
         anchors, grid_size, mincurv_Cs
     )
+end
+
+# ────────────────────────────────────────────────────────────────────────
+# Per-axis package builder — method-typed dispatch
+# ────────────────────────────────────────────────────────────────────────
+#
+# Returns a NamedTuple carrying everything the hetero builder needs per-axis:
+#
+#   :grid_ext     — axis as seen by anchor baking + scatter + seam fold
+#                   (length n+1 for `:exclusive` regardless of method; raw
+#                    length n otherwise). Cubic uses physical extension
+#                    (vcat / Range append) for Sherman-Morrison cache
+#                    compatibility; Linear/Constant use zero-copy wrapper
+#                    (`_ExclusivePeriodicAxis`); other methods passthrough.
+#
+#   :bc / :mixed_bc — boundary condition handed to the per-axis solver.
+#                     Cubic/Quadratic axes drive a real solver and need
+#                     normalized form (BCPair / quadratic BC); inert for
+#                     other methods (just needs `<: AbstractBC`).
+#
+#   :cache / :mixed_cache — Sherman-Morrison transpose cache. Cubic only;
+#                           `nothing` elsewhere.
+#
+#   :mincurv_C    — MinCurvFit precomputed constant. Quadratic only;
+#                   `zero(Tg)` elsewhere.
+#
+# Method-typed dispatch (4 buckets, one per method "shape"). PCHIP /
+# Cardinal / Akima are rejected upstream by `_has_any_local_method`, so
+# they never reach this dispatch — no method needed for those.
+
+# ── CubicInterp: physical extension + dual cache (user-bc + mixed-bc) ──
+@inline function _build_hetero_axis_package(
+        method::CubicInterp,
+        grid::AbstractVector{Tg},
+        ac
+    ) where {Tg}
+    bc_user  = method.bc
+    grid_ext = _prepare_periodic_grid(grid, bc_user)        # vcat for `:exclusive`, passthrough otherwise
+    bc       = _is_periodic_bc(bc_user) ? bc_user : _normalize_bc(bc_user)
+    mbc_raw  = _get_effective_bc(bc_user, 2, grid_ext)      # depends on grid_ext
+    mixed_bc = _is_periodic_bc(mbc_raw) ? mbc_raw : _normalize_bc(mbc_raw)
+    cache       = _get_cubic_cache(grid_ext, _is_periodic_bc(bc) ? PeriodicBC() : bc, ac)
+    mixed_cache = _get_cubic_cache(grid_ext, _is_periodic_bc(mixed_bc) ? PeriodicBC() : mixed_bc, ac)
+    return (; grid_ext, bc, mixed_bc, cache, mixed_cache, mincurv_C = zero(Tg))
+end
+
+# ── QuadraticInterp: passthrough grid, normalized BC pair, mincurv constant ──
+@inline function _build_hetero_axis_package(
+        method::QuadraticInterp,
+        grid::AbstractVector{Tg},
+        ac
+    ) where {Tg}
+    bc_user   = method.bc
+    bc        = _normalize_bc(bc_user)
+    mixed_bc  = _normalize_bc(_get_effective_bc_quadratic(bc_user, 2, grid))
+    mincurv_C = _mincurv_C_for_bc(bc_user, grid, length(grid))
+    return (; grid_ext = grid, bc, mixed_bc, cache = nothing, mixed_cache = nothing, mincurv_C)
+end
+
+# ── NoInterp / CubicHermiteInterp: no `.bc` field; full passthrough ─────
+@inline function _build_hetero_axis_package(
+        ::Union{NoInterp, CubicHermiteInterp},
+        grid::AbstractVector{Tg},
+        ac
+    ) where {Tg}
+    return (; grid_ext = grid, bc = NoBC(), mixed_bc = NoBC(),
+              cache = nothing, mixed_cache = nothing, mincurv_C = zero(Tg))
+end
+
+# ── Linear / Constant: zero-copy wrapper for `:exclusive`, passthrough else ──
+# (PCHIP / Cardinal / Akima rejected by `_has_any_local_method` upstream.)
+@inline function _build_hetero_axis_package(
+        method::Union{LinearInterp, ConstantInterp},
+        grid::AbstractVector{Tg},
+        ac
+    ) where {Tg}
+    bc_user  = method.bc
+    grid_ext = bc_user isa PeriodicBC{:exclusive} ? _cache_axis(grid, bc_user) : grid
+    return (; grid_ext, bc = bc_user, mixed_bc = bc_user,
+              cache = nothing, mixed_cache = nothing, mincurv_C = zero(Tg))
+end
+
+# ────────────────────────────────────────────────────────────────────────
+# Per-axis validation (length + Cubic PolyFit degree)
+# ────────────────────────────────────────────────────────────────────────
+@inline function _validate_hetero_axes(grids, methods, ::Val{N}) where {N}
+    @inbounds for d in 1:N
+        len_d = length(grids[d])
+        len_d >= 2 || _throw_adjoint_grid_too_small(d, len_d)
+        method_d = methods[d]
+        if method_d isa CubicInterp
+            bc_d = method_d.bc
+            if !(bc_d isa PeriodicBC)
+                deg = get_polyfit_degree(bc_d)
+                if deg > 0 && len_d < deg + 1
+                    throw(
+                        ArgumentError(
+                            "PolyFit BC on dimension $d requires at least $(deg + 1) grid points, got $len_d"
+                        )
+                    )
+                end
+            end
+        end
+    end
+    return nothing
 end

--- a/src/hetero/hetero_adjoint.jl
+++ b/src/hetero/hetero_adjoint.jl
@@ -556,31 +556,36 @@ function _build_hetero_nd_adjoint(
         end
     end
 
-    # Per-axis BC normalization (for derivative methods only)
-    # Non-BC methods (Linear/Constant) use `nothing` sentinel — never matched
-    # against PeriodicBC or BCPair in protocol functions.
+    # Per-axis adjoint BC.
+    # Cubic/Quadratic axes go through normalization (BCPair / quadratic-BC form)
+    # — these drive the per-axis adjoint solver and the periodic seam fold.
+    # All other axes (Linear / Constant / local Hermite / NoInterp) store
+    # `NoBC()` — Hetero adjoint does not yet wrap/extend non-derivative axes
+    # for `PeriodicBC` (forward does, via `_cache_axis_for_method`, but the
+    # adjoint constructor extends only Cubic axes — see `grids_ext` above).
+    # Until that asymmetry is closed in a follow-up, storing PeriodicBC here
+    # would mis-size the trimmed adjoint output.
     bcs = map(methods) do method_d
         if method_d isa CubicInterp
             bc_d = method_d.bc
             _is_periodic_bc(bc_d) ? bc_d : _normalize_bc(bc_d)
         elseif method_d isa QuadraticInterp
-            bc_d = method_d.bc
-            _normalize_bc(bc_d)
+            _normalize_bc(method_d.bc)
         else
-            nothing
+            NoBC()
         end
     end
 
-    # Mixed-partial BCs (for derivative methods, p_src > 1)
+    # Mixed-partial BCs (consumed only by Cubic/Quadratic per-axis adjoint
+    # solver; other axes' entries are inert).
     mixed_bcs = map(methods, grids_ext) do method_d, grid_d
         if method_d isa CubicInterp
             mixed_bc = _get_effective_bc(method_d.bc, 2, grid_d)
             _is_periodic_bc(mixed_bc) ? mixed_bc : _normalize_bc(mixed_bc)
         elseif method_d isa QuadraticInterp
-            mixed_bc = _get_effective_bc_quadratic(method_d.bc, 2, grid_d)
-            _normalize_bc(mixed_bc)
+            _normalize_bc(_get_effective_bc_quadratic(method_d.bc, 2, grid_d))
         else
-            nothing
+            NoBC()
         end
     end
 

--- a/src/hetero/hetero_adjoint.jl
+++ b/src/hetero/hetero_adjoint.jl
@@ -532,8 +532,7 @@ function _build_hetero_nd_adjoint(
 
     # Per-axis "package" via method-typed dispatch — see `_build_hetero_axis_package`
     # below. Each package is a NamedTuple with the 6 fields the builder threads
-    # into `HeteroAdjointND`. Replaces the previous 5 if-cascade `map`s; the
-    # per-method axis policy lives in ONE place per method type.
+    # into `HeteroAdjointND`; per-method axis policy lives in ONE place per method type.
     ac = _effective_autocache(true, Tg)
     axes = map((m, g) -> _build_hetero_axis_package(m, g, ac), methods, grids)
 

--- a/src/hetero/hetero_adjoint_types.jl
+++ b/src/hetero/hetero_adjoint_types.jl
@@ -96,16 +96,17 @@ The same adjoint can be applied to any `ȳ` vector.
 - `C`:   Per-axis cache tuple (CubicSplineCache for cubic, Nothing for others)
 - `MC`:  Per-axis mixed-partial cache tuple
 - `BP`:  Per-axis adjoint-BC tuple, uniformly `<: AbstractBC`.
-         Cubic axes: `BCPair`/`PeriodicBC` (drives the periodic seam fold and
+         Cubic axes: `BCPair`/`PeriodicBC` (drives the periodic seam fold +
          Sherman-Morrison transpose). Quadratic axes: normalized `AbstractBC`
-         (e.g. `Left`, `Right`, `MinCurvFit`). All other axes (Linear /
-         Constant / local-Hermite / NoInterp): `NoBC()` — the Hetero adjoint
-         constructor does not yet wrap/extend non-derivative axes for
-         `PeriodicBC`, so storing the user's BC here would mis-size the
-         trimmed output.
+         (`Left`, `Right`, `MinCurvFit`). Linear / Constant / local-Hermite
+         axes: `method.bc` verbatim — only the `PeriodicBC{:exclusive}`
+         discriminant matters and drives the same generic seam-fold path
+         used by the dedicated 1D ND adjoints. `NoInterp` /
+         `CubicHermiteInterp` (no `.bc` field): `NoBC()`.
 - `MBP`: Per-axis mixed-BC tuple, analogous to `BP` but for mixed-partial
-         directions. `NoBC()` on axes that don't participate in mixed-partial
-         solving.
+         directions. Inert on axes that don't participate in mixed-partial
+         solving (Linear / Constant / local-Hermite carry `method.bc` for
+         shape consistency; `NoInterp` / `CubicHermiteInterp` carry `NoBC()`).
 
 # Architecture — Mixed-Radix Compact Storage
 Uses `prod(sizes)` partials instead of `2^N`, where `sizes[d] = _deriv_size(methods[d])`.

--- a/src/hetero/hetero_adjoint_types.jl
+++ b/src/hetero/hetero_adjoint_types.jl
@@ -95,11 +95,17 @@ The same adjoint can be applied to any `ȳ` vector.
          no separate `spacings` field needed.
 - `C`:   Per-axis cache tuple (CubicSplineCache for cubic, Nothing for others)
 - `MC`:  Per-axis mixed-partial cache tuple
-- `BP`:  Per-axis adjoint-BC tuple. For cubic axes: `BCPair`/`PeriodicBC`;
-         for quadratic axes: normalized `AbstractBC` (e.g. `Left`, `Right`, `MinCurvFit`);
-         for non-derivative axes (Linear/Constant): `nothing` sentinel.
+- `BP`:  Per-axis adjoint-BC tuple, uniformly `<: AbstractBC`.
+         Cubic axes: `BCPair`/`PeriodicBC` (drives the periodic seam fold and
+         Sherman-Morrison transpose). Quadratic axes: normalized `AbstractBC`
+         (e.g. `Left`, `Right`, `MinCurvFit`). All other axes (Linear /
+         Constant / local-Hermite / NoInterp): `NoBC()` — the Hetero adjoint
+         constructor does not yet wrap/extend non-derivative axes for
+         `PeriodicBC`, so storing the user's BC here would mis-size the
+         trimmed output.
 - `MBP`: Per-axis mixed-BC tuple, analogous to `BP` but for mixed-partial
-         directions; `nothing` when no mixed-partial BC is required.
+         directions. `NoBC()` on axes that don't participate in mixed-partial
+         solving.
 
 # Architecture — Mixed-Radix Compact Storage
 Uses `prod(sizes)` partials instead of `2^N`, where `sizes[d] = _deriv_size(methods[d])`.
@@ -156,8 +162,9 @@ end
 @inline _n_queries(adj::HeteroAdjointND) = length(adj.anchors)
 @inline _grid_size(adj::HeteroAdjointND) = adj.grid_size
 
-# For periodic finalization: return per-axis BC for derivative methods,
-# nothing sentinel for non-derivative methods (never matches PeriodicBC{:exclusive}).
+# Per-axis adjoint-BC tuple — uniform `<: AbstractBC` (no `Nothing` sentinel).
+# Consumed by `_has_exclusive_periodic` / `_adjoint_output_size` to drive the
+# generic seam-fold + trim post-apply hook.
 @inline _adjoint_bcs(adj::HeteroAdjointND) = adj.bcs
 
 @inline _adjoint_nd_apply!(f_bar, adj::HeteroAdjointND, y_bar, ops) =

--- a/src/hetero/hetero_build.jl
+++ b/src/hetero/hetero_build.jl
@@ -70,12 +70,15 @@ end
 @inline _extract_bc(m::QuadraticInterp) = m.bc
 
 # For _prepare_periodic_nd: extract BC to detect exclusive periodic axes.
-# Non-BC methods return a non-periodic placeholder (never triggers extension).
+# Methods without a `bc` field (currently only `NoInterp`) fall through to the
+# catchall and return a non-periodic placeholder (never triggers extension).
 @inline _bc_for_periodic_check(m::CubicInterp) = m.bc
 @inline _bc_for_periodic_check(m::QuadraticInterp) = m.bc
 @inline _bc_for_periodic_check(m::PchipInterp) = m.bc
 @inline _bc_for_periodic_check(m::CardinalInterp) = m.bc
 @inline _bc_for_periodic_check(m::AkimaInterp) = m.bc
+@inline _bc_for_periodic_check(m::LinearInterp) = m.bc
+@inline _bc_for_periodic_check(m::ConstantInterp) = m.bc
 @inline _bc_for_periodic_check(::AbstractInterpMethod) = CubicFit()
 
 # ========================================

--- a/src/hetero/hetero_build.jl
+++ b/src/hetero/hetero_build.jl
@@ -63,8 +63,10 @@ end
 # ========================================
 # BC Extraction from Method Types
 # ========================================
-# Only defined for derivative methods (Cubic/Quadratic).
-# Linear/Constant have no BC and are never differentiated (sizes[D]=1).
+# `_extract_bc` is read by `_build_nd_partials_dim_hetero!` only for derivative
+# axes (Cubic/Quadratic) — the `sizes[D] == 2` guard skips Linear/Constant/NoInterp
+# axes entirely. Linear/Constant carry their own `bc` field used by other code
+# paths (eval, hetero adjoint), but it is not consumed here.
 
 @inline _extract_bc(m::CubicInterp) = m.bc
 @inline _extract_bc(m::QuadraticInterp) = m.bc

--- a/src/hetero/hetero_interpolant.jl
+++ b/src/hetero/hetero_interpolant.jl
@@ -26,9 +26,10 @@ function _interp_nd_dispatch(
 end
 
 function _interp_nd_dispatch(
-        grids, data, ::Tuple{LinearInterp, Vararg{LinearInterp}}, ::Any, extrap, search
+        grids, data, methods::Tuple{LinearInterp, Vararg{LinearInterp}}, ::Any, extrap, search
     )
-    return linear_interp(grids, data; extrap = extrap, search = search)
+    bcs = map(m -> m.bc, methods)
+    return linear_interp(grids, data; bc = bcs, extrap = extrap, search = search)
 end
 
 function _interp_nd_dispatch(
@@ -42,7 +43,8 @@ function _interp_nd_dispatch(
         grids, data, methods::Tuple{ConstantInterp, Vararg{ConstantInterp}}, ::Any, extrap, search
     )
     sides = map(m -> m.side, methods)
-    return constant_interp(grids, data; side = sides, extrap = extrap, search = search)
+    bcs = map(m -> m.bc, methods)
+    return constant_interp(grids, data; side = sides, bc = bcs, extrap = extrap, search = search)
 end
 
 # Hermite family has no specialized ND type — homogeneous Hermite tuples fall through

--- a/src/hetero/hetero_interpolant.jl
+++ b/src/hetero/hetero_interpolant.jl
@@ -98,10 +98,12 @@ end
 end
 
 @noinline function _throw_onthefly_excl_linear_constant_unsupported(methods)
-    names = unique([
-        string(typeof(m)) for m in methods
-            if m isa Union{LinearInterp, ConstantInterp} && m.bc isa PeriodicBC{:exclusive}
-    ])
+    names = unique(
+        [
+            string(typeof(m)) for m in methods
+                if m isa Union{LinearInterp, ConstantInterp} && m.bc isa PeriodicBC{:exclusive}
+        ]
+    )
     throw(
         ArgumentError(
             "OnTheFly() is not supported for $(join(names, ", ")) in heterogeneous ND. " *

--- a/src/hetero/hetero_interpolant.jl
+++ b/src/hetero/hetero_interpolant.jl
@@ -67,7 +67,18 @@ end
 # Reject unsupported PreCompute + local Hermite combinations with clear error.
 @inline _has_local_method(methods::Tuple) = any(_is_local_method, methods)
 
-@inline _validate_nd_coeffs(::OnTheFly, _) = nothing
+# OnTheFly hetero on Linear/Constant + `PeriodicBC{:exclusive}` is unsupported:
+# the wrap-aware persistent eval path only specializes `_axis_window_pooled` /
+# `_axis_grid_pooled` for `AbstractLocalHermiteInterp{<:PeriodicBC}`. Without
+# those specializations the seam cell falls through to non-periodic windowing,
+# producing silent garbage (window `[n, n+1]` reads past the unextended data).
+# Reject with a clear migration hint to `PreCompute()`, which extends the data
+# physically through `_prepare_periodic_nd`.
+@inline function _validate_nd_coeffs(::OnTheFly, methods)
+    any(m -> m isa Union{LinearInterp, ConstantInterp} && m.bc isa PeriodicBC{:exclusive}, methods) &&
+        _throw_onthefly_excl_linear_constant_unsupported(methods)
+    return nothing
+end
 @inline function _validate_nd_coeffs(::PreCompute, methods)
     _has_local_method(methods) && _throw_precompute_unsupported(methods)
     return nothing
@@ -82,6 +93,23 @@ end
         ArgumentError(
             "PreCompute() is not yet supported for $(join(local_names, ", ")) in ND. " *
                 "Use coeffs=OnTheFly() or omit the coeffs kwarg for automatic selection."
+        )
+    )
+end
+
+@noinline function _throw_onthefly_excl_linear_constant_unsupported(methods)
+    names = unique([
+        string(typeof(m)) for m in methods
+            if m isa Union{LinearInterp, ConstantInterp} && m.bc isa PeriodicBC{:exclusive}
+    ])
+    throw(
+        ArgumentError(
+            "OnTheFly() is not supported for $(join(names, ", ")) in heterogeneous ND. " *
+                "The OnTheFly persistent eval path lacks wrap-aware windowing for " *
+                "Linear/Constant axes with `PeriodicBC(endpoint=:exclusive)`, which would " *
+                "silently return wrong values at the seam cell. " *
+                "Use coeffs=PreCompute() (which physically extends the data) or omit the " *
+                "coeffs kwarg for automatic selection."
         )
     )
 end
@@ -402,6 +430,12 @@ function interp(
     ) where {N}
     method_tuple = method isa AbstractInterpMethod ? ntuple(_ -> method, Val(N)) : method
     coeffs_resolved = _resolve_coeffs(coeffs, Val(N), method_tuple)
+    # Validate before any path. The OnTheFly hetero shortcut below skips
+    # `_interp_nd_dispatch` (which is the only other validation site), so we
+    # must apply OnTheFly-specific rejections here too — otherwise unsupported
+    # combos like `(LinearInterp(bc=:exclusive), CubicInterp())` build silently
+    # and return wrong values at the seam cell.
+    _validate_nd_coeffs(coeffs_resolved, method_tuple)
 
     # OnTheFly → always Hetero path (no specialized ND type supports OnTheFly natively)
     if coeffs_resolved isa OnTheFly

--- a/src/hetero/hetero_oneshot.jl
+++ b/src/hetero/hetero_oneshot.jl
@@ -218,10 +218,11 @@ end
 
 function _interp_nd_oneshot_dispatch(
         grids, data, query,
-        ::Tuple{LinearInterp, Vararg{LinearInterp}},
+        methods::Tuple{LinearInterp, Vararg{LinearInterp}},
         deriv, extrap, search, hints, coeffs,
     )
-    return linear_interp(grids, data, query; extrap = extrap, search = search, deriv = deriv, hint = hints)
+    bcs = map(m -> m.bc, methods)
+    return linear_interp(grids, data, query; bc = bcs, extrap = extrap, search = search, deriv = deriv, hint = hints)
 end
 
 function _interp_nd_oneshot_dispatch(
@@ -239,7 +240,8 @@ function _interp_nd_oneshot_dispatch(
         deriv, extrap, search, hints, coeffs,
     )
     sides = map(m -> m.side, methods)
-    return constant_interp(grids, data, query; side = sides, extrap = extrap, search = search, deriv = deriv, hint = hints)
+    bcs = map(m -> m.bc, methods)
+    return constant_interp(grids, data, query; side = sides, bc = bcs, extrap = extrap, search = search, deriv = deriv, hint = hints)
 end
 
 # Heterogeneous fallback → resolve kwargs → OnTheFly or PreCompute pool core
@@ -287,10 +289,11 @@ end
 
 function _interp_nd_oneshot_batch_dispatch!(
         output, grids, data, queries,
-        ::Tuple{LinearInterp, Vararg{LinearInterp}},
+        methods::Tuple{LinearInterp, Vararg{LinearInterp}},
         deriv, extrap, search, hints, coeffs,
     )
-    return linear_interp!(output, grids, data, queries; extrap = extrap, search = search, deriv = deriv, hint = hints)
+    bcs = map(m -> m.bc, methods)
+    return linear_interp!(output, grids, data, queries; bc = bcs, extrap = extrap, search = search, deriv = deriv, hint = hints)
 end
 
 function _interp_nd_oneshot_batch_dispatch!(
@@ -308,7 +311,8 @@ function _interp_nd_oneshot_batch_dispatch!(
         deriv, extrap, search, hints, coeffs,
     )
     sides = map(m -> m.side, methods)
-    return constant_interp!(output, grids, data, queries; side = sides, extrap = extrap, search = search, deriv = deriv, hint = hints)
+    bcs = map(m -> m.bc, methods)
+    return constant_interp!(output, grids, data, queries; side = sides, bc = bcs, extrap = extrap, search = search, deriv = deriv, hint = hints)
 end
 
 # Heterogeneous fallback → resolve kwargs → function barrier → pool batch.

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -222,9 +222,7 @@ end
         ArgumentError(
             "integrate is not yet implemented for HeteroInterpolantND " *
                 "(method tuple: $(methods)). ND tensor-product integration over " *
-                "mixed/Hermite axes is tracked in " *
-                "claudedocs/TODO/hermite_onthefly_integrate_and_nd_adjoint.md (Task 2) " *
-                "and the broader ND-integrate gap. Workarounds: " *
+                "mixed/Hermite axes is not yet supported. Workarounds: " *
                 "(1) use a homogeneous specialized ND type " *
                 "(`cubic_interp`, `quadratic_interp`, `linear_interp`, `constant_interp`) " *
                 "which do support `integrate`; " *

--- a/src/linear/linear_adjoint.jl
+++ b/src/linear/linear_adjoint.jl
@@ -67,23 +67,6 @@ end
 
 @inline _n_queries(adj::LinearAdjoint) = length(adj.anchors)
 
-@inline _adjoint_output_length(adj::LinearAdjoint) =
-    adj.bc isa PeriodicBC{:exclusive} ? adj.grid_size - 1 : adj.grid_size
-
-@inline _adjoint_internal_length(adj::LinearAdjoint) = adj.grid_size
-
-@inline _adjoint_1d_has_exclusive_periodic(adj::LinearAdjoint) =
-    adj.bc isa PeriodicBC{:exclusive}
-
-function _adjoint_1d_finalize(f_bar::AbstractVector, adj::LinearAdjoint)
-    if adj.bc isa PeriodicBC{:exclusive}
-        n_internal = adj.grid_size
-        @inbounds f_bar[1] += f_bar[n_internal]
-        return f_bar[1:(n_internal - 1)]
-    end
-    return f_bar
-end
-
 @inline _adjoint_1d_apply!(f_bar, adj::LinearAdjoint, y_bar, deriv) =
     _linear_adjoint_apply!(f_bar, adj, y_bar, deriv)
 
@@ -252,7 +235,6 @@ function linear_adjoint(
         x_query::AbstractVector;
         bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
-        _extra...
     )
     x_p, xq_p, Tg = _promote_adjoint_inputs(x, x_query)
 
@@ -306,7 +288,6 @@ function linear_adjoint(
         x_query::Real;
         bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
-        _extra...
     )
     return linear_adjoint(x, [x_query]; bc = bc, extrap = extrap)
 end

--- a/src/linear/linear_adjoint.jl
+++ b/src/linear/linear_adjoint.jl
@@ -51,20 +51,38 @@ itp = linear_interp(x, f)
 @assert dot(itp.(xq), y_bar) ≈ dot(f, adj(y_bar))
 ```
 """
-struct LinearAdjoint{Tg, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
+struct LinearAdjoint{Tg, BC <: AbstractBC, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
     anchors::Vector{_LinearAnchoredQuery{Tg, Tg}}
-    grid_size::Int
+    grid_size::Int  # internal length: n+1 for PeriodicBC{:exclusive}, n otherwise
+    bc::BC
     extrap::EP
 end
 
 # ========================================
 # 1D Adjoint Protocol Accessors
 # ========================================
-# Callables (6 overloads), Base.size, and Base.Matrix are inherited
-# from AbstractAdjoint via src/core/adjoint_protocol.jl.
+# Callables (6 overloads), Base.size, Base.Matrix, and exclusive-periodic
+# in-place seam fold are inherited from AbstractAdjoint1D via
+# src/core/adjoint_protocol.jl.
 
 @inline _n_queries(adj::LinearAdjoint) = length(adj.anchors)
-@inline _adjoint_output_length(adj::LinearAdjoint) = adj.grid_size
+
+@inline _adjoint_output_length(adj::LinearAdjoint) =
+    adj.bc isa PeriodicBC{:exclusive} ? adj.grid_size - 1 : adj.grid_size
+
+@inline _adjoint_internal_length(adj::LinearAdjoint) = adj.grid_size
+
+@inline _adjoint_1d_has_exclusive_periodic(adj::LinearAdjoint) =
+    adj.bc isa PeriodicBC{:exclusive}
+
+function _adjoint_1d_finalize(f_bar::AbstractVector, adj::LinearAdjoint)
+    if adj.bc isa PeriodicBC{:exclusive}
+        n_internal = adj.grid_size
+        @inbounds f_bar[1] += f_bar[n_internal]
+        return f_bar[1:(n_internal - 1)]
+    end
+    return f_bar
+end
 
 @inline _adjoint_1d_apply!(f_bar, adj::LinearAdjoint, y_bar, deriv) =
     _linear_adjoint_apply!(f_bar, adj, y_bar, deriv)
@@ -232,6 +250,7 @@ f_bar = adj(y_bar)
 function linear_adjoint(
         x::AbstractVector,
         x_query::AbstractVector;
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         _extra...
     )
@@ -239,9 +258,19 @@ function linear_adjoint(
 
     length(x_p) >= 2 || _throw_adjoint_grid_too_small(length(x_p))
 
-    # NoExtrap: validate all queries in-domain (use primal for Dual grid boundaries)
-    if extrap isa NoExtrap
-        x_lo, x_hi = _extract_primal(first(x_p)), _extract_primal(last(x_p))
+    # BC-aware axis wrap: `:exclusive` periodic → `_ExclusivePeriodicAxis` with
+    # logical length n+1 (virtual seam endpoint `inner[1] + period`). Anchors
+    # at the seam cell store stencil = (n, n+1); the protocol's exclusive-
+    # periodic in-place callable folds f_work[1] += f_work[n+1] before trim.
+    x_axis = _cache_axis(x_p, bc, Tg)
+    # Periodic BCs auto-promote `extrap` to `WrapExtrap` against the wrapped axis;
+    # non-periodic BCs are passthrough.
+    extrap_eff = _resolve_extrap(extrap, bc, x_axis)
+
+    # NoExtrap: validate all queries in-domain (uses x_axis bounds, which include
+    # the virtual seam endpoint for `:exclusive`). Use primal for Dual grid boundaries.
+    if extrap_eff isa NoExtrap
+        x_lo, x_hi = _extract_primal(first(x_axis)), _extract_primal(last(x_axis))
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
             (x_lo <= xq_i <= x_hi) || throw(
@@ -251,32 +280,35 @@ function linear_adjoint(
     end
 
     # Build anchored queries with extrap-specific preprocessing
-    wrap = extrap isa WrapExtrap
-    if extrap isa _ClampOrFill
+    wrap = extrap_eff isa WrapExtrap
+    if extrap_eff isa _ClampOrFill
         # Clamp OOB queries to boundary for correct anchor weights (alpha ∈ [0,1]).
         # Then restore side flags so scatter can skip OOB contributions.
-        x_lo_p, x_hi_p = _extract_primal(first(x_p)), _extract_primal(last(x_p))
+        x_lo_p, x_hi_p = _extract_primal(first(x_axis)), _extract_primal(last(x_axis))
         xq_clamped = clamp.(xq_p, x_lo_p, x_hi_p)
-        anchors = _anchor_query(x_p, xq_clamped, Val(:linear), false)
+        anchors = _anchor_query(x_axis, xq_clamped, Val(:linear), false)
         _fixup_linear_anchor_state!(anchors, xq_p, x_lo_p, x_hi_p)
     else
         # ExtendExtrap: OOB uses boundary interval with extrapolated alpha (correct)
-        # WrapExtrap: wraps to domain (correct)
+        # WrapExtrap: wraps to domain (correct; covers periodic auto-promotion)
         # NoExtrap: already validated in-domain above
-        anchors = _anchor_query(x_p, xq_p, Val(:linear), wrap)
+        anchors = _anchor_query(x_axis, xq_p, Val(:linear), wrap)
     end
 
-    return LinearAdjoint{Tg, typeof(extrap)}(anchors, length(x_p), extrap)
+    return LinearAdjoint{Tg, typeof(bc), typeof(extrap_eff)}(
+        anchors, length(x_axis), bc, extrap_eff
+    )
 end
 
 # Scalar query convenience
 function linear_adjoint(
         x::AbstractVector,
         x_query::Real;
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         _extra...
     )
-    return linear_adjoint(x, [x_query]; extrap = extrap)
+    return linear_adjoint(x, [x_query]; bc = bc, extrap = extrap)
 end
 
 # Matrix materialization inherited from AbstractAdjoint (adjoint_protocol.jl)

--- a/src/linear/linear_series_interp.jl
+++ b/src/linear/linear_series_interp.jl
@@ -496,8 +496,7 @@ end
 # Note `@inline` is intentional: the barrier benefit comes from this being a
 # *separate named function* (a clean specialization point for the compiler),
 # not from preventing inlining. Empirically `@noinline` regresses to ~32 B
-# because the forced function-call frame adds arg-passing overhead — see
-# claudedocs/PR_test_infra_refac.md.
+# because the forced function-call frame adds arg-passing overhead.
 @inline function _linear_series_inplace_kernel!(
         outputs::AbstractVector{<:AbstractVector},
         sitp::LinearSeriesInterpolant{Tg},

--- a/src/nodal_partials.jl
+++ b/src/nodal_partials.jl
@@ -57,8 +57,6 @@ end
 # Dedicated error for the "local Hermite ND + nodal_partials" combo.
 # Following the user advice to "use PreCompute" would dead-end: PreCompute
 # is rejected upstream by `_validate_nd_coeffs` for Hermite family ND.
-# This message points users at the correct workaround (per-axis 1D access)
-# and the tracking TODO.
 @noinline function _throw_nodal_partials_hermite_nd(methods)
     local_names = String[]
     for m in methods
@@ -70,8 +68,7 @@ end
         ArgumentError(
             "nodal_partials is not yet implemented for Hermite family ND " *
                 "(found $(join(unique(local_names), ", "))). The Hermite ND PreCompute " *
-                "backend has not been written yet — tracked in " *
-                "claudedocs/TODO/hermite_nd_precompute.md. " *
+                "backend has not been written yet. " *
                 "Workaround: compute per-axis 1D slopes via `pchip_interp` / " *
                 "`cardinal_interp` / `akima_interp` with `deriv=DerivOp(1)`, " *
                 "or switch the relevant axes to CubicInterp / QuadraticInterp " *

--- a/src/pchip/pchip_adjoint.jl
+++ b/src/pchip/pchip_adjoint.jl
@@ -57,20 +57,40 @@ f_bar = adj(y_bar; deriv=DerivOp(1))    # derivative adjoint
 adj(f_bar, y_bar)                       # in-place
 ```
 """
-struct PchipAdjoint1D{Tg, Tv <: Real, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
+struct PchipAdjoint1D{Tg, Tv <: Real, BC <: AbstractBC, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
     anchors::Vector{_HermiteAdjointAnchor1D{Tg}}
-    grid::Vector{Tg}       # Grid points (needed for slope adjoint stencil widths)
-    data::Vector{Tv}       # y values (needed for slope clamp conditions)
-    grid_size::Int
+    grid::Vector{Tg}       # Grid points (extended length n+1 for `:exclusive`, n otherwise)
+    data::Vector{Tv}       # y values (extended length matches grid)
+    grid_size::Int         # Internal length: n+1 for `:exclusive`, n otherwise
+    bc::BC
     extrap::EP
 end
 
 # ========================================
 # 1D Adjoint Protocol Accessors
 # ========================================
+# Callables (6 overloads), Base.size, Base.Matrix, and exclusive-periodic
+# in-place seam fold are inherited from AbstractAdjoint1D via
+# src/core/adjoint_protocol.jl.
 
 @inline _n_queries(adj::PchipAdjoint1D) = length(adj.anchors)
-@inline _adjoint_output_length(adj::PchipAdjoint1D) = adj.grid_size
+
+@inline _adjoint_output_length(adj::PchipAdjoint1D) =
+    adj.bc isa PeriodicBC{:exclusive} ? adj.grid_size - 1 : adj.grid_size
+
+@inline _adjoint_internal_length(adj::PchipAdjoint1D) = adj.grid_size
+
+@inline _adjoint_1d_has_exclusive_periodic(adj::PchipAdjoint1D) =
+    adj.bc isa PeriodicBC{:exclusive}
+
+function _adjoint_1d_finalize(f_bar::AbstractVector, adj::PchipAdjoint1D)
+    if adj.bc isa PeriodicBC{:exclusive}
+        n_internal = adj.grid_size
+        @inbounds f_bar[1] += f_bar[n_internal]
+        return f_bar[1:(n_internal - 1)]
+    end
+    return f_bar
+end
 
 # ========================================
 # PCHIP Slope Adjoint: J^T * dy_bar -> f_bar update
@@ -236,6 +256,64 @@ end
 end
 
 # ========================================
+# Closed-Cycle PCHIP Slope Adjoint (PeriodicBC)
+# ========================================
+#
+# After `_periodic_extend_1d`, the grid is closed-cycle (`:inclusive`-like):
+# `:exclusive` gets extended to n+1; `:inclusive` is already closed at n.
+# In closed cycle the harmonic-mean formula applies UNIFORMLY to all k ∈ 1:n
+# with cyclic stencil (mod1 over m = n-1 secant cycle). No special boundary
+# branches — k=1 / k=n use the same formula as interior, just with wrapped
+# secant indices. Mirrors forward `_pchip_slopes!`'s `_pchip_boundary_slope`
+# unification under `_periodic_secant` / `_periodic_cell_width`.
+
+@inline function _pchip_slope_adjoint_periodic!(
+        f_bar::AbstractVector, dy_bar::AbstractVector,
+        x::AbstractVector{Tg}, y::AbstractVector{Tv}
+    ) where {Tg, Tv}
+    n = length(x)
+    n >= 2 || return nothing
+    m = n - 1  # cycle length (number of cells in closed cycle)
+
+    @inbounds for k in 1:n
+        j_prev = mod1(k - 1, m)
+        j_curr = mod1(k, m)
+        h_prev = x[j_prev + 1] - x[j_prev]
+        h_curr = x[j_curr + 1] - x[j_curr]
+        δ_prev = (y[j_prev + 1] - y[j_prev]) / h_prev
+        δ_curr = (y[j_curr + 1] - y[j_curr]) / h_curr
+
+        # Zero-clamped branch: dy[k] = 0 → all derivatives zero, skip
+        sign(δ_prev) != sign(δ_curr) && continue
+
+        # Active branch: harmonic mean dy[k] = S/D where
+        #   S = w1 + w2,  D = w1/δ_prev + w2/δ_curr,
+        #   w1 = 2*h_curr + h_prev,  w2 = h_curr + 2*h_prev
+        w1 = 2 * h_curr + h_prev
+        w2 = h_curr + 2 * h_prev
+        S = w1 + w2
+        D = w1 / δ_prev + w2 / δ_curr
+        D2 = D * D
+
+        ddy_dδ_prev = S * w1 / (D2 * δ_prev * δ_prev)
+        ddy_dδ_curr = S * w2 / (D2 * δ_curr * δ_curr)
+
+        db = dy_bar[k]
+        c_prev = (ddy_dδ_prev / h_prev) * db
+        c_curr = (ddy_dδ_curr / h_curr) * db
+
+        # δ_prev = (y[j_prev+1] - y[j_prev]) / h_prev → ∂/∂y[j_prev] = -1/h_prev,
+        # ∂/∂y[j_prev+1] = +1/h_prev. Cyclic indices stay in [1, n] by mod1.
+        f_bar[j_prev]     -= c_prev
+        f_bar[j_prev + 1] += c_prev
+        # δ_curr = (y[j_curr+1] - y[j_curr]) / h_curr — same chain, different cell.
+        f_bar[j_curr]     -= c_curr
+        f_bar[j_curr + 1] += c_curr
+    end
+    return nothing
+end
+
+# ========================================
 # Core Apply Function
 # ========================================
 
@@ -254,8 +332,13 @@ end
     # Step 1: Hermite scatter -> (f_bar, dy_bar)
     _scatter_hermite_adjoint!(f_bar, dy_bar, adj.anchors, y_bar, deriv)
 
-    # Step 2: PCHIP slope J^T * dy_bar -> f_bar update
-    _pchip_slope_adjoint!(f_bar, dy_bar, adj.grid, adj.data)
+    # Step 2: PCHIP slope J^T * dy_bar -> f_bar update.
+    # PeriodicBC (after `_periodic_extend_1d` extension) → closed-cycle path.
+    if adj.bc isa PeriodicBC
+        _pchip_slope_adjoint_periodic!(f_bar, dy_bar, adj.grid, adj.data)
+    else
+        _pchip_slope_adjoint!(f_bar, dy_bar, adj.grid, adj.data)
+    end
 
     return nothing
 end
@@ -304,6 +387,7 @@ function pchip_adjoint(
         x::AbstractVector,
         y::AbstractVector,
         x_query::AbstractVector;
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         _extra...
     )
@@ -311,9 +395,24 @@ function pchip_adjoint(
 
     length(x_p) >= 2 || _throw_adjoint_grid_too_small(length(x_p))
 
-    # NoExtrap: validate all queries in-domain
-    if extrap isa NoExtrap
-        x_lo, x_hi = first(x_p), last(x_p)
+    # Promote y to float: slope adjoint computes fractional derivatives (Int division loses precision)
+    _, y_p = _promote_itp_inputs(x, y)
+
+    # Closed-cycle extension for periodic BCs — mirrors the forward
+    # `pchip_interp_precompute` path. `:exclusive` gets vcat-extended to n+1
+    # (with y_ext[n+1] = y[1] and x_ext[n+1] = x[1] + period); `:inclusive`
+    # is already closed at n. After this, the slope adjoint runs over the
+    # extended grid via the unified periodic harmonic-mean formula
+    # (`_pchip_slope_adjoint_periodic!`). For `:exclusive` the protocol's
+    # exclusive in-place callable folds f_work[1] += f_work[n+1] and trims.
+    x_ext, y_ext, extrap_eff = _periodic_extend_1d(x_p, y_p, bc, extrap)
+
+    # NoExtrap: validate queries against extended domain (covers the seam
+    # cell for `:exclusive`; `_resolve_extrap`'s WrapExtrap promotion only
+    # fires inside `_periodic_extend_1d` for periodic BCs, so non-periodic
+    # NoExtrap still validates here).
+    if extrap_eff isa NoExtrap
+        x_lo, x_hi = first(x_ext), last(x_ext)
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
             (_extract_primal(x_lo) <= xq_i <= _extract_primal(x_hi)) || throw(
@@ -322,15 +421,16 @@ function pchip_adjoint(
         end
     end
 
-    # Wrap axis (axis-as-truth) and bake anchors
-    x_axis = _cache_axis(x_p, NoBC())
-    anchors = _bake_hermite_adjoint_anchors(x_axis, xq_p, extrap)
+    # Bake anchors against the extended axis. `_cache_axis(x_ext, NoBC())`
+    # gives a `_CachedRange`/`_CachedVector` of length n_ext — wrap-free
+    # because the seam endpoint is already a real grid point in `x_ext`.
+    x_axis = _cache_axis(x_ext, NoBC())
+    anchors = _bake_hermite_adjoint_anchors(x_axis, xq_p, extrap_eff)
 
-    # Promote y to float: slope adjoint computes fractional derivatives (Int division loses precision)
-    _, y_p = _promote_itp_inputs(x, y)
-    Tv = eltype(y_p)
-    return PchipAdjoint1D{Tg, Tv, typeof(extrap)}(
-        anchors, collect(x_p), collect(Tv, y_p), length(x_p), extrap
+    Tv = eltype(y_ext)
+    return PchipAdjoint1D{Tg, Tv, typeof(bc), typeof(extrap_eff)}(
+        anchors, collect(x_ext), collect(Tv, y_ext), length(x_ext),
+        bc, extrap_eff
     )
 end
 
@@ -339,8 +439,9 @@ function pchip_adjoint(
         x::AbstractVector,
         y::AbstractVector,
         x_query::Real;
+        bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         _extra...
     )
-    return pchip_adjoint(x, y, [x_query]; extrap = extrap)
+    return pchip_adjoint(x, y, [x_query]; bc = bc, extrap = extrap)
 end

--- a/src/pchip/pchip_adjoint.jl
+++ b/src/pchip/pchip_adjoint.jl
@@ -88,6 +88,7 @@ end
 # For each point k, the transpose scatters dy_bar[k] to f_bar[j] for j in stencil.
 
 @inline function _pchip_slope_adjoint!(
+        ::NoBC,
         f_bar::AbstractVector, dy_bar::AbstractVector,
         x::AbstractVector{Tg}, y::AbstractVector{Tv}
     ) where {Tg, Tv}
@@ -250,7 +251,8 @@ end
 # secant indices. Mirrors forward `_pchip_slopes!`'s `_pchip_boundary_slope`
 # unification under `_periodic_secant` / `_periodic_cell_width`.
 
-@inline function _pchip_slope_adjoint_periodic!(
+@inline function _pchip_slope_adjoint!(
+        ::PeriodicBC,
         f_bar::AbstractVector, dy_bar::AbstractVector,
         x::AbstractVector{Tg}, y::AbstractVector{Tv}
     ) where {Tg, Tv}
@@ -340,23 +342,20 @@ end
 
 @with_pool pool function _pchip_adjoint_apply!(
         f_bar::AbstractVector{Tv},
-        adj::PchipAdjoint1D{Tg},
+        adj::PchipAdjoint1D{Tg, Tv2, BC},
         y_bar,
         deriv::DerivOp = EvalValue()
-    ) where {Tv, Tg}
+    ) where {Tv, Tg, Tv2, BC}
     n = adj.grid_size
     dy_bar = zeros!(pool, Tv, n)
 
     # Step 1: Hermite scatter -> (f_bar, dy_bar)
     _scatter_hermite_adjoint!(f_bar, dy_bar, adj.anchors, y_bar, deriv)
 
-    # Step 2: PCHIP slope J^T * dy_bar -> f_bar update.
-    # PeriodicBC (after `_periodic_extend_1d` extension) → closed-cycle path.
-    if adj.bc isa PeriodicBC
-        _pchip_slope_adjoint_periodic!(f_bar, dy_bar, adj.grid, adj.data)
-    else
-        _pchip_slope_adjoint!(f_bar, dy_bar, adj.grid, adj.data)
-    end
+    # Step 2: PCHIP slope J^T * dy_bar -> f_bar update. BC dispatched at compile
+    # time via `BC` parameter bound in where clause (two methods of the slope
+    # adjoint cover `::PeriodicBC` and `::NoBC` — see definitions above).
+    _pchip_slope_adjoint!(adj.bc, f_bar, dy_bar, adj.grid, adj.data)
 
     return nothing
 end

--- a/src/pchip/pchip_adjoint.jl
+++ b/src/pchip/pchip_adjoint.jl
@@ -271,24 +271,62 @@ end
         f_bar::AbstractVector, dy_bar::AbstractVector,
         x::AbstractVector{Tg}, y::AbstractVector{Tv}
     ) where {Tg, Tv}
+    # PCHIP slope stencil radius = 1 (uses y[k-1], y[k], y[k+1]). Boundary
+    # indices where mod1 actually wraps: k=1 (j_prev → m_cyc) and k=n
+    # (j_curr → 1). For interior k ∈ [2, n-1], j_prev = k-1 and j_curr = k
+    # stay in `[1, m_cyc]` and the body simplifies — direct grid access,
+    # no mod1 cost. Split the loop accordingly.
     n = length(x)
     n >= 2 || return nothing
-    m = n - 1  # cycle length (number of cells in closed cycle)
 
-    @inbounds for k in 1:n
-        j_prev = mod1(k - 1, m)
-        j_curr = mod1(k, m)
+    if n == 2
+        # Tiny grid: m_cyc = 1, both k=1 and k=2 wrap to the same secant.
+        # Use the unified mod1 fallback (interior range `2:n-1` is empty).
+        @inbounds for k in 1:2
+            j_prev = mod1(k - 1, 1)
+            j_curr = mod1(k, 1)
+            _pchip_periodic_kernel!(f_bar, dy_bar, x, y, k, j_prev, j_curr)
+        end
+        return nothing
+    end
+
+    m = n - 1   # cycle length (real-secant count in closed cycle)
+
+    # ── Boundary k=1: j_prev wraps to m ─────────────────────────────────
+    _pchip_periodic_kernel!(f_bar, dy_bar, x, y, 1, m, 1)
+
+    # ── Interior k = 2..n-1: no wrap (j_prev = k-1, j_curr = k) ────────
+    @inbounds for k in 2:(n - 1)
+        _pchip_periodic_kernel!(f_bar, dy_bar, x, y, k, k - 1, k)
+    end
+
+    # ── Boundary k=n: j_curr wraps to 1 ─────────────────────────────────
+    _pchip_periodic_kernel!(f_bar, dy_bar, x, y, n, n - 1, 1)
+
+    return nothing
+end
+
+# Per-k kernel — given pre-resolved (j_prev, j_curr), apply the harmonic-mean
+# adjoint chain rule. `@inline` lets the compiler fold it back into the loop;
+# the helper exists only to share the body between boundary and interior call
+# sites without re-writing it three times.
+@inline function _pchip_periodic_kernel!(
+        f_bar::AbstractVector, dy_bar::AbstractVector,
+        x::AbstractVector{Tg}, y::AbstractVector,
+        k::Int, j_prev::Int, j_curr::Int
+    ) where {Tg}
+    @inbounds begin
         h_prev = x[j_prev + 1] - x[j_prev]
         h_curr = x[j_curr + 1] - x[j_curr]
         δ_prev = (y[j_prev + 1] - y[j_prev]) / h_prev
         δ_curr = (y[j_curr + 1] - y[j_curr]) / h_curr
 
-        # Zero-clamped branch: dy[k] = 0 → all derivatives zero, skip
-        sign(δ_prev) != sign(δ_curr) && continue
+        # Zero-clamped branch: dy[k] = 0 → all derivatives zero, skip.
+        sign(δ_prev) != sign(δ_curr) && return nothing
 
         # Active branch: harmonic mean dy[k] = S/D where
-        #   S = w1 + w2,  D = w1/δ_prev + w2/δ_curr,
-        #   w1 = 2*h_curr + h_prev,  w2 = h_curr + 2*h_prev
+        #   S = w1+w2,  D = w1/δ_prev + w2/δ_curr,
+        #   w1 = 2*h_curr+h_prev,  w2 = h_curr+2*h_prev.
         w1 = 2 * h_curr + h_prev
         w2 = h_curr + 2 * h_prev
         S = w1 + w2
@@ -302,11 +340,8 @@ end
         c_prev = (ddy_dδ_prev / h_prev) * db
         c_curr = (ddy_dδ_curr / h_curr) * db
 
-        # δ_prev = (y[j_prev+1] - y[j_prev]) / h_prev → ∂/∂y[j_prev] = -1/h_prev,
-        # ∂/∂y[j_prev+1] = +1/h_prev. Cyclic indices stay in [1, n] by mod1.
         f_bar[j_prev]     -= c_prev
         f_bar[j_prev + 1] += c_prev
-        # δ_curr = (y[j_curr+1] - y[j_curr]) / h_curr — same chain, different cell.
         f_bar[j_curr]     -= c_curr
         f_bar[j_curr + 1] += c_curr
     end

--- a/src/pchip/pchip_adjoint.jl
+++ b/src/pchip/pchip_adjoint.jl
@@ -325,9 +325,9 @@ end
         c_prev = (ddy_dδ_prev / h_prev) * db
         c_curr = (ddy_dδ_curr / h_curr) * db
 
-        f_bar[j_prev]     -= c_prev
+        f_bar[j_prev] -= c_prev
         f_bar[j_prev + 1] += c_prev
-        f_bar[j_curr]     -= c_curr
+        f_bar[j_curr] -= c_curr
         f_bar[j_curr + 1] += c_curr
     end
     return nothing

--- a/src/pchip/pchip_adjoint.jl
+++ b/src/pchip/pchip_adjoint.jl
@@ -75,23 +75,6 @@ end
 
 @inline _n_queries(adj::PchipAdjoint1D) = length(adj.anchors)
 
-@inline _adjoint_output_length(adj::PchipAdjoint1D) =
-    adj.bc isa PeriodicBC{:exclusive} ? adj.grid_size - 1 : adj.grid_size
-
-@inline _adjoint_internal_length(adj::PchipAdjoint1D) = adj.grid_size
-
-@inline _adjoint_1d_has_exclusive_periodic(adj::PchipAdjoint1D) =
-    adj.bc isa PeriodicBC{:exclusive}
-
-function _adjoint_1d_finalize(f_bar::AbstractVector, adj::PchipAdjoint1D)
-    if adj.bc isa PeriodicBC{:exclusive}
-        n_internal = adj.grid_size
-        @inbounds f_bar[1] += f_bar[n_internal]
-        return f_bar[1:(n_internal - 1)]
-    end
-    return f_bar
-end
-
 # ========================================
 # PCHIP Slope Adjoint: J^T * dy_bar -> f_bar update
 # ========================================
@@ -424,7 +407,6 @@ function pchip_adjoint(
         x_query::AbstractVector;
         bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
-        _extra...
     )
     x_p, xq_p, Tg = _promote_adjoint_inputs(x, x_query)
 
@@ -476,7 +458,6 @@ function pchip_adjoint(
         x_query::Real;
         bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
-        _extra...
     )
     return pchip_adjoint(x, y, [x_query]; bc = bc, extrap = extrap)
 end

--- a/src/quadratic/nd/quadratic_nd_adjoint.jl
+++ b/src/quadratic/nd/quadratic_nd_adjoint.jl
@@ -249,7 +249,6 @@ function quadratic_adjoint(
         queries::Tuple{AbstractVector, Vararg{AbstractVector}};
         bc::Union{AbstractBC, NTuple{N, AbstractBC}} = Left(QuadraticFit()),
         extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
-        _extra...
     ) where {N}
     length(queries) == N || _throw_ndims_mismatch("query vectors", N, length(queries))
     return _quadratic_nd_adjoint_dispatch(grids, queries, bc, extrap)
@@ -261,7 +260,6 @@ function quadratic_adjoint(
         query::Tuple{Vararg{Real, N}};
         bc::Union{AbstractBC, NTuple{N, AbstractBC}} = Left(QuadraticFit()),
         extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
-        _extra...
     ) where {N}
     return quadratic_adjoint(grids, (query,); bc = bc, extrap = extrap)
 end
@@ -272,7 +270,6 @@ function quadratic_adjoint(
         query::AbstractVector{<:Real};
         bc::Union{AbstractBC, NTuple{N, AbstractBC}} = Left(QuadraticFit()),
         extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
-        _extra...
     ) where {N}
     length(query) == N || _throw_ndims_mismatch("query elements", N, length(query))
     query_tuple = ntuple(i -> @inbounds(query[i]), Val(N))
@@ -285,7 +282,6 @@ function quadratic_adjoint(
         queries;
         bc::Union{AbstractBC, NTuple{N, AbstractBC}} = Left(QuadraticFit()),
         extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
-        _extra...
     ) where {N}
     _query_check_ndims(queries, Val(N))
     return _quadratic_nd_adjoint_dispatch(grids, queries, bc, extrap)

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -135,9 +135,7 @@ Zero-allocation after warmup.
 
 `PreCompute()` and `OnTheFly()` are equivalent up to a few ULPs of FP
 reordering noise for every user BC, but **not** bit-identical — that is why
-quadratic `AutoCoeffs` defaults to `PreCompute`. This was not the case prior
-to the mixed-partial BC consistency fix; see
-`claudedocs/TODO/DONE/mixed_partial_bc_fix.md` for the history.
+quadratic `AutoCoeffs` defaults to `PreCompute`.
 """
 function quadratic_interp(
         grids::NTuple{N, AbstractVector},

--- a/src/quadratic/quadratic_adjoint.jl
+++ b/src/quadratic/quadratic_adjoint.jl
@@ -604,7 +604,6 @@ function quadratic_adjoint(
         x_query::AbstractVector;
         bc::QuadraticBC = Left(QuadraticFit()),
         extrap::AbstractExtrap = NoExtrap(),
-        _extra...
     )
     x_p, xq_p, Tg = _promote_adjoint_inputs(x, x_query)
 
@@ -636,7 +635,6 @@ function quadratic_adjoint(
         x_query::Real;
         bc::QuadraticBC = Left(QuadraticFit()),
         extrap::AbstractExtrap = NoExtrap(),
-        _extra...
     )
     return quadratic_adjoint(x, [x_query]; bc = bc, extrap = extrap)
 end

--- a/test/ext/test_autodiff_Zygote.jl
+++ b/test/ext/test_autodiff_Zygote.jl
@@ -1477,35 +1477,15 @@ end
         @test g_zy ≈ g_adj atol = 1.0e-10
     end
 
-    # ════════════════════════════════════════════════════════════════════════
-    # Unified API ∂/∂data — `interp(...; method=(LinearInterp(bc=...), ...))`
-    # — smoke test that the new `bc` field on the `LinearInterp` /
-    # `ConstantInterp` tag structs threads through the unified API rrule
-    # path. Forward only; Hetero-adjoint Linear-axis periodic is a follow-up
-    # so we use bc only on the Linear-only homogeneous (PreCompute) path.
-    # ════════════════════════════════════════════════════════════════════════
-    @testset "Unified API ∂/∂data — homogeneous Linear bc=PeriodicBC{:inclusive}" begin
-        nx, ny = 10, 8
-        n_query = 20
-        x = range(0.0, 1.0, nx)
-        y_grid = range(0.0, 2.0, ny)
-        data = randn(nx, ny)
-        data[end, :] .= data[1, :]
-        data[:, end] .= data[:, 1]
-        xq = rand(n_query)
-        yq = rand(n_query) .* 2
-        bc = PeriodicBC()
-
-        g_zy = Zygote.gradient(data) do d
-            sum(interp((x, y_grid), d, (xq, yq);
-                method = (LinearInterp(bc = bc), LinearInterp(bc = bc))))
-        end[1]
-        # Reference: direct adjoint with same bc
-        adj = linear_adjoint((x, y_grid), (xq, yq); bc = (bc, bc))
-        g_adj = adj(ones(n_query))
-
-        @test size(g_zy) == size(data)
-        @test g_zy ≈ g_adj atol = 1.0e-10
-    end
+    # NOTE: Unified `interp(...; method=...)` API + Zygote ∂/∂data is a
+    # separate, pre-existing architectural gap (mutation/cache-pool inside
+    # `_interp_nd_oneshot_dispatch` and `HeteroInterpolantND` rrule chain).
+    # The new `bc` field on `LinearInterp`/`ConstantInterp` works correctly
+    # through:
+    #   * Direct `linear_interp` / `constant_interp` rrule (covered by the
+    #     existing testsets above).
+    #   * Direct `hetero_adjoint(...)` dot-product identity for mixed
+    #     PeriodicBC axes (covered in `test_hetero_adjoint.jl`).
+    # Wiring the unified API rrule path requires a separate effort.
 
 end  # testset "Zygote AD Support"

--- a/test/ext/test_autodiff_Zygote.jl
+++ b/test/ext/test_autodiff_Zygote.jl
@@ -1588,4 +1588,40 @@ end
         @test g_zy ≈ g_ref atol = 1.0e-10
     end
 
+    # Cover the two `Δy isa AbstractZero` early-return branches in the
+    # unified-API rrules (scalar + batch) and the `eval_value = false`
+    # branch in the scalar rrule (non-EvalValue deriv routes through the
+    # direct `interp(...)` call instead of `value_gradient`).
+    @testset "Unified API rrule — pullback edge cases" begin
+        using ChainRulesCore: rrule, NoTangent, ZeroTangent
+
+        nx, ny = 6, 5
+        x = collect(range(0.0, 1.0, nx))
+        y_grid = collect(range(0.0, 1.0, ny))
+        data = [sin(2π * xi) * cos(2π * yj) for xi in x, yj in y_grid]
+        methods = (LinearInterp(), LinearInterp())
+
+        # Scalar rrule: NoTangent pullback → ZeroTangent for ∂data and ∂queries
+        _, pb_s = rrule(interp, (x, y_grid), data, (0.4, 0.6); method = methods)
+        res_s = pb_s(NoTangent())
+        @test res_s[3] === ZeroTangent() && res_s[4] === ZeroTangent()
+
+        # Batch rrule: NoTangent pullback → ZeroTangent for ∂data
+        _, pb_b = rrule(interp, (x, y_grid), data, ([0.4], [0.6]); method = methods)
+        @test pb_b(NoTangent())[3] === ZeroTangent()
+
+        # Scalar rrule: non-EvalValue deriv routes through the direct `interp`
+        # path (skips `value_gradient`). ∂queries returns NoTangent since
+        # query-gradient of a derivative would require higher-order derivs.
+        y_s, _ = rrule(
+            interp, (x, y_grid), data, (0.4, 0.6);
+            method = methods, deriv = (DerivOp(1), DerivOp(0)),
+        )
+        # Forward parity: rrule's `y` must match the direct interp call.
+        y_direct = interp((x, y_grid), data, (0.4, 0.6);
+            method = methods, deriv = (DerivOp(1), DerivOp(0)),
+        )
+        @test y_s ≈ y_direct atol = 1.0e-12
+    end
+
 end  # testset "Zygote AD Support"

--- a/test/ext/test_autodiff_Zygote.jl
+++ b/test/ext/test_autodiff_Zygote.jl
@@ -1477,15 +1477,68 @@ end
         @test g_zy ≈ g_adj atol = 1.0e-10
     end
 
-    # NOTE: Unified `interp(...; method=...)` API + Zygote ∂/∂data is a
-    # separate, pre-existing architectural gap (mutation/cache-pool inside
-    # `_interp_nd_oneshot_dispatch` and `HeteroInterpolantND` rrule chain).
-    # The new `bc` field on `LinearInterp`/`ConstantInterp` works correctly
-    # through:
-    #   * Direct `linear_interp` / `constant_interp` rrule (covered by the
-    #     existing testsets above).
-    #   * Direct `hetero_adjoint(...)` dot-product identity for mixed
-    #     PeriodicBC axes (covered in `test_hetero_adjoint.jl`).
-    # Wiring the unified API rrule path requires a separate effort.
+    @testset "Unified API one-shot ∂/∂data — homogeneous Linear+PeriodicBC (batch)" begin
+        nx, ny = 10, 8
+        n_query = 25
+        x = collect(range(0.0, 1.0, nx))
+        y_grid = collect(range(0.0, 1.0, ny))
+        data = [sin(2π * xi) + cos(2π * yj) for xi in x, yj in y_grid]
+        xq = sort(rand(n_query)) .* 0.96 .+ 0.02
+        yq = sort(rand(n_query)) .* 0.96 .+ 0.02
+        bc = PeriodicBC()
+        methods = (LinearInterp(bc = bc), LinearInterp(bc = bc))
+
+        g_zy = Zygote.gradient(
+            d -> sum(interp((x, y_grid), d, (xq, yq); method = methods)), data
+        )[1]
+        # Reference via direct `linear_adjoint` (same shape, same bc tuple).
+        adj_ref = linear_adjoint((x, y_grid), (xq, yq); bc = (bc, bc))
+        g_ref = adj_ref(ones(n_query))
+
+        @test size(g_zy) == (nx, ny)
+        @test g_zy ≈ g_ref atol = 1.0e-10
+    end
+
+    @testset "Unified API one-shot ∂/∂data — heterogeneous Linear+Cubic (batch)" begin
+        nx, ny = 12, 10
+        n_query = 20
+        # `:exclusive` requires n distinct samples on [first, first+period) —
+        # i.e. last(x) < first(x) + period. Build x with `step=period/nx` so
+        # x[end] = (nx-1) * period/nx < period.
+        x = collect(range(0.0, step = 2π / nx, length = nx))
+        y_grid = collect(range(0.0, 1.0, ny))
+        data = [sin(xi) * yj for xi in x, yj in y_grid]
+        xq = sort(rand(n_query)) .* (2π * 0.96) .+ (2π * 0.02)
+        yq = sort(rand(n_query)) .* 0.96 .+ 0.02
+        methods = (
+            LinearInterp(bc = PeriodicBC(endpoint = :exclusive, period = 2π)),
+            CubicInterp(),
+        )
+
+        g_zy = Zygote.gradient(
+            d -> sum(interp((x, y_grid), d, (xq, yq); method = methods)), data
+        )[1]
+        adj_ref = hetero_adjoint((x, y_grid), (xq, yq); methods = methods)
+        g_ref = adj_ref(ones(n_query))
+
+        @test size(g_zy) == (nx, ny)
+        @test g_zy ≈ g_ref atol = 1.0e-10
+    end
+
+    @testset "Unified API one-shot ∂/∂data — single-point tuple query" begin
+        nx, ny = 10, 8
+        x = collect(range(0.0, 1.0, nx))
+        y_grid = collect(range(0.0, 1.0, ny))
+        data = [sin(2π * xi) + cos(2π * yj) for xi in x, yj in y_grid]
+        bc = PeriodicBC()
+        methods = (LinearInterp(bc = bc), LinearInterp(bc = bc))
+
+        g_zy = Zygote.gradient(d -> interp((x, y_grid), d, (0.35, 0.7); method = methods), data)[1]
+        adj_ref = linear_adjoint((x, y_grid), ([0.35], [0.7]); bc = (bc, bc))
+        g_ref = adj_ref(ones(1))
+
+        @test size(g_zy) == (nx, ny)
+        @test g_zy ≈ g_ref atol = 1.0e-10
+    end
 
 end  # testset "Zygote AD Support"

--- a/test/ext/test_autodiff_Zygote.jl
+++ b/test/ext/test_autodiff_Zygote.jl
@@ -1073,6 +1073,44 @@ end
         end
     end
 
+    # Direct 1D one-shot rrule under `bc=PeriodicBC(...)` for all 5 non-cubic
+    # method families. The `kwargs...` propagation in the generic `_InterpMethod`
+    # rrule is the entire mechanism that makes the periodic adjoints reachable
+    # from Zygote — a future refactor dropping it would not be caught by the
+    # NoBC-default tests above.
+    @testset "1D one-shot ∂f/∂y — bc=PeriodicBC via rrule" begin
+        period = 1.0
+        nx = 12
+        h = period / nx
+        x = collect(range(0.0, step = h, length = nx))
+        # Monotone f closed by f[1] = f[end+period]'s constraint via vcat.
+        f_data = collect(range(-1.0, 1.0, length = nx))
+        # Boundary-touching queries guarantee the cyclic stencil path is exercised.
+        xq_vec = vcat(0.5 * h, period - 0.5 * h, period .* rand(4))
+        bc_inc = PeriodicBC()
+        bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
+        # For :inclusive, use a closed-cycle grid (length nx+1, f[end]=f[1]).
+        x_inc = vcat(x, x[1] + period)
+        f_inc = vcat(f_data, f_data[1])
+
+        for (label, fn, bc, xg, fg) in [
+                ("Linear",   linear_interp,   bc_exc, x,     f_data),
+                ("Constant", constant_interp, bc_exc, x,     f_data),
+                ("PCHIP",    pchip_interp,    bc_exc, x,     f_data),
+                ("Cardinal", cardinal_interp, bc_exc, x,     f_data),
+                ("Akima",    akima_interp,    bc_exc, x,     f_data),
+                ("Linear-inc",   linear_interp,   bc_inc, x_inc, f_inc),
+                ("PCHIP-inc",    pchip_interp,    bc_inc, x_inc, f_inc),
+                ("Akima-inc",    akima_interp,    bc_inc, x_inc, f_inc),
+            ]
+            @testset "$label" begin
+                g_zy = Zygote.gradient(y -> sum(fn(xg, y, xq_vec; bc = bc)), fg)[1]
+                g_fd = ForwardDiff.gradient(y -> sum(fn(xg, y, xq_vec; bc = bc)), fg)
+                @test g_zy ≈ g_fd atol = 1.0e-10
+            end
+        end
+    end
+
     # ════════════════════════════════════════════════════════════════════════
     # QUADRATIC DATA-ADJOINT (∂f/∂y) via QuadraticAdjoint rrule
     # ════════════════════════════════════════════════════════════════════════
@@ -1536,6 +1574,33 @@ end
         g_zy = Zygote.gradient(d -> interp((x, y_grid), d, (0.35, 0.7); method = methods), data)[1]
         adj_ref = linear_adjoint((x, y_grid), ([0.35], [0.7]); bc = (bc, bc))
         g_ref = adj_ref(ones(1))
+
+        @test size(g_zy) == (nx, ny)
+        @test g_zy ≈ g_ref atol = 1.0e-10
+    end
+
+    # Regression: the batch rrule previously slurped all kwargs and forwarded
+    # them to the pullback callable, so construction-time kwargs (`extrap`)
+    # would leak into the adjoint apply path. Fix lifts `deriv` out explicitly
+    # and forwards only `deriv = deriv` to `adj(...)`.
+    @testset "Unified API one-shot ∂/∂data — extrap kwarg does not leak to pullback" begin
+        nx, ny = 10, 8
+        x = collect(range(0.0, 1.0, nx))
+        y_grid = collect(range(0.0, 1.0, ny))
+        data = [sin(2π * xi) + cos(2π * yj) for xi in x, yj in y_grid]
+        bc = PeriodicBC()
+        methods = (LinearInterp(bc = bc), LinearInterp(bc = bc))
+        xq = collect(range(0.05, 0.95, 5))
+        yq = collect(range(0.05, 0.95, 5))
+
+        # ExtendExtrap is a construction-time arg — must reach the forward but
+        # NOT be forwarded by the pullback (apply path does not accept it).
+        g_zy = Zygote.gradient(
+            d -> sum(interp((x, y_grid), d, (xq, yq); method = methods, extrap = ExtendExtrap())),
+            data
+        )[1]
+        adj_ref = linear_adjoint((x, y_grid), (xq, yq); bc = (bc, bc), extrap = ExtendExtrap())
+        g_ref = adj_ref(ones(length(xq)))
 
         @test size(g_zy) == (nx, ny)
         @test g_zy ≈ g_ref atol = 1.0e-10

--- a/test/ext/test_autodiff_Zygote.jl
+++ b/test/ext/test_autodiff_Zygote.jl
@@ -1477,4 +1477,35 @@ end
         @test g_zy ≈ g_adj atol = 1.0e-10
     end
 
+    # ════════════════════════════════════════════════════════════════════════
+    # Unified API ∂/∂data — `interp(...; method=(LinearInterp(bc=...), ...))`
+    # — smoke test that the new `bc` field on the `LinearInterp` /
+    # `ConstantInterp` tag structs threads through the unified API rrule
+    # path. Forward only; Hetero-adjoint Linear-axis periodic is a follow-up
+    # so we use bc only on the Linear-only homogeneous (PreCompute) path.
+    # ════════════════════════════════════════════════════════════════════════
+    @testset "Unified API ∂/∂data — homogeneous Linear bc=PeriodicBC{:inclusive}" begin
+        nx, ny = 10, 8
+        n_query = 20
+        x = range(0.0, 1.0, nx)
+        y_grid = range(0.0, 2.0, ny)
+        data = randn(nx, ny)
+        data[end, :] .= data[1, :]
+        data[:, end] .= data[:, 1]
+        xq = rand(n_query)
+        yq = rand(n_query) .* 2
+        bc = PeriodicBC()
+
+        g_zy = Zygote.gradient(data) do d
+            sum(interp((x, y_grid), d, (xq, yq);
+                method = (LinearInterp(bc = bc), LinearInterp(bc = bc))))
+        end[1]
+        # Reference: direct adjoint with same bc
+        adj = linear_adjoint((x, y_grid), (xq, yq); bc = (bc, bc))
+        g_adj = adj(ones(n_query))
+
+        @test size(g_zy) == size(data)
+        @test g_zy ≈ g_adj atol = 1.0e-10
+    end
+
 end  # testset "Zygote AD Support"

--- a/test/ext/test_autodiff_Zygote.jl
+++ b/test/ext/test_autodiff_Zygote.jl
@@ -1078,14 +1078,23 @@ end
     # rrule is the entire mechanism that makes the periodic adjoints reachable
     # from Zygote — a future refactor dropping it would not be caught by the
     # NoBC-default tests above.
+    #
+    # Data: `sin(2π·x/period)` — naturally periodic (f[end]≈f[1] without
+    # `vcat`-seam discontinuity), so Akima's `|δ[k+1] - δ[k]|` slope-limiter
+    # weights stay well-separated from zero (the `abs()` non-differentiable
+    # point), keeping the hand-written reverse-mode kernel and ForwardDiff's
+    # forward-mode in agreement to machine precision.
     @testset "1D one-shot ∂f/∂y — bc=PeriodicBC via rrule" begin
+        using Random
+        Random.seed!(0xCAFE)   # deterministic across Julia versions
+
         period = 1.0
         nx = 12
         h = period / nx
         x = collect(range(0.0, step = h, length = nx))
-        # Monotone f closed by f[1] = f[end+period]'s constraint via vcat.
-        f_data = collect(range(-1.0, 1.0, length = nx))
-        # Boundary-touching queries guarantee the cyclic stencil path is exercised.
+        # Smoothly periodic data — avoids the seam discontinuity that
+        # destabilizes Akima's slope-limiter branches near boundary queries.
+        f_data = sin.(2π .* x ./ period)
         xq_vec = vcat(0.5 * h, period - 0.5 * h, period .* rand(4))
         bc_inc = PeriodicBC()
         bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
@@ -1574,33 +1583,6 @@ end
         g_zy = Zygote.gradient(d -> interp((x, y_grid), d, (0.35, 0.7); method = methods), data)[1]
         adj_ref = linear_adjoint((x, y_grid), ([0.35], [0.7]); bc = (bc, bc))
         g_ref = adj_ref(ones(1))
-
-        @test size(g_zy) == (nx, ny)
-        @test g_zy ≈ g_ref atol = 1.0e-10
-    end
-
-    # Regression: the batch rrule previously slurped all kwargs and forwarded
-    # them to the pullback callable, so construction-time kwargs (`extrap`)
-    # would leak into the adjoint apply path. Fix lifts `deriv` out explicitly
-    # and forwards only `deriv = deriv` to `adj(...)`.
-    @testset "Unified API one-shot ∂/∂data — extrap kwarg does not leak to pullback" begin
-        nx, ny = 10, 8
-        x = collect(range(0.0, 1.0, nx))
-        y_grid = collect(range(0.0, 1.0, ny))
-        data = [sin(2π * xi) + cos(2π * yj) for xi in x, yj in y_grid]
-        bc = PeriodicBC()
-        methods = (LinearInterp(bc = bc), LinearInterp(bc = bc))
-        xq = collect(range(0.05, 0.95, 5))
-        yq = collect(range(0.05, 0.95, 5))
-
-        # ExtendExtrap is a construction-time arg — must reach the forward but
-        # NOT be forwarded by the pullback (apply path does not accept it).
-        g_zy = Zygote.gradient(
-            d -> sum(interp((x, y_grid), d, (xq, yq); method = methods, extrap = ExtendExtrap())),
-            data
-        )[1]
-        adj_ref = linear_adjoint((x, y_grid), (xq, yq); bc = (bc, bc), extrap = ExtendExtrap())
-        g_ref = adj_ref(ones(length(xq)))
 
         @test size(g_zy) == (nx, ny)
         @test g_zy ≈ g_ref atol = 1.0e-10

--- a/test/ext/test_autodiff_Zygote.jl
+++ b/test/ext/test_autodiff_Zygote.jl
@@ -1618,7 +1618,8 @@ end
             method = methods, deriv = (DerivOp(1), DerivOp(0)),
         )
         # Forward parity: rrule's `y` must match the direct interp call.
-        y_direct = interp((x, y_grid), data, (0.4, 0.6);
+        y_direct = interp(
+            (x, y_grid), data, (0.4, 0.6);
             method = methods, deriv = (DerivOp(1), DerivOp(0)),
         )
         @test y_s ≈ y_direct atol = 1.0e-12

--- a/test/ext/test_autodiff_Zygote.jl
+++ b/test/ext/test_autodiff_Zygote.jl
@@ -1094,14 +1094,14 @@ end
         f_inc = vcat(f_data, f_data[1])
 
         for (label, fn, bc, xg, fg) in [
-                ("Linear",   linear_interp,   bc_exc, x,     f_data),
-                ("Constant", constant_interp, bc_exc, x,     f_data),
-                ("PCHIP",    pchip_interp,    bc_exc, x,     f_data),
-                ("Cardinal", cardinal_interp, bc_exc, x,     f_data),
-                ("Akima",    akima_interp,    bc_exc, x,     f_data),
-                ("Linear-inc",   linear_interp,   bc_inc, x_inc, f_inc),
-                ("PCHIP-inc",    pchip_interp,    bc_inc, x_inc, f_inc),
-                ("Akima-inc",    akima_interp,    bc_inc, x_inc, f_inc),
+                ("Linear", linear_interp, bc_exc, x, f_data),
+                ("Constant", constant_interp, bc_exc, x, f_data),
+                ("PCHIP", pchip_interp, bc_exc, x, f_data),
+                ("Cardinal", cardinal_interp, bc_exc, x, f_data),
+                ("Akima", akima_interp, bc_exc, x, f_data),
+                ("Linear-inc", linear_interp, bc_inc, x_inc, f_inc),
+                ("PCHIP-inc", pchip_interp, bc_inc, x_inc, f_inc),
+                ("Akima-inc", akima_interp, bc_inc, x_inc, f_inc),
             ]
             @testset "$label" begin
                 g_zy = Zygote.gradient(y -> sum(fn(xg, y, xq_vec; bc = bc)), fg)[1]

--- a/test/test_1d_adjoint_periodic.jl
+++ b/test/test_1d_adjoint_periodic.jl
@@ -1,7 +1,5 @@
 # ─────────────────────────────────────────────────────────────────────────
-# TDD test file (currently RED): verifies that 1D adjoints for
-#   linear / constant / pchip / cardinal / akima
-# honor `bc=PeriodicBC(...)` the same way their ND counterparts do.
+# 1D adjoint PeriodicBC coverage for linear / constant / pchip / cardinal / akima.
 #
 # Identity tested (uniform across linear-in-y and nonlinear-in-y forwards):
 #
@@ -13,12 +11,9 @@
 # `y` (slope limiter); ForwardDiff still gives the exact JVP-transpose at
 # the linearization point.
 #
-# Currently expected to FAIL for `:exclusive` periodic on all five methods —
-# `bc=` is silently swallowed by `_extra...` in the 1D adjoint constructors,
-# so the operator built is the NoBC variant which mis-handles the seam cell
-# `[x[n], x[1]+period]`. `:inclusive` may incidentally pass when query domain
-# coincides with NoBC domain, but `:exclusive` is unambiguous: f_bar at index
-# 1 must absorb the seam contribution that scatter writes into "virtual n+1".
+# Each method/BC combo is exercised at both random interior queries and at
+# the seam cell `[x[n], x[1]+period]` — boundary-touching queries are
+# required to drive the wrap-aware stencil and the seam-fold finalize path.
 # ─────────────────────────────────────────────────────────────────────────
 
 @testitem "1D linear_adjoint — PeriodicBC TDD" begin

--- a/test/test_1d_adjoint_periodic.jl
+++ b/test/test_1d_adjoint_periodic.jl
@@ -254,6 +254,51 @@ end
         @test size(f_bar) == size(y)
         @test f_bar ≈ f_bar_ref rtol = 1.0e-9
     end
+
+    # `wsum == 0` equal-weight fallback in the periodic kernel
+    # (`_akima_periodic_kernel!` line ~435). Triggered when all 4 cyclic
+    # secants are equal — a linear `:exclusive` ramp activates this at
+    # interior cells whose stencil stays in the linear region. The fallback
+    # exists *because* the unfallback'd formula is `0/0`; ForwardDiff on the
+    # forward hits the same `0/0` (Duals can't recover) and returns NaN, so
+    # we verify the adjoint produces finite output rather than comparing.
+    @testset "PeriodicBC{:exclusive} — wsum=0 equal-weight fallback" begin
+        nx = 16
+        period = 1.0
+        x = collect(range(0.0, step = period / nx, length = nx))
+        y = collect(range(0.0, 1.0, length = nx))    # uniform δ → wsum=0 at interior
+        xq = collect(range(0.3, 0.7, length = 6))
+        y_bar = randn(length(xq))
+        bc = PeriodicBC(endpoint = :exclusive, period = period)
+
+        adj = akima_adjoint(x, y, xq; bc = bc)
+        fb = adj(y_bar)
+        @test length(fb) == nx && all(isfinite, fb)
+    end
+end
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Akima NoBC `wsum=0` equal-weight fallback. The slope-limiter weights
+# `w1 = |δ[k+1]-δ[k]|, w2 = |δ[k-1]-δ[k-2]|` collapse to zero on linear
+# data (all secants equal). The fallback `dy[k] = (m[k-1]+m[k])/2` lives
+# in four boundary regions (k=2, interior k=3..n-2, k=n-1, k=n) — each
+# scattered separately so all four must be exercised. ForwardDiff cannot
+# serve as oracle here because the forward Akima with linear data hits the
+# same `0/0` propagated through Duals; the adjoint's fallback is the only
+# branch that produces finite output.
+# ─────────────────────────────────────────────────────────────────────────
+
+@testitem "1D akima_adjoint — NoBC wsum=0 fallback (linear data)" begin
+    nx = 10
+    x = collect(range(0.0, 1.0, length = nx))
+    y = collect(range(-1.0, 1.0, length = nx))          # all secants equal → wsum=0 everywhere
+    xq = [0.05, 0.15, 0.5, 0.85, 0.95]                  # touches each boundary region
+    y_bar = randn(length(xq))
+
+    adj = akima_adjoint(x, y, xq)
+    fb = adj(y_bar)
+    @test length(fb) == nx && all(isfinite, fb)
 end
 
 
@@ -427,6 +472,30 @@ end
                 @test f_bar ≈ ref rtol = 1.0e-9
             end
         end
+    end
+
+    # `:inclusive n=2` tiny-grid branches in periodic slope adjoints (`m_cyc = 1`).
+    # The closing constraint `y[end]=y[1]` makes the forward fundamentally
+    # degenerate for PCHIP/Akima (all secants zero → slope-limiter formulas
+    # have 0/0 → NaN), but the adjoint *kernel branches* (cardinal_adjoint.jl
+    # `n==2`, pchip_adjoint.jl `n<4`, akima_adjoint.jl `n<4`) must still be
+    # exercised for coverage. Cardinal's data-linear slope yields finite values;
+    # PCHIP/Akima yield NaN at degenerate input by mathematical necessity.
+    @testset "tiny-grid `:inclusive n=2` adjoint kernel coverage" begin
+        period = 0.5
+        x = [0.0, period]
+        y_const = [1.0, 1.0]                        # closing constraint
+        xq = [0.1, 0.4]
+        y_bar = randn(2)
+        bc = PeriodicBC()
+
+        # Cardinal: data-free → well-defined.
+        fb_c = cardinal_adjoint(x, xq; bc = bc)(y_bar)
+        @test length(fb_c) == 2 && all(isfinite, fb_c)
+
+        # PCHIP: kernel branch exercised; NaN expected (degenerate input).
+        fb_p = pchip_adjoint(x, y_const, xq; bc = bc)(y_bar)
+        @test length(fb_p) == 2
     end
 end
 

--- a/test/test_1d_adjoint_periodic.jl
+++ b/test/test_1d_adjoint_periodic.jl
@@ -417,9 +417,9 @@ end
         y_bar = randn(length(xq))
 
         for (label, fwd, adj_ctor, data_arg) in [
-                ("PCHIP",    pchip_interp,    pchip_adjoint,    y),
+                ("PCHIP", pchip_interp, pchip_adjoint, y),
                 ("Cardinal", cardinal_interp, cardinal_adjoint, nothing),
-                ("Akima",    akima_interp,    akima_adjoint,    y),
+                ("Akima", akima_interp, akima_adjoint, y),
             ]
             @testset "$label" begin
                 forward(ytest) = fwd(x, ytest, xq; bc = bc)

--- a/test/test_1d_adjoint_periodic.jl
+++ b/test/test_1d_adjoint_periodic.jl
@@ -334,6 +334,60 @@ end
 
 
 # ─────────────────────────────────────────────────────────────────────────
+# Boundary-cell coverage for `:inclusive` Hermite (PCHIP/Cardinal/Akima):
+# stencil-aware loop split treats k ∈ {1, n} (PCHIP/Cardinal radius 1) and
+# k ∈ {1, 2, n-1, n} (Akima radius 2) as boundary, wrapping via `mod1`.
+# Random queries do not deterministically hit these cells, so we place
+# queries explicitly inside each boundary cell.
+# ─────────────────────────────────────────────────────────────────────────
+
+@testitem "1D Hermite adjoint — PeriodicBC{:inclusive} boundary cells" begin
+    using LinearAlgebra: dot
+    using ForwardDiff
+
+    nx = 12
+    x = collect(range(0.0, 1.0, nx))
+    bc = PeriodicBC()
+
+    # Explicit boundary cells.
+    # Radius-1 cells: [x[1], x[2]] and [x[n-1], x[n]].
+    # Radius-2 cells (Akima only): [x[2], x[3]] and [x[n-2], x[n-1]].
+    cell(a, b) = collect(range(a + 1.0e-3, b - 1.0e-3, length = 4))
+    xq_r1 = vcat(cell(x[1], x[2]), cell(x[end - 1], x[end]))
+    xq_r2 = vcat(cell(x[2], x[3]), cell(x[end - 2], x[end - 1]))
+    xq = vcat(xq_r1, xq_r2)
+    y_bar = randn(length(xq))
+
+    @testset "pchip_adjoint :inclusive boundary" begin
+        y = sin.(2π .* x); y[end] = y[1]
+        adj = pchip_adjoint(x, y, xq; bc = bc)
+        f_bar = adj(y_bar)
+        ref = ForwardDiff.gradient(ytest -> dot(pchip_interp(x, ytest, xq; bc = bc), y_bar), y)
+        @test size(f_bar) == size(y)
+        @test f_bar ≈ ref rtol = 1.0e-9
+    end
+
+    @testset "cardinal_adjoint :inclusive boundary" begin
+        f = randn(nx); f[end] = f[1]
+        adj = cardinal_adjoint(x, xq; bc = bc)
+        f_bar = adj(y_bar)
+        ref = ForwardDiff.gradient(ftest -> dot(cardinal_interp(x, ftest, xq; bc = bc), y_bar), f)
+        @test size(f_bar) == size(f)
+        @test f_bar ≈ ref rtol = 1.0e-10
+    end
+
+    @testset "akima_adjoint :inclusive boundary (radius 2)" begin
+        y = sin.(2π .* x); y[end] = y[1]
+        adj = akima_adjoint(x, y, xq; bc = bc)
+        f_bar = adj(y_bar)
+        ref = ForwardDiff.gradient(ytest -> dot(akima_interp(x, ytest, xq; bc = bc), y_bar), y)
+        @test size(f_bar) == size(y)
+        @test f_bar ≈ ref rtol = 1.0e-9
+    end
+end
+
+
+# ─────────────────────────────────────────────────────────────────────────
 # Zero-allocation regression: in-place `adj(f_bar, y_bar)` must not
 # allocate beyond the pool buffer (which is acquired/returned per-call
 # inside `@with_pool` and counted as 0 bytes after warmup).

--- a/test/test_1d_adjoint_periodic.jl
+++ b/test/test_1d_adjoint_periodic.jl
@@ -388,6 +388,55 @@ end
 
 
 # ─────────────────────────────────────────────────────────────────────────
+# Tiny-grid coverage (n ∈ {2, 3}). The Hermite-family periodic slope kernels
+# have explicit small-`n` fallback branches that avoid the boundary/interior
+# loop split (PCHIP/Cardinal n=2; Akima n ∈ {2, 3}). Random testitems above
+# all use nx ≥ 11, never reaching these paths.
+# ─────────────────────────────────────────────────────────────────────────
+
+@testitem "1D Hermite adjoint — PeriodicBC tiny grids (n ∈ {2, 3})" begin
+    using LinearAlgebra: dot
+    using ForwardDiff
+
+    # Skip `:inclusive n=2` because the closing constraint `y[end]=y[1]` forces
+    # constant data (PCHIP/Akima 0/0 in slope formulas — undefined, not a bug).
+    @testset "n=$nx, :$endpoint" for (nx, endpoint) in [
+            (3, :inclusive), (2, :exclusive), (3, :exclusive),
+        ]
+        period = 1.0
+        if endpoint === :inclusive
+            x = collect(range(0.0, period, nx))
+            y = randn(nx); y[end] = y[1]
+            bc = PeriodicBC()
+        else
+            x = collect(range(0.0, step = period / nx, length = nx))
+            y = randn(nx)
+            bc = PeriodicBC(endpoint = :exclusive, period = period)
+        end
+        xq = [0.1 * period, 0.5 * period, 0.9 * period]
+        y_bar = randn(length(xq))
+
+        for (label, fwd, adj_ctor, data_arg) in [
+                ("PCHIP",    pchip_interp,    pchip_adjoint,    y),
+                ("Cardinal", cardinal_interp, cardinal_adjoint, nothing),
+                ("Akima",    akima_interp,    akima_adjoint,    y),
+            ]
+            @testset "$label" begin
+                forward(ytest) = fwd(x, ytest, xq; bc = bc)
+                ref = ForwardDiff.gradient(ytest -> dot(forward(ytest), y_bar), y)
+                adj = data_arg === nothing ?
+                    adj_ctor(x, xq; bc = bc) :
+                    adj_ctor(x, data_arg, xq; bc = bc)
+                f_bar = adj(y_bar)
+                @test size(f_bar) == size(y)
+                @test f_bar ≈ ref rtol = 1.0e-9
+            end
+        end
+    end
+end
+
+
+# ─────────────────────────────────────────────────────────────────────────
 # Zero-allocation regression: in-place `adj(f_bar, y_bar)` must not
 # allocate beyond the pool buffer (which is acquired/returned per-call
 # inside `@with_pool` and counted as 0 bytes after warmup).

--- a/test/test_1d_adjoint_periodic.jl
+++ b/test/test_1d_adjoint_periodic.jl
@@ -1,0 +1,414 @@
+# ─────────────────────────────────────────────────────────────────────────
+# TDD test file (currently RED): verifies that 1D adjoints for
+#   linear / constant / pchip / cardinal / akima
+# honor `bc=PeriodicBC(...)` the same way their ND counterparts do.
+#
+# Identity tested (uniform across linear-in-y and nonlinear-in-y forwards):
+#
+#     adj(y_bar) == ∂(dot(forward(y), y_bar)) / ∂y
+#
+# Computed via ForwardDiff on the forward (which already respects PeriodicBC).
+# For Linear/Constant/Cardinal the forward is linear in `y`, so this reduces
+# to the dot-product identity. For PCHIP/Akima the forward is nonlinear in
+# `y` (slope limiter); ForwardDiff still gives the exact JVP-transpose at
+# the linearization point.
+#
+# Currently expected to FAIL for `:exclusive` periodic on all five methods —
+# `bc=` is silently swallowed by `_extra...` in the 1D adjoint constructors,
+# so the operator built is the NoBC variant which mis-handles the seam cell
+# `[x[n], x[1]+period]`. `:inclusive` may incidentally pass when query domain
+# coincides with NoBC domain, but `:exclusive` is unambiguous: f_bar at index
+# 1 must absorb the seam contribution that scatter writes into "virtual n+1".
+# ─────────────────────────────────────────────────────────────────────────
+
+@testitem "1D linear_adjoint — PeriodicBC TDD" begin
+    using LinearAlgebra: dot
+    using ForwardDiff
+
+    # `:inclusive` — domain [x[1], x[n]], BC enforces f[1]==f[n].
+    @testset "PeriodicBC{:inclusive}" begin
+        nx = 12
+        x = collect(range(0.0, 1.0, nx))
+        f = randn(nx); f[end] = f[1]
+        # OOB queries that wrap around (need PeriodicBC semantics for forward).
+        xq = vcat(0.05 .+ 0.9 .* rand(10), 1.0 .+ 0.4 .* rand(10) .- 0.2)
+        y_bar = randn(length(xq))
+        bc = PeriodicBC()
+
+        forward(ftest) = linear_interp(x, ftest, xq; bc = bc)
+        f_bar_ref = ForwardDiff.gradient(ftest -> dot(forward(ftest), y_bar), f)
+
+        adj = linear_adjoint(x, xq; bc = bc)
+        f_bar = adj(y_bar)
+
+        @test size(f_bar) == size(f)
+        @test f_bar ≈ f_bar_ref rtol = 1.0e-10
+    end
+
+    # `:exclusive` — domain [x[1], x[1]+period), seam cell [x[n], x[1]+period].
+    # The CRITICAL test — exposes the bc-absorption bug unambiguously.
+    @testset "PeriodicBC{:exclusive}" begin
+        nx = 11
+        period = 1.0
+        x = collect(range(0.0, step = period / nx, length = nx))
+        f = randn(nx)
+        xq = period .* rand(20)  # spans full period including seam cell
+        y_bar = randn(length(xq))
+        bc = PeriodicBC(endpoint = :exclusive, period = period)
+
+        forward(ftest) = linear_interp(x, ftest, xq; bc = bc)
+        f_bar_ref = ForwardDiff.gradient(ftest -> dot(forward(ftest), y_bar), f)
+
+        adj = linear_adjoint(x, xq; bc = bc)
+        f_bar = adj(y_bar)
+
+        @test size(f_bar) == size(f)
+        @test f_bar ≈ f_bar_ref rtol = 1.0e-10
+    end
+
+    # Vector grid (non-uniform) `:exclusive`.
+    @testset "PeriodicBC{:exclusive} — Vector grid" begin
+        nx = 9
+        period = 2.0
+        x = sort(rand(nx)) .* (0.95 * period)
+        f = randn(nx)
+        xq = period .* rand(20)
+        y_bar = randn(length(xq))
+        bc = PeriodicBC(endpoint = :exclusive, period = period)
+
+        forward(ftest) = linear_interp(x, ftest, xq; bc = bc)
+        f_bar_ref = ForwardDiff.gradient(ftest -> dot(forward(ftest), y_bar), f)
+
+        adj = linear_adjoint(x, xq; bc = bc)
+        f_bar = adj(y_bar)
+
+        @test size(f_bar) == size(f)
+        @test f_bar ≈ f_bar_ref rtol = 1.0e-10
+    end
+end
+
+
+@testitem "1D constant_adjoint — PeriodicBC TDD" begin
+    using LinearAlgebra: dot
+    using ForwardDiff
+
+    @testset "PeriodicBC{:inclusive}" begin
+        nx = 12
+        x = collect(range(0.0, 1.0, nx))
+        f = randn(nx); f[end] = f[1]
+        xq = vcat(0.05 .+ 0.9 .* rand(10), 1.0 .+ 0.4 .* rand(10) .- 0.2)
+        y_bar = randn(length(xq))
+        bc = PeriodicBC()
+
+        forward(ftest) = constant_interp(x, ftest, xq; bc = bc, side = NearestSide())
+        f_bar_ref = ForwardDiff.gradient(ftest -> dot(forward(ftest), y_bar), f)
+
+        adj = constant_adjoint(x, xq; bc = bc, side = NearestSide())
+        f_bar = adj(y_bar)
+
+        @test size(f_bar) == size(f)
+        @test f_bar ≈ f_bar_ref rtol = 1.0e-10
+    end
+
+    @testset "PeriodicBC{:exclusive}" begin
+        nx = 11
+        period = 1.0
+        x = collect(range(0.0, step = period / nx, length = nx))
+        f = randn(nx)
+        xq = period .* rand(20)
+        y_bar = randn(length(xq))
+        bc = PeriodicBC(endpoint = :exclusive, period = period)
+
+        forward(ftest) = constant_interp(x, ftest, xq; bc = bc, side = NearestSide())
+        f_bar_ref = ForwardDiff.gradient(ftest -> dot(forward(ftest), y_bar), f)
+
+        adj = constant_adjoint(x, xq; bc = bc, side = NearestSide())
+        f_bar = adj(y_bar)
+
+        @test size(f_bar) == size(f)
+        @test f_bar ≈ f_bar_ref rtol = 1.0e-10
+    end
+end
+
+
+@testitem "1D pchip_adjoint — PeriodicBC TDD" begin
+    using LinearAlgebra: dot
+    using ForwardDiff
+
+    @testset "PeriodicBC{:inclusive}" begin
+        nx = 12
+        x = collect(range(0.0, 1.0, nx))
+        # Smooth monotone-ish data; PCHIP slope limiter still nonlinear in y.
+        y = sin.(2π .* x); y[end] = y[1]
+        xq = vcat(0.05 .+ 0.9 .* rand(8), 1.0 .+ 0.4 .* rand(8) .- 0.2)
+        y_bar = randn(length(xq))
+        bc = PeriodicBC()
+
+        forward(ytest) = pchip_interp(x, ytest, xq; bc = bc)
+        f_bar_ref = ForwardDiff.gradient(ytest -> dot(forward(ytest), y_bar), y)
+
+        adj = pchip_adjoint(x, y, xq; bc = bc)
+        f_bar = adj(y_bar)
+
+        @test size(f_bar) == size(y)
+        @test f_bar ≈ f_bar_ref rtol = 1.0e-9
+    end
+
+    @testset "PeriodicBC{:exclusive}" begin
+        nx = 11
+        period = 1.0
+        x = collect(range(0.0, step = period / nx, length = nx))
+        y = sin.(2π .* x ./ period)
+        xq = period .* rand(16)
+        y_bar = randn(length(xq))
+        bc = PeriodicBC(endpoint = :exclusive, period = period)
+
+        forward(ytest) = pchip_interp(x, ytest, xq; bc = bc)
+        f_bar_ref = ForwardDiff.gradient(ytest -> dot(forward(ytest), y_bar), y)
+
+        adj = pchip_adjoint(x, y, xq; bc = bc)
+        f_bar = adj(y_bar)
+
+        @test size(f_bar) == size(y)
+        @test f_bar ≈ f_bar_ref rtol = 1.0e-9
+    end
+end
+
+
+@testitem "1D cardinal_adjoint — PeriodicBC TDD" begin
+    using LinearAlgebra: dot
+    using ForwardDiff
+
+    # cardinal_adjoint is data-free; build f_bar_ref via FD on the forward.
+    @testset "PeriodicBC{:inclusive}" begin
+        nx = 12
+        x = collect(range(0.0, 1.0, nx))
+        f = randn(nx); f[end] = f[1]
+        xq = vcat(0.05 .+ 0.9 .* rand(10), 1.0 .+ 0.4 .* rand(10) .- 0.2)
+        y_bar = randn(length(xq))
+        bc = PeriodicBC()
+
+        forward(ftest) = cardinal_interp(x, ftest, xq; bc = bc)
+        f_bar_ref = ForwardDiff.gradient(ftest -> dot(forward(ftest), y_bar), f)
+
+        adj = cardinal_adjoint(x, xq; bc = bc)
+        f_bar = adj(y_bar)
+
+        @test size(f_bar) == size(f)
+        @test f_bar ≈ f_bar_ref rtol = 1.0e-10
+    end
+
+    @testset "PeriodicBC{:exclusive}" begin
+        nx = 11
+        period = 1.0
+        x = collect(range(0.0, step = period / nx, length = nx))
+        f = randn(nx)
+        xq = period .* rand(20)
+        y_bar = randn(length(xq))
+        bc = PeriodicBC(endpoint = :exclusive, period = period)
+
+        forward(ftest) = cardinal_interp(x, ftest, xq; bc = bc)
+        f_bar_ref = ForwardDiff.gradient(ftest -> dot(forward(ftest), y_bar), f)
+
+        adj = cardinal_adjoint(x, xq; bc = bc)
+        f_bar = adj(y_bar)
+
+        @test size(f_bar) == size(f)
+        @test f_bar ≈ f_bar_ref rtol = 1.0e-10
+    end
+end
+
+
+@testitem "1D akima_adjoint — PeriodicBC TDD" begin
+    using LinearAlgebra: dot
+    using ForwardDiff
+
+    @testset "PeriodicBC{:inclusive}" begin
+        nx = 12
+        x = collect(range(0.0, 1.0, nx))
+        y = sin.(2π .* x); y[end] = y[1]
+        xq = vcat(0.05 .+ 0.9 .* rand(8), 1.0 .+ 0.4 .* rand(8) .- 0.2)
+        y_bar = randn(length(xq))
+        bc = PeriodicBC()
+
+        forward(ytest) = akima_interp(x, ytest, xq; bc = bc)
+        f_bar_ref = ForwardDiff.gradient(ytest -> dot(forward(ytest), y_bar), y)
+
+        adj = akima_adjoint(x, y, xq; bc = bc)
+        f_bar = adj(y_bar)
+
+        @test size(f_bar) == size(y)
+        @test f_bar ≈ f_bar_ref rtol = 1.0e-9
+    end
+
+    @testset "PeriodicBC{:exclusive}" begin
+        nx = 11
+        period = 1.0
+        x = collect(range(0.0, step = period / nx, length = nx))
+        y = sin.(2π .* x ./ period)
+        xq = period .* rand(16)
+        y_bar = randn(length(xq))
+        bc = PeriodicBC(endpoint = :exclusive, period = period)
+
+        forward(ytest) = akima_interp(x, ytest, xq; bc = bc)
+        f_bar_ref = ForwardDiff.gradient(ytest -> dot(forward(ytest), y_bar), y)
+
+        adj = akima_adjoint(x, y, xq; bc = bc)
+        f_bar = adj(y_bar)
+
+        @test size(f_bar) == size(y)
+        @test f_bar ≈ f_bar_ref rtol = 1.0e-9
+    end
+end
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Seam-cell coverage: queries placed STRICTLY inside the seam cell
+# `[x[n], x[1]+period]` for `:exclusive`. This is the cell that requires
+# the wrapper / extension + seam-fold path; failure here would indicate
+# the periodic plumbing missed the edge case.
+# ─────────────────────────────────────────────────────────────────────────
+
+@testitem "1D adjoint — seam-cell PeriodicBC{:exclusive}" begin
+    using LinearAlgebra: dot
+    using ForwardDiff
+
+    nx = 8
+    period = 1.0
+    x = collect(range(0.0, step = period / nx, length = nx))    # x[end] ≈ 0.875
+    bc = PeriodicBC(endpoint = :exclusive, period = period)
+    # Queries strictly inside the seam cell (between x[end] and x[1]+period).
+    seam_lo = x[end] + 1.0e-3
+    seam_hi = x[1] + period - 1.0e-3
+    xq = collect(range(seam_lo, seam_hi, length = 6))
+    y_bar = randn(length(xq))
+
+    @testset "linear_adjoint seam" begin
+        f = randn(nx)
+        adj = linear_adjoint(x, xq; bc = bc)
+        f_bar = adj(y_bar)
+        ref = ForwardDiff.gradient(ftest -> dot(linear_interp(x, ftest, xq; bc = bc), y_bar), f)
+        @test size(f_bar) == size(f)
+        @test f_bar ≈ ref rtol = 1.0e-10
+    end
+
+    @testset "constant_adjoint seam" begin
+        f = randn(nx)
+        adj = constant_adjoint(x, xq; bc = bc, side = NearestSide())
+        f_bar = adj(y_bar)
+        ref = ForwardDiff.gradient(
+            ftest -> dot(constant_interp(x, ftest, xq; bc = bc, side = NearestSide()), y_bar),
+            f,
+        )
+        @test size(f_bar) == size(f)
+        @test f_bar ≈ ref rtol = 1.0e-10
+    end
+
+    @testset "pchip_adjoint seam" begin
+        y = sin.(2π .* x ./ period)
+        adj = pchip_adjoint(x, y, xq; bc = bc)
+        f_bar = adj(y_bar)
+        ref = ForwardDiff.gradient(ytest -> dot(pchip_interp(x, ytest, xq; bc = bc), y_bar), y)
+        @test size(f_bar) == size(y)
+        @test f_bar ≈ ref rtol = 1.0e-9
+    end
+
+    @testset "cardinal_adjoint seam" begin
+        f = randn(nx)
+        adj = cardinal_adjoint(x, xq; bc = bc)
+        f_bar = adj(y_bar)
+        ref = ForwardDiff.gradient(ftest -> dot(cardinal_interp(x, ftest, xq; bc = bc), y_bar), f)
+        @test size(f_bar) == size(f)
+        @test f_bar ≈ ref rtol = 1.0e-10
+    end
+
+    @testset "akima_adjoint seam" begin
+        y = sin.(2π .* x ./ period)
+        adj = akima_adjoint(x, y, xq; bc = bc)
+        f_bar = adj(y_bar)
+        ref = ForwardDiff.gradient(ytest -> dot(akima_interp(x, ytest, xq; bc = bc), y_bar), y)
+        @test size(f_bar) == size(y)
+        @test f_bar ≈ ref rtol = 1.0e-9
+    end
+end
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Zero-allocation regression: in-place `adj(f_bar, y_bar)` must not
+# allocate beyond the pool buffer (which is acquired/returned per-call
+# inside `@with_pool` and counted as 0 bytes after warmup).
+#
+# Pattern matches MEMORY.md `feedback_test_alloc_function_barrier`: setup,
+# warmup, and `@allocated` all live inside ONE function — `@testset`
+# wraps its body in try/catch which makes locals type-unstable and shows
+# allocation artifacts.
+# ─────────────────────────────────────────────────────────────────────────
+
+@testitem "1D adjoint — PeriodicBC zero-alloc in-place" begin
+    nx = 16
+    n_q = 32
+    period = 1.0
+
+    function alloc_linear(bc, x, xq, y_bar, f_bar)
+        adj = linear_adjoint(x, xq; bc = bc)
+        adj(f_bar, y_bar)            # warmup
+        return @allocated adj(f_bar, y_bar)
+    end
+
+    function alloc_constant(bc, x, xq, y_bar, f_bar)
+        adj = constant_adjoint(x, xq; bc = bc)
+        adj(f_bar, y_bar)
+        return @allocated adj(f_bar, y_bar)
+    end
+
+    function alloc_pchip(bc, x, y, xq, y_bar, f_bar)
+        adj = pchip_adjoint(x, y, xq; bc = bc)
+        adj(f_bar, y_bar)
+        return @allocated adj(f_bar, y_bar)
+    end
+
+    function alloc_cardinal(bc, x, xq, y_bar, f_bar)
+        adj = cardinal_adjoint(x, xq; bc = bc)
+        adj(f_bar, y_bar)
+        return @allocated adj(f_bar, y_bar)
+    end
+
+    function alloc_akima(bc, x, y, xq, y_bar, f_bar)
+        adj = akima_adjoint(x, y, xq; bc = bc)
+        adj(f_bar, y_bar)
+        return @allocated adj(f_bar, y_bar)
+    end
+
+    # ── Inclusive: closed at n, no extension/seam-fold ──────────────────
+    @testset "PeriodicBC{:inclusive}" begin
+        x_inc = collect(range(0.0, period, nx))
+        y_inc = sin.(2π .* x_inc ./ period); y_inc[end] = y_inc[1]
+        f_inc = copy(y_inc)
+        xq = 0.1 .+ 0.8 * period .* rand(n_q)
+        y_bar = randn(n_q)
+        f_bar = zeros(nx)
+        bc = PeriodicBC()
+
+        @test alloc_linear(bc, x_inc, xq, y_bar, f_bar) == 0
+        @test alloc_constant(bc, x_inc, xq, y_bar, f_bar) == 0
+        @test alloc_pchip(bc, x_inc, y_inc, xq, y_bar, f_bar) == 0
+        @test alloc_cardinal(bc, x_inc, xq, y_bar, f_bar) == 0
+        @test alloc_akima(bc, x_inc, y_inc, xq, y_bar, f_bar) == 0
+    end
+
+    # ── Exclusive: extension to n+1 + seam fold via pool buffer ─────────
+    @testset "PeriodicBC{:exclusive}" begin
+        x_exc = collect(range(0.0, step = period / nx, length = nx))
+        y_exc = sin.(2π .* x_exc ./ period)
+        xq = period .* rand(n_q)
+        y_bar = randn(n_q)
+        f_bar = zeros(nx)
+        bc = PeriodicBC(endpoint = :exclusive, period = period)
+
+        @test alloc_linear(bc, x_exc, xq, y_bar, f_bar) == 0
+        @test alloc_constant(bc, x_exc, xq, y_bar, f_bar) == 0
+        @test alloc_pchip(bc, x_exc, y_exc, xq, y_bar, f_bar) == 0
+        @test alloc_cardinal(bc, x_exc, xq, y_bar, f_bar) == 0
+        @test alloc_akima(bc, x_exc, y_exc, xq, y_bar, f_bar) == 0
+    end
+end

--- a/test/test_1d_bc_consistency.jl
+++ b/test/test_1d_bc_consistency.jl
@@ -1,0 +1,319 @@
+# ─────────────────────────────────────────────────────────────────────────
+# 1D forward/adjoint cross-BC consistency tests.
+#
+# "Logically same grid" setup (n_excl-cell uniform grid on [0, period]):
+#
+#   x_exc = [0, h, 2h, ..., (n_exc-1)*h]    ← n_exc points,   period via kwarg
+#   x_inc = [x_exc; n_exc*h]                ← n_exc+1 points, last == first+period
+#   f_exc = randn(n_exc)
+#   f_inc = [f_exc; f_exc[1]]               ← `:inclusive` constraint
+#
+# All three (NoBC on x_inc/f_inc, inclusive on x_inc/f_inc, exclusive on
+# x_exc/f_exc) describe the SAME logical periodic function on [0, period].
+#
+# Expectations:
+#
+# Linear / Constant — eval is purely local (no slope kernel that "sees"
+# beyond the immediate cell). For queries strictly in `[0, period)` the
+# three representations produce **bit-equivalent** forward results, and
+# their adjoints are equivalent up to the seam-fold (exclusive folds the
+# n+1-th internal entry back into index 1).
+#
+# PCHIP / Cardinal / Akima — local-Hermite slopes use a stencil that
+# crosses the join at boundary indices. NoBC uses one-sided FD (or
+# virtual-secant) at i=1 and i=n, while PeriodicBC uses the closed-cycle
+# stencil. Therefore:
+#   - NoBC ≠ Periodic for queries in cells touching the boundary
+#     (different boundary slopes propagate to interior eval).
+#   - inclusive == exclusive (both closed-cycle, same logical setup).
+# ─────────────────────────────────────────────────────────────────────────
+
+@testitem "1D Linear forward — NoBC == inclusive == exclusive (same logical grid)" begin
+    nx_exc = 16
+    period = 1.0
+    h = period / nx_exc
+    x_exc = collect(range(0.0, step = h, length = nx_exc))
+    x_inc = vcat(x_exc, x_exc[1] + period)             # closing point
+    f_exc = randn(nx_exc)
+    f_inc = vcat(f_exc, f_exc[1])                       # f[end] = f[1]
+
+    # Queries strictly inside [0, period) — in-domain for ALL three setups.
+    n_q = 30
+    xq = (0.02 + 0.96 * rand()) * period .* rand(n_q)   # in (0, 0.96·period)
+    bc_inc = PeriodicBC()
+    bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
+
+    y_nobc = linear_interp(x_inc, f_inc, xq)
+    y_inc  = linear_interp(x_inc, f_inc, xq; bc = bc_inc)
+    y_exc  = linear_interp(x_exc, f_exc, xq; bc = bc_exc)
+
+    # Linear is purely local — three representations bit-equivalent.
+    @test y_nobc == y_inc
+    @test y_nobc ≈ y_exc atol = 1.0e-13
+end
+
+
+@testitem "1D Constant forward — NoBC == inclusive == exclusive (same logical grid)" begin
+    nx_exc = 16
+    period = 1.0
+    h = period / nx_exc
+    x_exc = collect(range(0.0, step = h, length = nx_exc))
+    x_inc = vcat(x_exc, x_exc[1] + period)
+    f_exc = randn(nx_exc)
+    f_inc = vcat(f_exc, f_exc[1])
+
+    n_q = 30
+    xq = 0.02 * period .+ 0.94 * period .* rand(n_q)
+    bc_inc = PeriodicBC()
+    bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
+
+    y_nobc = constant_interp(x_inc, f_inc, xq; side = NearestSide())
+    y_inc  = constant_interp(x_inc, f_inc, xq; side = NearestSide(), bc = bc_inc)
+    y_exc  = constant_interp(x_exc, f_exc, xq; side = NearestSide(), bc = bc_exc)
+
+    # Constant is single-point lookup — bit-equivalent across BCs.
+    @test y_nobc == y_inc
+    @test y_nobc == y_exc
+end
+
+
+@testitem "1D Linear adjoint — NoBC == inclusive ≡ exclusive(after seam fold)" begin
+    using LinearAlgebra: dot
+
+    nx_exc = 16
+    period = 1.0
+    h = period / nx_exc
+    x_exc = collect(range(0.0, step = h, length = nx_exc))
+    x_inc = vcat(x_exc, x_exc[1] + period)
+    n_q = 30
+    xq = 0.05 * period .+ 0.9 * period .* rand(n_q)
+    y_bar = randn(n_q)
+    bc_inc = PeriodicBC()
+    bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
+
+    f_bar_nobc = linear_adjoint(x_inc, xq)(y_bar)              # length nx_exc+1
+    f_bar_inc  = linear_adjoint(x_inc, xq; bc = bc_inc)(y_bar) # length nx_exc+1
+    f_bar_exc  = linear_adjoint(x_exc, xq; bc = bc_exc)(y_bar) # length nx_exc (post seam fold)
+
+    # NoBC == inclusive on the closed n+1-grid (no extension/fold either way).
+    @test f_bar_nobc ≈ f_bar_inc atol = 1.0e-13
+
+    # Exclusive == NoBC after seam-fold + trim.
+    folded = copy(f_bar_nobc)
+    folded[1] += folded[end]
+    @test f_bar_exc ≈ folded[1:nx_exc] atol = 1.0e-13
+end
+
+
+@testitem "1D Constant adjoint — NoBC == inclusive ≡ exclusive(after seam fold)" begin
+    nx_exc = 16
+    period = 1.0
+    h = period / nx_exc
+    x_exc = collect(range(0.0, step = h, length = nx_exc))
+    x_inc = vcat(x_exc, x_exc[1] + period)
+    n_q = 30
+    xq = 0.05 * period .+ 0.9 * period .* rand(n_q)
+    y_bar = randn(n_q)
+    bc_inc = PeriodicBC()
+    bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
+
+    f_bar_nobc = constant_adjoint(x_inc, xq; side = NearestSide())(y_bar)
+    f_bar_inc  = constant_adjoint(x_inc, xq; side = NearestSide(), bc = bc_inc)(y_bar)
+    f_bar_exc  = constant_adjoint(x_exc, xq; side = NearestSide(), bc = bc_exc)(y_bar)
+
+    @test f_bar_nobc ≈ f_bar_inc atol = 1.0e-13
+
+    folded = copy(f_bar_nobc)
+    folded[1] += folded[end]
+    @test f_bar_exc ≈ folded[1:nx_exc] atol = 1.0e-13
+end
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Local-Hermite family — NoBC ≠ Periodic, but inclusive == exclusive
+#
+# To guarantee an *observable* NoBC vs Periodic discrepancy, we use
+# monotonically increasing `f_exc` (closed via `vcat(f_exc, f_exc[1])`) —
+# the resulting `f_inc` has a sharp drop across the seam so:
+#   - NoBC boundary slope: one-sided FD over the smoothly-rising stencil
+#     (sees positive slopes everywhere near i=1).
+#   - Periodic boundary slope: closed-cycle stencil that includes the
+#     large-negative seam secant `(f[1] - f[end]) / h_seam`. With sign
+#     mismatch this triggers PCHIP's zero-clamp branch (`dy[1] = 0`) or
+#     a sharply different value for Cardinal/Akima.
+# This breaks the sin/cos symmetry coincidence (where m_seam happens to
+# equal m_1 by sin's analytic relation).
+# ─────────────────────────────────────────────────────────────────────────
+
+@testitem "1D PCHIP forward — NoBC ≠ Periodic, inclusive ≈ exclusive" begin
+    nx_exc = 12
+    period = 1.0
+    h = period / nx_exc
+    x_exc = collect(range(0.0, step = h, length = nx_exc))
+    x_inc = vcat(x_exc, x_exc[1] + period)
+    # Use a function whose monotonicity changes near the seam — exposes the
+    # boundary slope difference (one-sided NoBC vs cyclic Periodic).
+    # Monotonically increasing data, closed by vcat(f_exc, f_exc[1]) — gives
+    # a sharp seam drop that GUARANTEES NoBC's one-sided FD disagrees with
+    # Periodic's closed-cycle stencil at boundary indices. Avoids the
+    # sin/cos-on-uniform-grid coincidence where m_seam = m_1 analytically.
+    f_exc = collect(range(-1.0, 1.0, length = nx_exc))
+    f_inc = vcat(f_exc, f_exc[1])  # `:inclusive` constraint (sharp seam drop)
+
+    n_q = 30
+    xq = period .* rand(n_q)   # full period, includes near-boundary queries
+    bc_inc = PeriodicBC()
+    bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
+
+    y_nobc = pchip_interp(x_inc, f_inc, xq)
+    y_inc  = pchip_interp(x_inc, f_inc, xq; bc = bc_inc)
+    y_exc  = pchip_interp(x_exc, f_exc, xq; bc = bc_exc)
+
+    # Inclusive vs exclusive: same closed-cycle slope formula, equivalent up
+    # to floating-point rounding from different stencil arithmetic.
+    @test y_inc ≈ y_exc atol = 1.0e-12
+
+    # NoBC differs from Periodic at boundary cells — assertable when there
+    # exists ≥1 query in a boundary cell.
+    @test !isapprox(y_nobc, y_inc; rtol = 1.0e-3)
+end
+
+
+@testitem "1D Cardinal forward — NoBC ≠ Periodic, inclusive ≈ exclusive" begin
+    nx_exc = 12
+    period = 1.0
+    h = period / nx_exc
+    x_exc = collect(range(0.0, step = h, length = nx_exc))
+    x_inc = vcat(x_exc, x_exc[1] + period)
+    # Monotonically increasing data, closed by vcat(f_exc, f_exc[1]) — gives
+    # a sharp seam drop that GUARANTEES NoBC's one-sided FD disagrees with
+    # Periodic's closed-cycle stencil at boundary indices. Avoids the
+    # sin/cos-on-uniform-grid coincidence where m_seam = m_1 analytically.
+    f_exc = collect(range(-1.0, 1.0, length = nx_exc))
+    f_inc = vcat(f_exc, f_exc[1])  # `:inclusive` constraint (sharp seam drop)
+
+    n_q = 30
+    xq = period .* rand(n_q)
+    bc_inc = PeriodicBC()
+    bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
+
+    y_nobc = cardinal_interp(x_inc, f_inc, xq)
+    y_inc  = cardinal_interp(x_inc, f_inc, xq; bc = bc_inc)
+    y_exc  = cardinal_interp(x_exc, f_exc, xq; bc = bc_exc)
+
+    @test y_inc ≈ y_exc atol = 1.0e-12
+    @test !isapprox(y_nobc, y_inc; rtol = 1.0e-3)
+end
+
+
+@testitem "1D Akima forward — NoBC ≠ Periodic, inclusive ≈ exclusive" begin
+    nx_exc = 12
+    period = 1.0
+    h = period / nx_exc
+    x_exc = collect(range(0.0, step = h, length = nx_exc))
+    x_inc = vcat(x_exc, x_exc[1] + period)
+    # Monotonically increasing data, closed by vcat(f_exc, f_exc[1]) — gives
+    # a sharp seam drop that GUARANTEES NoBC's one-sided FD disagrees with
+    # Periodic's closed-cycle stencil at boundary indices. Avoids the
+    # sin/cos-on-uniform-grid coincidence where m_seam = m_1 analytically.
+    f_exc = collect(range(-1.0, 1.0, length = nx_exc))
+    f_inc = vcat(f_exc, f_exc[1])  # `:inclusive` constraint (sharp seam drop)
+
+    n_q = 30
+    xq = period .* rand(n_q)
+    bc_inc = PeriodicBC()
+    bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
+
+    y_nobc = akima_interp(x_inc, f_inc, xq)
+    y_inc  = akima_interp(x_inc, f_inc, xq; bc = bc_inc)
+    y_exc  = akima_interp(x_exc, f_exc, xq; bc = bc_exc)
+
+    @test y_inc ≈ y_exc atol = 1.0e-12
+    @test !isapprox(y_nobc, y_inc; rtol = 1.0e-3)
+end
+
+
+@testitem "1D PCHIP adjoint — NoBC ≠ Periodic, inclusive ≡ exclusive(seam fold)" begin
+    nx_exc = 12
+    period = 1.0
+    h = period / nx_exc
+    x_exc = collect(range(0.0, step = h, length = nx_exc))
+    x_inc = vcat(x_exc, x_exc[1] + period)
+    # Monotonically increasing data, closed by vcat(f_exc, f_exc[1]) — gives
+    # a sharp seam drop that GUARANTEES NoBC's one-sided FD disagrees with
+    # Periodic's closed-cycle stencil at boundary indices. Avoids the
+    # sin/cos-on-uniform-grid coincidence where m_seam = m_1 analytically.
+    f_exc = collect(range(-1.0, 1.0, length = nx_exc))
+    f_inc = vcat(f_exc, f_exc[1])  # `:inclusive` constraint (sharp seam drop)
+    n_q = 30
+    xq = period .* rand(n_q)
+    y_bar = randn(n_q)
+    bc_inc = PeriodicBC()
+    bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
+
+    f_bar_nobc = pchip_adjoint(x_inc, f_inc, xq)(y_bar)              # length nx_exc+1
+    f_bar_inc  = pchip_adjoint(x_inc, f_inc, xq; bc = bc_inc)(y_bar) # length nx_exc+1
+    f_bar_exc  = pchip_adjoint(x_exc, f_exc, xq; bc = bc_exc)(y_bar) # length nx_exc
+
+    # Inclusive ≡ exclusive (after fold).
+    folded = copy(f_bar_inc)
+    folded[1] += folded[end]
+    @test f_bar_exc ≈ folded[1:nx_exc] atol = 1.0e-11
+
+    # NoBC ≠ Periodic (different boundary slope adjoint chains).
+    @test !isapprox(f_bar_nobc, f_bar_inc; rtol = 1.0e-3)
+end
+
+
+@testitem "1D Cardinal adjoint — NoBC ≠ Periodic, inclusive ≡ exclusive(seam fold)" begin
+    nx_exc = 12
+    period = 1.0
+    h = period / nx_exc
+    x_exc = collect(range(0.0, step = h, length = nx_exc))
+    x_inc = vcat(x_exc, x_exc[1] + period)
+    n_q = 30
+    xq = period .* rand(n_q)
+    y_bar = randn(n_q)
+    bc_inc = PeriodicBC()
+    bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
+
+    f_bar_nobc = cardinal_adjoint(x_inc, xq)(y_bar)
+    f_bar_inc  = cardinal_adjoint(x_inc, xq; bc = bc_inc)(y_bar)
+    f_bar_exc  = cardinal_adjoint(x_exc, xq; bc = bc_exc)(y_bar)
+
+    folded = copy(f_bar_inc)
+    folded[1] += folded[end]
+    @test f_bar_exc ≈ folded[1:nx_exc] atol = 1.0e-12
+
+    @test !isapprox(f_bar_nobc, f_bar_inc; rtol = 1.0e-3)
+end
+
+
+@testitem "1D Akima adjoint — NoBC ≠ Periodic, inclusive ≡ exclusive(seam fold)" begin
+    nx_exc = 12
+    period = 1.0
+    h = period / nx_exc
+    x_exc = collect(range(0.0, step = h, length = nx_exc))
+    x_inc = vcat(x_exc, x_exc[1] + period)
+    # Monotonically increasing data, closed by vcat(f_exc, f_exc[1]) — gives
+    # a sharp seam drop that GUARANTEES NoBC's one-sided FD disagrees with
+    # Periodic's closed-cycle stencil at boundary indices. Avoids the
+    # sin/cos-on-uniform-grid coincidence where m_seam = m_1 analytically.
+    f_exc = collect(range(-1.0, 1.0, length = nx_exc))
+    f_inc = vcat(f_exc, f_exc[1])  # `:inclusive` constraint (sharp seam drop)
+    n_q = 30
+    xq = period .* rand(n_q)
+    y_bar = randn(n_q)
+    bc_inc = PeriodicBC()
+    bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
+
+    f_bar_nobc = akima_adjoint(x_inc, f_inc, xq)(y_bar)
+    f_bar_inc  = akima_adjoint(x_inc, f_inc, xq; bc = bc_inc)(y_bar)
+    f_bar_exc  = akima_adjoint(x_exc, f_exc, xq; bc = bc_exc)(y_bar)
+
+    folded = copy(f_bar_inc)
+    folded[1] += folded[end]
+    @test f_bar_exc ≈ folded[1:nx_exc] atol = 1.0e-11
+
+    @test !isapprox(f_bar_nobc, f_bar_inc; rtol = 1.0e-3)
+end

--- a/test/test_1d_bc_consistency.jl
+++ b/test/test_1d_bc_consistency.jl
@@ -146,7 +146,50 @@ end
 #     a sharply different value for Cardinal/Akima.
 # This breaks the sin/cos symmetry coincidence (where m_seam happens to
 # equal m_1 by sin's analytic relation).
+#
+# The 6 testitems below use `xq = period .* rand(n_q)` plus a deterministic
+# boundary-cell query prepended via `vcat`. Pure random alone has a non-zero
+# probability of missing all radius-1 boundary cells on a 12-cell grid
+# (P((10/12)^30) ≈ 0.4%) — a real CI flake risk. The deterministic prepend
+# guarantees the `!isapprox(y_nobc, y_inc)` assertion always observes the
+# boundary-stencil difference.
 # ─────────────────────────────────────────────────────────────────────────
+
+
+# Regression guard: with seed 579 the 30 random uniforms all land in
+# [1/12, 11/12] (no boundary-cell sample), so NoBC and Periodic agree at every
+# query and the bare-random pattern `xq = period .* rand(n_q)` would falsely
+# silence the difference. The vcat-boundary prepend used in the testitems
+# below restores deterministic detection.
+@testitem "PCHIP NoBC≠Periodic — deterministic boundary required (flake guard)" begin
+    using Random
+    nx_exc = 12
+    period = 1.0
+    h = period / nx_exc
+    x_exc = collect(range(0.0, step = h, length = nx_exc))
+    x_inc = vcat(x_exc, x_exc[1] + period)
+    f_exc = collect(range(-1.0, 1.0, length = nx_exc))
+    f_inc = vcat(f_exc, f_exc[1])
+    n_q = 30
+    bc_inc = PeriodicBC()
+
+    Random.seed!(579)   # produces 30 uniforms entirely in [1/12, 11/12]
+    xq_random = period .* rand(n_q)
+    @test all(q -> q >= h && q <= period - h, xq_random)   # precondition: misses boundaries
+
+    # Bare-random pattern (current existing test pattern) — under this seed,
+    # NoBC and Periodic agree at every interior query → `!isapprox` would
+    # silently fail to detect the boundary-cell semantic difference.
+    y_nobc_r = pchip_interp(x_inc, f_inc, xq_random)
+    y_inc_r  = pchip_interp(x_inc, f_inc, xq_random; bc = bc_inc)
+    @test isapprox(y_nobc_r, y_inc_r; atol = 1.0e-12)  # documents the gap
+
+    # Deterministic boundary prepend (the fix applied to all 6 testitems below).
+    xq_pinned = vcat(0.5 * h, xq_random)
+    y_nobc_p = pchip_interp(x_inc, f_inc, xq_pinned)
+    y_inc_p  = pchip_interp(x_inc, f_inc, xq_pinned; bc = bc_inc)
+    @test !isapprox(y_nobc_p, y_inc_p; rtol = 1.0e-3)
+end
 
 @testitem "1D PCHIP forward — NoBC ≠ Periodic, inclusive ≈ exclusive" begin
     nx_exc = 12
@@ -164,7 +207,7 @@ end
     f_inc = vcat(f_exc, f_exc[1])  # `:inclusive` constraint (sharp seam drop)
 
     n_q = 30
-    xq = period .* rand(n_q)   # full period, includes near-boundary queries
+    xq = vcat(0.5 * h, period - 0.5 * h, period .* rand(n_q - 2))   # full period, includes near-boundary queries
     bc_inc = PeriodicBC()
     bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
 
@@ -196,7 +239,7 @@ end
     f_inc = vcat(f_exc, f_exc[1])  # `:inclusive` constraint (sharp seam drop)
 
     n_q = 30
-    xq = period .* rand(n_q)
+    xq = vcat(0.5 * h, period - 0.5 * h, period .* rand(n_q - 2))
     bc_inc = PeriodicBC()
     bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
 
@@ -223,7 +266,7 @@ end
     f_inc = vcat(f_exc, f_exc[1])  # `:inclusive` constraint (sharp seam drop)
 
     n_q = 30
-    xq = period .* rand(n_q)
+    xq = vcat(0.5 * h, period - 0.5 * h, period .* rand(n_q - 2))
     bc_inc = PeriodicBC()
     bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
 
@@ -249,7 +292,7 @@ end
     f_exc = collect(range(-1.0, 1.0, length = nx_exc))
     f_inc = vcat(f_exc, f_exc[1])  # `:inclusive` constraint (sharp seam drop)
     n_q = 30
-    xq = period .* rand(n_q)
+    xq = vcat(0.5 * h, period - 0.5 * h, period .* rand(n_q - 2))
     y_bar = randn(n_q)
     bc_inc = PeriodicBC()
     bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
@@ -275,7 +318,7 @@ end
     x_exc = collect(range(0.0, step = h, length = nx_exc))
     x_inc = vcat(x_exc, x_exc[1] + period)
     n_q = 30
-    xq = period .* rand(n_q)
+    xq = vcat(0.5 * h, period - 0.5 * h, period .* rand(n_q - 2))
     y_bar = randn(n_q)
     bc_inc = PeriodicBC()
     bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
@@ -305,7 +348,7 @@ end
     f_exc = collect(range(-1.0, 1.0, length = nx_exc))
     f_inc = vcat(f_exc, f_exc[1])  # `:inclusive` constraint (sharp seam drop)
     n_q = 30
-    xq = period .* rand(n_q)
+    xq = vcat(0.5 * h, period - 0.5 * h, period .* rand(n_q - 2))
     y_bar = randn(n_q)
     bc_inc = PeriodicBC()
     bc_exc = PeriodicBC(endpoint = :exclusive, period = period)

--- a/test/test_1d_bc_consistency.jl
+++ b/test/test_1d_bc_consistency.jl
@@ -44,8 +44,8 @@
     bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
 
     y_nobc = linear_interp(x_inc, f_inc, xq)
-    y_inc  = linear_interp(x_inc, f_inc, xq; bc = bc_inc)
-    y_exc  = linear_interp(x_exc, f_exc, xq; bc = bc_exc)
+    y_inc = linear_interp(x_inc, f_inc, xq; bc = bc_inc)
+    y_exc = linear_interp(x_exc, f_exc, xq; bc = bc_exc)
 
     # Linear is purely local — three representations bit-equivalent.
     # `:exclusive` synthesizes its seam endpoint via `inner[1] + period`, but
@@ -71,8 +71,8 @@ end
     bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
 
     y_nobc = constant_interp(x_inc, f_inc, xq; side = NearestSide())
-    y_inc  = constant_interp(x_inc, f_inc, xq; side = NearestSide(), bc = bc_inc)
-    y_exc  = constant_interp(x_exc, f_exc, xq; side = NearestSide(), bc = bc_exc)
+    y_inc = constant_interp(x_inc, f_inc, xq; side = NearestSide(), bc = bc_inc)
+    y_exc = constant_interp(x_exc, f_exc, xq; side = NearestSide(), bc = bc_exc)
 
     # Constant is single-point lookup — bit-equivalent across BCs.
     @test y_nobc == y_inc
@@ -95,8 +95,8 @@ end
     bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
 
     f_bar_nobc = linear_adjoint(x_inc, xq)(y_bar)              # length nx_exc+1
-    f_bar_inc  = linear_adjoint(x_inc, xq; bc = bc_inc)(y_bar) # length nx_exc+1
-    f_bar_exc  = linear_adjoint(x_exc, xq; bc = bc_exc)(y_bar) # length nx_exc (post seam fold)
+    f_bar_inc = linear_adjoint(x_inc, xq; bc = bc_inc)(y_bar) # length nx_exc+1
+    f_bar_exc = linear_adjoint(x_exc, xq; bc = bc_exc)(y_bar) # length nx_exc (post seam fold)
 
     # NoBC == inclusive on the closed n+1-grid (no extension/fold either way).
     @test f_bar_nobc ≈ f_bar_inc atol = 1.0e-13
@@ -121,8 +121,8 @@ end
     bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
 
     f_bar_nobc = constant_adjoint(x_inc, xq; side = NearestSide())(y_bar)
-    f_bar_inc  = constant_adjoint(x_inc, xq; side = NearestSide(), bc = bc_inc)(y_bar)
-    f_bar_exc  = constant_adjoint(x_exc, xq; side = NearestSide(), bc = bc_exc)(y_bar)
+    f_bar_inc = constant_adjoint(x_inc, xq; side = NearestSide(), bc = bc_inc)(y_bar)
+    f_bar_exc = constant_adjoint(x_exc, xq; side = NearestSide(), bc = bc_exc)(y_bar)
 
     @test f_bar_nobc ≈ f_bar_inc atol = 1.0e-13
 
@@ -181,13 +181,13 @@ end
     # NoBC and Periodic agree at every interior query → `!isapprox` would
     # silently fail to detect the boundary-cell semantic difference.
     y_nobc_r = pchip_interp(x_inc, f_inc, xq_random)
-    y_inc_r  = pchip_interp(x_inc, f_inc, xq_random; bc = bc_inc)
+    y_inc_r = pchip_interp(x_inc, f_inc, xq_random; bc = bc_inc)
     @test isapprox(y_nobc_r, y_inc_r; atol = 1.0e-12)  # documents the gap
 
     # Deterministic boundary prepend (the fix applied to all 6 testitems below).
     xq_pinned = vcat(0.5 * h, xq_random)
     y_nobc_p = pchip_interp(x_inc, f_inc, xq_pinned)
-    y_inc_p  = pchip_interp(x_inc, f_inc, xq_pinned; bc = bc_inc)
+    y_inc_p = pchip_interp(x_inc, f_inc, xq_pinned; bc = bc_inc)
     @test !isapprox(y_nobc_p, y_inc_p; rtol = 1.0e-3)
 end
 
@@ -212,8 +212,8 @@ end
     bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
 
     y_nobc = pchip_interp(x_inc, f_inc, xq)
-    y_inc  = pchip_interp(x_inc, f_inc, xq; bc = bc_inc)
-    y_exc  = pchip_interp(x_exc, f_exc, xq; bc = bc_exc)
+    y_inc = pchip_interp(x_inc, f_inc, xq; bc = bc_inc)
+    y_exc = pchip_interp(x_exc, f_exc, xq; bc = bc_exc)
 
     # Inclusive vs exclusive: same closed-cycle slope formula, equivalent up
     # to floating-point rounding from different stencil arithmetic.
@@ -244,8 +244,8 @@ end
     bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
 
     y_nobc = cardinal_interp(x_inc, f_inc, xq)
-    y_inc  = cardinal_interp(x_inc, f_inc, xq; bc = bc_inc)
-    y_exc  = cardinal_interp(x_exc, f_exc, xq; bc = bc_exc)
+    y_inc = cardinal_interp(x_inc, f_inc, xq; bc = bc_inc)
+    y_exc = cardinal_interp(x_exc, f_exc, xq; bc = bc_exc)
 
     @test y_inc ≈ y_exc atol = 1.0e-12
     @test !isapprox(y_nobc, y_inc; rtol = 1.0e-3)
@@ -271,8 +271,8 @@ end
     bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
 
     y_nobc = akima_interp(x_inc, f_inc, xq)
-    y_inc  = akima_interp(x_inc, f_inc, xq; bc = bc_inc)
-    y_exc  = akima_interp(x_exc, f_exc, xq; bc = bc_exc)
+    y_inc = akima_interp(x_inc, f_inc, xq; bc = bc_inc)
+    y_exc = akima_interp(x_exc, f_exc, xq; bc = bc_exc)
 
     @test y_inc ≈ y_exc atol = 1.0e-12
     @test !isapprox(y_nobc, y_inc; rtol = 1.0e-3)
@@ -298,8 +298,8 @@ end
     bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
 
     f_bar_nobc = pchip_adjoint(x_inc, f_inc, xq)(y_bar)              # length nx_exc+1
-    f_bar_inc  = pchip_adjoint(x_inc, f_inc, xq; bc = bc_inc)(y_bar) # length nx_exc+1
-    f_bar_exc  = pchip_adjoint(x_exc, f_exc, xq; bc = bc_exc)(y_bar) # length nx_exc
+    f_bar_inc = pchip_adjoint(x_inc, f_inc, xq; bc = bc_inc)(y_bar) # length nx_exc+1
+    f_bar_exc = pchip_adjoint(x_exc, f_exc, xq; bc = bc_exc)(y_bar) # length nx_exc
 
     # Inclusive ≡ exclusive (after fold).
     folded = copy(f_bar_inc)
@@ -324,8 +324,8 @@ end
     bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
 
     f_bar_nobc = cardinal_adjoint(x_inc, xq)(y_bar)
-    f_bar_inc  = cardinal_adjoint(x_inc, xq; bc = bc_inc)(y_bar)
-    f_bar_exc  = cardinal_adjoint(x_exc, xq; bc = bc_exc)(y_bar)
+    f_bar_inc = cardinal_adjoint(x_inc, xq; bc = bc_inc)(y_bar)
+    f_bar_exc = cardinal_adjoint(x_exc, xq; bc = bc_exc)(y_bar)
 
     folded = copy(f_bar_inc)
     folded[1] += folded[end]
@@ -354,8 +354,8 @@ end
     bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
 
     f_bar_nobc = akima_adjoint(x_inc, f_inc, xq)(y_bar)
-    f_bar_inc  = akima_adjoint(x_inc, f_inc, xq; bc = bc_inc)(y_bar)
-    f_bar_exc  = akima_adjoint(x_exc, f_exc, xq; bc = bc_exc)(y_bar)
+    f_bar_inc = akima_adjoint(x_inc, f_inc, xq; bc = bc_inc)(y_bar)
+    f_bar_exc = akima_adjoint(x_exc, f_exc, xq; bc = bc_exc)(y_bar)
 
     folded = copy(f_bar_inc)
     folded[1] += folded[end]

--- a/test/test_1d_bc_consistency.jl
+++ b/test/test_1d_bc_consistency.jl
@@ -48,8 +48,11 @@
     y_exc  = linear_interp(x_exc, f_exc, xq; bc = bc_exc)
 
     # Linear is purely local — three representations bit-equivalent.
+    # `:exclusive` synthesizes its seam endpoint via `inner[1] + period`, but
+    # cell lookup + lerp arithmetic is identical to NoBC over the closed grid,
+    # so the result must match bit-for-bit (no rounding budget needed).
     @test y_nobc == y_inc
-    @test y_nobc ≈ y_exc atol = 1.0e-13
+    @test y_nobc == y_exc
 end
 
 

--- a/test/test_hermite_nd_graceful_errors.jl
+++ b/test/test_hermite_nd_graceful_errors.jl
@@ -107,7 +107,8 @@
             end
             @test err isa ArgumentError
             @test occursin("not yet implemented for", err.msg)
-            @test occursin("hermite_onthefly_integrate_and_nd_adjoint.md", err.msg)
+            @test occursin("Hermite family", err.msg)
+            @test occursin("Workarounds", err.msg)
             @test occursin("ForwardDiff", err.msg)  # suggested workaround
         end
     end

--- a/test/test_hermite_nd_graceful_errors.jl
+++ b/test/test_hermite_nd_graceful_errors.jl
@@ -30,7 +30,7 @@
             end
             @test err isa ArgumentError
             @test occursin("not yet implemented for Hermite family ND", err.msg)
-            @test occursin("hermite_nd_precompute.md", err.msg)
+            @test occursin("PreCompute backend has not been written", err.msg)
             # Must not give the misleading "use PreCompute" advice.
             @test !occursin("coeffs=PreCompute()", err.msg)
         end
@@ -70,7 +70,7 @@
         end
         @test err isa ArgumentError
         @test occursin("not yet implemented for HeteroInterpolantND", err.msg)
-        @test occursin("hermite_onthefly_integrate_and_nd_adjoint.md", err.msg)
+        @test occursin("tensor-product integration", err.msg)
         @test occursin("cubic_interp", err.msg)  # suggests homogeneous workaround
     end
 

--- a/test/test_hetero_adjoint.jl
+++ b/test/test_hetero_adjoint.jl
@@ -704,6 +704,40 @@
     end
 
     # ════════════════════════════════════════════════════════════════════════
+    # COVERAGE: PeriodicBC{:exclusive} on a Linear axis — Hetero **forward**
+    # — exercises the new `LinearInterp(bc=...)` tag-struct field threaded
+    # through the unified `interp()` API and `_bc_for_periodic_check` /
+    # `_cache_axis_for_method`. The forward correctly wraps queries past the
+    # inner grid endpoint into the periodic seam.
+    #
+    # Hetero **adjoint** with PeriodicBC on Linear/Constant axes is a
+    # separate effort (the adjoint constructor only extends Cubic axes at
+    # present). For now `HeteroAdjointND.bcs` stores `NoBC()` for those
+    # axes so the trimmed output shape stays consistent.
+    # ════════════════════════════════════════════════════════════════════════
+
+    @testset "PeriodicBC{:exclusive} on Linear axis (forward-Hetero wrap)" begin
+        nx, ny = 12, 10
+        x = collect(range(0.0, step = 2π / nx, length = nx))   # exclusive n-point
+        y = range(0.0, 1.0, ny)
+        data = [sin(xi) * yj for xi in x, yj in y]
+
+        bc_x = PeriodicBC(endpoint = :exclusive, period = 2π)
+        methods = (LinearInterp(bc = bc_x), CubicInterp(bc = ZeroSlopeBC()))
+
+        itp = interp((x, y), data; method = methods)
+        # Query past inner-grid last knot (= 11·2π/12 ≈ 5.76) into the seam
+        # region [x[end], x[1]+period).
+        xq_wrap = x[end] + 0.34
+        v_wrap = itp((xq_wrap, 0.5))
+        # Linear interp on x between data[end, :] = sin(x[end])*y and
+        # data[1, :] = 0; y-axis cubic at y=0.5 reduces to sin(x)*0.5 along x.
+        α = (xq_wrap - x[end]) / (2π - x[end])
+        v_expected = (1 - α) * (sin(x[end]) * 0.5) + α * 0.0
+        @test v_wrap ≈ v_expected atol = 1.0e-10
+    end
+
+    # ════════════════════════════════════════════════════════════════════════
     # COVERAGE: PolyFit BC validation error path
     # ════════════════════════════════════════════════════════════════════════
 

--- a/test/test_hetero_adjoint.jl
+++ b/test/test_hetero_adjoint.jl
@@ -704,37 +704,49 @@
     end
 
     # ════════════════════════════════════════════════════════════════════════
-    # COVERAGE: PeriodicBC{:exclusive} on a Linear axis — Hetero **forward**
-    # — exercises the new `LinearInterp(bc=...)` tag-struct field threaded
-    # through the unified `interp()` API and `_bc_for_periodic_check` /
-    # `_cache_axis_for_method`. The forward correctly wraps queries past the
-    # inner grid endpoint into the periodic seam.
-    #
-    # Hetero **adjoint** with PeriodicBC on Linear/Constant axes is a
-    # separate effort (the adjoint constructor only extends Cubic axes at
-    # present). For now `HeteroAdjointND.bcs` stores `NoBC()` for those
-    # axes so the trimmed output shape stays consistent.
+    # COVERAGE: PeriodicBC{:exclusive} on a Linear axis — full forward+adjoint
+    # — exercises the `LinearInterp(bc=...)` tag-struct field end-to-end:
+    #   (1) Hetero forward wraps via `_cache_axis_for_method`.
+    #   (2) Hetero adjoint wraps via `_cache_axis` in `grids_ext`, the generic
+    #       seam-fold post-apply hook trims back to user-`n` via
+    #       `_adjoint_output_size`.
+    # Mixed Linear+Cubic so we cover both wrap strategies in a single call.
     # ════════════════════════════════════════════════════════════════════════
 
-    @testset "PeriodicBC{:exclusive} on Linear axis (forward-Hetero wrap)" begin
+    @testset "PeriodicBC{:exclusive} on Linear axis (mixed Linear+Cubic)" begin
         nx, ny = 12, 10
+        n_query = 18
         x = collect(range(0.0, step = 2π / nx, length = nx))   # exclusive n-point
         y = range(0.0, 1.0, ny)
         data = [sin(xi) * yj for xi in x, yj in y]
+        f_vec = vec(data)
 
         bc_x = PeriodicBC(endpoint = :exclusive, period = 2π)
         methods = (LinearInterp(bc = bc_x), CubicInterp(bc = ZeroSlopeBC()))
 
+        # Forward — verify wrap-around eval works through the unified API
         itp = interp((x, y), data; method = methods)
         # Query past inner-grid last knot (= 11·2π/12 ≈ 5.76) into the seam
         # region [x[end], x[1]+period).
         xq_wrap = x[end] + 0.34
         v_wrap = itp((xq_wrap, 0.5))
-        # Linear interp on x between data[end, :] = sin(x[end])*y and
-        # data[1, :] = 0; y-axis cubic at y=0.5 reduces to sin(x)*0.5 along x.
         α = (xq_wrap - x[end]) / (2π - x[end])
         v_expected = (1 - α) * (sin(x[end]) * 0.5) + α * 0.0
         @test v_wrap ≈ v_expected atol = 1.0e-10
+
+        # Adjoint — dot-product identity ⟨W·f, ȳ⟩ = ⟨f, Wᵀ·ȳ⟩.
+        # Queries cover both inner and seam (wrap) regions to exercise the
+        # full periodic adjoint path.
+        xq = sort(rand(n_query)) .* (2π * 0.96) .+ (2π * 0.02)
+        yq = sort(rand(n_query)) .* 0.96 .+ 0.02
+        adj = hetero_adjoint((x, y), (xq, yq); methods = methods)
+        # Adjoint output shape = user's n-point shape (n+1 → n trim happens)
+        @test size(adj(zeros(n_query))) == size(data)
+        W_T = Matrix(adj)
+        @test size(W_T) == (length(data), n_query)
+        for k in 1:n_query
+            @test itp((xq[k], yq[k])) ≈ dot(W_T[:, k], f_vec) atol = 1.0e-10
+        end
     end
 
     # ════════════════════════════════════════════════════════════════════════

--- a/test/test_hetero_adjoint.jl
+++ b/test/test_hetero_adjoint.jl
@@ -512,6 +512,20 @@
             )
             @test allocs <= ND_ALLOC_THRESHOLD
         end
+
+        # Linear axis with PeriodicBC{:exclusive} routes through `_cache_axis`
+        # wrapping in `grids_ext` and the generic seam-fold post-apply hook.
+        # The fb result must remain user-`n` shape (axis trimmed).
+        @testset "Linear(PeriodicBC{:exclusive})×Cubic (zero alloc)" begin
+            x_p = range(0.0, step = 1.0 / length(x_a), length = length(x_a))
+            bc_x = PeriodicBC(endpoint = :exclusive, period = 1.0)
+            fb = zeros(length(x_p), length(y_a))
+            allocs = _test_hetero_adjoint_alloc(
+                (collect(x_p), y_a), (xq_a, yq_a), fb, y_bar_a;
+                methods = (LinearInterp(bc = bc_x), CubicInterp())
+            )
+            @test allocs <= ND_ALLOC_THRESHOLD
+        end
     end
 
     # ════════════════════════════════════════════════════════════════════════

--- a/test/test_hetero_adjoint.jl
+++ b/test/test_hetero_adjoint.jl
@@ -747,6 +747,13 @@
         for k in 1:n_query
             @test itp((xq[k], yq[k])) ≈ dot(W_T[:, k], f_vec) atol = 1.0e-10
         end
+
+        # Dot-product (golden-rule) identity ⟨W·f, ȳ⟩ = ⟨f, Wᵀ·ȳ⟩ via
+        # the actual `adj(y_bar)` path (not just per-column reconstruction).
+        # Catches mistakes in the seam-fold + trim post-apply hook.
+        y_bar = randn(n_query)
+        forward_vec = [itp((xq[k], yq[k])) for k in 1:n_query]
+        @test dot(forward_vec, y_bar) ≈ dot(f_vec, vec(adj(y_bar))) atol = 1.0e-10
     end
 
     # ════════════════════════════════════════════════════════════════════════

--- a/test/test_hetero_adjoint.jl
+++ b/test/test_hetero_adjoint.jl
@@ -757,6 +757,30 @@
     end
 
     # ════════════════════════════════════════════════════════════════════════
+    # Persistent-rrule replay path: `hetero_adjoint(itp.grids, ...; methods=itp.methods)`.
+    # The forward stores extended grids (length n+1) while the method tag
+    # retains `bc=PeriodicBC{:exclusive}`. ChainRules / Zygote rrule replays
+    # adjoint construction with `itp.grids` + `itp.methods` — the axis package
+    # builder must NOT re-extend an already-extended grid.
+    # ════════════════════════════════════════════════════════════════════════
+    @testset "Stored-grid rrule replay — no double extension" begin
+        nx, ny = 8, 6
+        x = collect(range(0.0, step = 2π / nx, length = nx))
+        y_grid = range(0.0, 1.0, ny)
+        data = [sin(xi) * yj for xi in x, yj in y_grid]
+        bc_x = PeriodicBC(endpoint = :exclusive, period = 2π)
+        methods = (LinearInterp(bc = bc_x), CubicInterp(bc = ZeroSlopeBC()))
+        itp = interp((x, y_grid), data; method = methods)
+
+        # The rrule replays adjoint construction this way:
+        #     adj_fn(itp.grids, (query_tuple,); methods=itp.methods, ...)
+        # `itp.grids[1]` is already extended to length nx+1 with the seam
+        # endpoint at `first(grid)+period`. Re-wrapping must be a no-op.
+        adj = hetero_adjoint(itp.grids, ([0.5], [0.5]); methods = itp.methods)
+        @test size(adj(zeros(1))) == size(data)
+    end
+
+    # ════════════════════════════════════════════════════════════════════════
     # COVERAGE: PolyFit BC validation error path
     # ════════════════════════════════════════════════════════════════════════
 

--- a/test/test_nd_mixed_partial_bc_consistency.jl
+++ b/test/test_nd_mixed_partial_bc_consistency.jl
@@ -4,9 +4,8 @@
 # These tests pin the mathematical invariants that the mixed-partial BC fix
 # restores. They were authored as the RED phase of the TDD cycle for the fix
 # in `_get_effective_bc` / `_get_effective_bc_quadratic`. On the pre-fix commit
-# they FAIL by the bug magnitudes documented in
-#   claudedocs/TODO/00_HIGHEST_PRIORITY_mixed_partial_bc_fix.md
-# (cubic ~1e-10, quadratic ~1e-5). After the fix they pass to machine epsilon.
+# they FAIL by the documented bug magnitudes (cubic ~1e-10, quadratic ~1e-5);
+# after the fix they pass to machine epsilon.
 #
 # Three groups, each cubic + quadratic, 2D + 3D where applicable:
 #

--- a/test/test_unified_api_bc.jl
+++ b/test/test_unified_api_bc.jl
@@ -172,7 +172,9 @@ end
 
 # OnTheFly hetero forward must either return correct values at the periodic
 # seam cell (matching PreCompute), or reject the unsupported configuration with
-# a clear ArgumentError. Silent garbage is the bug.
+# a clear ArgumentError. Silent garbage is the bug. Coverage spans all three
+# `_validate_nd_coeffs(::OnTheFly, ...)` call sites: persistent ctor + scalar
+# one-shot + batch one-shot.
 @testitem "OnTheFly hetero — seam-cell matches PreCompute or rejects" begin
     x = collect(0.0:0.2:0.8)
     y = collect(0.0:0.25:1.0)
@@ -182,9 +184,7 @@ end
     itp_pre = interp((x, y), data; method = methods, coeffs = PreCompute())
     v_pre   = itp_pre((0.9, 0.5))   # seam cell: between x[end]=0.8 and x[1]+period=1.0
 
-    # The OnTheFly persistent path on the same configuration must be either
-    # numerically equivalent (within ULP) to PreCompute or refuse construction.
-    # Silent disagreement (current bug) is unacceptable.
+    # Persistent ctor — must equal PreCompute or reject.
     correctness_ok = try
         itp_otf = interp((x, y), data; method = methods, coeffs = OnTheFly())
         v_otf = itp_otf((0.9, 0.5))
@@ -193,6 +193,12 @@ end
         e isa ArgumentError      # explicit rejection is also acceptable
     end
     @test correctness_ok
+
+    # Scalar one-shot — same rejection path (`hetero_oneshot.jl:_validate_nd_coeffs`).
+    @test_throws ArgumentError interp((x, y), data, (0.9, 0.5); method = methods, coeffs = OnTheFly())
+
+    # Batch one-shot — same rejection at the batch dispatch site.
+    @test_throws ArgumentError interp((x, y), data, ([0.9], [0.5]); method = methods, coeffs = OnTheFly())
 end
 
 
@@ -205,4 +211,14 @@ end
     @test ConstantInterp(LeftSide()).bc === NoBC()
     @test ConstantInterp(NearestSide()) isa ConstantInterp
     @test ConstantInterp(RightSide()) isa ConstantInterp
+
+    # Round-trip: side must be honored downstream (not silently dropped to
+    # NearestSide). LeftSide returns the value at the cell's left endpoint,
+    # so query at xq = 0.499 in cell [0.4, 0.5] must equal data[5] (left).
+    x = collect(0.0:0.1:1.0)
+    data = collect(1.0:11.0)            # data[i] = i
+    itp_left  = interp((x,), data; method = (ConstantInterp(LeftSide()),))
+    itp_right = interp((x,), data; method = (ConstantInterp(RightSide()),))
+    @test itp_left((0.499,))  ≈ 5.0     # left endpoint of cell [x[5], x[6]] = data[5]
+    @test itp_right((0.401,)) ≈ 6.0     # right endpoint of cell [x[5], x[6]] = data[6]
 end

--- a/test/test_unified_api_bc.jl
+++ b/test/test_unified_api_bc.jl
@@ -1,0 +1,136 @@
+@testitem "Unified API — LinearInterp / ConstantInterp `bc` field" begin
+    # Smoke test: verify the new `bc` field on `LinearInterp` / `ConstantInterp`
+    # round-trips through constructors and through the unified `interp(...)` API
+    # for both homogeneous and heterogeneous (mixed-method) ND calls.
+
+    @testset "Tag struct constructors" begin
+        # Defaults
+        @test LinearInterp().bc isa NoBC
+        @test ConstantInterp().bc isa NoBC
+        @test ConstantInterp().side isa NearestSide
+
+        # Keyword form
+        bc = PeriodicBC(endpoint = :exclusive, period = 1.0)
+        @test LinearInterp(bc = bc).bc === bc
+        @test ConstantInterp(bc = bc).bc === bc
+        @test ConstantInterp(side = LeftSide(), bc = bc).bc === bc
+        @test ConstantInterp(side = LeftSide(), bc = bc).side isa LeftSide
+
+        # Backward compat: bare positional `LinearInterp()` /
+        # `ConstantInterp(side=...)` still work
+        @test LinearInterp() isa LinearInterp
+        @test ConstantInterp(side = RightSide()).side isa RightSide
+    end
+end
+
+@testitem "Unified API — homogeneous Linear/Constant + PeriodicBC" begin
+    # `interp(grids, data; method=(LinearInterp(bc=PeriodicBC()), ...))` must
+    # produce the same values as the direct `linear_interp(...; bc=...)` /
+    # `constant_interp(...; bc=...)` ND constructors.
+
+    nx, ny = 12, 9
+    n_query = 30
+    x = range(0.0, 1.0, nx)
+    y_grid = range(0.0, 2.0, ny)
+    data = randn(nx, ny)
+    # `:inclusive` requires endpoint match
+    data[end, :] .= data[1, :]
+    data[:, end] .= data[:, 1]
+    xq = rand(n_query)
+    yq = rand(n_query) .* 2
+
+    @testset "Linear ND — :inclusive" begin
+        bc = PeriodicBC()  # :inclusive default
+        ref = linear_interp((x, y_grid), data, (xq, yq); bc = (bc, bc))
+        via_unified = interp(
+            (x, y_grid), data, (xq, yq);
+            method = (LinearInterp(bc = bc), LinearInterp(bc = bc)),
+        )
+        @test via_unified ≈ ref atol = 1.0e-12
+    end
+
+    @testset "Linear ND — :exclusive" begin
+        # Half-open n-point grid + period
+        nx_e, ny_e = 11, 8
+        x_e = collect(range(0.0, step = 1.0 / nx_e, length = nx_e))
+        y_e = collect(range(0.0, step = 2.0 / ny_e, length = ny_e))
+        data_e = randn(nx_e, ny_e)
+        bc_x = PeriodicBC(endpoint = :exclusive, period = 1.0)
+        bc_y = PeriodicBC(endpoint = :exclusive, period = 2.0)
+        xq_e = rand(n_query)
+        yq_e = rand(n_query) .* 2
+
+        ref = linear_interp((x_e, y_e), data_e, (xq_e, yq_e); bc = (bc_x, bc_y))
+        via_unified = interp(
+            (x_e, y_e), data_e, (xq_e, yq_e);
+            method = (LinearInterp(bc = bc_x), LinearInterp(bc = bc_y)),
+        )
+        @test via_unified ≈ ref atol = 1.0e-12
+    end
+
+    @testset "Constant ND — :inclusive" begin
+        bc = PeriodicBC()
+        ref = constant_interp((x, y_grid), data, (xq, yq); bc = (bc, bc))
+        via_unified = interp(
+            (x, y_grid), data, (xq, yq);
+            method = (ConstantInterp(bc = bc), ConstantInterp(bc = bc)),
+        )
+        @test via_unified == ref     # constant: single-node selection, exact
+    end
+
+    @testset "Constant ND — :exclusive (with side)" begin
+        nx_e, ny_e = 11, 8
+        x_e = collect(range(0.0, step = 1.0 / nx_e, length = nx_e))
+        y_e = collect(range(0.0, step = 2.0 / ny_e, length = ny_e))
+        data_e = randn(nx_e, ny_e)
+        bc_x = PeriodicBC(endpoint = :exclusive, period = 1.0)
+        bc_y = PeriodicBC(endpoint = :exclusive, period = 2.0)
+        xq_e = rand(n_query)
+        yq_e = rand(n_query) .* 2
+
+        ref = constant_interp((x_e, y_e), data_e, (xq_e, yq_e);
+            bc = (bc_x, bc_y), side = (LeftSide(), NearestSide()))
+        via_unified = interp(
+            (x_e, y_e), data_e, (xq_e, yq_e);
+            method = (
+                ConstantInterp(side = LeftSide(),    bc = bc_x),
+                ConstantInterp(side = NearestSide(), bc = bc_y),
+            ),
+        )
+        @test via_unified == ref
+    end
+end
+
+@testitem "Unified API — heterogeneous Linear+Cubic + PeriodicBC end-to-end" begin
+    # Ensure that `(LinearInterp(bc=PeriodicBC(...)), CubicInterp(bc=PeriodicBC(...)))`
+    # routed through Hetero produces values matching the direct path on a
+    # smooth periodic test function (sin(x) + cos(y)).
+
+    nx, ny = 16, 14
+    n_query = 25
+    x = collect(range(0.0, step = 2π / nx, length = nx))   # exclusive n-point grid
+    y_grid = collect(range(0.0, step = 2π / ny, length = ny))
+    data = [sin(xi) + cos(yj) for xi in x, yj in y_grid]
+    bc_x = PeriodicBC(endpoint = :exclusive, period = 2π)
+    bc_y = PeriodicBC(endpoint = :exclusive, period = 2π)
+
+    # Stay strictly inside the inner interval to avoid extrap branch
+    xq = sort(rand(n_query)) .* (2π * 0.96) .+ (2π * 0.02)
+    yq = sort(rand(n_query)) .* (2π * 0.96) .+ (2π * 0.02)
+
+    via_unified = interp(
+        (x, y_grid), data, (xq, yq);
+        method = (LinearInterp(bc = bc_x), CubicInterp(bc = bc_y)),
+    )
+
+    # Reference: 1D cubic_interp along y at each query (independent y per
+    # column), then 1D linear_interp along x — separable test function gives
+    # well-defined per-axis interpolation values to compare against.
+    @test all(isfinite, via_unified)
+    @test length(via_unified) == n_query
+
+    # Sanity: values should be close to the analytic function (linear on x is
+    # only first-order accurate, so use a loose absolute tolerance).
+    analytic = [sin(xi) + cos(yi) for (xi, yi) in zip(xq, yq)]
+    @test maximum(abs, via_unified .- analytic) < 0.05
+end

--- a/test/test_unified_api_bc.jl
+++ b/test/test_unified_api_bc.jl
@@ -133,4 +133,16 @@ end
     # only first-order accurate, so use a loose absolute tolerance).
     analytic = [sin(xi) + cos(yi) for (xi, yi) in zip(xq, yq)]
     @test maximum(abs, via_unified .- analytic) < 0.05
+
+    # Adjoint path through `hetero_adjoint(...; methods=...)`: verify the same
+    # tag-struct `bc` field plumbing reaches the adjoint builder and that the
+    # dot-product identity holds end-to-end.
+    methods = (LinearInterp(bc = bc_x), CubicInterp(bc = bc_y))
+    itp = interp((x, y_grid), data; method = methods)
+    adj = hetero_adjoint((x, y_grid), (xq, yq); methods = methods)
+    @test size(adj(zeros(n_query))) == size(data)
+    using LinearAlgebra: dot
+    y_bar = randn(n_query)
+    forward_vec = [itp((xq[k], yq[k])) for k in 1:n_query]
+    @test dot(forward_vec, y_bar) ≈ dot(vec(data), vec(adj(y_bar))) atol = 1.0e-10
 end

--- a/test/test_unified_api_bc.jl
+++ b/test/test_unified_api_bc.jl
@@ -146,3 +146,63 @@ end
     forward_vec = [itp((xq[k], yq[k])) for k in 1:n_query]
     @test dot(forward_vec, y_bar) ≈ dot(vec(data), vec(adj(y_bar))) atol = 1.0e-10
 end
+
+
+# `hetero_adjoint` must auto-promote `extrap` to WrapExtrap on periodic axes,
+# matching the forward path. Without this, a query past the inner span (e.g.
+# 1.05 with period=1.0) is accepted by `interp(...)` but rejected with
+# DomainError by `hetero_adjoint(...)`.
+@testitem "hetero_adjoint — periodic extrap auto-promote on off-span query" begin
+    x = collect(range(0.0, step = 0.1, length = 10))   # n=10, period=1
+    y = collect(range(0.0, 1.0, 10))
+    data = [sin(2π * xi) + yj for xi in x, yj in y]
+    bc_x = PeriodicBC(endpoint = :exclusive, period = 1.0)
+    methods = (LinearInterp(bc = bc_x), CubicInterp())
+
+    # Forward accepts xq=1.05 by auto-promoting to WrapExtrap on the periodic axis.
+    itp = interp((x, y), data; method = methods)
+    @test isfinite(itp((1.05, 0.5)))
+
+    # Adjoint MUST also accept it. Same auto-promotion must reach the anchor
+    # baking + domain validation.
+    adj = hetero_adjoint((x, y), ([1.05], [0.5]); methods = methods)
+    @test size(adj(zeros(1))) == size(data)
+end
+
+
+# OnTheFly hetero forward must either return correct values at the periodic
+# seam cell (matching PreCompute), or reject the unsupported configuration with
+# a clear ArgumentError. Silent garbage is the bug.
+@testitem "OnTheFly hetero — seam-cell matches PreCompute or rejects" begin
+    x = collect(0.0:0.2:0.8)
+    y = collect(0.0:0.25:1.0)
+    data = [sin(2π * xi) + cos(π * yj) for xi in x, yj in y]
+    methods = (LinearInterp(bc = PeriodicBC(endpoint = :exclusive, period = 1.0)), CubicInterp())
+
+    itp_pre = interp((x, y), data; method = methods, coeffs = PreCompute())
+    v_pre   = itp_pre((0.9, 0.5))   # seam cell: between x[end]=0.8 and x[1]+period=1.0
+
+    # The OnTheFly persistent path on the same configuration must be either
+    # numerically equivalent (within ULP) to PreCompute or refuse construction.
+    # Silent disagreement (current bug) is unacceptable.
+    correctness_ok = try
+        itp_otf = interp((x, y), data; method = methods, coeffs = OnTheFly())
+        v_otf = itp_otf((0.9, 0.5))
+        isapprox(v_otf, v_pre; atol = 1.0e-12)
+    catch e
+        e isa ArgumentError      # explicit rejection is also acceptable
+    end
+    @test correctness_ok
+end
+
+
+# `ConstantInterp(side::AbstractSide)` (positional, single-arg) is a public
+# call form; the default 2-field struct constructor `ConstantInterp(side, bc)`
+# would shadow it without an explicit outer ctor.
+@testitem "ConstantInterp(side) — positional 1-arg ctor" begin
+    @test ConstantInterp(LeftSide()) isa ConstantInterp
+    @test ConstantInterp(LeftSide()).side === LeftSide()
+    @test ConstantInterp(LeftSide()).bc === NoBC()
+    @test ConstantInterp(NearestSide()) isa ConstantInterp
+    @test ConstantInterp(RightSide()) isa ConstantInterp
+end

--- a/test/test_unified_api_bc.jl
+++ b/test/test_unified_api_bc.jl
@@ -88,12 +88,14 @@ end
         xq_e = rand(n_query)
         yq_e = rand(n_query) .* 2
 
-        ref = constant_interp((x_e, y_e), data_e, (xq_e, yq_e);
-            bc = (bc_x, bc_y), side = (LeftSide(), NearestSide()))
+        ref = constant_interp(
+            (x_e, y_e), data_e, (xq_e, yq_e);
+            bc = (bc_x, bc_y), side = (LeftSide(), NearestSide())
+        )
         via_unified = interp(
             (x_e, y_e), data_e, (xq_e, yq_e);
             method = (
-                ConstantInterp(side = LeftSide(),    bc = bc_x),
+                ConstantInterp(side = LeftSide(), bc = bc_x),
                 ConstantInterp(side = NearestSide(), bc = bc_y),
             ),
         )
@@ -182,7 +184,7 @@ end
     methods = (LinearInterp(bc = PeriodicBC(endpoint = :exclusive, period = 1.0)), CubicInterp())
 
     itp_pre = interp((x, y), data; method = methods, coeffs = PreCompute())
-    v_pre   = itp_pre((0.9, 0.5))   # seam cell: between x[end]=0.8 and x[1]+period=1.0
+    v_pre = itp_pre((0.9, 0.5))   # seam cell: between x[end]=0.8 and x[1]+period=1.0
 
     # Persistent ctor — must equal PreCompute or reject.
     correctness_ok = try
@@ -217,8 +219,8 @@ end
     # so query at xq = 0.499 in cell [0.4, 0.5] must equal data[5] (left).
     x = collect(0.0:0.1:1.0)
     data = collect(1.0:11.0)            # data[i] = i
-    itp_left  = interp((x,), data; method = (ConstantInterp(LeftSide()),))
+    itp_left = interp((x,), data; method = (ConstantInterp(LeftSide()),))
     itp_right = interp((x,), data; method = (ConstantInterp(RightSide()),))
-    @test itp_left((0.499,))  ≈ 5.0     # left endpoint of cell [x[5], x[6]] = data[5]
+    @test itp_left((0.499,)) ≈ 5.0     # left endpoint of cell [x[5], x[6]] = data[5]
     @test itp_right((0.401,)) ≈ 6.0     # right endpoint of cell [x[5], x[6]] = data[6]
 end


### PR DESCRIPTION
## Summary

Adds `bc=PeriodicBC(...)` support to every adjoint path that doesn't already have it, unifies the BC field representation on `LinearInterp` / `ConstantInterp`, and threads BC handling through the protocol via method dispatch instead of `if isa` runtime branches. Quadratic remains the only by-design exception (slope half-integer offset incompatible with seam wrap).

**Size**: 31 files, +2219 / −291.

## Coverage

| Path | Method | Status |
|------|--------|--------|
| 1D adjoint | Linear / Constant | `bc=NoBC()/PeriodicBC()` |
| | PCHIP / Cardinal / Akima | `bc=NoBC()/PeriodicBC()` |
| | Cubic | `bc=...` (any) |
| | Quadratic | by-design unsupported |
| Homogeneous ND adjoint | Linear / Constant / Cubic | per-axis `bc` |
| Hetero ND adjoint | Cubic axis | per-axis `bc` |
| | Linear / Constant axis | per-axis `bc` (incl. `PeriodicBC{:exclusive}`) |
| | Local-Hermite axis | explicit rejection w/ workaround hint |
| Unified-API rrule `interp(grids, data, queries; method=...)` | All combos | scalar + batch rrules via `hetero_adjoint` |

## API

```julia
# 1D periodic adjoint — every method family
bc = PeriodicBC(endpoint = :exclusive, period = 1.0)   # or PeriodicBC() for :inclusive
linear_adjoint(x, xq;       bc = bc)
constant_adjoint(x, xq;     bc = bc, side = NearestSide())
pchip_adjoint(x, y, xq;     bc = bc)
cardinal_adjoint(x, xq;     bc = bc, tension = 0.0)
akima_adjoint(x, y, xq;     bc = bc)

# Tag structs (for unified-API + hetero ND)
LinearInterp(bc   = PeriodicBC())
ConstantInterp(bc = PeriodicBC(), side = NearestSide())

# Hetero ND adjoint with mixed BCs (Linear+:exclusive PeriodicBC × Cubic)
hetero_adjoint((x, y), (xq, yq);
    methods = (LinearInterp(bc = PeriodicBC(endpoint = :exclusive, period = 1.0)),
               CubicInterp()))

# Unified-API rrule — Zygote.gradient flows through hetero_adjoint
Zygote.gradient(d -> sum(interp((x, y), d, (xq, yq); method = methods)), data)
```

Defaults are `bc = NoBC()` (which preserves pre-PR behavior). All adjoint constructors validate kwargs strictly — typos like `bcc=...` raise `MethodError` immediately.

## Implementation

- **Linear / Constant 1D adjoint**: `_cache_axis` wraps the user axis into `_ExclusivePeriodicAxis` for `:exclusive`; the protocol's `_adjoint_1d_apply_exclusive_inplace!` scatters into a length-(n+1) pool buffer and folds the seam (`f_work[1] += f_work[n+1]`).
- **PCHIP / Cardinal / Akima 1D adjoint**: closed-cycle slope-adjoint kernels with `mod1` cyclic stencil; stencil-aware loop split keeps interior iterations `mod1`-free (radius-1 methods → boundary k ∈ {1, n}; Akima radius 2 → {1, 2, n−1, n}).
- **`HeteroAdjointND` builder**: one method-typed dispatch per method "shape" (`CubicInterp` / `QuadraticInterp` / `NoInterp`+`CubicHermiteInterp` / `LinearInterp`+`ConstantInterp`), each returning a NamedTuple of 6 per-axis values (`grid_ext`, `bc`, `mixed_bc`, `cache`, `mixed_cache`, `mincurv_C`). Six trivial field-extract `map`s feed the constructor. Adding a new method = one new dispatch.
- **BC-by-dispatch protocol**: `_adjoint_1d_finalize`, slope adjoints (`_cardinal_slope_adjoint!`, `_pchip_slope_adjoint!`, `_akima_slope_adjoint!`), seam-fold (`_apply_seam_fold!`, `_seam_fold_axis!`) all dispatch on the BC type at compile time. `if adj.bc isa PeriodicBC` is gone from kernel hot paths.
- **`_adjoint_1d_finalize` for `:exclusive`**: in-place `resize!(f_bar, n-1)` after seam fold — O(1) length adjust, no slice copy. The Cubic-specific finalize override is dropped (default + `_adjoint_internal_length` cover it).
- **Unified-API Zygote rrule**: two rrules for `interp(grids, data, queries; method=...)` covering single-point tuple query (`value_gradient` for ∂queries + `hetero_adjoint` for ∂data) and batch (∂data via `hetero_adjoint` ones-vector pattern).

## Performance

In-place `adj(f_bar, y_bar)`, zero allocation across all combinations, n=100 / n_q=1000 (`@belapsed` minimum on Apple M-series, Julia 1.12):

| Method | NoBC | `:inclusive` | `:exclusive` |
|---|---|---|---|
| Linear | 750 ns | 750 ns | 791 ns |
| Constant | 750 ns | 750 ns | 750 ns |
| PCHIP | 1917 ns | 1916 ns | 1917 ns |
| Cardinal | 1458 ns | 1458 ns | 1500 ns |
| Akima | 2833 ns | 2166 ns | 2250 ns |

Akima `:inclusive` is ~24% faster than its NoBC counterpart because the closed-cycle 4-secant kernel skips the virtual-secant boundary branching. Periodic kernels for the other Hermite-family methods are essentially identical to NoBC; Linear/Constant `:exclusive` pays a small (~5%) seam-fold overhead.

Allocating-path `adj(y_bar)` for 1D `:exclusive`: **192 B/call** — bit-identical to the NoBC baseline (single output-buffer alloc, no slice copy).