### PR TITLE
(refac+feat): `constant_interp` raw-eltype duck-type contract

### DIFF
--- a/src/constant/constant_adjoint.jl
+++ b/src/constant/constant_adjoint.jl
@@ -221,15 +221,14 @@ f_bar = adj(y_bar)
 - `NoExtrap` validates all queries are in-domain at construction time.
 """
 function constant_adjoint(
-        x::AbstractVector,
+        x::AbstractVector{Tg},
         x_query::AbstractVector;
         bc::AbstractBC = NoBC(),
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
-    )
+    ) where {Tg}
     # Selection kernel → raw eltype contract (cubic/linear/… keep using the
     # shared `_promote_adjoint_inputs` for their Float-promotion needs).
-    Tg = eltype(x)
     x_p = x
     xq_p = _promote_query_typed(x_query, Tg)
 

--- a/src/constant/constant_adjoint.jl
+++ b/src/constant/constant_adjoint.jl
@@ -20,7 +20,7 @@
 # ========================================
 
 """
-    ConstantAdjoint{Tg, SD, EP}
+    ConstantAdjoint{Tg, Tq, BC, SD, EP}
 
 Adjoint (transpose) operator for 1D constant interpolation.
 Computes `f̄ = Wᵀȳ` where `W` is the forward constant interpolation weight matrix.
@@ -30,6 +30,8 @@ The same adjoint can be applied to any `ȳ` vector.
 
 # Type Parameters
 - `Tg`: Grid type (unconstrained — supports duck types like ForwardDiff.Dual)
+- `Tq`: Anchor query coordinate type, `promote_type(Tg, eltype(x_query))`
+- `BC`: Boundary condition type
 - `SD`: Side selection mode (`NearestSide`, `LeftSide`, `RightSide`)
 - `EP`: Extrapolation policy type (`NoExtrap`, `ExtendExtrap`, `ClampExtrap`, `FillExtrap`, `WrapExtrap`)
 
@@ -56,8 +58,8 @@ itp = constant_interp(x, f; side=NearestSide())
 @assert dot(itp.(xq), y_bar) ≈ dot(f, adj(y_bar))
 ```
 """
-struct ConstantAdjoint{Tg, BC <: AbstractBC, SD <: AbstractSide, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
-    anchors::Vector{_ConstantAnchoredQuery{Tg, Tg}}
+struct ConstantAdjoint{Tg, Tq, BC <: AbstractBC, SD <: AbstractSide, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
+    anchors::Vector{_ConstantAnchoredQuery{Tg, Tq}}
     grid_size::Int  # internal length: n+1 for PeriodicBC{:exclusive}, n otherwise
     x_hi::Tg
     bc::BC
@@ -165,16 +167,16 @@ gets `state=IN_DOMAIN` (inside). This restores the correct OOB state flag based 
 original query position, so scatter can skip OOB contributions.
 """
 function _fixup_constant_anchor_state!(
-        anchors::Vector{_ConstantAnchoredQuery{Tg, Tg}},
+        anchors::Vector{_ConstantAnchoredQuery{Tg, Tq}},
         xq_original::AbstractVector,
         x_lo, x_hi
-    ) where {Tg}
+    ) where {Tg, Tq}
     @inbounds for i in eachindex(anchors)
         xq_i = xq_original[i]
         (x_lo <= xq_i <= x_hi) && continue
         state = xq_i < x_lo ? OOB_LEFT : OOB_RIGHT
         aq = anchors[i]
-        anchors[i] = _ConstantAnchoredQuery{Tg, Tg}(
+        anchors[i] = _ConstantAnchoredQuery{Tg, Tq}(
             aq.stencil, aq.xq, state, aq.h, aq.dL
         )
     end
@@ -271,7 +273,8 @@ function constant_adjoint(
         anchors = _anchor_query(x_axis, xq_p, Val(:constant), wrap)
     end
 
-    return ConstantAdjoint{Tg, typeof(bc), typeof(side), typeof(extrap_eff)}(
+    Tq = eltype(anchors).parameters[2]
+    return ConstantAdjoint{Tg, Tq, typeof(bc), typeof(side), typeof(extrap_eff)}(
         anchors, length(x_axis), x_hi, bc, side, extrap_eff
     )
 end

--- a/src/constant/constant_adjoint.jl
+++ b/src/constant/constant_adjoint.jl
@@ -227,7 +227,11 @@ function constant_adjoint(
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
     )
-    x_p, xq_p, Tg = _promote_adjoint_inputs(x, x_query)
+    # Selection kernel → raw eltype contract (cubic/linear/… keep using the
+    # shared `_promote_adjoint_inputs` for their Float-promotion needs).
+    Tg = eltype(x)
+    x_p = x
+    xq_p = _promote_query_typed(x_query, Tg)
 
     length(x_p) >= 2 || _throw_adjoint_grid_too_small(length(x_p))
 

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -112,8 +112,8 @@ itp1(aq)              # Ultra-fast: skips interval search
 itp2(aq)              # Reuses same anchor
 ```
 """
-# Unified scalar anchor construction. _constant_anchor_query_impl handles
-# Tg conversion internally, so no separate Real wrapper is needed.
+# Pass xq as-is — `_constant_anchor_query_impl` handles `oftype` promotion
+# so narrower grids never truncate wider queries.
 @inline function _anchor_query(
         x::AbstractVector{T},
         xq,
@@ -121,7 +121,7 @@ itp2(aq)              # Reuses same anchor
         wrap::Bool = false,
         searcher::P = DEFAULT_SEARCHER
     ) where {T, P <: Searcher}
-    return _constant_anchor_query_impl(x, T(xq), wrap, _resolve_searcher_for_grid(x, searcher))
+    return _constant_anchor_query_impl(x, xq, wrap, _resolve_searcher_for_grid(x, searcher))
 end
 
 """
@@ -158,10 +158,11 @@ function _anchor_query(
         searcher::P = _to_searcher(LinearBinarySearch())
     ) where {T, S <: Real, P <: Searcher}
     searcher_resolved = _resolve_searcher_for_grid(x, searcher)
-    output = Vector{_ConstantAnchoredQuery{T, T}}(undef, length(xq))
+    Tq = promote_type(T, S)
+    output = Vector{_ConstantAnchoredQuery{T, Tq}}(undef, length(xq))
 
     @inbounds for k in eachindex(xq)
-        output[k] = _constant_anchor_query_impl(x, T(xq[k]), wrap, searcher_resolved)
+        output[k] = _constant_anchor_query_impl(x, xq[k], wrap, searcher_resolved)
     end
     return output
 end
@@ -184,18 +185,18 @@ the caller reuses `buffer`. Writes `length(xq)` entries.
 The same `buffer` object, filled with anchored queries.
 """
 @inline function _fill_anchors!(
-        buffer::AbstractVector{_ConstantAnchoredQuery{T, T}},
+        buffer::AbstractVector{_ConstantAnchoredQuery{T, Tq}},
         x::AbstractVector{T},
         xq::AbstractVector{S},
         ::Val{:constant},
         wrap::Bool = false,
         searcher::P = _to_searcher(LinearBinarySearch())
-    ) where {T, S <: Real, P <: Searcher}
+    ) where {T, Tq, S <: Real, P <: Searcher}
     @assert length(buffer) >= length(xq) "Buffer too small: $(length(buffer)) < $(length(xq))"
     searcher_resolved = _resolve_searcher_for_grid(x, searcher)
 
     @inbounds for k in eachindex(xq)
-        buffer[k] = _constant_anchor_query_impl(x, T(xq[k]), wrap, searcher_resolved)
+        buffer[k] = _constant_anchor_query_impl(x, xq[k], wrap, searcher_resolved)
     end
     return buffer
 end

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -219,10 +219,8 @@ Internal implementation of _anchor_query for constant interpolation.
     ) where {T, Tq <: Real, P <: Searcher}
     loc = _anchor_loc(x, xq, wrap, policy)
 
-    # Raw subtraction (not `_get_h`): constant only uses `h` for `dL <= h/2`
-    # comparison, so preserving `eltype(x)` keeps the anchor type uniform
-    # across Vector/CachedRange/CachedVector grids.
-    h = loc.xR - loc.xL
+    # Compute geometry (constant-internal concern)
+    h = _get_h(x, loc.xL, loc.xR)
     dL = loc.xq - loc.xL
     # Promote xq to match dL type (Float64 query + Dual grid → dL is Dual)
     xq_promoted = oftype(dL, loc.xq)

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -219,8 +219,10 @@ Internal implementation of _anchor_query for constant interpolation.
     ) where {T, Tq <: Real, P <: Searcher}
     loc = _anchor_loc(x, xq, wrap, policy)
 
-    # Compute geometry (constant-internal concern)
-    h = _get_h(x, loc.xL, loc.xR)
+    # Raw subtraction (not `_get_h`): constant only uses `h` for `dL <= h/2`
+    # comparison, so preserving `eltype(x)` keeps the anchor type uniform
+    # across Vector/CachedRange/CachedVector grids.
+    h = loc.xR - loc.xL
     dL = loc.xq - loc.xL
     # Promote xq to match dL type (Float64 query + Dual grid → dL is Dual)
     xq_promoted = oftype(dL, loc.xq)

--- a/src/constant/constant_interpolant.jl
+++ b/src/constant/constant_interpolant.jl
@@ -113,13 +113,11 @@ end
         extrap::AbstractExtrap = NoExtrap(),
         search::AbstractSearchPolicy = AutoSearch()
     ) where {TX, TY}
-    Tg = _promote_grid_float(TX, TY)
-    # BC-aware caching wrap (zero-copy of buffer); ownership copy + element
-    # promotion is delegated to the inner constructor's `_convert_copy(x, Tg)`
-    # / `_convert_copy(y, Tv)` symmetric pair. Same template as Linear.
+    # Selection kernel → raw eltype contract.
+    Tg = TX
     x_eff = _cache_axis(x, bc, Tg)
     y_eff = _resolve_data(y, bc)
     extrap_eff = _resolve_extrap(extrap, bc, x_eff, y_eff)
-    extrap_p = _promote_extrap(extrap_eff, _value_type(TY, Tg))
+    extrap_p = _promote_extrap(extrap_eff, TY)
     return ConstantInterpolant(x_eff, y_eff, extrap_p, side, search; bc = bc)
 end

--- a/src/constant/constant_interpolant.jl
+++ b/src/constant/constant_interpolant.jl
@@ -20,6 +20,51 @@ end
     return _constant_vector_loop!(output, itp.x, itp.y, xq, extrap, itp.side, op, searcher)
 end
 
+# ========================================
+# Callable Overrides — selection-kernel output type
+# ========================================
+# The shared 1D protocol allocates `Vector{_output_eltype(Tv, Tg, Tq)}` which
+# widens Tv via promote_type. That's correct for arithmetic kernels (Linear,
+# Cubic, …) but violates Constant's raw-Tv contract — `itp([0.5])` would
+# return `Vector{Float64}` while `itp(0.5)` and the oneshot return raw `Tv`.
+#
+# These overrides keep raw `Tv` for plain numeric queries (`_PromotableValue`)
+# and widen only for duck-typed queries (Dual, Measurement, …) so AD carriers
+# round-trip without being stripped. Scalar / 1D-batch / ND-batch share the
+# same rule for consistency with the oneshot family in `constant_oneshot.jl`.
+
+@inline _constant_out_eltype(::Type{Tv}, ::Type{Tq}) where {Tv, Tq} =
+    Tq <: _PromotableValue ? Tv : promote_type(Tv, Tq)
+
+@inline function (itp::ConstantInterpolant{Tg, Tv})(
+        xq::Tq;
+        deriv::DerivOp = EvalValue(),
+        search::AbstractSearchPolicy = _itp_search(itp),
+        hint::Union{Nothing, Base.RefValue{Int}} = nothing
+    ) where {Tg, Tv, Tq <: Real}
+    grid = _itp_grid(itp)
+    extrap = _itp_extrap(itp)
+    @boundscheck _check_domain(grid, xq, extrap)
+    searcher = _resolve_search(grid, xq, search, hint)
+    val = _constant_eval_at_point(itp.x, itp.y, xq, extrap, itp.side, deriv, searcher)
+    return convert(_constant_out_eltype(Tv, Tq), val)
+end
+
+function (itp::ConstantInterpolant{Tg, Tv})(
+        xq::AbstractVector{Tq};
+        deriv::DerivOp = EvalValue(),
+        search::AbstractSearchPolicy = _itp_search(itp),
+        hint::Union{Nothing, Base.RefValue{Int}} = nothing
+    ) where {Tg, Tv, Tq <: Real}
+    grid = _itp_grid(itp)
+    extrap = _itp_extrap(itp)
+    T_out = _constant_out_eltype(Tv, Tq)
+    output = Vector{T_out}(undef, length(xq))
+    searcher = _resolve_search(grid, xq, search, hint)
+    _itp_vector_loop!(output, itp, xq, extrap, deriv, searcher)
+    return output
+end
+
 # ─────────────────────────────────────────────────────────────
 # Vector loop (function barrier)
 # Julia specializes on concrete Searcher type P, eliminating Union-split

--- a/src/constant/constant_interpolant.jl
+++ b/src/constant/constant_interpolant.jl
@@ -100,24 +100,19 @@ end
 # ========================================
 # Generic Constructor (User API)
 # ========================================
-# Handles all Real grid types (Int, Float32, Float64, etc.)
-# Type promotion done here, then forwards to typed ConstantInterpolant constructor.
-#
-# PERFORMANCE: Typed signature enables compile-time specialization.
-# _promote_itp_inputs becomes no-op when types already match (Float64 → Float64).
+# Selection kernel → raw eltype contract (Int in → Int out). Signature
+# parametrized directly on `{Tg, Tv}` — no `_promote_grid_float` indirection.
 @inline function constant_interp(
-        x::AbstractVector{TX},
-        y::AbstractVector{TY};
+        x::AbstractVector{Tg},
+        y::AbstractVector{Tv};
         bc::AbstractBC = NoBC(),
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
         search::AbstractSearchPolicy = AutoSearch()
-    ) where {TX, TY}
-    # Selection kernel → raw eltype contract.
-    Tg = TX
+    ) where {Tg, Tv}
     x_eff = _cache_axis(x, bc, Tg)
     y_eff = _resolve_data(y, bc)
     extrap_eff = _resolve_extrap(extrap, bc, x_eff, y_eff)
-    extrap_p = _promote_extrap(extrap_eff, TY)
+    extrap_p = _promote_extrap(extrap_eff, Tv)
     return ConstantInterpolant(x_eff, y_eff, extrap_p, side, search; bc = bc)
 end

--- a/src/constant/constant_interpolant.jl
+++ b/src/constant/constant_interpolant.jl
@@ -21,49 +21,14 @@ end
 end
 
 # ========================================
-# Callable Overrides — selection-kernel output type
+# Selection-kernel output eltype trait
 # ========================================
-# The shared 1D protocol allocates `Vector{_output_eltype(Tv, Tg, Tq)}` which
-# widens Tv via promote_type. That's correct for arithmetic kernels (Linear,
-# Cubic, …) but violates Constant's raw-Tv contract — `itp([0.5])` would
-# return `Vector{Float64}` while `itp(0.5)` and the oneshot return raw `Tv`.
-#
-# These overrides keep raw `Tv` for plain numeric queries (`_PromotableValue`)
-# and widen only for duck-typed queries (Dual, Measurement, …) so AD carriers
-# round-trip without being stripped. Scalar / 1D-batch / ND-batch share the
-# same rule for consistency with the oneshot family in `constant_oneshot.jl`.
-
-@inline _constant_out_eltype(::Type{Tv}, ::Type{Tq}) where {Tv, Tq} =
+# Override the shared `_output_eltype(itp, Tq)` trait so the protocol's scalar
+# + batch callables keep raw `Tv` for plain numeric queries (selection kernel)
+# and only widen for duck-typed queries (Dual, …) so AD carriers round-trip.
+# Single source of truth — no callable overrides needed.
+@inline _output_eltype(::ConstantInterpolant{Tg, Tv}, ::Type{Tq}) where {Tg, Tv, Tq} =
     Tq <: _PromotableValue ? Tv : promote_type(Tv, Tq)
-
-@inline function (itp::ConstantInterpolant{Tg, Tv})(
-        xq::Tq;
-        deriv::DerivOp = EvalValue(),
-        search::AbstractSearchPolicy = _itp_search(itp),
-        hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg, Tv, Tq <: Real}
-    grid = _itp_grid(itp)
-    extrap = _itp_extrap(itp)
-    @boundscheck _check_domain(grid, xq, extrap)
-    searcher = _resolve_search(grid, xq, search, hint)
-    val = _constant_eval_at_point(itp.x, itp.y, xq, extrap, itp.side, deriv, searcher)
-    return convert(_constant_out_eltype(Tv, Tq), val)
-end
-
-function (itp::ConstantInterpolant{Tg, Tv})(
-        xq::AbstractVector{Tq};
-        deriv::DerivOp = EvalValue(),
-        search::AbstractSearchPolicy = _itp_search(itp),
-        hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg, Tv, Tq <: Real}
-    grid = _itp_grid(itp)
-    extrap = _itp_extrap(itp)
-    T_out = _constant_out_eltype(Tv, Tq)
-    output = Vector{T_out}(undef, length(xq))
-    searcher = _resolve_search(grid, xq, search, hint)
-    _itp_vector_loop!(output, itp, xq, extrap, deriv, searcher)
-    return output
-end
 
 # ─────────────────────────────────────────────────────────────
 # Vector loop (function barrier)

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -257,8 +257,9 @@ sorted_queries = sort(rand(1000))
 vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_window=8))
 ```
 """
-# Unified allocating vector one-shot. Output eltype = `eltype(y)` (raw Tv,
-# Tg not promoted into output).
+# Unified allocating vector one-shot. Output eltype = `eltype(y)` for plain
+# numeric queries (raw Tv contract); widens to `promote_type(Tv, Tq)` for
+# duck-typed queries (Dual, Measurement, …) so AD carriers aren't stripped.
 function constant_interp(
         x::AbstractVector,
         y::AbstractVector,
@@ -269,7 +270,9 @@ function constant_interp(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
     )
-    T_out = eltype(y)
+    Tv = eltype(y)
+    Tq = eltype(x_targets)
+    T_out = Tq <: _PromotableValue ? Tv : promote_type(Tv, Tq)
     output = Vector{T_out}(undef, length(x_targets))
     constant_interp!(output, x, y, x_targets; bc, extrap, side, deriv, search)
     return output

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -138,7 +138,8 @@ Constant (step/piecewise constant) interpolation at a single point.
   - `LinearBinarySearch(linear_window=8)`: Linear search within window, then binary fallback
 
 # Returns
-- Interpolated value (Float type)
+- Interpolated value, eltype `eltype(y)` (raw Tv; widens to `promote_type(Tv, Tq)`
+  only for duck-typed queries).
 
 # Example
 ```julia
@@ -158,7 +159,7 @@ vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_wi
 """
 # Public scalar one-shot API.
 # Zero-alloc: _prepare_grid returns Vector as-is, Range → _CachedRange (stack).
-# Kernel arithmetic auto-promotes Int×Float via _get_h float() wrappers.
+# Selection kernel (no `inv_h * dL` arithmetic) — raw Int grids pass through.
 @inline function constant_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
@@ -210,8 +211,8 @@ output = zeros(1000)
 constant_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear_window=8))
 ```
 """
-# Unified in-place entry point. Handles promotion internally via _promote_itp_inputs,
-# so no separate Real/Mixed-type wrapper is needed (same pattern as the scalar API).
+# Unified in-place entry. Resolvers normalize inputs; selection kernel
+# preserves `eltype(y)`. No Real/Mixed wrapper needed.
 function constant_interp!(
         output::AbstractVector,
         x::AbstractVector,
@@ -256,8 +257,8 @@ sorted_queries = sort(rand(1000))
 vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_window=8))
 ```
 """
-# Unified allocating vector one-shot. Calls the unified constant_interp! which
-# handles promotion internally. Output type includes Tg for duck grids.
+# Unified allocating vector one-shot. Output eltype = `eltype(y)` (raw Tv,
+# Tg not promoted into output).
 function constant_interp(
         x::AbstractVector,
         y::AbstractVector,

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -178,9 +178,7 @@ vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_wi
     y_eff = _resolve_data(y, bc)
     extrap_eff = _resolve_extrap(extrap, bc, x_eff, y_eff)
     searcher = _resolve_search(x_eff, xi, search, hint, NoBC())
-    result = _constant_eval_at_point(x_eff, y_eff, xi, extrap_eff, side, deriv, searcher)
-    # Single-exit coerce: Int/Rational y returns y[idx] directly; promote to Float.
-    return Tv <: _PromotableValue && !(Tv <: AbstractFloat) ? float(result) : result
+    return _constant_eval_at_point(x_eff, y_eff, xi, extrap_eff, side, deriv, searcher)
 end
 
 # ========================================
@@ -270,8 +268,7 @@ function constant_interp(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
     )
-    Tg = _promote_grid_float(eltype(x), eltype(y))
-    T_out = _output_eltype(eltype(y), Tg)
+    T_out = eltype(y)
     output = Vector{T_out}(undef, length(x_targets))
     constant_interp!(output, x, y, x_targets; bc, extrap, side, deriv, search)
     return output

--- a/src/constant/constant_oneshot_series.jl
+++ b/src/constant/constant_oneshot_series.jl
@@ -207,8 +207,3 @@ function constant_interp(
     constant_interp!(outputs, x, s, xqs; bc, side, extrap, deriv, search)
     return outputs
 end
-
-# NOTE: the former Real type promotion wrappers (Tg <: Real) have been removed.
-# The hot-path methods above now use unconstrained Tg, and _to_float handles
-# grid normalization for all types (Int, Float, Dual, etc.), preventing
-# infinite recursion on duck types like ForwardDiff.Dual <: Real.

--- a/src/constant/constant_oneshot_series.jl
+++ b/src/constant/constant_oneshot_series.jl
@@ -77,7 +77,7 @@ end
     _validate_series_lengths(s, length(x))
     x = _to_float(x, Tg)
     K = n_series(s)
-    Tv_out = _value_type(_series_eltype(s), Tg)
+    Tv_out = _series_eltype(s)
     output = Vector{Tv_out}(undef, K)
     if _is_periodic_bc(bc)
         searcher = _resolve_search(x, xq, search, hint, bc)
@@ -202,7 +202,7 @@ function constant_interp(
         search::AbstractSearchPolicy = AutoSearch()
     ) where {Tg, Tq <: Real}
     K = n_series(s)
-    Tv_out = _value_type(_series_eltype(s), Tg)
+    Tv_out = _series_eltype(s)
     outputs = [Vector{Tv_out}(undef, length(xqs)) for _ in 1:K]
     constant_interp!(outputs, x, s, xqs; bc, side, extrap, deriv, search)
     return outputs

--- a/src/constant/constant_oneshot_series.jl
+++ b/src/constant/constant_oneshot_series.jl
@@ -77,7 +77,10 @@ end
     _validate_series_lengths(s, length(x))
     x = _to_float(x, Tg)
     K = n_series(s)
-    Tv_out = _series_eltype(s)
+    Tv = _series_eltype(s)
+    # Duck-typed queries (Dual, …) widen to keep AD carrier; plain queries
+    # preserve raw Tv. Mirrors ConstantSeriesInterpolant scalar callable.
+    Tv_out = Tq <: _PromotableValue ? Tv : promote_type(Tv, Tq)
     output = Vector{Tv_out}(undef, K)
     if _is_periodic_bc(bc)
         searcher = _resolve_search(x, xq, search, hint, bc)
@@ -202,7 +205,9 @@ function constant_interp(
         search::AbstractSearchPolicy = AutoSearch()
     ) where {Tg, Tq <: Real}
     K = n_series(s)
-    Tv_out = _series_eltype(s)
+    Tv = _series_eltype(s)
+    # Same Tv_out rule as the scalar series oneshot — duck queries widen.
+    Tv_out = Tq <: _PromotableValue ? Tv : promote_type(Tv, Tq)
     outputs = [Vector{Tv_out}(undef, length(xqs)) for _ in 1:K]
     constant_interp!(outputs, x, s, xqs; bc, side, extrap, deriv, search)
     return outputs

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -348,15 +348,8 @@ function constant_interp(
         extrap::AbstractExtrap = NoExtrap(),
         search::AbstractSearchPolicy = AutoSearch()
     ) where {Tg}
-    # Type promotion: widen grid if y's float base is wider than Tg
-    Tv = _series_eltype(s)
-    Tg_new = _promote_grid_float(Tg, Tv)
-    if Tg_new !== Tg
-        return constant_interp(_to_float(x, Tg_new), s; bc, side, extrap, search)
-    end
-
+    Tv_out = _series_eltype(s)
     n_pts = length(x)
-    Tv_out = _value_type(Tv, Tg)
     y_mat, _ = _build_series_mat(s, n_pts, Tv_out)
 
     # Periodic path: extend x + y_mat to `:inclusive` form, normalize BC label

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -402,7 +402,12 @@ function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, P, Tq <: Real}
-    T_out = _series_output_type(Tv, Tq)
+    # Selection kernel returns `y[idx]::Tv` — Tv flows through unchanged for
+    # plain numerical queries. Duck-typed queries (Dual, …) get the legacy
+    # `promote_type(Tv, Tq)` widening so AD callers keep their input-Dual →
+    # output-Dual API contract (the partial wrt xq is 0 for constant, but the
+    # carrier type must match).
+    T_out = Tq <: _PromotableValue ? Tv : promote_type(Tv, Tq)
     out = Vector{T_out}(undef, n_series(sitp))
     return sitp(out, xq; deriv = deriv, search = search, hint = hint)
 end

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -393,8 +393,8 @@ Returns a vector of values, one per y-series.
 - `deriv=DerivOp(1),DerivOp(2)`: Returns zeros (step function derivative is zero everywhere)
 
 # AD Support
-When `xq` is a ForwardDiff.Dual, the output type is promoted to preserve
-derivatives. Output type is `promote_type(Tv, Tq)`.
+Plain queries (`Tq <: _PromotableValue`) → output eltype `Tv` unchanged.
+Duck-typed queries (e.g. `ForwardDiff.Dual`) widen to `promote_type(Tv, Tq)`.
 """
 function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
         xq::Tq;

--- a/src/constant/constant_types.jl
+++ b/src/constant/constant_types.jl
@@ -60,17 +60,16 @@ struct ConstantInterpolant{Tg, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{
     side::SD         # Side selection (compile-time specialized)
     search_policy::P  # Default search policy (immutable, thread-safe)
 
-    # Inner: `_cache_axis` (insurance) then `_convert_copy` for ownership +
-    # eltype promotion. `bc` kwarg lets direct-ctor callers request periodic.
+    # Inner: `_cache_axis` (insurance) then `_convert_copy` for ownership.
+    # `{Tg, Tv}` parametrized directly — selection kernel → raw eltype
+    # contract (Int in → Int out), unlike arithmetic methods that thread
+    # `_promote_grid_float(TX, TY)` through here.
     function ConstantInterpolant(
-            x::AbstractVector, y::AbstractVector, ev::E, sv::SD, search::P;
+            x::AbstractVector{Tg}, y::AbstractVector{Tv}, ev::E, sv::SD, search::P;
             bc::AbstractBC = NoBC()
-        ) where {E <: AbstractExtrap, SD <: AbstractSide, P <: AbstractSearchPolicy}
+        ) where {Tg, Tv, E <: AbstractExtrap, SD <: AbstractSide, P <: AbstractSearchPolicy}
         _check_compatible_length(x, y)
         length(x) >= 2 || _throw_grid_too_small(length(x))
-        # Selection kernel → raw eltype contract (Int in → Int out).
-        Tg = eltype(x)
-        Tv = eltype(y)
         xc = _convert_copy(_cache_axis(x, bc, Tg), Tg)
         yc = _convert_copy(y, Tv)
         return new{Tg, Tv, typeof(xc), typeof(yc), E, SD, P}(xc, yc, ev, sv, search)
@@ -80,14 +79,13 @@ end
 # Outer constructor: convenience kwarg wrapper. Wraps the axis here so the
 # inner ctor's `_cache_axis` insurance is an idempotent passthrough.
 @inline function ConstantInterpolant(
-        x::AbstractVector,
+        x::AbstractVector{Tg},
         y::AbstractVector;
         bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         side::AbstractSide = NearestSide(),
         search::AbstractSearchPolicy = AutoSearch()
-    )
-    Tg = eltype(x)
+    ) where {Tg}
     x_eff = _cache_axis(x, bc, Tg)
     return ConstantInterpolant(x_eff, y, extrap, side, search; bc = bc)
 end

--- a/src/constant/constant_types.jl
+++ b/src/constant/constant_types.jl
@@ -68,8 +68,9 @@ struct ConstantInterpolant{Tg, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{
         ) where {E <: AbstractExtrap, SD <: AbstractSide, P <: AbstractSearchPolicy}
         _check_compatible_length(x, y)
         length(x) >= 2 || _throw_grid_too_small(length(x))
-        Tg = _promote_grid_float(eltype(x), eltype(y))
-        Tv = _value_type(eltype(y), Tg)
+        # Selection kernel → raw eltype contract (Int in → Int out).
+        Tg = eltype(x)
+        Tv = eltype(y)
         xc = _convert_copy(_cache_axis(x, bc, Tg), Tg)
         yc = _convert_copy(y, Tv)
         return new{Tg, Tv, typeof(xc), typeof(yc), E, SD, P}(xc, yc, ev, sv, search)
@@ -86,7 +87,7 @@ end
         side::AbstractSide = NearestSide(),
         search::AbstractSearchPolicy = AutoSearch()
     )
-    Tg = _promote_grid_float(eltype(x), eltype(y))
+    Tg = eltype(x)
     x_eff = _cache_axis(x, bc, Tg)
     return ConstantInterpolant(x_eff, y, extrap, side, search; bc = bc)
 end

--- a/src/constant/constant_types.jl
+++ b/src/constant/constant_types.jl
@@ -14,7 +14,7 @@ Returned by `constant_interp(x, y)` (2-argument form).
 # Type Parameters
 - `Tg`: Grid type (unconstrained) for x-coordinates
 - `Tv`: Value type (unconstrained)
-- `X<:AbstractVector{Tg}`: Grid vector type — `_CachedRange{Tg}` for Range
+- `X<:AbstractVector{Tg}`: Grid vector type — `_CachedRange{Tg,Tinv}` for Range
         input, `_CachedVector{Tg,Tinv}` for Vector input,
         `_ExclusivePeriodicAxis` for Vector + `:exclusive` PeriodicBC.
 - `Y<:AbstractVector{Tv}`: y values — plain `Vector{Tv}` for non-periodic,

--- a/src/constant/nd/constant_nd_adjoint.jl
+++ b/src/constant/nd/constant_nd_adjoint.jl
@@ -42,11 +42,13 @@ function _bake_constant_nd_anchors(
     _query_validate(queries)
     _validate_nd_domain(grids, queries, extraps)
 
-    anchors = Vector{NTuple{N, _ConstantAnchoredQuery{Tg, Tg}}}(undef, nq)
+    # Tq widens to query precision so narrower grids never truncate.
+    Tq = promote_type(Tg, _query_eltype(queries))
+    anchors = Vector{NTuple{N, _ConstantAnchoredQuery{Tg, Tq}}}(undef, nq)
     @inbounds for q in 1:nq
         query_q = _extract_query_point(queries, q, Val(N))
         per_axis = ntuple(Val(N)) do d
-            xq_raw = Tg(query_q[d])
+            xq_raw = Tq(query_q[d])
             xq_d = _extrap_axis(xq_raw, grids[d], extraps[d])
             idx, idxR, xL, _ = search_interval(DEFAULT_SEARCHER, grids[d], xq_d)
             h = _get_h(grids[d], idx)
@@ -60,7 +62,7 @@ function _bake_constant_nd_anchors(
                 IN_DOMAIN
             end
 
-            return _ConstantAnchoredQuery{Tg, Tg}(_IdxPair(idx, idxR), xq_d, state_flag, h, dL)
+            return _ConstantAnchoredQuery{Tg, Tq}(_IdxPair(idx, idxR), xq_d, state_flag, h, dL)
         end
         anchors[q] = per_axis
     end
@@ -79,9 +81,9 @@ Uses `_compute_single_offset` per axis — matches the ND forward kernel exactly
 (no right-boundary special case, unlike the 1D path).
 """
 @inline function _constant_nd_target(
-        per_axis::NTuple{N, _ConstantAnchoredQuery{Tg, Tg}},
+        per_axis::NTuple{N, _ConstantAnchoredQuery},
         sides::Tuple{Vararg{AbstractSide, N}}
-    ) where {N, Tg}
+    ) where {N}
     return ntuple(Val(N)) do d
         aq = per_axis[d]
         aq.idxL + _compute_single_offset(sides[d], aq.h, aq.dL)
@@ -117,10 +119,10 @@ end
 # Scalar y_bar: single query, direct scatter
 function _constant_adjoint_nd_apply!(
         f_bar::AbstractArray{Tv, N},
-        adj::ConstantAdjointND{Tg, N},
+        adj::ConstantAdjointND,
         y_bar::Real,
         ops::NTuple{N, AbstractEvalOp}
-    ) where {Tv, Tg, N}
+    ) where {Tv, N}
     _has_any_derivative(ops, Val(N)) && return nothing
     @inbounds begin
         per_axis = adj.anchors[1]
@@ -134,10 +136,10 @@ end
 # Vector/Tuple y_bar: loop over elements
 function _constant_adjoint_nd_apply!(
         f_bar::AbstractArray{Tv, N},
-        adj::ConstantAdjointND{Tg, N},
+        adj::ConstantAdjointND,
         y_bar,
         ops::NTuple{N, AbstractEvalOp}
-    ) where {Tv, Tg, N}
+    ) where {Tv, N}
     # Any derivative → f_bar stays zero (already zero-filled by caller)
     _has_any_derivative(ops, Val(N)) && return nothing
 

--- a/src/constant/nd/constant_nd_adjoint.jl
+++ b/src/constant/nd/constant_nd_adjoint.jl
@@ -81,9 +81,9 @@ Uses `_compute_single_offset` per axis — matches the ND forward kernel exactly
 (no right-boundary special case, unlike the 1D path).
 """
 @inline function _constant_nd_target(
-        per_axis::NTuple{N, _ConstantAnchoredQuery},
+        per_axis::NTuple{N, _ConstantAnchoredQuery{Tg, Tq}},
         sides::Tuple{Vararg{AbstractSide, N}}
-    ) where {N}
+    ) where {N, Tg, Tq}
     return ntuple(Val(N)) do d
         aq = per_axis[d]
         aq.idxL + _compute_single_offset(sides[d], aq.h, aq.dL)

--- a/src/constant/nd/constant_nd_adjoint.jl
+++ b/src/constant/nd/constant_nd_adjoint.jl
@@ -238,8 +238,8 @@ end
 @inline function _constant_adjoint_dispatch(
         grids::NTuple{N, AbstractVector}, queries, bc, side, extrap
     ) where {N}
+    # Selection-kernel adjoint: raw eltype contract (no `float()` widening).
     Tg = _promote_grid_eltype(grids)
-    Tg = float(Tg)
     grids_typed = _convert_grids_typed(grids, Tg)
 
     bcs = _resolve_bcs_nd(bc, Val(N))

--- a/src/constant/nd/constant_nd_adjoint_types.jl
+++ b/src/constant/nd/constant_nd_adjoint_types.jl
@@ -16,7 +16,7 @@
 # ========================================
 
 """
-    ConstantAdjointND{Tg, N, G, B, EP, SD}
+    ConstantAdjointND{Tg, N, G, B, EP, SD, Tq}
 
 Adjoint (transpose) operator for N-dimensional constant interpolation.
 Computes `f̄ = Wᵀȳ` where `W` is the forward ND constant interpolation weight matrix.
@@ -55,25 +55,26 @@ struct ConstantAdjointND{
         B <: NTuple{N, AbstractBC},
         EP <: Tuple{Vararg{AbstractExtrap, N}},
         SD <: Tuple{Vararg{AbstractSide, N}},
+        Tq,
     } <: AbstractAdjointND{Tg, N}
     grids::G
     bcs::B
     extraps::EP
     sides::SD
-    anchors::Vector{NTuple{N, _ConstantAnchoredQuery{Tg, Tg}}}
+    anchors::Vector{NTuple{N, _ConstantAnchoredQuery{Tg, Tq}}}
     grid_size::NTuple{N, Int}
 
     # Inner ctor: ownership copy via wrapper-aware `_convert_copy`,
     # idempotent `_cache_axis` insurance for direct ctor calls.
     function ConstantAdjointND(
             grids::Tuple{Vararg{AbstractVector{Tg}, N}}, bcs::B, extraps::EP, sides::SD,
-            anchors::Vector{NTuple{N, _ConstantAnchoredQuery{Tg, Tg}}}, grid_size::NTuple{N, Int}
+            anchors::Vector{NTuple{N, _ConstantAnchoredQuery{Tg, Tq}}}, grid_size::NTuple{N, Int}
         ) where {
             Tg, N, B <: NTuple{N, AbstractBC},
-            EP <: Tuple{Vararg{AbstractExtrap, N}}, SD <: Tuple{Vararg{AbstractSide, N}},
+            EP <: Tuple{Vararg{AbstractExtrap, N}}, SD <: Tuple{Vararg{AbstractSide, N}}, Tq,
         }
         grids_c = map((g, bc) -> _convert_copy(_cache_axis(g, bc, Tg), Tg), grids, bcs)
-        return new{Tg, N, typeof(grids_c), B, EP, SD}(grids_c, bcs, extraps, sides, anchors, grid_size)
+        return new{Tg, N, typeof(grids_c), B, EP, SD, Tq}(grids_c, bcs, extraps, sides, anchors, grid_size)
     end
 end
 
@@ -96,7 +97,7 @@ end
 # Type Introspection
 # ========================================
 
-Base.ndims(::ConstantAdjointND{Tg, N}) where {Tg, N} = N + 1
+Base.ndims(adj::ConstantAdjointND) = length(adj.grid_size) + 1
 function Base.size(adj::ConstantAdjointND)
     out_size = _adjoint_output_size(adj)
     return (out_size..., _n_queries(adj))

--- a/src/constant/nd/constant_nd_eval.jl
+++ b/src/constant/nd/constant_nd_eval.jl
@@ -9,10 +9,9 @@
 # Callable Interface
 # ========================================
 
-# Scalar tuple query
-# Output: raw `Tv` for plain numeric queries (selection kernel contract);
-# widens via `_constant_out_eltype` for duck queries so the Dual / Measurement
-# carrier round-trips without being stripped.
+# Scalar tuple query — wraps the selection-kernel value in `convert` against
+# the `_output_eltype(itp, Tq)` trait so plain numeric queries keep raw `Tv`
+# while duck-typed queries (Dual, …) get their carrier preserved.
 @inline function (itp::ConstantInterpolantND{Tg, Tv, N})(
         query::Tuple{Vararg{Real, N}};
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
@@ -26,23 +25,12 @@
     mono = _scalar_mono(hint, Val(N))
     val = _eval_constant_nd(itp, resolved, ops, policies, hints, mono)
     Tq = promote_type(map(typeof, query)...)
-    return convert(_constant_out_eltype(Tv, Tq), val)
+    return convert(_output_eltype(itp, Tq), val)
 end
 
-# Allocating batch — override the shared protocol's `_output_eltype(Tv,Tg,Tq)`
-# widening to keep raw `Tv` for plain numeric queries. In-place batch
-# (`itp(output, queries)`) stays on the inherited protocol path.
-function (itp::ConstantInterpolantND{Tg, Tv, N})(
-        queries;
-        deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
-        search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
-        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
-    ) where {Tg, Tv, N}
-    Tq = _query_eltype(queries)
-    T_out = _constant_out_eltype(Tv, Tq)
-    output = Vector{T_out}(undef, _query_length(queries))
-    return itp(output, queries; deriv = deriv, search = search, hint = hint)
-end
+# In-place + allocating batch use the inherited `AbstractInterpolantND`
+# protocol; output eltype comes from the `_output_eltype(itp, Tq)` trait
+# overridden in `constant_nd_types.jl`.
 
 # Zero-fill for any derivative is handled by _deriv_zero_fill trait below.
 

--- a/src/constant/nd/constant_nd_eval.jl
+++ b/src/constant/nd/constant_nd_eval.jl
@@ -10,6 +10,9 @@
 # ========================================
 
 # Scalar tuple query
+# Output: raw `Tv` for plain numeric queries (selection kernel contract);
+# widens via `_constant_out_eltype` for duck queries so the Dual / Measurement
+# carrier round-trips without being stripped.
 @inline function (itp::ConstantInterpolantND{Tg, Tv, N})(
         query::Tuple{Vararg{Real, N}};
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
@@ -21,11 +24,26 @@
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
     mono = _scalar_mono(hint, Val(N))
-    return _eval_constant_nd(itp, resolved, ops, policies, hints, mono)
+    val = _eval_constant_nd(itp, resolved, ops, policies, hints, mono)
+    Tq = promote_type(map(typeof, query)...)
+    return convert(_constant_out_eltype(Tv, Tq), val)
 end
 
-# In-place batch evaluation (SoA + AoS) is handled by the unified
-# AbstractInterpolantND callable in nd_interpolant_protocol.jl.
+# Allocating batch — override the shared protocol's `_output_eltype(Tv,Tg,Tq)`
+# widening to keep raw `Tv` for plain numeric queries. In-place batch
+# (`itp(output, queries)`) stays on the inherited protocol path.
+function (itp::ConstantInterpolantND{Tg, Tv, N})(
+        queries;
+        deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
+        search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
+    ) where {Tg, Tv, N}
+    Tq = _query_eltype(queries)
+    T_out = _constant_out_eltype(Tv, Tq)
+    output = Vector{T_out}(undef, _query_length(queries))
+    return itp(output, queries; deriv = deriv, search = search, hint = hint)
+end
+
 # Zero-fill for any derivative is handled by _deriv_zero_fill trait below.
 
 # Derivative zero-fill trait: constant has zero derivative at all orders

--- a/src/constant/nd/constant_nd_interpolant.jl
+++ b/src/constant/nd/constant_nd_interpolant.jl
@@ -57,9 +57,11 @@ function constant_interp(
     # Validate grid dimensions
     _validate_nd_grids(grids, data)
 
-    # Promote grid/data types
-    grids_typed, _, Tv, _ = _nd_promote_grids(grids, data)
-    data_typed = Tv === Tv_raw ? data : Tv.(data)
+    # Selection kernel → raw eltype contract (Int in → Int out), N-axis
+    # generalization of the 1D policy: `Tg = promote_type(eltype.(grids)...)`
+    # without Float widening, `Tv = eltype(data)`.
+    grids_typed, _, Tv = _nd_promote_grids_raw(grids, data)
+    data_typed = data
 
     # Resolve per-axis configuration
     bcs = _resolve_bcs_nd(bc, Val(N))

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -148,7 +148,7 @@ function constant_interp(
         return 0 * first(data)
     end
 
-    grids_typed, _, _, _ = _nd_promote_grids(grids, data)
+    grids_typed, _, _ = _nd_promote_grids_raw(grids, data)
     _validate_nd_grids(grids_typed, data)
 
     bcs = _resolve_bcs_nd(bc, Val(N))
@@ -183,7 +183,7 @@ function constant_interp(
         return zeros(Tv, _query_length(queries))
     end
 
-    grids_typed, _, _, _ = _nd_promote_grids(grids, data)
+    grids_typed, _, _ = _nd_promote_grids_raw(grids, data)
     _validate_nd_grids(grids_typed, data)
 
     bcs = _resolve_bcs_nd(bc, Val(N))
@@ -226,7 +226,7 @@ function constant_interp!(
         return output
     end
 
-    grids_typed, _, _, _ = _nd_promote_grids(grids, data)
+    grids_typed, _, _ = _nd_promote_grids_raw(grids, data)
     _validate_nd_grids(grids_typed, data)
 
     bcs = _resolve_bcs_nd(bc, Val(N))

--- a/src/constant/nd/constant_nd_types.jl
+++ b/src/constant/nd/constant_nd_types.jl
@@ -79,3 +79,9 @@ end
 # Type introspection
 @inline grid_type(::ConstantInterpolantND{Tg}) where {Tg} = Tg
 @inline value_type(::ConstantInterpolantND{Tg, Tv}) where {Tg, Tv} = Tv
+
+# Selection-kernel output eltype trait — raw `Tv` for plain queries, widen
+# only for duck queries (Dual, Measurement, …). Mirrors the 1D override in
+# `constant_interpolant.jl`.
+@inline _output_eltype(::ConstantInterpolantND{Tg, Tv, N}, ::Type{Tq}) where {Tg, Tv, N, Tq} =
+    Tq <: _PromotableValue ? Tv : promote_type(Tv, Tq)

--- a/src/core/cached_range.jl
+++ b/src/core/cached_range.jl
@@ -21,11 +21,8 @@ All `AbstractRange` inputs are normalized to `_CachedRange` via `_to_float` at p
 API boundaries. This means downstream code only needs to handle two grid types:
 `_CachedRange{T,Tinv}` (uniform) and `Vector{T}` (non-uniform).
 
-`Tinv == typeof(inv(oneunit(T)))`. For `T <: AbstractFloat`, `Tinv == T` and the
-struct is byte-identical to the historical single-parameter form. For raw `T = Int`
-(e.g., `constant_interp(0:10, ::Vector{Int})` — see Phase 1 of the eltype refactor),
-`Tinv = Float64` while `h` and the other geometry fields stay `Int`. Mirrors the
-`_CachedVector{T, Tinv}` pattern in `cached_vector.jl`.
+`Tinv == typeof(inv(oneunit(T)))` — equals `T` for `T <: AbstractFloat`, equals
+`Float64` for raw `T = Int`. Mirrors `_CachedVector{T, Tinv}`.
 
 # Fields
 - `lo::T`        — `first(x)`, cached as plain `T` (used for index computation)

--- a/src/core/cached_range.jl
+++ b/src/core/cached_range.jl
@@ -155,13 +155,13 @@ function _to_float(x::_CachedRange, ::Type{T}) where {T}
 end
 
 """
-    _to_float_adding_endpoint(x::AbstractRange, ::Type{FT}) -> _CachedRange{FT}
+    _to_float_adding_endpoint(x::AbstractRange, ::Type{FT}) -> _CachedRange{FT, Tinv}
 
 Extend `x` by one step (for exclusive periodic grids: length n → n+1),
-converting to `_CachedRange{FT}`.
+converting to `_CachedRange{FT, Tinv}` (`Tinv = typeof(inv(oneunit(FT)))`).
 
 Dispatch:
-- `_CachedRange{FT}`: pure field copy + one addition — zero recomputation
+- `_CachedRange{FT, Tinv}`: pure field copy + one addition — zero recomputation
 - Other `AbstractRange` (OrdinalRange, StepRangeLen, LinRange, ...): convert + extend
 """
 # domain_hi = hi_new (exact): the extension uses cached plain-T fields only

--- a/src/core/cached_range.jl
+++ b/src/core/cached_range.jl
@@ -2,29 +2,37 @@
 # _CachedRange: Normalized AbstractRange
 # ========================================
 #
-# All AbstractRange inputs are normalized to _CachedRange{T} at system boundaries
+# All AbstractRange inputs are normalized to _CachedRange{T,Tinv} at system boundaries
 # (via `_to_float`). After normalization, the grid type space is exactly
-# {_CachedRange{T}, Vector{T}} — eliminating downstream dispatch explosion.
+# {_CachedRange{T,Tinv}, Vector{T}} — eliminating downstream dispatch explosion.
+# `Tinv = typeof(inv(oneunit(T)))` — equals `T` for `T <: AbstractFloat`, equals
+# `Float64` for `T = Int` (mirrors the `_CachedVector{T, Tinv}` shape).
 #
 # Include order: grid_spacing.jl → cached_range.jl → search.jl → utils.jl
 
 """
-    _CachedRange{T} <: AbstractRange{T}
+    _CachedRange{T, Tinv} <: AbstractRange{T}
 
 `AbstractRange` subtype that pre-caches `first`, `last`, `step`, and `inv(step)` as
-plain `T` fields, enabling multiply-instead-of-divide search and avoiding
+plain `T`/`Tinv` fields, enabling multiply-instead-of-divide search and avoiding
 TwicePrecision dispatch overhead.
 
 All `AbstractRange` inputs are normalized to `_CachedRange` via `_to_float` at public
 API boundaries. This means downstream code only needs to handle two grid types:
-`_CachedRange{T}` (uniform) and `Vector{T}` (non-uniform).
+`_CachedRange{T,Tinv}` (uniform) and `Vector{T}` (non-uniform).
+
+`Tinv == typeof(inv(oneunit(T)))`. For `T <: AbstractFloat`, `Tinv == T` and the
+struct is byte-identical to the historical single-parameter form. For raw `T = Int`
+(e.g., `constant_interp(0:10, ::Vector{Int})` — see Phase 1 of the eltype refactor),
+`Tinv = Float64` while `h` and the other geometry fields stay `Int`. Mirrors the
+`_CachedVector{T, Tinv}` pattern in `cached_vector.jl`.
 
 # Fields
-- `lo::T`       — `first(x)`, cached as plain `T` (used for index computation)
-- `hi::T`       — `last(x)`, cached as plain `T` (used for index computation)
-- `h::T`        — `step(x)`, cached as plain `T`
-- `inv_h::T`    — precomputed `1/step(x)`, enables multiply-not-divide in `_search_direct`
-- `len::Int`    — `length(x)`
+- `lo::T`        — `first(x)`, cached as plain `T` (used for index computation)
+- `hi::T`        — `last(x)`, cached as plain `T` (used for index computation)
+- `h::T`         — `step(x)`, cached as plain `T`
+- `inv_h::Tinv`  — precomputed `1/step(x)`, enables multiply-not-divide in `_search_direct`
+- `len::Int`     — `length(x)`
 - `domain_lo::T` — safe lower bound for domain checks (≤ lo, prevents false DomainError)
 - `domain_hi::T` — safe upper bound for domain checks (≥ hi, prevents false DomainError)
 
@@ -36,19 +44,19 @@ Because `_CachedRange <: AbstractRange`, all existing `AbstractRange` dispatch
 (DirectSearch routing, `_resolve_search_policy`, `search_interval`, etc.) propagates
 automatically without any changes at call sites.
 """
-struct _CachedRange{T} <: AbstractRange{T}
+struct _CachedRange{T, Tinv} <: AbstractRange{T}
     lo::T
     hi::T
     h::T
-    inv_h::T
+    inv_h::Tinv
     len::Int
     domain_lo::T
     domain_hi::T
 end
 
 # Exact constructor: domain_lo == lo, domain_hi == hi (default for non-TwicePrecision paths)
-@inline function _CachedRange{T}(lo::T, hi::T, h::T, inv_h::T, len::Int) where {T}
-    return _CachedRange{T}(lo, hi, h, inv_h, len, lo, hi)
+@inline function _CachedRange{T, Tinv}(lo::T, hi::T, h::T, inv_h::Tinv, len::Int) where {T, Tinv}
+    return _CachedRange{T, Tinv}(lo, hi, h, inv_h, len, lo, hi)
 end
 
 # Convenience: construct from any AbstractRange{T}, using its own eltype.
@@ -78,12 +86,12 @@ end
 # Without this method, any code that windows or slices a `_CachedRange` (e.g. the
 # Hermite ND cell-local OnTheFly path in hetero_eval.jl) would silently degrade
 # its grid to a non-range type.
-@inline function Base.getindex(r::_CachedRange{T}, idx::AbstractUnitRange{<:Integer}) where {T}
+@inline function Base.getindex(r::_CachedRange{T, Tinv}, idx::AbstractUnitRange{<:Integer}) where {T, Tinv}
     @boundscheck checkbounds(r, idx)
     new_len = length(idx)
     # Empty slice: return a length-0 _CachedRange anchored at r.lo (callers that
     # would dereference this hit the same checkbounds wall they would on r itself).
-    new_len == 0 && return _CachedRange{T}(r.lo, r.lo, r.h, r.inv_h, 0)
+    new_len == 0 && return _CachedRange{T, Tinv}(r.lo, r.lo, r.h, r.inv_h, 0)
     i_lo = Int(first(idx))
     i_hi = Int(last(idx))
     # Reuse cached endpoints when the slice touches them — preserves the exact-bit
@@ -91,7 +99,7 @@ end
     # any downstream Tg-precision comparison stable.
     new_lo = i_lo == 1 ? r.lo : muladd(i_lo - 1, r.h, r.lo)
     new_hi = i_hi == r.len ? r.hi : muladd(i_hi - 1, r.h, r.lo)
-    return _CachedRange{T}(new_lo, new_hi, r.h, r.inv_h, new_len)
+    return _CachedRange{T, Tinv}(new_lo, new_hi, r.h, r.inv_h, new_len)
 end
 
 # `view` follows `getindex` semantics for ranges — both return a fresh range, no
@@ -114,7 +122,8 @@ on `StepRangeLen`, `LinRange`, `OrdinalRange`, etc.
 """
 function _to_float(x::AbstractRange, ::Type{T}) where {T}
     h = T(step(x))
-    return _CachedRange{T}(T(first(x)), T(last(x)), h, inv(h), length(x))
+    inv_h = inv(h)
+    return _CachedRange{T, typeof(inv_h)}(T(first(x)), T(last(x)), h, inv_h, length(x))
 end
 
 # x86_64: TwicePrecision first()/last() ~9ns each on Intel — bypass via plain-T muladd.
@@ -131,12 +140,12 @@ end
 
         domain_lo = prevfloat(lo)
         domain_hi = nextfloat(hi)
-        return _CachedRange{FT}(lo, hi, h, inv(h), length(x), domain_lo, domain_hi)
+        return _CachedRange{FT, FT}(lo, hi, h, inv(h), length(x), domain_lo, domain_hi)
     end
 end
 
 # _CachedRange same-type pass-through: already normalized, return as-is.
-_to_float(x::_CachedRange{T}, ::Type{T}) where {T} = x
+_to_float(x::_CachedRange{T, Tinv}, ::Type{T}) where {T, Tinv} = x
 
 # _CachedRange type-mismatch (e.g. Float32 → Float64 via _convert_grid):
 # Uses 5-arg constructor (domain = exact). Any x86_64 domain widening from the source
@@ -144,7 +153,8 @@ _to_float(x::_CachedRange{T}, ::Type{T}) where {T} = x
 # so re-widening would need to be based on the new FT, not the old T.
 function _to_float(x::_CachedRange, ::Type{T}) where {T}
     h = T(x.h)
-    return _CachedRange{T}(T(x.lo), T(x.hi), h, inv(h), x.len)
+    inv_h = inv(h)
+    return _CachedRange{T, typeof(inv_h)}(T(x.lo), T(x.hi), h, inv_h, x.len)
 end
 
 """
@@ -159,9 +169,9 @@ Dispatch:
 """
 # domain_hi = hi_new (exact): the extension uses cached plain-T fields only
 # (no TwicePrecision involved), so no additional rounding uncertainty.
-@inline function _to_float_adding_endpoint(x::_CachedRange{T}, ::Type{T}) where {T}
+@inline function _to_float_adding_endpoint(x::_CachedRange{T, Tinv}, ::Type{T}) where {T, Tinv}
     hi_new = x.hi + x.h
-    return _CachedRange{T}(
+    return _CachedRange{T, Tinv}(
         x.lo, hi_new, x.h, x.inv_h, x.len + 1,
         x.domain_lo, hi_new
     )
@@ -178,7 +188,7 @@ end
 # Different-type → `_to_float(r, T)` rebuilds with the target eltype.
 # Mirrors the pattern in cached_vector.jl / periodic_axis.jl for unified
 # `map(g -> _convert_copy(g, Tg), grids)` use across grid wrapper types.
-@inline _convert_copy(r::_CachedRange{T}, ::Type{T}) where {T} = r
+@inline _convert_copy(r::_CachedRange{T, Tinv}, ::Type{T}) where {T, Tinv} = r
 @inline _convert_copy(r::_CachedRange, ::Type{T}) where {T} = _to_float(r, T)
 
 # 3-arg grid-based accessors: _CachedRange has h/inv_h cached in the struct.

--- a/src/core/cached_vector.jl
+++ b/src/core/cached_vector.jl
@@ -139,15 +139,16 @@ end
 @inline _get_inv_h(x::_CachedRange, ::Int) = x.inv_h
 
 # AbstractRange (non-_CachedRange) — uniform spacing via step()
-# float() ensures Int ranges produce Float h/inv_h for kernel compatibility.
-@inline _get_h(x::AbstractRange, ::Int) = float(step(x))
-@inline _get_inv_h(x::AbstractRange, ::Int) = inv(float(step(x)))
+@inline _get_h(x::AbstractRange, ::Int) = step(x)
+@inline _get_inv_h(x::AbstractRange, ::Int) = inv(step(x))
 
-# AbstractVector — compute on-the-fly (one-shot path, no cache available)
-# Used for raw user `x::Vector` in oneshot APIs. Subtraction is single-cycle
-# and `x[i]`/`x[i+1]` are typically cache-resident from the search step.
+# AbstractVector — compute on-the-fly (one-shot path, no cache available).
+# Raw eltype preserved (`Int → Int`, `Rational → Rational`). Arithmetic kernels
+# that follow this with `inv_h * y * dL` auto-promote naturally — no need to
+# eager-Float here. `_get_inv_h` returns `typeof(inv(h))` (Float64 for Int h,
+# Rational for Rational h, T for Float T).
 @inline Base.@propagate_inbounds _get_h(x::AbstractVector, i::Int) =
-    @inbounds float(x[i + 1] - x[i])
+    @inbounds x[i + 1] - x[i]
 @inline Base.@propagate_inbounds _get_inv_h(x::AbstractVector, i::Int) =
     inv(_get_h(x, i))
 
@@ -155,8 +156,8 @@ end
 # `x[i]` / `x[i+1]` loads. Used by oneshot kernels (and the wrapper-level
 # `_ExclusivePeriodicAxis` 3-arg overload at `periodic_axis.jl:384`, which
 # delegates here for any `_CachedVector` / raw `Vector` inner).
-@inline _get_h(::AbstractVector, xL::Real, xR::Real) = float(xR - xL)
-@inline _get_inv_h(::AbstractVector, xL::Real, xR::Real) = inv(float(xR - xL))
+@inline _get_h(::AbstractVector, xL::Real, xR::Real) = xR - xL
+@inline _get_inv_h(::AbstractVector, xL::Real, xR::Real) = inv(xR - xL)
 
 # Persistent axis wrapping is split into two stages (see `periodic_axis.jl`):
 #   - outer surface API: `_cache_axis(x, bc)` — bc-aware wrap, zero-copy

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -24,6 +24,17 @@
 @inline _itp_extrap(itp::AbstractInterpolant1D) = itp.extrap
 @inline _itp_search(itp::AbstractInterpolant1D) = itp.search_policy
 
+# ── Output eltype trait ──
+# Arithmetic kernels (Linear, Cubic, …) widen via `_output_eltype(Tv, Tg, Tq)`
+# because the kernel produces a wider result from the arithmetic. Selection
+# kernels (Constant) override this to keep raw `Tv` for plain queries and
+# only widen for duck-typed queries (Dual, Measurement, …) so AD carriers
+# round-trip. Both scalar and batch protocol callables go through this single
+# trait; on the scalar path the result is wrapped in `convert(...)` (identity
+# when the kernel already produced the trait's type).
+@inline _output_eltype(::AbstractInterpolant1D{Tg, Tv}, ::Type{Tq}) where {Tg, Tv, Tq} =
+    _output_eltype(Tv, Tg, Tq)
+
 # ========================================
 # 1D Scalar Call — Hot Path
 # ========================================
@@ -40,13 +51,15 @@
     extrap = _itp_extrap(itp)
     @boundscheck _check_domain(grid, xq, extrap)
     searcher = _resolve_search(grid, xq, search, hint)
-    return _itp_eval_scalar(itp, xq, extrap, deriv, searcher)
+    val = _itp_eval_scalar(itp, xq, extrap, deriv, searcher)
+    return convert(_output_eltype(itp, typeof(xq)), val)
 end
 
 # ========================================
 # 1D Vector Call — Allocating
 # ========================================
-# Output type promoted to wider type for precision preservation.
+# Output eltype: trait `_output_eltype(itp, Tq)` — defaults to widening
+# `promote_type(Tv, Tg, Tq)`; Constant overrides for raw-Tv contract.
 
 function (itp::AbstractInterpolant1D{Tg, Tv})(
         xq::AbstractVector{Tq};
@@ -56,10 +69,7 @@ function (itp::AbstractInterpolant1D{Tg, Tv})(
     ) where {Tg, Tv, Tq <: Real}
     grid = _itp_grid(itp)
     extrap = _itp_extrap(itp)
-    # Include Tg in promotion: when the grid is Dual, interpolation weights
-    # carry grid partials, so the output type must reflect Tg arithmetic.
-    T_out = _output_eltype(Tv, Tg, Tq)
-    output = Vector{T_out}(undef, length(xq))
+    output = Vector{_output_eltype(itp, Tq)}(undef, length(xq))
     searcher = _resolve_search(grid, xq, search, hint)
     _itp_vector_loop!(output, itp, xq, extrap, deriv, searcher)
     return output
@@ -93,6 +103,10 @@ end
 # Default: no zero-fill (Cubic, Quadratic evaluate all derivative orders).
 
 @inline _deriv_zero_fill(::AbstractInterpolantND, ::NTuple{N, AbstractEvalOp}, ::Val{N}) where {N} = false
+
+# ── Output eltype trait (ND) — mirrors the 1D version. ──
+@inline _output_eltype(::AbstractInterpolantND{Tg, Tv, N}, ::Type{Tq}) where {Tg, Tv, N, Tq} =
+    _output_eltype(Tv, Tg, Tq)
 
 # ========================================
 # Unified Batch Interpolant Evaluation (Generic ND)
@@ -196,6 +210,6 @@ function (itp::AbstractInterpolantND{Tg, Tv, N})(
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
     Tq = _query_eltype(queries)
-    output = Vector{_output_eltype(Tv, Tg, Tq)}(undef, _query_length(queries))
+    output = Vector{_output_eltype(itp, Tq)}(undef, _query_length(queries))
     return itp(output, queries; deriv = deriv, search = search, hint = hint)
 end

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1087,3 +1087,27 @@ grids_typed, Tg, Tv, Tz = _nd_promote_grids(grids, data) # full (oneshot/build)
     Tz = _output_eltype(Tv, Tg)
     return grids_typed, Tg, Tv, Tz
 end
+
+"""
+    _nd_promote_grids_raw(grids, data) -> (grids_typed, Tg, Tv)
+
+Raw-eltype variant of `_nd_promote_grids`: skips the `float()` widening, keeps
+`Tv = eltype(data)`. Used by selection-kernel methods (Constant) where there
+is no x·y arithmetic and the output contract follows `eltype(data)` directly.
+
+- `Tg = promote_type(eltype.(grids)...)` (via `@generated` `_promote_grid_eltype`,
+  unrolled at compile time — zero alloc).
+- `Tv = eltype(data)` — no promotion.
+- `grids_typed`: each axis converted to share `Tg` (container heterogeneity
+  preserved — Range stays Range, Vector stays Vector).
+
+Arithmetic methods keep `_nd_promote_grids` (Float-widened Tg, value-promoted Tv).
+"""
+@inline function _nd_promote_grids_raw(
+        grids::NTuple{N, AbstractVector},
+        data::AbstractArray{Tv, N}
+    ) where {Tv, N}
+    Tg = _promote_grid_eltype(grids)
+    grids_typed = _convert_grids_typed(grids, Tg)
+    return grids_typed, Tg, Tv
+end

--- a/src/core/search.jl
+++ b/src/core/search.jl
@@ -549,12 +549,13 @@ via arithmetic rather than iterative search, exploiting uniform grid spacing.
 end
 
 """
-    _search_direct(x::_CachedRange{T}, xq::Real)
+    _search_direct(x::_CachedRange{T, Tinv}, xq::Real)
 
-`_CachedRange` specialization: all fields are plain `T` — no TwicePrecision arithmetic.
+`_CachedRange` specialization: geometry fields are plain `T`, `inv_h` is `Tinv`
+(equals `T` for Float grids, `Float64` for `T = Int`) — no TwicePrecision arithmetic.
 Uses precomputed `inv_h` (multiply instead of divide) for the index calculation.
 """
-@inline function _search_direct(x::_CachedRange{T}, xq::Real) where {T}
+@inline function _search_direct(x::_CachedRange{T, Tinv}, xq::Real) where {T, Tinv}
     # Primal-based index: see _search_direct(::AbstractRange, ...) comment.
     idx = clamp(unsafe_trunc(Int, _extract_primal(muladd(xq - x.lo, x.inv_h, 1))), 1, x.len - 1)
     xL = muladd(idx - 1, x.h, x.lo)

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -340,19 +340,13 @@ Used in interpolant inner constructors to merge promotion + immutability copy.
 """
     _promote_query_typed(xq::AbstractVector, ::Type{Tg}) -> AbstractVector
 
-Convert query vector to the appropriate float type for the given grid type `Tg`.
-
-Standard numeric queries (`_PromotableValue`: Integer, AbstractFloat, Rational)
-are promoted to grid precision (or `float(Tq)` if grid is duck-typed).
-Duck-typed queries (e.g. `Dual` for query-side AD) pass through unchanged —
-same `_PromotableValue` guard as value promotion in `_promote_itp_inputs`.
+Widen query vector to `promote_type(Tg, Tq)` — never narrows query precision.
+Duck-typed queries (`Dual`, `Measurement`, …) pass through unchanged.
 """
 @inline function _promote_query_typed(xq::AbstractVector{Tq}, ::Type{Tg}) where {Tq <: Real, Tg}
     if Tq <: _PromotableValue
-        # Standard numeric: promote to grid type (duck or float)
-        return _to_float(xq, Tg)
+        return _to_float(xq, promote_type(Tg, Tq))
     else
-        # Duck type (Dual, Measurement, etc.) — pass through unchanged
         return xq
     end
 end

--- a/src/cubic/cubic_cache_pool.jl
+++ b/src/cubic/cubic_cache_pool.jl
@@ -45,11 +45,15 @@ abstract type AbstractCacheEntry{T <: AbstractFloat, X <: AbstractVector{T}} end
 
 # Map user input grid type to the cache's wrapped axis type. Mirrors
 # `_resolve_axis_copied(x, bc, T)`:
-# - Non-periodic / `:inclusive`: Range → `_CachedRange{T}`,
+# - Non-periodic / `:inclusive`: Range → `_CachedRange{T, Tinv}`,
 #   Vector → `_CachedVector{T, Tinv}`.
 # - `:exclusive` periodic: extra `_ExclusivePeriodicAxis` wrapper around the
 #   above inner.
-@inline _cached_axis_type(::Type{<:AbstractRange}, ::Type{T}) where {T} = _CachedRange{T}
+# Cubic always promotes to `T <: AbstractFloat`, so `Tinv == T` here — pin the
+# 2nd parameter to `T` to keep the bank's `EntryType` concrete (otherwise the
+# 1-param `_CachedRange{T}` form would be a UnionAll after the Phase 1
+# `_CachedRange{T, Tinv}` refactor, defeating type-specialization in the bank).
+@inline _cached_axis_type(::Type{<:AbstractRange}, ::Type{T}) where {T} = _CachedRange{T, T}
 @inline _cached_axis_type(::Type{<:AbstractVector}, ::Type{T}) where {T} =
     _CachedVector{T, typeof(inv(oneunit(T)))}
 
@@ -705,9 +709,10 @@ Type-Free design: bc_pair should already be cache-compatible (via _cache_bc_pair
     return _lookup_or_insert!(bank, x, bc_pair)
 end
 
-# _CachedRange: bank keyed on _CachedRange{T}. objectid is deterministic for isbits → fast hit.
-@inline function _get_derivative_cache_impl(x::_CachedRange{T}, bc_pair::BCPair{L, R}) where {T <: AbstractFloat, L <: PointBC, R <: PointBC}
-    bank = _get_derivative_bank(_CachedRange{T}, bc_pair)
+# _CachedRange: bank keyed on _CachedRange{T, T} (Tinv == T for Float grids).
+# objectid is deterministic for isbits → fast hit.
+@inline function _get_derivative_cache_impl(x::_CachedRange{T, T}, bc_pair::BCPair{L, R}) where {T <: AbstractFloat, L <: PointBC, R <: PointBC}
+    bank = _get_derivative_bank(_CachedRange{T, T}, bc_pair)
     return _lookup_or_insert!(bank, x, bc_pair)
 end
 
@@ -747,9 +752,9 @@ caches partition into separate banks — see `PeriodicCacheEntry`).
     return _lookup_or_insert!(bank, x, bc)
 end
 
-# _CachedRange: bank keyed on _CachedRange{T}.
-@inline function _get_periodic_cache_impl(x::_CachedRange{T}, bc::PeriodicBC) where {T <: AbstractFloat}
-    bank = _get_periodic_bank(_CachedRange{T}, bc)
+# _CachedRange: bank keyed on _CachedRange{T, T} (Tinv == T for Float grids).
+@inline function _get_periodic_cache_impl(x::_CachedRange{T, T}, bc::PeriodicBC) where {T <: AbstractFloat}
+    bank = _get_periodic_bank(_CachedRange{T, T}, bc)
     return _lookup_or_insert!(bank, x, bc)
 end
 

--- a/src/cubic/cubic_cache_pool.jl
+++ b/src/cubic/cubic_cache_pool.jl
@@ -49,10 +49,8 @@ abstract type AbstractCacheEntry{T <: AbstractFloat, X <: AbstractVector{T}} end
 #   Vector → `_CachedVector{T, Tinv}`.
 # - `:exclusive` periodic: extra `_ExclusivePeriodicAxis` wrapper around the
 #   above inner.
-# Cubic always promotes to `T <: AbstractFloat`, so `Tinv == T` here — pin the
-# 2nd parameter to `T` to keep the bank's `EntryType` concrete (otherwise the
-# 1-param `_CachedRange{T}` form would be a UnionAll after the Phase 1
-# `_CachedRange{T, Tinv}` refactor, defeating type-specialization in the bank).
+# Cubic always promotes to `T <: AbstractFloat`, so `Tinv == T`; pin it
+# explicitly to keep `EntryType` concrete in the bank.
 @inline _cached_axis_type(::Type{<:AbstractRange}, ::Type{T}) where {T} = _CachedRange{T, T}
 @inline _cached_axis_type(::Type{<:AbstractVector}, ::Type{T}) where {T} =
     _CachedVector{T, typeof(inv(oneunit(T)))}

--- a/src/cubic/nd/cubic_nd_math.jl
+++ b/src/cubic/nd/cubic_nd_math.jl
@@ -86,8 +86,8 @@ end
 # - yL, yR: Function values at left/right endpoints (type Tv)
 # - dyL, dyR: Derivative values at endpoints (type Tv)
 # - h: Interval width (type Tg)
-# - inv_h: 1/h precomputed (type Tg)
-# - dL: Distance from left endpoint xq - xL (type Tg or query type)
+# - inv_h: 1/h precomputed (type Tinv; decoupled from Tg)
+# - dL: Distance from left endpoint xq - xL (type Tq — query type)
 
 """
     _hermite_kernel_1d(::EvalValue, yL, yR, dyL, dyR, h, inv_h, dL)

--- a/src/cubic/nd/cubic_nd_math.jl
+++ b/src/cubic/nd/cubic_nd_math.jl
@@ -99,8 +99,8 @@ Returns interpolated function value.
 @inline function _hermite_kernel_1d(
         ::EvalValue,
         yL, yR, dyL, dyR,
-        h::Tg, inv_h::Tg, dL::Tq
-    ) where {Tg, Tq}
+        h::Tg, inv_h::Tinv, dL::Tq
+    ) where {Tg, Tinv, Tq}
     # Promote to output type for intermediate calculations
     t = dL * inv_h
 
@@ -123,8 +123,8 @@ Evaluate first derivative: dP/dx = (dP/dt) / h
 @inline function _hermite_kernel_1d(
         ::EvalDeriv1,
         yL, yR, dyL, dyR,
-        h::Tg, inv_h::Tg, dL::Tq
-    ) where {Tg, Tq}
+        h::Tg, inv_h::Tinv, dL::Tq
+    ) where {Tg, Tinv, Tq}
     # Let t remain in coordinate type - basis derivatives stay real
     t = dL * inv_h
     t_sq = t * t
@@ -151,8 +151,8 @@ Evaluate second derivative: d²P/dx² = (d²P/dt²) / h²
 @inline function _hermite_kernel_1d(
         ::EvalDeriv2,
         yL, yR, dyL, dyR,
-        h::Tg, inv_h::Tg, dL::Tq
-    ) where {Tg, Tq}
+        h::Tg, inv_h::Tinv, dL::Tq
+    ) where {Tg, Tinv, Tq}
     # Let t remain in coordinate type - basis derivatives stay real
     t = dL * inv_h
 
@@ -179,8 +179,8 @@ Evaluate third derivative: d³P/dx³ = (d³P/dt³) / h³ (constant within interv
 @inline function _hermite_kernel_1d(
         ::EvalDeriv3,
         yL, yR, dyL, dyR,
-        h::Tg, inv_h::Tg, dL::Tq
-    ) where {Tg, Tq}
+        h::Tg, inv_h::Tinv, dL::Tq
+    ) where {Tg, Tinv, Tq}
     # Third derivatives are constants: d³h00/dt³=12, d³h10/dt³=6, d³h01/dt³=-12, d³h11/dt³=6
     # Auto-promote naturally through arithmetic with value types
     value_contrib = 12 * (yL - yR)
@@ -199,8 +199,8 @@ Generic fallback: N-th derivative of cubic Hermite is zero for N ≥ 4.
 @inline function _hermite_kernel_1d(
         ::DerivOp{N},
         yL, ::Any, ::Any, ::Any,
-        ::Tg, ::Tg, ::Tq
-    ) where {N, Tg, Tq}
+        ::Tg, ::Tinv, ::Tq
+    ) where {N, Tg, Tinv, Tq}
     return 0 * yL
 end
 

--- a/test/test_bc_complex_int.jl
+++ b/test/test_bc_complex_int.jl
@@ -52,8 +52,9 @@
 
     @testset "constant_interp" begin
         itp = constant_interp(x, y_cint)
-        @test itp isa ConstantInterpolant{Float64, ComplexF64}
-        @test itp(1.5) isa ComplexF64
+        # Constant duck-types: Complex{Int} y preserved (no widening to ComplexF64).
+        @test itp isa ConstantInterpolant{Float64, Complex{Int}}
+        @test itp(1.5) isa Complex{Int}
     end
 
     @testset "quadratic_interp" begin

--- a/test/test_complex_constant.jl
+++ b/test/test_complex_constant.jl
@@ -56,11 +56,11 @@
 
         itp = constant_interp(x, y)
 
-        # x promoted to Float64, y promoted to ComplexF64
-        @test itp isa ConstantInterpolant{Float64, ComplexF64}
+        # Constant duck-types: Int grid stays Int, Complex{Int} preserved.
+        @test itp isa ConstantInterpolant{Int, Complex{Int}}
 
         val = itp(0.5)
-        @test val isa ComplexF64
+        @test val isa Complex{Int}
     end
 
     # ========================================
@@ -72,8 +72,8 @@
 
         itp = constant_interp(x, y)
 
-        # Grid promoted to Float64 to match Complex{Float64}
-        @test itp isa ConstantInterpolant{Float64, ComplexF64}
+        # Constant duck-types: Float32 grid preserved, ComplexF64 preserved.
+        @test itp isa ConstantInterpolant{Float32, ComplexF64}
 
         val = itp(0.5)
         @test val isa ComplexF64

--- a/test/test_complex_constant_series.jl
+++ b/test/test_complex_constant_series.jl
@@ -58,15 +58,15 @@
 
         sitp = constant_interp(x, Series(y1, y2))
 
-        # x promoted to Float64, y promoted to ComplexF64
-        @test sitp isa ConstantSeriesInterpolant{Float64, ComplexF64}
+        # Constant duck-types: Int grid stays Int, Complex{Int} preserved.
+        @test sitp isa ConstantSeriesInterpolant{Int, Complex{Int}}
 
         vals = sitp(5.5)
-        @test vals isa Vector{ComplexF64}
+        @test vals isa Vector{Complex{Int}}
 
-        # Constant interpolation returns step value (nearest by default)
-        # At 5.5 with NearestSide(), rounds to index 6 (x=5) → value 5+10i
-        @test isapprox(vals[1], 5.0 + 10.0im, rtol = 1.0e-10)
+        # Constant interpolation returns step value (nearest by default).
+        # At 5.5 with NearestSide(), rounds to index 6 (x=5) → value 5+10i.
+        @test vals[1] === 5 + 10im
     end
 
     # ========================================
@@ -79,8 +79,8 @@
 
         sitp = constant_interp(x, Series(y1, y2))
 
-        # Grid promoted to Float64 to match Complex{Float64}
-        @test sitp isa ConstantSeriesInterpolant{Float64, ComplexF64}
+        # Constant duck-types: Float32 grid preserved, ComplexF64 preserved.
+        @test sitp isa ConstantSeriesInterpolant{Float32, ComplexF64}
 
         vals = sitp(0.5)
         @test vals isa Vector{ComplexF64}
@@ -268,8 +268,11 @@
     # ========================================
     # Tg Calculation Policy (Query Independence)
     # ========================================
-    @testset "Lossless type promotion" begin
-        # Float32 data + Float64 query → Float64 output (wider type wins)
+    @testset "Eltype contract: selection kernel preserves Tv" begin
+        # Constant duck-types output to `_series_eltype(s)`: query type Tq does
+        # NOT widen the output for plain numerical Tq (Float/Int/Rational/Complex)
+        # — kernel just returns `y[idx]::Tv`. Duck-typed Tq (Dual) still
+        # promotes for AD-API compatibility, but plain Float64 keeps Tv.
         x32 = Float32.(0:0.1:1)
         y1 = sin.(x32)
         y2 = cos.(x32)
@@ -277,9 +280,8 @@
         sitp = constant_interp(x32, Series(y1, y2))
         @test sitp isa ConstantSeriesInterpolant{Float32, Float32}
 
-        # Float64 query promotes output to Float64 (lossless - wider type)
-        result = sitp(0.5)  # 0.5 is Float64
-        @test eltype(result) === Float64
+        result = sitp(0.5)  # 0.5 is Float64 — but Tv (Float32) wins for constant.
+        @test eltype(result) === Float32
     end
 
 end

--- a/test/test_constant.jl
+++ b/test/test_constant.jl
@@ -164,9 +164,11 @@ end
     @testset "Real type wrapper (Integer input)" begin
         x_int = [0, 1, 2, 3, 4]
         y_int = [10, 20, 30, 40, 50]
+        # Constant duck-types output to `eltype(y)` — Int in → Int out (no Float
+        # widening, since the kernel is selection, not arithmetic).
         result = constant_interp(x_int, y_int, 1.5)
-        @test result isa Float64
-        @test result == 20.0
+        @test result isa Int
+        @test result == 20
     end
 
     @testset "Real→Float wrappers (coverage)" begin
@@ -187,12 +189,11 @@ end
         itp(out, [0, 1, 2])  # Integer query vector
         @test out ≈ [10.0, 20.0, 30.0]
 
-        # Test 3: Vector allocating Real→Float wrapper (lines 422-434)
-        # constant_interp(x::AbstractVector{T}, y::AbstractVector{T}, x_targets::AbstractVector{S})
-        # where T<:Real (Integer grid + Integer query)
+        # Test 3: Vector allocating with Integer grid + Integer query.
+        # Constant duck-types output to `eltype(y)` — no Float widening.
         result_vec = constant_interp(x_int, y_int, [0, 1, 2])
-        @test result_vec isa Vector{Float64}
-        @test result_vec ≈ [10.0, 20.0, 30.0]
+        @test result_vec isa Vector{Int}
+        @test result_vec == [10, 20, 30]
 
         # Test 4: In-place Real→Float wrapper (lines 440-468)
         # constant_interp!(output, x::AbstractVector{T}, y::AbstractVector{T}, x_targets::AbstractVector{S})

--- a/test/test_constant_eltype.jl
+++ b/test/test_constant_eltype.jl
@@ -430,10 +430,10 @@ end
         x = Float64.(0:4)
         y = [10, 20, 30, 40, 50]
         itp = constant_interp(x, y; extrap = FillExtrap(-1))
-        @test itp(1.5) === 20  # in-domain: raw Tv preserved
-        # `_promote_extrap` widens fill value with Tg(=Float64) at construction,
-        # so OOB returns Float64. Pending raw-Tv contract decision.
-        @test_broken itp.extrap === FillExtrap(-1)
+        @test itp.extrap === FillExtrap{Int}(-1)  # raw Tv stored
+        @test itp(1.5) === 20                      # in-domain: raw Tv preserved
+        # OOB widens to promote_type(Tv, Tq) — Dual-AD-friendly; pending a
+        # separate raw-Tv-on-OOB decision.
         @test_broken itp(-1.0) === -1
     end
 
@@ -480,5 +480,61 @@ end
         itp = constant_interp((x, y), data)
         @test itp isa ConstantInterpolantND{Float64, Int, 2}
         @test @inferred(itp((1.5, 2.5))) === data[2, 3]
+    end
+end
+
+# ============================================================================
+# Group 8: Anchor query precision — Tq = promote_type(Tg, eltype(xq))
+# ============================================================================
+# Narrower grids (Int, Float32) must not truncate wider queries — verified
+# end-to-end via the forward/adjoint dot-product identity.
+@testitem "Constant anchor: Tq = promote_type(Tg, eltype(xq))" begin
+    using LinearAlgebra: dot
+    import FastInterpolations: ConstantAdjoint, _ConstantAnchoredQuery
+
+    @testset "Int grid + Float query — 1D adjoint, dot identity" begin
+        x = collect(0:9)
+        y = collect(10.0:10.0:100.0)
+        xq = [0.5, 1.5, 2.5, 3.5]
+        y_bar = [0.1, 0.2, -0.3, 0.4]
+
+        itp = constant_interp(x, y)
+        adj = constant_adjoint(x, xq)
+        @test adj isa ConstantAdjoint{Int, Float64}
+        @test eltype(adj.anchors) === _ConstantAnchoredQuery{Int, Float64}
+        @test dot(itp.(xq), y_bar) ≈ dot(y, adj(y_bar))
+    end
+
+    @testset "Int grid + Float query — Series vector eval" begin
+        x = collect(0:4)
+        y1 = collect(10.0:10.0:50.0)
+        y2 = collect(100.0:100.0:500.0)
+        sitp = constant_interp(x, Series(y1, y2))
+        result = sitp([0.5, 1.5, 2.5])  # fractional Float queries on Int grid
+        @test result == [[10.0, 20.0, 30.0], [100.0, 200.0, 300.0]]
+    end
+
+    @testset "Int grids + Float queries — ND adjoint, dot identity" begin
+        x = collect(0:3); y = collect(0:3)
+        data = Float64[10 * i + j for i in 1:4, j in 1:4]
+        queries = [(0.5, 1.5), (1.5, 2.5), (2.5, 0.5)]
+        y_bar = [1.0, -0.5, 0.7]
+
+        itp = constant_interp((x, y), data)
+        adj = constant_adjoint((x, y), queries)
+        @test dot(itp.(queries), y_bar) ≈ dot(data, adj(y_bar))
+    end
+
+    @testset "Float32 grid + Float64 query — NearestSide tie-break consistency" begin
+        x = Float32[0, 1, 2]
+        y = Float32[10, 20, 30]
+        xq = [nextfloat(0.5)]   # strictly > 0.5 in Float64; collapses to 0.5f0 if narrowed
+        y_bar = [1.0]
+
+        itp = constant_interp(x, y)
+        adj = constant_adjoint(x, xq)
+        @test itp(xq[1]) === 20.0f0       # right cell (dL > h/2 in Float64)
+        @test adj(y_bar) ≈ Float32[0, 1, 0]
+        @test dot([itp(xq[1])], y_bar) ≈ dot(y, adj(y_bar))
     end
 end

--- a/test/test_constant_eltype.jl
+++ b/test/test_constant_eltype.jl
@@ -374,3 +374,111 @@ end
         @test (@allocated itp((0.5, 0.5))) <= ND_ALLOC_THRESHOLD
     end
 end
+
+# ============================================================================
+# Group 5: ComplexF32 raw-eltype (no silent widening to ComplexF64)
+# ============================================================================
+@testitem "Constant eltype duck-type — ComplexF32 stays ComplexF32" begin
+    using LinearAlgebra: dot
+    import FastInterpolations: ConstantInterpolant, ConstantInterpolantND
+
+    @testset "1D persistent" begin
+        x = Float32.(0:4)
+        y = ComplexF32[1 + 1im, 2 + 2im, 3 + 3im, 4 + 4im, 5 + 5im]
+        itp = constant_interp(x, y)
+        @test itp isa ConstantInterpolant{Float32, ComplexF32}
+        @test itp(1.5f0) === ComplexF32(2 + 2im)
+        @test eltype(itp.(Float32[0.5, 1.5, 2.5])) === ComplexF32
+    end
+
+    @testset "1D series" begin
+        x = Float32.(0:4)
+        y1 = ComplexF32[1, 2, 3, 4, 5]
+        y2 = ComplexF32[10, 20, 30, 40, 50]
+        sitp = constant_interp(x, Series(y1, y2))
+        out = sitp(1.5f0)
+        @test eltype(out) === ComplexF32
+        @test out == ComplexF32[2, 20]
+    end
+
+    @testset "ND persistent" begin
+        x = Float32.(0:3); y = Float32.(0:3)
+        data = ComplexF32[(i + j) + (i - j)im for i in 1:4, j in 1:4]
+        itp = constant_interp((x, y), data)
+        @test itp isa ConstantInterpolantND{Float32, ComplexF32, 2}
+        @test itp((1.5f0, 2.5f0)) === data[2, 3]
+    end
+
+    @testset "ND adjoint (Float32 grid, ComplexF32 y_bar)" begin
+        x = Float32.(0:3); y = Float32.(0:3)
+        data = ComplexF32[(i + j) + (i - j)im for i in 1:4, j in 1:4]
+        itp = constant_interp((x, y), data)
+        queries = [(0.5f0, 0.5f0), (1.5f0, 2.5f0), (2.5f0, 0.5f0)]
+        y_bar = ComplexF32[1 + 1im, 2 - 1im, 3 + 0im]
+        adj = constant_adjoint((x, y), queries)
+        out = adj(y_bar)
+        @test eltype(out) === ComplexF32
+        @test dot(itp.(queries), y_bar) ≈ dot(data, out)
+    end
+end
+
+# ============================================================================
+# Group 6: FillExtrap × duck-typed Y (raw-Tv fill value contract)
+# ============================================================================
+@testitem "Constant eltype duck-type — FillExtrap raw-Tv contract" begin
+    @testset "1D persistent: Int data + Int fill" begin
+        x = Float64.(0:4)
+        y = [10, 20, 30, 40, 50]
+        itp = constant_interp(x, y; extrap = FillExtrap(-1))
+        @test itp(1.5) === 20  # in-domain: raw Tv preserved
+        # `_promote_extrap` widens fill value with Tg(=Float64) at construction,
+        # so OOB returns Float64. Pending raw-Tv contract decision.
+        @test_broken itp.extrap === FillExtrap(-1)
+        @test_broken itp(-1.0) === -1
+    end
+
+    @testset "1D persistent: Int data + Float fill → InexactError on construction" begin
+        x = Float64.(0:4)
+        y = [10, 20, 30, 40, 50]
+        @test_throws InexactError constant_interp(x, y; extrap = FillExtrap(NaN))
+    end
+
+    @testset "ND persistent: ComplexF64 data + Complex fill → Complex output" begin
+        x = collect(0.0:1:3); y = collect(0.0:1:3)
+        data = ComplexF64[(i + j) + (i - j)im for i in 1:4, j in 1:4]
+        fill_val = ComplexF64(-1 + 0im)
+        itp = constant_interp((x, y), data; extrap = FillExtrap(fill_val))
+        @test itp((-1.0, -1.0)) === fill_val
+        @test eltype(itp.([(0.5, 0.5), (-1.0, 5.0)])) === ComplexF64
+    end
+end
+
+# ============================================================================
+# Group 7: @inferred coverage on the new branched output-type paths
+# ============================================================================
+@testitem "Constant eltype duck-type — @inferred coverage" begin
+    import FastInterpolations: ConstantInterpolantND
+
+    @testset "1D Series scalar — Tv pass-through branch" begin
+        x = collect(0.0:0.1:1.0)
+        y1 = collect(1:11)
+        y2 = collect(11:21)
+        sitp = constant_interp(x, Series(y1, y2))
+        @test @inferred(sitp(0.55)) isa Vector{Int}
+    end
+
+    @testset "1D Series scalar — ComplexF32 Tv branch" begin
+        x = Float32.(0:0.1:1.0)
+        y1 = ComplexF32.(1:11)
+        sitp = constant_interp(x, Series(y1))
+        @test @inferred(sitp(0.55f0)) isa Vector{ComplexF32}
+    end
+
+    @testset "ND persistent forward (Int data)" begin
+        x = collect(0.0:1:3); y = collect(0.0:1:3)
+        data = [10 * i + j for i in 1:4, j in 1:4]
+        itp = constant_interp((x, y), data)
+        @test itp isa ConstantInterpolantND{Float64, Int, 2}
+        @test @inferred(itp((1.5, 2.5))) === data[2, 3]
+    end
+end

--- a/test/test_constant_eltype.jl
+++ b/test/test_constant_eltype.jl
@@ -86,13 +86,13 @@
             @test r == 30
         end
 
-        @testset "vector alloc oneshot: Vector{Int} 결과" begin
+        @testset "vector alloc oneshot returns Vector{Int}" begin
             v = constant_interp(x_int, y_int, [0, 1, 2, 3])
             @test v isa Vector{Int}
             @test v == [10, 20, 30, 40]
         end
 
-        @testset "in-place oneshot: Vector{Int} output 수용" begin
+        @testset "in-place oneshot accepts Vector{Int} output" begin
             out = zeros(Int, 4)
             constant_interp!(out, x_int, y_int, [0, 1, 2, 3])
             @test out == [10, 20, 30, 40]
@@ -548,5 +548,45 @@ end
         itp = constant_interp((x, y), data)
         adj = constant_adjoint((x, y), queries)
         @test dot([itp(queries[1])], y_bar) ≈ dot(data, adj(y_bar))
+    end
+end
+
+# ============================================================================
+# Group 9: Oneshot duck-typed query passthrough (Dual carrier preserved)
+# ============================================================================
+# Persistent callables already widen `T_out = promote_type(Tv, Tq)` for non-
+# `_PromotableValue` queries. The allocating oneshot paths must match — else
+# AD callers silently get raw Tv back, stripping their Dual carrier.
+@testitem "Constant oneshot: duck queries widen, plain queries stay raw" begin
+    using ForwardDiff
+    using ForwardDiff: Dual
+
+    x = [0.0, 1.0, 2.0, 3.0]
+    y = [10, 20, 30, 40]
+    s = Series(y)
+    xq_d = Dual(0.5, 1.0)
+
+    @testset "vector oneshot: Dual xq → Dual output" begin
+        out = constant_interp(x, y, [xq_d, Dual(1.5, 1.0)])
+        @test eltype(out) <: Dual
+        @test ForwardDiff.value.(out) == [10.0, 20.0]
+    end
+
+    @testset "scalar series oneshot: Dual xq → Dual output" begin
+        out = constant_interp(x, s, xq_d)
+        @test eltype(out) <: Dual
+        @test ForwardDiff.value.(out) == [10.0]
+    end
+
+    @testset "batch series oneshot: Dual xq → Dual output" begin
+        out = constant_interp(x, s, [xq_d])
+        @test eltype(eltype(out)) <: Dual
+        @test ForwardDiff.value.(out[1]) == [10.0]
+    end
+
+    @testset "plain Float xq still returns raw Tv (no widening)" begin
+        @test constant_interp(x, y, [0.5, 1.5]) isa Vector{Int}
+        @test constant_interp(x, s, 0.5)        isa Vector{Int}
+        @test constant_interp(x, s, [0.5, 1.5]) isa Vector{Vector{Int}}
     end
 end

--- a/test/test_constant_eltype.jl
+++ b/test/test_constant_eltype.jl
@@ -248,7 +248,7 @@ end
 end
 
 # ============================================================================
-# Group 4: ND (Phase 2 — selection kernel generalizes to per-axis cell pick)
+# Group 4: ND — selection kernel generalizes to per-axis cell pick
 # ============================================================================
 # Constant ND follows the same raw-eltype contract:
 #   Tg = promote_type(eltype.(grids)...)   (no `float()` widening)

--- a/test/test_constant_eltype.jl
+++ b/test/test_constant_eltype.jl
@@ -586,7 +586,7 @@ end
 
     @testset "plain Float xq still returns raw Tv (no widening)" begin
         @test constant_interp(x, y, [0.5, 1.5]) isa Vector{Int}
-        @test constant_interp(x, s, 0.5)        isa Vector{Int}
+        @test constant_interp(x, s, 0.5) isa Vector{Int}
         @test constant_interp(x, s, [0.5, 1.5]) isa Vector{Vector{Int}}
     end
 end

--- a/test/test_constant_eltype.jl
+++ b/test/test_constant_eltype.jl
@@ -1,0 +1,248 @@
+# Tests for constant_interp eltype duck-type policy (1D).
+#
+# Constant is a pure selection kernel (`y_left` for LeftSide, `dL <= h/2 ? y_left
+# : y_right` for NearestSide) — no x·y arithmetic. The output contract therefore
+# follows `eltype(y)` rather than the eager Float widening used by arithmetic
+# methods (Linear/Cubic/…). These tests pin that contract end-to-end across
+# persistent, oneshot, series, periodic, adjoint, and show paths.
+#
+# Range Int grids land on `_CachedRange{Int, Float64}` via the `Tinv`-aware
+# `_to_float` (mirroring `_CachedVector{T, Tinv}`).
+
+# ============================================================================
+# Group 1: Forward paths (persistent / oneshot / series / periodic / show)
+# ============================================================================
+@testitem "Constant eltype duck-type — forward" begin
+    import FastInterpolations: ConstantInterpolant, ConstantSeriesInterpolant,
+        _CachedRange, _CachedVector, _ExclusivePeriodicAxis
+
+    @testset "Persistent constructor (1D)" begin
+        @testset "Int Vector x, Int y → output Int" begin
+            x = [0, 1, 2, 3, 4]
+            y = [10, 20, 30, 40, 50]
+            itp = constant_interp(x, y)
+            @test itp isa ConstantInterpolant{Int, Int}
+            @test eltype(itp.y) === Int
+            @test itp.x isa _CachedVector{Int, Float64}
+            @test itp(1.5) isa Int
+            @test itp(1.5) == 20
+        end
+
+        @testset "Int Range x, Int y → itp.x::_CachedRange{Int, Float64}" begin
+            x = 0:1:4
+            y = [10, 20, 30, 40, 50]
+            itp = constant_interp(x, y)
+            @test itp isa ConstantInterpolant{Int, Int}
+            @test itp.x isa _CachedRange{Int, Float64}
+            @test itp.x.h === 1
+            @test itp.x.inv_h === 1.0
+            @test itp(2.5) isa Int
+            @test itp(2.5) == 30
+        end
+
+        @testset "Rational x, Rational y → output Rational{Int}" begin
+            x = Rational{Int}[0 // 1, 1 // 1, 2 // 1, 3 // 1, 4 // 1]
+            y = Rational{Int}[1 // 2, 3 // 2, 5 // 2, 7 // 2, 9 // 2]
+            itp = constant_interp(x, y)
+            @test itp isa ConstantInterpolant{Rational{Int}, Rational{Int}}
+            @test itp(3 // 2) isa Rational{Int}
+            @test itp(3 // 2) === 3 // 2
+        end
+
+        @testset "Float64 x, Int y → output Int (NEW: no Float widening)" begin
+            x = [0.0, 1.0, 2.0, 3.0, 4.0]
+            y = [10, 20, 30, 40, 50]
+            itp = constant_interp(x, y)
+            @test itp isa ConstantInterpolant{Float64, Int}
+            @test itp(1.5) isa Int
+            @test itp(1.5) == 20
+        end
+
+        @testset "Float32 x, Float32 y → output Float32 (regression guard)" begin
+            x = Float32[0.0, 1.0, 2.0, 3.0, 4.0]
+            y = Float32[10.0, 20.0, 30.0, 40.0, 50.0]
+            itp = constant_interp(x, y)
+            @test itp isa ConstantInterpolant{Float32, Float32}
+            @test itp(1.5f0) isa Float32
+        end
+
+        @testset "Complex y preserved" begin
+            x = [0.0, 1.0, 2.0]
+            y = ComplexF64[1.0 + 2.0im, 3.0 + 4.0im, 5.0 + 6.0im]
+            itp = constant_interp(x, y)
+            @test itp isa ConstantInterpolant{Float64, ComplexF64}
+            @test itp(0.5) isa ComplexF64
+            @test itp(0.5) === 1.0 + 2.0im
+        end
+    end
+
+    @testset "Oneshot (scalar / vector-alloc / in-place)" begin
+        x_int = [0, 1, 2, 3, 4]
+        y_int = [10, 20, 30, 40, 50]
+
+        @testset "scalar oneshot: Int input → Int output" begin
+            r = constant_interp(x_int, y_int, 2)
+            @test r isa Int
+            @test r == 30
+        end
+
+        @testset "vector alloc oneshot: Vector{Int} 결과" begin
+            v = constant_interp(x_int, y_int, [0, 1, 2, 3])
+            @test v isa Vector{Int}
+            @test v == [10, 20, 30, 40]
+        end
+
+        @testset "in-place oneshot: Vector{Int} output 수용" begin
+            out = zeros(Int, 4)
+            constant_interp!(out, x_int, y_int, [0, 1, 2, 3])
+            @test out == [10, 20, 30, 40]
+        end
+    end
+
+    @testset "PeriodicBC" begin
+        @testset "inclusive + Int Vector x + Int y" begin
+            x = [0, 1, 2, 3]
+            y = [10, 20, 30, 10]  # closed cycle
+            itp = constant_interp(x, y; bc = PeriodicBC())
+            @test itp isa ConstantInterpolant{Int, Int}
+            @test itp(0.5) isa Int
+            @test itp(3.5) isa Int  # wraps to first cell
+        end
+
+        @testset "exclusive + Int Vector x + Int y" begin
+            x = [0, 1, 2]
+            y = [10, 20, 30]
+            itp = constant_interp(x, y; bc = PeriodicBC(endpoint = :exclusive, period = 3))
+            @test itp isa ConstantInterpolant{Int, Int}
+            @test itp.x isa _ExclusivePeriodicAxis
+            @test itp(0.5) isa Int
+        end
+
+        @testset "inclusive + Int Range x + Int y → _CachedRange{Int, Float64}" begin
+            x = 0:1:3                # length 4 — closed cycle (x[end] == x[1] + period)
+            y = [10, 20, 30, 10]     # closed: y[end] == y[1]
+            itp = constant_interp(x, y; bc = PeriodicBC())
+            @test itp isa ConstantInterpolant{Int, Int}
+            @test itp.x isa _CachedRange{Int, Float64}
+            @test itp(0.5) isa Int
+            @test itp(0.5) == 10
+        end
+    end
+
+    @testset "Series interp" begin
+        @testset "ConstantSeriesInterpolant(Vector{Int}, Series(Vector{Int}, Vector{Int}))" begin
+            x = [0, 1, 2, 3, 4]
+            y1 = [10, 20, 30, 40, 50]
+            y2 = [100, 200, 300, 400, 500]
+            sitp = constant_interp(x, FastInterpolations.Series(y1, y2))
+            @test sitp isa ConstantSeriesInterpolant
+            r = sitp(1)  # scalar query — returns a tuple of K series values
+            @test all(ri isa Int for ri in r)
+            @test r[1] == 20
+            @test r[2] == 200
+        end
+
+        @testset "scalar oneshot series: Int x + Series + Int xq → Int" begin
+            x = [0, 1, 2, 3, 4]
+            y1 = [10, 20, 30, 40, 50]
+            s = FastInterpolations.Series(y1)
+            r = constant_interp(x, s, 2)
+            @test all(ri isa Int for ri in r)
+            @test r[1] == 30
+        end
+    end
+
+    @testset "Show output (non-Float eltype)" begin
+        x = [0, 1, 2, 3]
+        y = [10, 20, 30, 40]
+        itp = constant_interp(x, y)
+        s = repr("text/plain", itp)
+        # Header should mention Int eltype (Int64 on 64-bit, Int32 on 32-bit).
+        @test occursin("Int", s)
+        @test occursin("ConstantInterpolant", s)
+    end
+end
+
+# ============================================================================
+# Group 2: Adjoint
+# ============================================================================
+@testitem "Constant eltype duck-type — adjoint" begin
+    using LinearAlgebra: dot
+    import FastInterpolations: ConstantAdjoint, _ConstantAnchoredQuery
+
+    @testset "ConstantAdjoint with Int grid + Int xq — anchor type" begin
+        x = collect(0:1:9)  # Vector{Int}
+        xq = [2, 4, 6, 8]
+        adj = constant_adjoint(x, xq)
+        @test adj isa ConstantAdjoint
+        @test eltype(adj.anchors) <: _ConstantAnchoredQuery{Int}
+    end
+
+    @testset "Dot-product identity (Int f + Int ȳ) under NearestSide" begin
+        x = collect(0:1:9)
+        xq = [2, 4, 6, 8]
+        f = collect(10:10:100)  # Vector{Int}, length 10
+        y_bar = [1, 2, 3, 4]    # Vector{Int}
+        itp = constant_interp(x, f)
+        adj = constant_adjoint(x, xq)
+        # ⟨W·f, ȳ⟩ == ⟨f, Wᵀ·ȳ⟩  — exact equality with Int data
+        @test dot(itp.(xq), y_bar) == dot(f, adj(y_bar))
+    end
+
+    @testset "Rational grid + Rational xq — Rational preserved" begin
+        x = Rational{Int}[0 // 1, 1 // 1, 2 // 1, 3 // 1, 4 // 1]
+        xq = Rational{Int}[1 // 2, 3 // 2]
+        f = Rational{Int}[1 // 1, 2 // 1, 3 // 1, 4 // 1, 5 // 1]
+        y_bar = Rational{Int}[1 // 1, 2 // 1]
+        itp = constant_interp(x, f)
+        adj = constant_adjoint(x, xq)
+        # Rational arithmetic is exact — strict ==
+        @test dot(itp.(xq), y_bar) == dot(f, adj(y_bar))
+    end
+
+    @testset "Side × extrap matrix (NoExtrap / ClampExtrap)" begin
+        x = collect(0:1:9)
+        xq = [2, 4, 6, 8]
+        f = collect(10:10:100)
+        y_bar = [1, 2, 3, 4]
+        itp_args = (extrap = NoExtrap(),)
+        for sd in (LeftSide(), RightSide(), NearestSide())
+            for ex in (NoExtrap(), ClampExtrap())
+                itp = constant_interp(x, f; side = sd, extrap = ex)
+                adj = constant_adjoint(x, xq; side = sd, extrap = ex)
+                @test dot(itp.(xq), y_bar) == dot(f, adj(y_bar))
+            end
+        end
+    end
+end
+
+# ============================================================================
+# Group 3: Float64 zero-alloc regression (no perf change on float path)
+# ============================================================================
+@testitem "Constant eltype duck-type — Float64 zero-alloc regression" setup = [AllocConstants] begin
+    @testset "Scalar persistent eval @allocated unchanged" begin
+        x = collect(0.0:0.1:1.0)
+        y = sin.(x)
+        itp = constant_interp(x, y)
+        itp(0.5)  # warmup
+        @test (@allocated itp(0.5)) <= ALLOC_THRESHOLD
+    end
+
+    @testset "Range Float64 scalar eval @allocated unchanged" begin
+        x = 0.0:0.1:1.0
+        y = collect(sin.(x))
+        itp = constant_interp(x, y)
+        itp(0.5)
+        @test (@allocated itp(0.5)) <= ALLOC_THRESHOLD
+    end
+
+    @testset "Vector in-place loop @allocated unchanged" begin
+        x = collect(0.0:0.1:1.0)
+        y = sin.(x)
+        xq = collect(0.05:0.1:0.95)
+        out = similar(xq)
+        itp = constant_interp(x, y)
+        itp(out, xq)  # warmup
+        @test (@allocated itp(out, xq)) <= ALLOC_THRESHOLD
+    end
+end

--- a/test/test_constant_eltype.jl
+++ b/test/test_constant_eltype.jl
@@ -537,4 +537,16 @@ end
         @test adj(y_bar) ≈ Float32[0, 1, 0]
         @test dot([itp(xq[1])], y_bar) ≈ dot(y, adj(y_bar))
     end
+
+    @testset "Float32 ND grids + Float64 queries — tie-break consistency" begin
+        x = Float32[0, 1, 2]
+        y = Float32[0, 1, 2]
+        data = Float64[10 * i + j for i in 1:3, j in 1:3]
+        queries = [(nextfloat(0.5), nextfloat(0.5))]
+        y_bar = [1.0]
+
+        itp = constant_interp((x, y), data)
+        adj = constant_adjoint((x, y), queries)
+        @test dot([itp(queries[1])], y_bar) ≈ dot(data, adj(y_bar))
+    end
 end

--- a/test/test_constant_eltype.jl
+++ b/test/test_constant_eltype.jl
@@ -603,27 +603,27 @@ end
 
     @testset "1D Int data + Float xq — scalar/batch/oneshot/broadcast agree" begin
         itp = constant_interp([0.0, 1.0, 2.0, 3.0], [10, 20, 30, 40])
-        @test itp(0.5)                       === 10
-        @test itp([0.5])                     == [10]
-        @test itp([0.5])                     isa Vector{Int}
-        @test itp.([0.5])                    isa Vector{Int}
+        @test itp(0.5) === 10
+        @test itp([0.5]) == [10]
+        @test itp([0.5]) isa Vector{Int}
+        @test itp.([0.5]) isa Vector{Int}
         @test constant_interp([0.0, 1.0, 2.0, 3.0], [10, 20, 30, 40], [0.5]) isa Vector{Int}
     end
 
     @testset "ND Int data + Float xq — scalar/batch/oneshot agree" begin
         x = [0.0, 1.0]; y = [0.0, 1.0]; data = [10 20; 30 40]
         itp = constant_interp((x, y), data)
-        @test itp((0.5, 0.5))                === 10
-        @test itp([(0.5, 0.5)])              == [10]
-        @test itp([(0.5, 0.5)])              isa Vector{Int}
+        @test itp((0.5, 0.5)) === 10
+        @test itp([(0.5, 0.5)]) == [10]
+        @test itp([(0.5, 0.5)]) isa Vector{Int}
         @test constant_interp((x, y), data, [(0.5, 0.5)]) isa Vector{Int}
     end
 
     @testset "1D persistent Dual → carrier preserved (scalar + batch)" begin
         itp = constant_interp([0.0, 1.0, 2.0, 3.0], [10, 20, 30, 40])
         d = Dual(0.5, 1.0)
-        @test itp(d)    isa Dual{Nothing, Float64, 1}
-        @test itp([d])  isa Vector{<:Dual{Nothing, Float64, 1}}
+        @test itp(d) isa Dual{Nothing, Float64, 1}
+        @test itp([d]) isa Vector{<:Dual{Nothing, Float64, 1}}
         @test itp.([d]) isa Vector{<:Dual{Nothing, Float64, 1}}
     end
 
@@ -631,7 +631,7 @@ end
         x = [0.0, 1.0]; y = [0.0, 1.0]; data = [10 20; 30 40]
         itp = constant_interp((x, y), data)
         d = Dual(0.5, 1.0)
-        @test itp((d, d))     isa Dual{Nothing, Float64, 1}
-        @test itp([(d, d)])   isa Vector{<:Dual{Nothing, Float64, 1}}
+        @test itp((d, d)) isa Dual{Nothing, Float64, 1}
+        @test itp([(d, d)]) isa Vector{<:Dual{Nothing, Float64, 1}}
     end
 end

--- a/test/test_constant_eltype.jl
+++ b/test/test_constant_eltype.jl
@@ -246,3 +246,131 @@ end
         @test (@allocated itp(out, xq)) <= ALLOC_THRESHOLD
     end
 end
+
+# ============================================================================
+# Group 4: ND (Phase 2 — selection kernel generalizes to per-axis cell pick)
+# ============================================================================
+# Constant ND follows the same raw-eltype contract:
+#   Tg = promote_type(eltype.(grids)...)   (no `float()` widening)
+#   Tv = eltype(data)
+# Container heterogeneity (Range × Vector axes) was always supported via
+# `_convert_grids_typed`; eltype heterogeneity is unified to a single Tg via
+# `promote_type` (Int × Float → Float, Int × Rational → Rational, …).
+@testitem "Constant eltype duck-type — ND forward + adjoint" begin
+    using LinearAlgebra: dot
+    import FastInterpolations: ConstantInterpolantND, _CachedRange, _CachedVector
+
+    @testset "2D persistent — homogeneous eltypes" begin
+        @testset "Int × Int axes, Int data → ConstantInterpolantND{Int, Int, 2}" begin
+            x = 0:1:4
+            y = [0, 1, 2, 3]
+            data = [10 * i + j for i in 1:5, j in 1:4]   # Int matrix
+            itp = constant_interp((x, y), data)
+            @test itp isa ConstantInterpolantND{Int, Int, 2}
+            @test itp((2.5, 1.5)) isa Int
+            @test itp.grids[1] isa _CachedRange{Int, Float64}
+            @test itp.grids[2] isa _CachedVector{Int, Float64}
+        end
+
+        @testset "Rational × Rational axes, Rational data" begin
+            x = Rational{Int}[0 // 1, 1 // 1, 2 // 1, 3 // 1]
+            y = Rational{Int}[0 // 1, 1 // 1, 2 // 1]
+            data = Rational{Int}[i // 1 + j // 2 for i in 1:4, j in 1:3]
+            itp = constant_interp((x, y), data)
+            @test itp isa ConstantInterpolantND{Rational{Int}, Rational{Int}, 2}
+            @test itp((3 // 2, 1 // 2)) isa Rational{Int}
+        end
+
+        @testset "Float32 × Float32 axes → Float32 preserved (regression guard)" begin
+            x = Float32[0, 1, 2, 3, 4]
+            y = Float32[0, 1, 2, 3]
+            data = Float32[i + j for i in 1:5, j in 1:4]
+            itp = constant_interp((x, y), data)
+            @test itp isa ConstantInterpolantND{Float32, Float32, 2}
+            @test itp((2.5f0, 1.5f0)) isa Float32
+        end
+    end
+
+    @testset "2D persistent — heterogeneous container types (Range × Vector)" begin
+        # Container heterogeneity was always supported; pin it under the new
+        # raw-eltype policy too. Both axes share a single Tg via promote_type.
+        x = 0:1:4                # Int Range
+        y = [0.0, 1.0, 2.0, 3.0] # Float Vector
+        data = [Float64(i + j) for i in 1:5, j in 1:4]
+        itp = constant_interp((x, y), data)
+        # promote_type(Int, Float64) == Float64 → Tg unified.
+        @test itp isa ConstantInterpolantND{Float64, Float64, 2}
+        @test itp((2.5, 1.5)) isa Float64
+    end
+
+    @testset "Int data + Float axes — output tracks `eltype(data)`" begin
+        # Axes Float, data Int → Tv=Int, Tg=Float64.
+        x = [0.0, 1.0, 2.0, 3.0]
+        y = [0.0, 1.0, 2.0]
+        data = [10 * i + j for i in 1:4, j in 1:3]  # Int matrix
+        itp = constant_interp((x, y), data)
+        @test itp isa ConstantInterpolantND{Float64, Int, 2}
+        @test itp((1.5, 0.5)) isa Int
+    end
+
+    @testset "3D sanity — Int^3 → Int output" begin
+        x = 0:1:3
+        y = 0:1:2
+        z = 0:1:2
+        data = [i + 10j + 100k for i in 1:4, j in 1:3, k in 1:3]  # Int 3D
+        itp = constant_interp((x, y, z), data)
+        @test itp isa ConstantInterpolantND{Int, Int, 3}
+        @test itp((1.5, 0.5, 1.5)) isa Int
+    end
+
+    @testset "PeriodicBC + Int axes (inclusive)" begin
+        x = 0:1:3                # length 4, closed cycle in y data
+        y = 0:1:2
+        # Closed-cycle data: data[end, :] == data[1, :] (period 3 in x).
+        data = [(i == 4 ? 1 : i) + 10j for i in 1:4, j in 1:3]
+        itp = constant_interp((x, y), data; bc = (PeriodicBC(), NoBC()))
+        @test itp isa ConstantInterpolantND{Int, Int, 2}
+        @test itp((0.5, 1.5)) isa Int
+    end
+
+    @testset "ND oneshot scalar — Int input → Int output" begin
+        x = 0:1:4
+        y = 0:1:3
+        data = [10 * i + j for i in 1:5, j in 1:4]
+        r = constant_interp((x, y), data, (2.5, 1.5))
+        @test r isa Int
+    end
+
+    @testset "ND oneshot batch — Vector{Int} preserved" begin
+        x = 0:1:4
+        y = 0:1:3
+        data = [10 * i + j for i in 1:5, j in 1:4]
+        queries = [(2.5, 1.5), (0.5, 0.5), (3.5, 2.5)]
+        vals = constant_interp((x, y), data, queries)
+        @test vals isa Vector{Int}
+        @test length(vals) == 3
+    end
+
+    @testset "ND adjoint — Int grid + Int xq dot-product identity (exact ==)" begin
+        x = collect(0:1:5)
+        y = collect(0:1:4)
+        f = [10 * i + j for i in 1:6, j in 1:5]    # Int data
+        queries = [(2, 1), (4, 3), (1, 2)]
+        y_bar = [1, 2, 3]
+        itp = constant_interp((x, y), f)
+        adj = constant_adjoint((x, y), queries)
+        # Exact equality with Int — selection kernel + Int data + Int weights.
+        @test dot([itp(q) for q in queries], y_bar) == dot(vec(f), vec(adj(y_bar)))
+    end
+end
+
+@testitem "Constant eltype duck-type — ND Float64 zero-alloc regression" setup = [AllocConstants] begin
+    @testset "2D scalar eval @allocated unchanged (Float64 path)" begin
+        x = collect(0.0:0.1:1.0)
+        y = collect(0.0:0.1:1.0)
+        data = [sin(2π * xi) * cos(2π * yj) for xi in x, yj in y]
+        itp = constant_interp((x, y), data)
+        itp((0.5, 0.5))   # warmup
+        @test (@allocated itp((0.5, 0.5))) <= ND_ALLOC_THRESHOLD
+    end
+end

--- a/test/test_constant_eltype.jl
+++ b/test/test_constant_eltype.jl
@@ -431,10 +431,8 @@ end
         y = [10, 20, 30, 40, 50]
         itp = constant_interp(x, y; extrap = FillExtrap(-1))
         @test itp.extrap === FillExtrap{Int}(-1)  # raw Tv stored
-        @test itp(1.5) === 20                      # in-domain: raw Tv preserved
-        # OOB widens to promote_type(Tv, Tq) — Dual-AD-friendly; pending a
-        # separate raw-Tv-on-OOB decision.
-        @test_broken itp(-1.0) === -1
+        @test itp(1.5) === 20                      # in-domain
+        @test itp(-1.0) === -1                     # OOB also raw Tv (scalar callable convert)
     end
 
     @testset "1D persistent: Int data + Float fill → InexactError on construction" begin
@@ -588,5 +586,52 @@ end
         @test constant_interp(x, y, [0.5, 1.5]) isa Vector{Int}
         @test constant_interp(x, s, 0.5) isa Vector{Int}
         @test constant_interp(x, s, [0.5, 1.5]) isa Vector{Vector{Int}}
+    end
+end
+
+# ============================================================================
+# Group 10: Persistent batch/scalar match oneshot output rules (Codex P2 + Dual)
+# ============================================================================
+# The shared 1D / ND `AbstractInterpolant` protocols allocate via
+# `_output_eltype(Tv, Tg, Tq)` which widens — that's correct for arithmetic
+# kernels but breaks Constant's raw-Tv contract. Constant overrides the
+# scalar + batch callables so scalar / `itp([xq])` / `itp.([xq])` / oneshot
+# all agree, and duck queries widen consistently across the family.
+@testitem "Constant persistent: batch + scalar follow raw-Tv contract + duck widen" begin
+    using ForwardDiff
+    using ForwardDiff: Dual
+
+    @testset "1D Int data + Float xq — scalar/batch/oneshot/broadcast agree" begin
+        itp = constant_interp([0.0, 1.0, 2.0, 3.0], [10, 20, 30, 40])
+        @test itp(0.5)                       === 10
+        @test itp([0.5])                     == [10]
+        @test itp([0.5])                     isa Vector{Int}
+        @test itp.([0.5])                    isa Vector{Int}
+        @test constant_interp([0.0, 1.0, 2.0, 3.0], [10, 20, 30, 40], [0.5]) isa Vector{Int}
+    end
+
+    @testset "ND Int data + Float xq — scalar/batch/oneshot agree" begin
+        x = [0.0, 1.0]; y = [0.0, 1.0]; data = [10 20; 30 40]
+        itp = constant_interp((x, y), data)
+        @test itp((0.5, 0.5))                === 10
+        @test itp([(0.5, 0.5)])              == [10]
+        @test itp([(0.5, 0.5)])              isa Vector{Int}
+        @test constant_interp((x, y), data, [(0.5, 0.5)]) isa Vector{Int}
+    end
+
+    @testset "1D persistent Dual → carrier preserved (scalar + batch)" begin
+        itp = constant_interp([0.0, 1.0, 2.0, 3.0], [10, 20, 30, 40])
+        d = Dual(0.5, 1.0)
+        @test itp(d)    isa Dual{Nothing, Float64, 1}
+        @test itp([d])  isa Vector{<:Dual{Nothing, Float64, 1}}
+        @test itp.([d]) isa Vector{<:Dual{Nothing, Float64, 1}}
+    end
+
+    @testset "ND persistent Dual → carrier preserved (scalar + batch)" begin
+        x = [0.0, 1.0]; y = [0.0, 1.0]; data = [10 20; 30 40]
+        itp = constant_interp((x, y), data)
+        d = Dual(0.5, 1.0)
+        @test itp((d, d))     isa Dual{Nothing, Float64, 1}
+        @test itp([(d, d)])   isa Vector{<:Dual{Nothing, Float64, 1}}
     end
 end

--- a/test/test_constant_oneshot_series.jl
+++ b/test/test_constant_oneshot_series.jl
@@ -136,21 +136,23 @@
         @test measure(x, y_sin, y_cos) <= ALLOC_THRESHOLD
     end
 
-    @testset "Type promotion: Integer series" begin
+    @testset "Eltype contract: Integer series stays Int" begin
         x_f = collect(0.0:1.0:4.0)
         y1_int = [0, 1, 3, 4, 7]
         y2_int = [2, 3, 1, 0, 5]
         vals = constant_interp(x_f, Series(y1_int, y2_int), 1.5)
-        @test vals isa Vector{Float64}
-        ref1 = constant_interp(x_f, Float64.(y1_int), 1.5)
-        @test vals[1] ≈ ref1
+        @test vals isa Vector{Int}
+        @test vals[1] == constant_interp(x_f, y1_int, 1.5)
     end
 
-    @testset "Type promotion: FillExtrap with Integer series" begin
+    @testset "Eltype contract: FillExtrap fill_value must be compatible with y eltype" begin
         x_f = collect(0.0:1.0:4.0)
         y_int = [0, 1, 3, 4, 7]
-        vals = constant_interp(x_f, Series(y_int), 5.0; extrap = FillExtrap(0.5))
-        @test vals[1] ≈ 0.5
+        # Int series + Int fill_value → output is Int.
+        vals = constant_interp(x_f, Series(y_int), 5.0; extrap = FillExtrap(9))
+        @test vals[1] == 9
+        # Int series + Float fill_value → InexactError (raw eltype contract is strict).
+        @test_throws InexactError constant_interp(x_f, Series(y_int), 5.0; extrap = FillExtrap(0.5))
     end
 
     @testset "Scalar: Vector-of-Vectors" begin

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -531,7 +531,8 @@
         y = Float64.(0:10)
         itp = constant_interp(x, y; bc = PeriodicBC(endpoint = :exclusive, period = 11.0))
         @test itp.x isa FastInterpolations._ExclusivePeriodicAxis
-        @test itp.x.inner isa _CachedRange{Float64}
+        # Constant duck-types grid eltype: Int Range stays Int (Tinv = Float64).
+        @test itp.x.inner isa _CachedRange{Int, Float64}
         @test length(itp.x) == 12
         @test length(itp.x.inner) == 11
         ref = constant_interp(Float64.(0:10), y; bc = PeriodicBC(endpoint = :exclusive, period = 11.0))

--- a/test/test_constant_series_interp.jl
+++ b/test/test_constant_series_interp.jl
@@ -370,38 +370,40 @@
     # Type Promotion Tests (coverage for Real type wrappers)
     # ========================================
 
-    @testset "type promotion" begin
-        @testset "Integer x with Float y vectors (promotes to Float64)" begin
-            x_int = collect(1:10)  # Integer vector
+    # Constant duck-types eltype: Int x stays Int (no Float widening), Float y
+    # series stays Float. Output tracks Series eltype.
+    @testset "eltype contract (raw eltype, no Float promotion)" begin
+        @testset "Integer x with Float y vectors → Tg=Int, Tv=Float64" begin
+            x_int = collect(1:10)
             y1 = sin.(Float64.(x_int))
             y2 = cos.(Float64.(x_int))
 
             sitp = constant_interp(x_int, Series(y1, y2))
-            @test sitp isa FI.ConstantSeriesInterpolant{Float64}
+            @test sitp isa FI.ConstantSeriesInterpolant{Int, Float64}
 
             result = sitp(5.5)
             @test length(result) == 2
             @test all(isfinite, result)
         end
 
-        @testset "Integer x with Integer y vectors (promotes to Float64)" begin
+        @testset "Integer x with Integer y vectors → Tg=Int, Tv=Int" begin
             x_int = collect(1:10)
             y1_int = collect(1:10)
             y2_int = collect(10:-1:1)
 
             sitp = constant_interp(x_int, Series(y1_int, y2_int))
-            @test sitp isa FI.ConstantSeriesInterpolant{Float64}
+            @test sitp isa FI.ConstantSeriesInterpolant{Int, Int}
 
             result = sitp(5.5)
             @test length(result) == 2
         end
 
-        @testset "Integer x with Integer y matrix (promotes to Float64)" begin
+        @testset "Integer x with Integer y matrix → Tg=Int, Tv=Int" begin
             x_int = collect(1:10)
             Y_int = [i * j for i in 1:10, j in 1:3]
 
             sitp = constant_interp(x_int, Series(Y_int))
-            @test sitp isa FI.ConstantSeriesInterpolant{Float64}
+            @test sitp isa FI.ConstantSeriesInterpolant{Int, Int}
             @test FI.n_series(sitp) == 3
 
             result = sitp(5.5)

--- a/test/test_grid_accessors.jl
+++ b/test/test_grid_accessors.jl
@@ -64,17 +64,18 @@
         Tuple{Any, _CachedVector, Int}
     end
 
-    @testset "Int grid → Float h" begin
-        # `_get_h` always promotes to float for kernel compatibility
+    @testset "Int grid → raw Int h, Float inv_h" begin
+        # `_get_h` preserves raw eltype (no `float()` widening). `_get_inv_h`
+        # promotes naturally via `inv(::Int) → Float64`. `_CachedVector` and
+        # raw Vector both follow the same contract.
         x_int = [0, 1, 3, 6]
         c_int = _CachedVector(x_int)
 
-        @test _get_h(x_int, 1) === 1.0  # float() of (x[2]-x[1])=1
-        @test _get_h(x_int, 2) === 2.0
+        @test _get_h(x_int, 1) === 1
+        @test _get_h(x_int, 2) === 2
         @test _get_inv_h(x_int, 2) === 0.5
 
-        # _CachedVector for Int grid: h stays Int, inv_h is Float64
-        @test _get_h(c_int, 1) === 1   # raw cached Int
+        @test _get_h(c_int, 1) === 1
         @test _get_inv_h(c_int, 2) === 0.5
     end
 

--- a/test/test_mixed_precision_extrap.jl
+++ b/test/test_mixed_precision_extrap.jl
@@ -198,18 +198,25 @@ end
     # ignored Tg, defaulted Int eltype to Float64, and the inner ctor's
     # `_promote_grid_float(Float64, Float32)` then widened y to Float64 too.
     # Cubic (still on the legacy `_resolve_axis_copied(x, bc, T)` builder) was
-    # unaffected; the migrated families (Linear / Constant / PCHIP / Cardinal /
-    # Akima + their Series + ND) lost the Float32 promotion contract.
+    # unaffected; the migrated families (Linear / PCHIP / Cardinal / Akima +
+    # their Series + ND) lost the Float32 promotion contract.
+    #
+    # Constant is an exception: under the raw-eltype duck-typing policy
+    # (`Tg = eltype(x)`, `Tv = eltype(y)`), `constant_interp(1:4, Float32[...])`
+    # keeps `Tg = Int`. The selection kernel performs no x·y arithmetic, so
+    # there is no precision argument for widening x. Verified explicitly below.
     x_int = 1:4
     y32 = Float32[1.0, 2.0, 3.0, 4.0]
 
-    @testset "1D Linear / Constant" begin
+    @testset "1D Linear" begin
         itp_l = linear_interp(x_int, y32)
         @test itp_l.x isa FastInterpolations._CachedRange{Float32}
         @test itp_l.y isa Vector{Float32}
+    end
 
+    @testset "1D Constant (raw-eltype: Tg stays Int)" begin
         itp_c = constant_interp(x_int, y32)
-        @test itp_c.x isa FastInterpolations._CachedRange{Float32}
+        @test itp_c.x isa FastInterpolations._CachedRange{Int, Float64}
         @test itp_c.y isa Vector{Float32}
     end
 
@@ -236,13 +243,15 @@ end
         @test itp.y isa Vector{Float32}
     end
 
-    @testset "1D Series (Linear / Constant)" begin
+    @testset "1D Series (Linear)" begin
         sitp_l = linear_interp(x_int, Series(y32, y32))
         @test sitp_l.x isa FastInterpolations._CachedRange{Float32}
         @test sitp_l.y isa Matrix{Float32}
+    end
 
+    @testset "1D Series (Constant): raw-eltype keeps Tg = Int" begin
         sitp_c = constant_interp(x_int, Series(y32, y32))
-        @test sitp_c.x isa FastInterpolations._CachedRange{Float32}
+        @test sitp_c.x isa FastInterpolations._CachedRange{Int, Float64}
         @test sitp_c.y isa Matrix{Float32}
     end
 

--- a/test/test_precision_vector_queries.jl
+++ b/test/test_precision_vector_queries.jl
@@ -50,9 +50,10 @@
 
         @testset "Allocating vector call" begin
             @test result_vec ≈ result_broadcast rtol = PRECISION_RTOL
-            @test eltype(result_vec) == Float64  # Output should be promoted
-            # Note: broadcast may return Tv (value type) which is Float32 for constant
-            # This is acceptable as constant interpolation returns y[idx] directly
+            # Constant is a selection kernel — output keeps raw `Tv` (Float32),
+            # not promoted to the query precision. Scalar / broadcast / batch
+            # all agree on this contract for plain numeric queries.
+            @test eltype(result_vec) == Float32
         end
 
         @testset "In-place vector call" begin

--- a/test/test_promotion_alloc.jl
+++ b/test/test_promotion_alloc.jl
@@ -119,9 +119,9 @@
         y_int = [0, 1, 3, 2, 5]
         xq_test = [0.5, 1.5, 2.5, 3.5]
 
-        # Allocating batch (all methods)
+        # Allocating batch (all methods). Constant duck-types: Int y → Vector{Int}.
         @test linear_interp(x_int, y_int, xq_test) isa Vector{Float64}
-        @test constant_interp(x_int, y_int, xq_test) isa Vector{Float64}
+        @test constant_interp(x_int, y_int, xq_test) isa Vector{Int}
         @test quadratic_interp(x_int, y_int, xq_test) isa Vector{Float64}
         @test cubic_interp(x_int, y_int, xq_test; extrap = ExtendExtrap()) isa Vector{Float64}
         @test pchip_interp(x_int, y_int, xq_test; extrap = ExtendExtrap()) isa Vector{Float64}

--- a/test/test_series_wrapper.jl
+++ b/test/test_series_wrapper.jl
@@ -199,7 +199,9 @@
     end
 
     # ────────────────────────────────────────────
-    # Int grid + Float32 values: grid narrows to Float32
+    # Int grid + Float32 values: arithmetic methods narrow Tg to Float32 via
+    # `_promote_grid_float`; Constant keeps raw `Tg = eltype(x) = Int` because
+    # its selection kernel returns `y[idx]::Tv` without x·y arithmetic.
     # ────────────────────────────────────────────
     @testset "Int grid + Float32 values promotion" begin
         x_int = collect(1:10)
@@ -209,8 +211,9 @@
         sitp_lin = linear_interp(x_int, Series(y_f32a, y_f32b))
         @test grid_type(sitp_lin) == Float32
 
+        # Constant duck-types: grid stays Int (no narrowing), Tv stays Float32.
         sitp_cst = constant_interp(x_int, Series(y_f32a, y_f32b))
-        @test grid_type(sitp_cst) == Float32
+        @test grid_type(sitp_cst) == Int
 
         sitp_quad = quadratic_interp(x_int, Series(y_f32a, y_f32b))
         @test grid_type(sitp_quad) == Float32

--- a/test/test_type_stability.jl
+++ b/test/test_type_stability.jl
@@ -228,14 +228,15 @@
             x_int = 1:5
             y_float = Float64[10, 20, 30, 40, 50]
 
+            # Constant duck-types: Int x stays Int (no Float widening), Tv=eltype(y).
             citp = @inferred constant_interp(x_int, y_float)
-            @test citp isa ConstantInterpolant{Float64}
-            @test eltype(citp.x) === Float64
+            @test citp isa ConstantInterpolant{Int, Float64}
+            @test eltype(citp.x) === Int
 
             # Integer Vector grid
             x_int_vec = [1, 2, 3, 4, 5]
             citp_vec = @inferred constant_interp(x_int_vec, y_float)
-            @test citp_vec isa ConstantInterpolant{Float64}
+            @test citp_vec isa ConstantInterpolant{Int, Float64}
 
             # Verify interpolation works correctly
             @test citp(2.5) isa Float64
@@ -268,8 +269,9 @@
             @test eltype(litp.x) === Float64
             @test eltype(litp.y) === Float64
 
+            # Constant duck-types: Int x stays Int, Int y stays Int.
             citp = @inferred constant_interp(x_int, y_int)
-            @test citp isa ConstantInterpolant{Float64}
+            @test citp isa ConstantInterpolant{Int, Int}
 
             qitp = @inferred quadratic_interp(x_int, y_int)
             @test qitp isa QuadraticInterpolant{Float64}


### PR DESCRIPTION
## Motivation

`constant_interp` is a lookup table — `y[idx]` selection with a side comparison, no `xq * inv_h` arithmetic on `X`. The output should be whatever is in the table. Master always force-promoted both `X` and `Y` to `Float64`, so an `Int` lookup table returned `Float64`:

```julia
# Before (master): Int lookup returns Float64 — unwanted
itp = constant_interp(0:9, [10, 20, 30, 40, 50, 60, 70, 80, 90, 100])
itp(1.5)              # 20.0 :: Float64
eltype(itp.y)         # Float64

# After (this PR): raw Tv preserved
itp = constant_interp(0:9, [10, 20, 30, 40, 50, 60, 70, 80, 90, 100])
itp(1.5)              # 20    :: Int
eltype(itp.y)         # Int
```

Same for `ComplexF32`, `Rational`, custom value types — all flow through. Other methods (Linear, Cubic, …) keep widening: they consume `X` via Float arithmetic, so the contract genuinely differs. Constant is the only selection-kernel exception.

**Size**: 13 commits, 31 files, +822 / −221.

## Contract change (Constant only — other methods unchanged)

| `constant_interp` path           | Master                        | Branch                                 |
|----------------------------------|-------------------------------|----------------------------------------|
| `eltype(itp.y)`                  | `Float64` (force)             | `eltype(y)`                            |
| `eltype(itp.x)`                  | `Float64` (force)             | `eltype(x)`                            |
| ND build `data_typed`            | always `Tv.(data)` copy       | aliased when `Tv === eltype(data)`     |
| `constant_adjoint` anchor query  | narrows to `Tg`               | `promote_type(Tg, eltype(xq))`         |
| Series scalar output             | `promote_type(Tv, Tq)` always | `Tv` for plain queries, widen for Dual |

## Implementation

- **Eltype hoist**: Constant ctors (1D / ND / Series) thread `{Tg, Tv}` from the user signature directly; `_PromotableValue` and duck types both pass through.
- **`_CachedRange{T, Tinv}`**: separate `Tinv = typeof(inv(oneunit(T)))` so an `Int` range caches `h::Int, inv_h::Float64`. `cubic_cache_pool` pins `{T, T}` explicitly.
- **Anchor `Tq` decouple**: builders produce `_ConstantAnchoredQuery{Tg, promote_type(Tg, eltype(xq))}`. `ConstantAdjoint` and `ConstantAdjointND` gain a `Tq` type parameter. Matches Linear's pattern.
- **`_promote_query_typed`**: widens via `promote_type(Tg, Tq)` — never narrows.
- **Hermite kernels**: `h::Tg` and `inv_h::Tinv` decoupled.
- **`_get_h` / `_get_inv_h`**: drop redundant `float(...)` on raw vector / range fallbacks.

## Performance

Forward scalar eval, 1000-pt grid, `AutoSearch`, zero alloc. Setup:

```julia
using BenchmarkTools, FastInterpolations
x_int   = collect(0:1000)              # Vector{Int}
x_float = Float64.(0:1000)             # Vector{Float64}
y       = sin.(0.01 .* x_int)          # Vector{Float64}

itp_int   = constant_interp(x_int,   y)   # _CachedVector{Int,     Float64}
itp_float = constant_interp(x_float, y)   # _CachedVector{Float64, Float64}

@benchmark $itp_int(500.7)    samples = 10000
@benchmark $itp_float(500.7)  samples = 10000
```

Measured (Apple M-series, Julia 1.12):

| Method   | `Int` grid    | `Float64` grid |
|----------|---------------|----------------|
| Constant | **9.67 ns**   | 12.05 ns       |
| Linear   | 12.30 ns      | 12.30 ns       |
| Cubic    | 14.86 ns      | 14.86 ns       |

`Int`-grid Constant gains ~20 % because the cached axis stays `_CachedVector{Int, Float64}` (vs master's force-widened `{Float64, Float64}`) — Int arithmetic in `_search_direct` and the `NearestSide` comparison is faster than the `Float64` path. Steady-state per-call gain, not a ctor-time amortization. Linear / Cubic are byte-identical to master.

## Out of scope

- `FillExtrap` OOB returns `promote_type(Tv, Tq)`, not raw `Tv` — Dual-AD compatibility today; pinned `@test_broken` in Group 6.
- Extending the raw-eltype contract to Linear / Cubic / … is not justified (zero measured perf gain — `X` is consumed by Float arithmetic). The anchor `Tq = promote_type(Tg, eltype(xq))` pattern is now shared between Constant and Linear for any future need.
