### PR TITLE
(fix): ND oneshot per-axis adaptive search + Series oneshot batch loop-order

### DIFF
--- a/benchmark/ci_benchmark.jl
+++ b/benchmark/ci_benchmark.jl
@@ -345,6 +345,86 @@ for (glabel, itp) in [("range", itp_cubic), ("vec", itp_cubic_vec)]
 end
 
 # ══════════════════════════════════════════════════════════════════════════════
+# ND One-Shot: Vector grid × Query pattern (per-axis adaptive search)
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Exercises the per-axis adaptive search dispatch inside ND oneshot batch
+# (sort axis → LinearBinary + persistent hint, rand axis → Binary). Vector
+# grids force the runtime search path; Range grids would use O(1) arithmetic
+# regardless of query pattern and hide the dispatch behavior. Includes a
+# `sort_rand` mixed case so a regression that disables per-axis selection
+# (collapsing both axes to a single policy) shows up here.
+
+println("Setting up ND one-shot grid×query pattern benchmarks...")
+
+const N_ND_GQ = 51
+const NQ_ND_GQ = 1000
+const x2d_vec_gq = collect(range(0.0, 10.0, N_ND_GQ))
+const y2d_vec_gq = collect(range(0.0, 6.0, N_ND_GQ))
+const data2d_gq = [sin(xi) * cos(yj) for xi in x2d_vec_gq, yj in y2d_vec_gq]
+const qx_sort_gq = collect(range(0.1, 9.9, NQ_ND_GQ))
+const qy_sort_gq = collect(range(0.1, 5.9, NQ_ND_GQ))
+const qx_rand_gq = shuffle(MersenneTwister(BENCH_RNG_SEED), copy(qx_sort_gq))
+const qy_rand_gq = shuffle(MersenneTwister(BENCH_RNG_SEED + 1), copy(qy_sort_gq))
+
+const _ND_GQ_PATTERNS = (
+    ("sort_sort", qx_sort_gq, qy_sort_gq),
+    ("rand_rand", qx_rand_gq, qy_rand_gq),
+    ("sort_rand", qx_sort_gq, qy_rand_gq),
+)
+
+# 13. ND One-Shot: Vector × Vector grid × query pattern
+for (lbl, qx, qy) in _ND_GQ_PATTERNS
+    let b = @benchmarkable linear_interp(($x2d_vec_gq, $y2d_vec_gq), $data2d_gq, ($qx, $qy))
+        b.params.evals = EVALS_MED
+        suite["13_nd_oneshot_gridquery"]["bilinear_2d_$(lbl)"] = b
+    end
+end
+
+for (lbl, qx, qy) in _ND_GQ_PATTERNS
+    clear_cubic_cache!()
+    cubic_interp((x2d_vec_gq, y2d_vec_gq), data2d_gq, (qx, qy))  # prime cache
+    let b = @benchmarkable cubic_interp(($x2d_vec_gq, $y2d_vec_gq), $data2d_gq, ($qx, $qy))
+        b.params.evals = EVALS_SLOW
+        suite["13_nd_oneshot_gridquery"]["bicubic_2d_$(lbl)"] = b
+    end
+end
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Linear / Constant Series One-Shot Batch (in-place)
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Detects regressions in the Series oneshot vector-batch code path
+# (`{linear,constant}_interp!(outs, x, ::Series, xqs)`). Vector grid + many
+# random queries is the configuration where the loop ordering
+# (Q outer × K inner vs K outer × Q inner) materially changes per-query cache
+# behavior on the `outputs[k][j]` write pattern. The in-place API is used so
+# the timing reflects pure computation — no per-call output allocation, no GC
+# pressure. (`8_cubic_multi` already covers Cubic series in-place.)
+
+println("Setting up Linear/Constant Series one-shot batch benchmarks...")
+
+const N_SER = 100
+const K_SER = 8
+const NQ_SER = 1000
+const x_ser = collect(range(0.0, 2π, N_SER + 1))
+const Y_ser = hcat([sin.(j .* x_ser) for j in 1:K_SER]...)
+const Ys_ser = Series(Y_ser)
+const q_ser_rand = rand(MersenneTwister(BENCH_RNG_SEED), NQ_SER) .* 2π
+const outs_ser = [Vector{Float64}(undef, NQ_SER) for _ in 1:K_SER]
+
+# 14. Linear / Constant Series one-shot batch (in-place)
+let b = @benchmarkable linear_interp!($outs_ser, $x_ser, $Ys_ser, $q_ser_rand)
+    b.params.evals = EVALS_SLOW
+    suite["14_series_oneshot_batch"]["linear_inplace_vec_k$(K_SER)_q$(NQ_SER)_rand"] = b
+end
+
+let b = @benchmarkable constant_interp!($outs_ser, $x_ser, $Ys_ser, $q_ser_rand)
+    b.params.evals = EVALS_SLOW
+    suite["14_series_oneshot_batch"]["constant_inplace_vec_k$(K_SER)_q$(NQ_SER)_rand"] = b
+end
+
+# ══════════════════════════════════════════════════════════════════════════════
 # CLI Argument Parsing
 # ══════════════════════════════════════════════════════════════════════════════
 

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -221,7 +221,7 @@ Internal implementation of _anchor_query for constant interpolation.
     loc = _anchor_loc(x, xq, wrap, policy)
 
     # Compute geometry (constant-internal concern)
-    h = _get_h(x, loc.xL, loc.xR)
+    h = _get_h(x, loc.idx, loc.xL, loc.xR)
     dL = loc.xq - loc.xL
     # Promote xq to match dL type (Float64 query + Dual grid → dL is Dual)
     xq_promoted = oftype(dL, loc.xq)

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -38,7 +38,7 @@
     end
     idx, idx_R, xL, xR = search_interval(searcher, x, xi)
     dL = xi - xL
-    @inbounds return _constant_kernel(op, y[idx], y[idx_R], _get_h(x, xL, xR), dL, side)
+    @inbounds return _constant_kernel(op, y[idx], y[idx_R], _get_h(x, idx, xL, xR), dL, side)
 end
 
 # ExtendExtrap: constant function has zero slope → extend = clamp.
@@ -73,7 +73,7 @@ end
     end
     idx, idx_R, xL, xR = search_interval(searcher, x, xi)
     dL = xi - xL
-    @inbounds return _constant_kernel(op, y[idx], y[idx_R], _get_h(x, xL, xR), dL, side)
+    @inbounds return _constant_kernel(op, y[idx], y[idx_R], _get_h(x, idx, xL, xR), dL, side)
 end
 
 # WrapExtrap: wrap query to domain → search + kernel.
@@ -94,10 +94,10 @@ end
     dL = xi_wrapped - xL
     # Unwrap data once: `search_interval` already resolved the seam (idx_R = 1
     # at seam cell), so direct inner access skips the wrapper's cyclic
-    # `Base.getindex` branch on each `y[idx]` / `y[idx_R]`. The 3-arg
-    # `_get_h(x, xL, xR)` is already wrapper-aware and branch-free.
+    # `Base.getindex` branch on each `y[idx]` / `y[idx_R]`. The 4-arg
+    # `_get_h(x, idx, xL, xR)` is wrapper- and cache-aware.
     yi = _raw(y)
-    @inbounds return _constant_kernel(op, yi[idx], yi[idx_R], _get_h(x, xL, xR), dL, side)
+    @inbounds return _constant_kernel(op, yi[idx], yi[idx_R], _get_h(x, idx, xL, xR), dL, side)
 end
 
 

--- a/src/constant/constant_oneshot_series.jl
+++ b/src/constant/constant_oneshot_series.jl
@@ -238,8 +238,8 @@ end
     return outputs
 end
 
-# Adaptive entry. `length(xqs)` selects the loop order — see
-# `_SERIES_BATCH_LOOP_THRESHOLD` docs in `src/core/series_utils.jl`.
+# Adaptive entry. `length(xqs)` and `K` feed `_series_use_kq_loop` to select
+# the loop order — see `src/core/series_utils.jl`.
 # `x_last = Tg(last(x))` is computed inside each helper from the same
 # `x_eff` it uses (preserves the right-continuous short-circuit inside
 # `_constant_eval_at_anchor` for inclusive queries at `xq == x[n]`).

--- a/src/constant/constant_oneshot_series.jl
+++ b/src/constant/constant_oneshot_series.jl
@@ -133,10 +133,116 @@ end
 # ║                         VECTOR ONE-SHOT API                              ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
-# Zero-pool vector-batch: Q outer × K inner, mirrors the Linear counterpart
-# with `side` + `x_last` propagation. `x_last = Tg(last(x))` on the ORIGINAL
-# grid — preserves the right-continuous short-circuit inside
-# `_constant_eval_at_anchor` for inclusive queries at `xq == x[n]`.
+# Q outer × K inner — small-NQ fast path. Anchor is stack-resident across
+# the K-inner loop. No pool acquired, so callers with tiny `xqs` don't pay
+# pool-setup overhead. `_is_periodic_bc(bc)` is compile-time-resolved.
+@inline function _constant_series_batch_qk!(
+        outputs::AbstractVector{<:AbstractVector},
+        x::AbstractVector,
+        vecs,
+        xqs::AbstractVector,
+        bc::AbstractBC,
+        op::AbstractEvalOp,
+        side::AbstractSide,
+        extrap::AbstractExtrap,
+        search::AbstractSearchPolicy
+    )
+    K = length(vecs)
+    NQ = length(xqs)
+    Tg_actual = eltype(x)
+
+    if _is_periodic_bc(bc)
+        x_eff = _resolve_axis(x, bc)
+        extrap_p = _resolve_extrap(NoExtrap(), bc, x_eff)
+        searcher = _resolve_search(x_eff, xqs, search, nothing, NoBC())
+        x_last = @inbounds Tg_actual(last(x_eff))
+        @inbounds for j in 1:NQ
+            xq_wrapped = _wrap_to_domain(xqs[j], x_eff)
+            idxL, idxR, xL, _ = search_interval(searcher, x_eff, xq_wrapped)
+            h = _get_h(x_eff, idxL)
+            dL = xq_wrapped - xL
+            xq_promoted = oftype(dL, xq_wrapped)
+            aq = _ConstantAnchoredQuery(_IdxPair(idxL, idxR), xq_promoted, IN_DOMAIN, h, dL)
+            for k in 1:K
+                outputs[k][j] = _constant_eval_at_anchor(vecs[k], x_last, aq, op, side, extrap_p)
+            end
+        end
+        return outputs
+    end
+
+    extrap_eff = _check_domain(x, xqs, extrap)
+    searcher = _resolve_search(x, xqs, search, nothing)
+    wrap = extrap_eff isa WrapExtrap
+    x_last = @inbounds Tg_actual(last(x))
+    @inbounds for j in 1:NQ
+        aq = _anchor_query(x, xqs[j], Val(:constant), wrap, searcher)
+        for k in 1:K
+            outputs[k][j] = _constant_eval_at_anchor(vecs[k], x_last, aq, op, side, extrap_eff)
+        end
+    end
+    return outputs
+end
+
+# K outer × Q inner with pool-acquired anchor vector — large-NQ fast path.
+# Inner loop streams a single `outputs[k]` Vector, which LLVM auto-SIMDs
+# (~K× fewer cache-line jumps on the write side than the Q×K shape).
+@inline @with_pool pool function _constant_series_batch_kq!(
+        outputs::AbstractVector{<:AbstractVector},
+        x::AbstractVector{Tg},
+        vecs,
+        xqs::AbstractVector{Tq},
+        bc::AbstractBC,
+        op::AbstractEvalOp,
+        side::AbstractSide,
+        extrap::AbstractExtrap,
+        search::AbstractSearchPolicy
+    ) where {Tg, Tq <: Real}
+    K = length(vecs)
+    NQ = length(xqs)
+    Tg_actual = eltype(x)
+    Tqp = promote_type(Tg_actual, Tq)
+
+    if _is_periodic_bc(bc)
+        x_eff = _resolve_axis(x, bc)
+        extrap_p = _resolve_extrap(NoExtrap(), bc, x_eff)
+        searcher = _resolve_search(x_eff, xqs, search, nothing, NoBC())
+        x_last = @inbounds Tg_actual(last(x_eff))
+        aq_vec = acquire!(pool, _ConstantAnchoredQuery{Tg_actual, Tqp}, NQ)
+        @inbounds for j in 1:NQ
+            xq_wrapped = _wrap_to_domain(xqs[j], x_eff)
+            idxL, idxR, xL, _ = search_interval(searcher, x_eff, xq_wrapped)
+            h = _get_h(x_eff, idxL)
+            dL = xq_wrapped - xL
+            xq_promoted = oftype(dL, xq_wrapped)
+            aq_vec[j] = _ConstantAnchoredQuery(_IdxPair(idxL, idxR), xq_promoted, IN_DOMAIN, h, dL)
+        end
+        @inbounds for k in 1:K
+            for j in 1:NQ
+                outputs[k][j] = _constant_eval_at_anchor(vecs[k], x_last, aq_vec[j], op, side, extrap_p)
+            end
+        end
+        return outputs
+    end
+
+    extrap_eff = _check_domain(x, xqs, extrap)
+    searcher = _resolve_search(x, xqs, search, nothing)
+    wrap = extrap_eff isa WrapExtrap
+    x_last = @inbounds Tg_actual(last(x))
+    aq_vec = acquire!(pool, _ConstantAnchoredQuery{Tg_actual, Tqp}, NQ)
+    _fill_anchors!(aq_vec, x, xqs, Val(:constant), wrap, searcher)
+    @inbounds for k in 1:K
+        for j in 1:NQ
+            outputs[k][j] = _constant_eval_at_anchor(vecs[k], x_last, aq_vec[j], op, side, extrap_eff)
+        end
+    end
+    return outputs
+end
+
+# Adaptive entry. `length(xqs)` selects the loop order — see
+# `_SERIES_BATCH_LOOP_THRESHOLD` docs in `src/core/series_utils.jl`.
+# `x_last = Tg(last(x))` is computed inside each helper from the same
+# `x_eff` it uses (preserves the right-continuous short-circuit inside
+# `_constant_eval_at_anchor` for inclusive queries at `xq == x[n]`).
 @inline function constant_interp!(
         outputs::AbstractVector{<:AbstractVector},
         x::AbstractVector{Tg},
@@ -153,45 +259,17 @@ end
     K = n_series(s)
     _validate_series_outputs(outputs, K, length(xqs))
     vecs = _series_vectors(s)
-    Tg_actual = eltype(x)
-
-    if _is_periodic_bc(bc)
-        if bc isa PeriodicBC{:inclusive}
-            @inbounds for k in 1:K
-                _check_periodic_endpoints(bc, vecs[k])
-            end
-        end
-        x_eff = _resolve_axis(x, bc)
-        extrap_p = _resolve_extrap(NoExtrap(), bc, x_eff)
-        searcher = _resolve_search(x_eff, xqs, search, nothing, NoBC())
-        x_last = @inbounds Tg_actual(last(x_eff))
-        @inbounds for j in eachindex(xqs)
-            xq_wrapped = _wrap_to_domain(xqs[j], x_eff)
-            idxL, idxR, xL, _ = search_interval(searcher, x_eff, xq_wrapped)
-            # Index-based dispatch (cached step on Range, seam width on wrapper).
-            h = _get_h(x_eff, idxL)
-            dL = xq_wrapped - xL
-            xq_promoted = oftype(dL, xq_wrapped)
-            aq = _ConstantAnchoredQuery(_IdxPair(idxL, idxR), xq_promoted, IN_DOMAIN, h, dL)
-            for k in 1:K
-                outputs[k][j] = _constant_eval_at_anchor(vecs[k], x_last, aq, deriv, side, extrap_p)
-            end
-        end
-        return outputs
-    end
-
-    # Non-periodic: `_anchor_query` handles WrapExtrap query-wrap + OOB state.
-    extrap_eff = _check_domain(x, xqs, extrap)
-    searcher = _resolve_search(x, xqs, search, nothing)
-    wrap = extrap_eff isa WrapExtrap
-    x_last = @inbounds Tg_actual(last(x))
-    @inbounds for j in eachindex(xqs)
-        aq = _anchor_query(x, xqs[j], Val(:constant), wrap, searcher)
-        for k in 1:K
-            outputs[k][j] = _constant_eval_at_anchor(vecs[k], x_last, aq, deriv, side, extrap_eff)
+    if bc isa PeriodicBC{:inclusive}
+        @inbounds for k in 1:K
+            _check_periodic_endpoints(bc, vecs[k])
         end
     end
-    return outputs
+
+    if _series_use_kq_loop(length(xqs), K)
+        return _constant_series_batch_kq!(outputs, x, vecs, xqs, bc, deriv, side, extrap, search)
+    else
+        return _constant_series_batch_qk!(outputs, x, vecs, xqs, bc, deriv, side, extrap, search)
+    end
 end
 
 function constant_interp(

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -497,8 +497,8 @@ function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
     return _constant_series_inplace_kernel!(outputs, sitp, xq_typed, searcher, deriv)
 end
 
-# Thin function barrier: see comment on `_linear_series_inplace_kernel!`.
-@inline function _constant_series_inplace_kernel!(
+# Q×K — small-NQ fast path. Stack-resident anchor per query, no pool.
+@inline function _constant_series_qk!(
         outputs::AbstractVector{<:AbstractVector},
         sitp::ConstantSeriesInterpolant{Tg},
         xq_typed::AbstractVector,
@@ -514,7 +514,6 @@ end
     side_val = sitp.side
     x_min = Tg(first(sitp.x))
     x_max = Tg(last(sitp.x))
-
     @inbounds for j in eachindex(xq_typed)
         aq = _anchor_query(x_grid, xq_typed[j], Val(:constant), wrap, searcher)
         for k in 1:n_ser
@@ -524,6 +523,55 @@ end
         end
     end
     return outputs
+end
+
+# K×Q — large-NQ fast path. Pool-acquired anchor vector, sequential `outputs[k]`
+# inner loop (SIMD-able).
+@inline @with_pool pool function _constant_series_kq!(
+        outputs::AbstractVector{<:AbstractVector},
+        sitp::ConstantSeriesInterpolant{Tg},
+        xq_typed::AbstractVector,
+        searcher::Searcher,
+        deriv::DerivOp
+    ) where {Tg}
+    wrap = _should_wrap(sitp)
+    y = sitp.y
+    x_grid = sitp.x
+    n_pts = n_points(sitp)
+    n_ser = n_series(sitp)
+    extrap = sitp.extrap
+    side_val = sitp.side
+    x_min = Tg(first(sitp.x))
+    x_max = Tg(last(sitp.x))
+    NQ = length(xq_typed)
+    Tqp = promote_type(Tg, eltype(xq_typed))
+    aq_vec = acquire!(pool, _ConstantAnchoredQuery{Tg, Tqp}, NQ)
+    _fill_anchors!(aq_vec, x_grid, xq_typed, Val(:constant), wrap, searcher)
+    @inbounds for k in 1:n_ser
+        for j in 1:NQ
+            outputs[k][j] = _eval_constant_series_with_extrap(
+                y, x_grid, n_pts, x_min, x_max, k, aq_vec[j], extrap, side_val, deriv
+            )
+        end
+    end
+    return outputs
+end
+
+# Thin function barrier: see comment on `_linear_series_inplace_kernel!`.
+# Adaptive: `length(xq_typed)` selects the loop order — see
+# `_SERIES_BATCH_LOOP_THRESHOLD` docs in `src/core/series_utils.jl`.
+@inline function _constant_series_inplace_kernel!(
+        outputs::AbstractVector{<:AbstractVector},
+        sitp::ConstantSeriesInterpolant{Tg},
+        xq_typed::AbstractVector,
+        searcher::Searcher,
+        deriv::DerivOp
+    ) where {Tg}
+    if _series_use_kq_loop(length(xq_typed), n_series(sitp))
+        return _constant_series_kq!(outputs, sitp, xq_typed, searcher, deriv)
+    else
+        return _constant_series_qk!(outputs, sitp, xq_typed, searcher, deriv)
+    end
 end
 
 """

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -558,8 +558,8 @@ end
 end
 
 # Thin function barrier: see comment on `_linear_series_inplace_kernel!`.
-# Adaptive: `length(xq_typed)` selects the loop order — see
-# `_SERIES_BATCH_LOOP_THRESHOLD` docs in `src/core/series_utils.jl`.
+# Adaptive: `length(xq_typed)` and `n_series(sitp)` feed `_series_use_kq_loop`
+# to select the loop order — see `src/core/series_utils.jl`.
 @inline function _constant_series_inplace_kernel!(
         outputs::AbstractVector{<:AbstractVector},
         sitp::ConstantSeriesInterpolant{Tg},

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -50,11 +50,9 @@ function _constant_interp_nd_oneshot(
 end
 
 """
-    _constant_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps_val, side_vals, policies, hints, mono)
+    _constant_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps_val, side_vals, search, hint)
 
 In-place batch one-shot ND constant evaluation.
-Uses query protocol (`_query_length`, `_query_extract`) — works with any query format.
-Writes results into `output`. No heap allocation beyond spacings.
 """
 function _constant_interp_nd_oneshot_batch!(
         output::AbstractVector,
@@ -64,10 +62,11 @@ function _constant_interp_nd_oneshot_batch!(
         bcs::NTuple{N, AbstractBC},
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
         side_vals::Tuple{Vararg{AbstractSide, N}},
-        policies::NTuple{N, AbstractSearchPolicy},
-        hints,  # Nothing or NTuple{N, Ref{Int}}
-        mono::NTuple{N, Bool},
+        search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}},
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}},
     ) where {Tg, Tv, N}
+    # Resolve here so the fresh Ref tuple stays local to this frame (stack-elidable).
+    policies, hints = _resolve_oneshot_search_nd(search, queries, hint, Val(N))
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
@@ -91,7 +90,7 @@ function _constant_interp_nd_oneshot_batch!(
 end
 
 """
-    _constant_interp_nd_oneshot_batch(grids, data, queries, bcs, extraps_val, side_vals, searches, hints=nothing)
+    _constant_interp_nd_oneshot_batch(grids, data, queries, bcs, extraps_val, side_vals, search, hint)
 
 Allocating wrapper: creates output vector, delegates to in-place batch.
 """
@@ -102,12 +101,11 @@ function _constant_interp_nd_oneshot_batch(
         bcs::NTuple{N, AbstractBC},
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
         side_vals::Tuple{Vararg{AbstractSide, N}},
-        policies::NTuple{N, AbstractSearchPolicy},
-        hints,  # Nothing or NTuple{N, Ref{Int}}
-        mono::NTuple{N, Bool},
+        search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}},
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}},
     ) where {Tg, Tv, N}
     output = Vector{Tv}(undef, _query_length(queries))
-    return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps_val, side_vals, policies, hints, mono)
+    return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps_val, side_vals, search, hint)
 end
 
 # ========================================
@@ -117,13 +115,12 @@ end
 @inline _is_any_deriv(op::DerivOp) = !(op isa DerivOp{0})
 @inline _is_any_deriv(ops::Tuple{Vararg{DerivOp}}) = any(op -> !(op isa DerivOp{0}), ops)
 
-# Function barrier: forces Julia to runtime-dispatch on the concrete
-# searches tuple type before entering the @with_pool boundary.
-function _constant_nd_batch_dispatch!(output, grids, data, queries, bcs, extraps, sides, policies, hints, mono)
-    return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps, sides, policies, hints, mono)
+# Function barrier — specializes on concrete `search` type.
+function _constant_nd_batch_dispatch!(output, grids, data, queries, bcs, extraps, sides, search, hint)
+    return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps, sides, search, hint)
 end
-function _constant_nd_batch_dispatch(grids, data, queries, bcs, extraps, sides, policies, hints, mono)
-    return _constant_interp_nd_oneshot_batch(grids, data, queries, bcs, extraps, sides, policies, hints, mono)
+function _constant_nd_batch_dispatch(grids, data, queries, bcs, extraps, sides, search, hint)
+    return _constant_interp_nd_oneshot_batch(grids, data, queries, bcs, extraps, sides, search, hint)
 end
 
 # ========================================
@@ -192,12 +189,10 @@ function constant_interp(
 
     bcs = _resolve_bcs_nd(bc, Val(N))
     sides = _resolve_side_nd(side, Val(N))
-    policies = _resolve_search_nd(search, Val(N))
-    mono = _check_mono_nd(policies, queries)
 
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)
     return _constant_nd_batch_dispatch(
-        grids_typed, data, queries, bcs, extraps_val, sides, policies, hint, mono
+        grids_typed, data, queries, bcs, extraps_val, sides, search, hint
     )::Vector{Tv}
 end
 
@@ -235,11 +230,9 @@ function constant_interp!(
 
     bcs = _resolve_bcs_nd(bc, Val(N))
     sides = _resolve_side_nd(side, Val(N))
-    policies = _resolve_search_nd(search, Val(N))
-    mono = _check_mono_nd(policies, queries)
 
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)
     return _constant_nd_batch_dispatch!(
-        output, grids_typed, data, queries, bcs, extraps_val, sides, policies, hint, mono
+        output, grids_typed, data, queries, bcs, extraps_val, sides, search, hint
     )
 end

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -42,7 +42,10 @@ function _constant_interp_nd_oneshot(
     extraps_eff = _resolve_extrap(extraps_val, bcs, grids_eff, data, Val(N))
     q_eval = _handle_all_extraps(query, grids_eff, extraps_eff)
     stencils, Ls, Rs = _search_all_intervals_stencil(q_eval, grids_eff, searches, hints, nobcs)
-    hs = map(_get_h, grids_eff, Ls, Rs)
+    # 4-arg `_get_h(g, idx, xL, xR)` — cached path for `_CachedVector` (idx)
+    # / `_CachedRange` (scalar field); raw `Vector` falls back to `xR - xL`.
+    idxLs = map(first, stencils)
+    hs = map(_get_h, grids_eff, idxLs, Ls, Rs)
     return _constant_nd_kernel(data, stencils, hs, side_vals, q_eval, Ls)
 end
 
@@ -80,7 +83,8 @@ function _constant_interp_nd_oneshot_batch!(
         end
         q_eval = _handle_all_extraps(query_k, grids_eff, extraps_eff)
         stencils, Ls, Rs = _search_all_intervals_stencil(q_eval, grids_eff, policies, hints, nobcs)
-        hs = map(_get_h, grids_eff, Ls, Rs)
+        idxLs = map(first, stencils)
+        hs = map(_get_h, grids_eff, idxLs, Ls, Rs)
         output[k] = _constant_nd_kernel(data, stencils, hs, side_vals, q_eval, Ls)
     end
     return output

--- a/src/core/axis_types.jl
+++ b/src/core/axis_types.jl
@@ -1,0 +1,174 @@
+# ========================================
+# Axis Types — central struct definitions
+# ========================================
+#
+# All grid wrapper struct definitions live here, loaded early in the include
+# chain so downstream method files can freely cross-reference any axis type
+# without ordering constraints.
+#
+# Method dispatches live in owner files:
+#   - `cached_range.jl`    → all `_CachedRange` methods (`_to_float`, `_get_h`,
+#                            `_resolve_axis`, `_cache_axis*`, view/slice)
+#   - `cached_vector.jl`   → all `_CachedVector` methods (build ctor,
+#                            `_get_h`, `_resolve_axis`, `_cache_axis*`)
+#   - `periodic_axis.jl`   → all `_ExclusivePeriodicAxis` methods (seam-aware
+#                            `_get_h`, search, view, fold, dispatch table doc)
+#
+# Include order (in `core/core.jl`):
+#   ... → eval_ops.jl → bc_types.jl → ... → axis_types.jl
+#                                            → cached_range.jl
+#                                            → cached_vector.jl
+#                                            → ... → periodic_axis.jl
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _CachedRange — normalized AbstractRange
+# ─────────────────────────────────────────────────────────────────────────────
+"""
+    _CachedRange{T, Tinv} <: AbstractRange{T}
+
+`AbstractRange` subtype that pre-caches `first`, `last`, `step`, and
+`inv(step)` as plain `T`/`Tinv` fields. All `AbstractRange` user inputs are
+normalized to `_CachedRange` via `_to_float` at public API boundaries.
+
+`Tinv == typeof(inv(oneunit(T)))` — equals `T` for `T<:AbstractFloat`,
+`Float64` for `T=Int`. Mirrors `_CachedVector{T,Tinv}`.
+
+# Fields
+- `lo::T`, `hi::T` — cached `first`/`last`
+- `h::T`, `inv_h::Tinv` — cached `step` and reciprocal
+- `len::Int` — cached length
+- `domain_lo::T`, `domain_hi::T` — safe bounds for domain checks (= `lo`/`hi`
+  on the exact path; widened by ≈1 ULP on the x86_64 TwicePrecision fast path)
+"""
+struct _CachedRange{T, Tinv} <: AbstractRange{T}
+    lo::T
+    hi::T
+    h::T
+    inv_h::Tinv
+    len::Int
+    domain_lo::T
+    domain_hi::T
+end
+
+# Exact 5-arg ctor: `domain_lo == lo`, `domain_hi == hi` (non-TwicePrecision).
+@inline function _CachedRange{T, Tinv}(lo::T, hi::T, h::T, inv_h::Tinv, len::Int) where {T, Tinv}
+    return _CachedRange{T, Tinv}(lo, hi, h, inv_h, len, lo, hi)
+end
+
+# Identity passthrough — re-wrapping would discard the cached fields.
+_CachedRange(x::_CachedRange) = x
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _CachedVector — Vector grid with cached spacing
+# ─────────────────────────────────────────────────────────────────────────────
+"""
+    _CachedVector{T, Tinv} <: AbstractVector{T}
+
+Vector grid wrapper that caches per-cell spacing (`h`) and reciprocal
+(`inv_h`) for fast O(1) lookup. `inner` is always a concrete `Vector{T}`
+(see "Design choice" in `cached_vector.jl` outer ctor doc).
+"""
+struct _CachedVector{T, Tinv} <: AbstractVector{T}
+    inner::Vector{T}
+    h::Vector{T}        # length n-1
+    inv_h::Vector{Tinv} # length n-1
+end
+
+# Identity passthrough — re-wrapping would discard the cached `h`/`inv_h`.
+_CachedVector(c::_CachedVector) = c
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _ExclusivePeriodicAxis — virtual length-(n+1) wrap for `:exclusive` PeriodicBC
+# ─────────────────────────────────────────────────────────────────────────────
+"""
+    _ExclusivePeriodicAxis{Tg, X<:AbstractVector{Tg}, Tp} <: AbstractVector{Tg}
+
+Representation wrapper for `PeriodicBC{:exclusive, L}` non-uniform Vector
+*axis* grids. Reports `length == n+1` so search algorithms find the seam
+cell. `inner[i]` for `1 ≤ i ≤ n` returns the raw grid; the virtual seam
+slot returns `inner[1] + period`.
+
+# Fields
+- `inner::X` — raw axis (length n). Typically `Vector{Tg}` / `_CachedVector` /
+  `AbstractRange` / `_CachedRange`.
+- `period::Tp` — period span (type independent of `Tg`).
+- `_x_max::Tg` — precomputed `inner[1] + Tg(period)`; single-load `last(g)`.
+"""
+struct _ExclusivePeriodicAxis{Tg, X <: AbstractVector{Tg}, Tp} <: AbstractVector{Tg}
+    inner::X
+    period::Tp
+    _x_max::Tg
+
+    function _ExclusivePeriodicAxis{Tg, X, Tp}(inner::X, period::Tp) where {Tg, X <: AbstractVector{Tg}, Tp}
+        x_max = @inbounds inner[1] + Tg(period)
+        @inbounds inner[end] < x_max || _throw_excl_axis_period_too_small(period, x_max, inner[end])
+        _validate_exclusive_period(inner, period)
+        return new{Tg, X, Tp}(inner, period, x_max)
+    end
+end
+
+# Convenience outer ctor — type params inferred from inputs.
+@inline _ExclusivePeriodicAxis(inner::AbstractVector{Tg}, period) where {Tg} =
+    _ExclusivePeriodicAxis{Tg, typeof(inner), typeof(period)}(inner, period)
+
+# Inner-ctor validation. No-op for Vector inners (period unverifiable);
+# Range inners cross-validate against `step × length` (= one period for the
+# n-cell exclusive form). Same numerical contract as
+# `_check_periodic_endpoints` in `periodic.jl`.
+#
+# Dependencies (`_PromotableValue`, `_extract_primal`) are resolved at first
+# call, not at struct-def time — both are in scope before any ctor invocation.
+@inline _validate_exclusive_period(::AbstractVector, _) = nothing
+@inline _validate_exclusive_period(inner::AbstractRange, period) =
+    _validate_exclusive_period_impl(inner, period, eltype(inner))
+
+@inline function _validate_exclusive_period_impl(
+        inner::AbstractRange, period, ::Type{T}
+    ) where {T <: AbstractFloat}
+    inferred = step(inner) * length(inner)
+    isapprox(T(period), T(inferred); atol = 8 * eps(T), rtol = sqrt(eps(T))) ||
+        _throw_excl_axis_period_mismatch(period, first(inner), inferred)
+    return nothing
+end
+
+@inline function _validate_exclusive_period_impl(
+        inner::AbstractRange, period, ::Type{Complex{T}}
+    ) where {T <: AbstractFloat}
+    inferred = step(inner) * length(inner)
+    isapprox(Complex{T}(period), Complex{T}(inferred); atol = 8 * eps(T), rtol = sqrt(eps(T))) ||
+        _throw_excl_axis_period_mismatch(period, first(inner), inferred)
+    return nothing
+end
+
+@inline function _validate_exclusive_period_impl(
+        inner::AbstractRange, period, ::Type{T}
+    ) where {T <: _PromotableValue}
+    # Integer / Rational grids: exact equality (default `isapprox` tolerance).
+    inferred = step(inner) * length(inner)
+    isapprox(period, inferred) ||
+        _throw_excl_axis_period_mismatch(period, first(inner), inferred)
+    return nothing
+end
+
+@inline function _validate_exclusive_period_impl(inner::AbstractRange, period, ::Type)
+    # Duck-type fallback (Dual, Measurement, ...): strict equality on primal.
+    inferred = step(inner) * length(inner)
+    _extract_primal(period) == _extract_primal(inferred) ||
+        _throw_excl_axis_period_mismatch(period, first(inner), inferred)
+    return nothing
+end
+
+@noinline _throw_excl_axis_period_too_small(period, x_max, last_x) = throw(
+    ArgumentError(
+        "PeriodicBC(:exclusive) period=$period places virtual endpoint at $x_max, " *
+            "not after last grid point x[end]=$last_x"
+    )
+)
+
+@noinline _throw_excl_axis_period_mismatch(period, x0, inferred) = throw(
+    ArgumentError(
+        "PeriodicBC's period=$period conflicts with Range-inferred period = " *
+            "$(x0 + inferred) - $x0 = $inferred. " *
+            "Either adjust `period` or omit it for auto-inference."
+    )
+)

--- a/src/core/cached_range.jl
+++ b/src/core/cached_range.jl
@@ -1,65 +1,22 @@
 # ========================================
-# _CachedRange: Normalized AbstractRange
+# _CachedRange methods — normalized AbstractRange behavior
 # ========================================
 #
-# All AbstractRange inputs are normalized to _CachedRange{T,Tinv} at system boundaries
-# (via `_to_float`). After normalization, the grid type space is exactly
-# {_CachedRange{T,Tinv}, Vector{T}} — eliminating downstream dispatch explosion.
-# `Tinv = typeof(inv(oneunit(T)))` — equals `T` for `T <: AbstractFloat`, equals
-# `Float64` for `T = Int` (mirrors the `_CachedVector{T, Tinv}` shape).
+# Struct definition + 5-arg inner ctor + `_CachedRange(::_CachedRange)` identity
+# live in `axis_types.jl` (loaded earlier). This file owns:
+#   - `_to_float` (Range → `_CachedRange` normalizer)
+#   - AbstractArray interface (`length`, `size`, `first`, `last`, `step`,
+#     `getindex(::Int)`, `getindex(::AbstractUnitRange)`, `view`)
+#   - `_convert_copy`
+#   - `_get_h` / `_get_inv_h`
+#   - `_resolve_axis` / `_cache_axis` / `_cache_axis_pooled` (all BC variants
+#     for raw `AbstractRange` and pre-wrapped `_CachedRange` input)
 #
-# Include order: grid_spacing.jl → cached_range.jl → search.jl → utils.jl
-
-"""
-    _CachedRange{T, Tinv} <: AbstractRange{T}
-
-`AbstractRange` subtype that pre-caches `first`, `last`, `step`, and `inv(step)` as
-plain `T`/`Tinv` fields, enabling multiply-instead-of-divide search and avoiding
-TwicePrecision dispatch overhead.
-
-All `AbstractRange` inputs are normalized to `_CachedRange` via `_to_float` at public
-API boundaries. This means downstream code only needs to handle two grid types:
-`_CachedRange{T,Tinv}` (uniform) and `Vector{T}` (non-uniform).
-
-`Tinv == typeof(inv(oneunit(T)))` — equals `T` for `T <: AbstractFloat`, equals
-`Float64` for raw `T = Int`. Mirrors `_CachedVector{T, Tinv}`.
-
-# Fields
-- `lo::T`        — `first(x)`, cached as plain `T` (used for index computation)
-- `hi::T`        — `last(x)`, cached as plain `T` (used for index computation)
-- `h::T`         — `step(x)`, cached as plain `T`
-- `inv_h::Tinv`  — precomputed `1/step(x)`, enables multiply-not-divide in `_search_direct`
-- `len::Int`     — `length(x)`
-- `domain_lo::T` — safe lower bound for domain checks (≤ lo, prevents false DomainError)
-- `domain_hi::T` — safe upper bound for domain checks (≥ hi, prevents false DomainError)
-
-The `domain_lo`/`domain_hi` fields equal `lo`/`hi` in the exact path (ARM, non-TwicePrecision).
-On x86_64 with TwicePrecision fast path, they are widened by 1 ULP to account for
-possible rounding difference between fast plain-T arithmetic and exact TwicePrecision.
-
-Because `_CachedRange <: AbstractRange`, all existing `AbstractRange` dispatch
-(DirectSearch routing, `_resolve_search_policy`, `search_interval`, etc.) propagates
-automatically without any changes at call sites.
-"""
-struct _CachedRange{T, Tinv} <: AbstractRange{T}
-    lo::T
-    hi::T
-    h::T
-    inv_h::Tinv
-    len::Int
-    domain_lo::T
-    domain_hi::T
-end
-
-# Exact constructor: domain_lo == lo, domain_hi == hi (default for non-TwicePrecision paths)
-@inline function _CachedRange{T, Tinv}(lo::T, hi::T, h::T, inv_h::Tinv, len::Int) where {T, Tinv}
-    return _CachedRange{T, Tinv}(lo, hi, h, inv_h, len, lo, hi)
-end
+# Include order: grid_spacing.jl → axis_types.jl → cached_range.jl → ...
 
 # Convenience: construct from any AbstractRange{T}, using its own eltype.
-# Internal code should prefer _to_float(x, Tg) when the desired target type Tg differs from eltype(x).
+# Prefer `_to_float(x, Tg)` at call sites when the desired target differs.
 _CachedRange(x::AbstractRange{T}) where {T} = _to_float(x, T)
-_CachedRange(x::_CachedRange) = x
 
 Base.length(r::_CachedRange) = r.len
 Base.size(r::_CachedRange) = (r.len,)
@@ -193,3 +150,54 @@ end
 # in grid_spacing.jl. The cached form ignores both endpoints (uniform step).
 @inline _get_h(x::_CachedRange, ::Real, ::Real) = x.h
 @inline _get_inv_h(x::_CachedRange, ::Real, ::Real) = x.inv_h
+
+# ========================================
+# `_resolve_axis` — one-shot Range wrapping
+# ========================================
+@inline _resolve_axis(x::AbstractRange) = _to_float(x, float(eltype(x)))
+@inline _resolve_axis(x::AbstractRange, ::AbstractBC) = _to_float(x, float(eltype(x)))
+@inline _resolve_axis(c::_CachedRange) = c
+
+# `:exclusive` raw-input one-shot path — wrap into `_ExclusivePeriodicAxis`.
+@inline function _resolve_axis(x::AbstractRange, bc::PeriodicBC{:exclusive})
+    bc_resolved = _resolve_bc_period(x, bc)
+    return _ExclusivePeriodicAxis(_to_float(x, float(eltype(x))), bc_resolved.period)
+end
+
+# ========================================
+# `_cache_axis` — persistent-path Range wrapping
+# ========================================
+# Full DISPATCH TABLE for `_cache_axis(x, bc, Tg)` (cross-input-type) lives in
+# `periodic_axis.jl` as the central reference. Owner-file entries below.
+@inline _cache_axis(x::AbstractRange) = _to_float(x, float(eltype(x)))
+@inline _cache_axis(x::AbstractRange, ::AbstractBC) = _to_float(x, float(eltype(x)))
+@inline _cache_axis(c::_CachedRange) = c
+@inline _cache_axis(c::_CachedRange, ::AbstractBC) = c
+
+# `:exclusive` 2-arg variants — produce `_ExclusivePeriodicAxis`.
+@inline function _cache_axis(x::AbstractRange, bc::PeriodicBC{:exclusive})
+    bc_resolved = _resolve_bc_period(x, bc)
+    return _ExclusivePeriodicAxis(_to_float(x, float(eltype(x))), bc_resolved.period)
+end
+@inline function _cache_axis(c::_CachedRange, bc::PeriodicBC{:exclusive})
+    bc_resolved = _resolve_bc_period(c, bc)
+    return _ExclusivePeriodicAxis(c, bc_resolved.period)
+end
+
+# 3-arg Tg-aware. Raw Range respects Tg via `_to_float`. Pre-wrapped passes
+# through — downstream `_convert_copy(_, Tg)` enforces Tg (intentional contract;
+# see DISPATCH TABLE in `periodic_axis.jl`).
+@inline _cache_axis(x::AbstractRange, ::AbstractBC, ::Type{Tg}) where {Tg} = _to_float(x, Tg)
+@inline _cache_axis(c::_CachedRange, bc::AbstractBC, ::Type{Tg}) where {Tg} = _cache_axis(c, bc)
+@inline function _cache_axis(x::AbstractRange, bc::PeriodicBC{:exclusive}, ::Type{Tg}) where {Tg}
+    bc_resolved = _resolve_bc_period(x, bc)
+    return _ExclusivePeriodicAxis(_to_float(x, Tg), bc_resolved.period)
+end
+@inline _cache_axis(c::_CachedRange, bc::PeriodicBC{:exclusive}, ::Type{Tg}) where {Tg} = _cache_axis(c, bc)
+
+# ========================================
+# `_cache_axis_pooled` — one-shot Range wrapping
+# ========================================
+# Range types have stack-only `_CachedRange` — no pool buffer needed.
+@inline _cache_axis_pooled(_, x::AbstractRange) = _to_float(x, float(eltype(x)))
+@inline _cache_axis_pooled(_, x::_CachedRange) = x

--- a/src/core/cached_range.jl
+++ b/src/core/cached_range.jl
@@ -145,11 +145,12 @@ end
 @inline _convert_copy(r::_CachedRange{T, Tinv}, ::Type{T}) where {T, Tinv} = r
 @inline _convert_copy(r::_CachedRange, ::Type{T}) where {T} = _to_float(r, T)
 
-# 3-arg grid-based accessors: _CachedRange has h/inv_h cached in the struct.
-# Args are (x, xL, xR) — natural L→R order, matching AbstractVector fallbacks
-# in grid_spacing.jl. The cached form ignores both endpoints (uniform step).
-@inline _get_h(x::_CachedRange, ::Real, ::Real) = x.h
-@inline _get_inv_h(x::_CachedRange, ::Real, ::Real) = x.inv_h
+# 4-arg grid-based accessors: `(x, idx, xL, xR)`. All four are produced by
+# `search_interval`; the dispatch picks the cheapest field per axis type.
+# `_CachedRange` ignores all three because `h`/`inv_h` are scalar fields
+# (uniform spacing — same value for every cell).
+@inline _get_h(x::_CachedRange, ::Int, ::Real, ::Real) = x.h
+@inline _get_inv_h(x::_CachedRange, ::Int, ::Real, ::Real) = x.inv_h
 
 # ========================================
 # `_resolve_axis` — one-shot Range wrapping

--- a/src/core/cached_vector.jl
+++ b/src/core/cached_vector.jl
@@ -163,12 +163,20 @@ end
 @inline Base.@propagate_inbounds _get_inv_h(x::AbstractVector, i::Int) =
     inv(_get_h(x, i))
 
-# 3-arg: caller already has `xL` / `xR` in registers from search → bypass the
-# `x[i]` / `x[i+1]` loads. Used by oneshot kernels (and the wrapper-level
-# `_ExclusivePeriodicAxis` 3-arg overload at `periodic_axis.jl:384`, which
-# delegates here for any `_CachedVector` / raw `Vector` inner).
-@inline _get_h(::AbstractVector, xL::Real, xR::Real) = xR - xL
-@inline _get_inv_h(::AbstractVector, xL::Real, xR::Real) = inv(xR - xL)
+# 4-arg form: `(x, idx, xL, xR)` — every search result delivers all four;
+# dispatch picks the cheapest path per axis type.
+#
+# `_CachedVector`: idx-indexed cache wins (1 load, no fp ops). The xL/xR
+# fields are ignored — they're already encoded in `c.inv_h[idx]`.
+@inline Base.@propagate_inbounds _get_h(x::_CachedVector, idx::Int, ::Real, ::Real) =
+    @inbounds x.h[idx]
+@inline Base.@propagate_inbounds _get_inv_h(x::_CachedVector, idx::Int, ::Real, ::Real) =
+    @inbounds x.inv_h[idx]
+
+# Raw `AbstractVector` fallback: no cache → `xR - xL` straight from search.
+# `idx` is ignored here (kept in signature for uniform call shape).
+@inline _get_h(::AbstractVector, ::Int, xL::Real, xR::Real) = xR - xL
+@inline _get_inv_h(::AbstractVector, ::Int, xL::Real, xR::Real) = inv(xR - xL)
 
 # Persistent axis wrapping is split into two stages (see `periodic_axis.jl`):
 #   - outer surface API: `_cache_axis(x, bc)` — bc-aware wrap, zero-copy

--- a/src/core/cached_vector.jl
+++ b/src/core/cached_vector.jl
@@ -8,22 +8,29 @@
 #
 # All non-Range AbstractVector inputs to persistent interpolant constructors
 # are normalized to `_CachedVector` via `_store_grid`. After normalization,
-# the grid type space for persistent paths is exactly:
-#   {_CachedRange{T}, _CachedVector{T,Tinv}}
+# the grid type space for persistent paths is `{_CachedRange, _CachedVector}`,
 # enabling a single 2-arg `_get_h(grid, i)` dispatch surface.
 #
 # Include order: grid_spacing.jl → cached_range.jl → cached_vector.jl → ...
 
 """
-    _CachedVector{T, Tinv} <: AbstractVector{T}
+    _CachedVector{T, Tinv, I} <: AbstractVector{T}
 
 Vector grid wrapper that caches per-cell spacing (`h`) and reciprocal
 (`inv_h`) for fast O(1) lookup during persistent interpolant evaluation.
 
 # Fields
-- `inner::Vector{T}` — Original grid values (length n). Always concrete `Vector{T}`.
+- `inner::I` — Original grid values (length n). Storage type varies by
+  construction path: persistent paths materialize to `Vector{T}` for
+  ownership (mutation safety + stable layout); one-shot pool paths alias
+  the caller's input (e.g. `SubArray{T}` view) to avoid an otherwise
+  pointless copy.
 - `h::Vector{T}` — Cell widths, `h[i] = inner[i+1] - inner[i]` (length n-1).
-- `inv_h::Vector{Tinv}` — Precomputed reciprocals (length n-1).
+  Persistent path: fresh `Vector{T}` from heap. One-shot path:
+  `acquire!(pool, T, n-1)` returns a `Vector{T}` from the pool's task-local
+  storage (reused across calls — zero-alloc after warmup).
+- `inv_h::Vector{Tinv}` — Precomputed reciprocals (length n-1). Same storage
+  rule as `h`.
 
 # Type parameters
 - `T` — Grid element type. Can be `Int`, `Float64`, `ForwardDiff.Dual`,
@@ -31,26 +38,36 @@ Vector grid wrapper that caches per-cell spacing (`h`) and reciprocal
 - `Tinv` — Reciprocal type, equal to `typeof(inv(oneunit(T)))`. For Float
   grids `Tinv == T`; for Int grids `Tinv == Float64` (since `inv(::Int)`
   returns `Float64`).
+- `I <: AbstractVector{T}` — Concrete inner-storage type. Tracked as a
+  type parameter so `getindex(c, i) = c.inner[i]` specializes on the
+  concrete storage (no runtime dispatch on `SubArray`/`Vector` mix).
+  `h` / `inv_h` are NOT parametrized — they are always `Vector{T}` /
+  `Vector{Tinv}` because `acquire!` returns a `Vector`, not a view.
 
 # Behavior
 - `<: AbstractVector{T}` so existing search and eval kernels accept it
   transparently — same trick `_CachedRange` uses with `<: AbstractRange`.
 - `Base.getindex(c, i)` forwards to `inner[i]` — zero overhead vs raw `Vector`.
 - `length(c) == length(c.inner)` — same as raw vector.
+- `Base.copy(c)` materializes `inner` to `Vector{T}` (ownership contract)
+  regardless of source storage type — so the copy path normalizes one-shot
+  view-backed wrappers into owned `Vector`-backed wrappers suitable for
+  long-lived persistent storage. `h` / `inv_h` are already `Vector`, so
+  `copy` of those is a straight memcpy.
 
 # Example
 ```julia
 x = [0.0, 0.3, 0.7, 1.0]      # non-uniform Float grid
-cv = _CachedVector(x)          # _CachedVector{Float64, Float64}
+cv = _CachedVector(x)          # _CachedVector{Float64, Float64, Vector{Float64}}
 
 x_int = [0, 1, 3, 6]           # Int grid
-cv_int = _CachedVector(x_int)  # _CachedVector{Int, Float64}
+cv_int = _CachedVector(x_int)  # _CachedVector{Int, Float64, Vector{Int}}
 ```
 """
-struct _CachedVector{T, Tinv} <: AbstractVector{T}
-    inner::Vector{T}
-    h::Vector{T}        # length n-1
-    inv_h::Vector{Tinv} # length n-1
+struct _CachedVector{T, Tinv, I <: AbstractVector{T}} <: AbstractVector{T}
+    inner::I
+    h::Vector{T}        # length n-1; heap (persistent) or pool-acquired (one-shot)
+    inv_h::Vector{Tinv} # length n-1; same storage rule as `h`
 end
 
 # ---------- AbstractVector interface ----------
@@ -69,27 +86,17 @@ Base.IndexStyle(::Type{<:_CachedVector}) = IndexLinear()
 _CachedVector(c::_CachedVector) = c
 
 # ---------- Wrapper-preserving copy ----------
-# Default Base `copy(::AbstractVector)` uses `similar` + `copyto!` which
-# materializes wrappers as plain `Vector{T}`, destroying the wrapper type.
-# Persistent ND constructors do `map(copy, grids)` for mutation safety;
-# without this overload, that call would silently drop the cached `h`/`inv_h`
-# fields on every grid axis.
-#
-# True deep copy: every field gets a fresh allocation owned by the result.
-# `copy(c.h)` and `copy(c.inv_h)` are fast `memcpy`s (no element-wise
-# recomputation — h/inv_h were already computed by the source's constructor).
-# Aliasing the cache fields would violate `copy`'s ownership contract
-# (source and result must be fully independent), even though the cache
-# fields have no public mutation API.
+# Default `copy(::AbstractVector)` materializes to plain `Vector{T}`, destroying
+# the wrapper. Persistent ND ctors do `map(copy, grids)` for mutation safety —
+# this overload preserves wrapper + h/inv_h caches via independent buffers
+# (every field is a fresh allocation owned by the result; aliasing would
+# violate `copy`'s ownership contract).
 @inline Base.copy(c::_CachedVector) =
-    _CachedVector{eltype(c.inner), eltype(c.inv_h)}(copy(c.inner), copy(c.h), copy(c.inv_h))
+    _CachedVector(copy(c.inner), copy(c.h), copy(c.inv_h))
 
 # ---------- Wrapper-aware `_convert_copy` ----------
-# Single-pass type-conversion + ownership. Same-type → delegate to
-# `Base.copy` (preserves wrapper, recursive copy of inner). Different-type
-# → rebuild wrapper from a type-converted inner (one allocation pass —
-# `_convert_copy(c.inner, T)` produces the new buffer; `_CachedVector`
-# constructor recomputes `h`/`inv_h` for the converted eltype).
+# Same-type → `Base.copy`. Different-type → rebuild from type-converted inner
+# (one pass; ctor recomputes h/inv_h for the new eltype).
 @inline _convert_copy(c::_CachedVector{T}, ::Type{T}) where {T} = copy(c)
 @inline _convert_copy(c::_CachedVector, ::Type{T}) where {T} =
     _CachedVector(_convert_copy(c.inner, T))
@@ -117,8 +124,71 @@ function _CachedVector(x::AbstractVector{T}) where {T}
         inv_h[i] = inv(h[i])
     end
     inner = x isa Vector{T} ? x : Vector{T}(x)
-    return _CachedVector{T, Tinv}(inner, h, inv_h)
+    return _CachedVector(inner, h, inv_h)
 end
+
+# ---------- Pool-backed construction (transient caches) ----------
+# Same shape as the outer ctor, but `h`/`inv_h` come from `pool` (zero-alloc
+# after warmup). UNLIKE the persistent outer ctor, this *aliases* `x` directly
+# — the wrapper lifetime is bounded by the enclosing `@with_pool` scope, so
+# aliasing is safe and avoids materializing a `Vector{T}` from view inputs
+# (e.g. `view(big_grid, k:k+N)`). The `I` type parameter tracks the concrete
+# storage type so downstream `getindex` specializes per concrete inner.
+@inline function _cache_axis_pooled(pool, x::AbstractVector{T}) where {T}
+    n = length(x)
+    n >= 2 || throw(ArgumentError("_cache_axis_pooled requires at least 2 grid points, got $n"))
+    Tinv = typeof(inv(oneunit(T)))
+    h = acquire!(pool, T, n - 1)
+    inv_h = acquire!(pool, Tinv, n - 1)
+    @inbounds for i in 1:(n - 1)
+        h[i] = x[i + 1] - x[i]
+        inv_h[i] = inv(h[i])
+    end
+    return _CachedVector(x, h, inv_h)
+end
+
+# Range / pre-wrapped passthroughs — no buffer to acquire (Range has cached
+# scalar h, pre-wrapped axes already carry their caches).
+@inline _cache_axis_pooled(_, x::AbstractRange) = _to_float(x, float(eltype(x)))
+@inline _cache_axis_pooled(_, x::_CachedRange) = x
+@inline _cache_axis_pooled(_, x::_CachedVector) = x
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3-arg form: `_cache_axis_pooled(pool, x, Tg)` — target eltype explicit
+# ─────────────────────────────────────────────────────────────────────────────
+# Catch-all delegation: `_to_float(x, Tg)` first (eltype-aware normalization),
+# then dispatch to the matching 2-arg overload by output type. This is the
+# *one-shot* twin of the persistent `_cache_axis(x, bc, Tg)` 3-arg form — but
+# UNLIKE the persistent variant (which *intentionally* ignores Tg on pre-wrapped
+# axes — see the DISPATCH TABLE in `periodic_axis.jl`), the pooled 3-arg form
+# honors `Tg` uniformly via `_to_float` for every input type.
+#
+#   x type         + Tg            → result   (notes)
+#   ─────────────────────────────────────────────────────────────────────────
+#   Vector{Tg}      + Tg            → pool-backed `_CachedVector{Tg}`
+#                                       (`_to_float` identity → 2-arg pool wrap)
+#   Vector{S}       + Tg, S ≠ Tg    → pool-backed `_CachedVector{Tg}` ⚠️ warns once
+#                                       (`_to_float` heap-allocates `Tg.(x)` then
+#                                        2-arg builds the wrapper)
+#   AbstractRange   + Tg            → `_CachedRange{Tg}`  (zero pool, immutable
+#                                       struct; eltype always Tg)
+#   _CachedRange{Tg}  + Tg            → identity passthrough
+#   _CachedRange{S}   + Tg, S ≠ Tg    → fresh `_CachedRange{Tg}` (heap-allocs
+#                                       inv_h scalar; NOT pool-backed)
+#   _CachedVector{Tg} + Tg            → identity passthrough
+#   _CachedVector{S}  + Tg, S ≠ Tg    → ⚠️ pre-built h/inv_h cache is DROPPED:
+#                                       `_to_float(::AbstractVector, Tg)`
+#                                       fallback broadcasts `Tg.(c)` into a
+#                                       fresh Vector (losing wrapper fields),
+#                                       then 2-arg rebuilds `_CachedVector{Tg}`
+#                                       with pool-backed h/inv_h
+#
+# Bottom line: `_cache_axis_pooled(pool, x, Tg)` *always* returns a wrapper
+# with eltype `Tg`. The fast paths (same-eltype Vector/Range/wrapped) are
+# zero-alloc; eltype mismatches incur a one-time conversion alloc (and warn
+# on raw `Vector{S}` per `_to_float`'s `_warn_type_conversion`).
+@inline _cache_axis_pooled(pool, x, ::Type{Tg}) where {Tg} =
+    _cache_axis_pooled(pool, _to_float(x, Tg))
 
 # ========================================
 # Unified 2-arg accessors: _get_h, _get_inv_h

--- a/src/core/cached_vector.jl
+++ b/src/core/cached_vector.jl
@@ -1,74 +1,18 @@
 # ========================================
-# _CachedVector: Vector grid with cached spacing
+# _CachedVector methods — Vector grid with cached spacing
 # ========================================
 #
-# Non-uniform Vector grid wrapper that caches per-cell spacing (`h`) and
-# reciprocal (`inv_h`) for fast lookup. Parallel to `_CachedRange` (which
-# wraps uniform AbstractRange grids).
+# Struct definition + `_CachedVector(::_CachedVector)` identity ctor live in
+# `axis_types.jl` (loaded earlier). This file owns:
+#   - AbstractArray interface (`size`, `length`, `getindex`, `firstindex`,
+#     `lastindex`, `eltype`, `IndexStyle`)
+#   - `_CachedVector(x::AbstractVector{T})` build ctor (computes h/inv_h)
+#   - `Base.copy` / `_convert_copy`
+#   - `_get_h` / `_get_inv_h`
+#   - `_resolve_axis` / `_cache_axis` / `_cache_axis_pooled` (all BC variants
+#     for raw `AbstractVector` and pre-wrapped `_CachedVector` input)
 #
-# All non-Range AbstractVector inputs to persistent interpolant constructors
-# are normalized to `_CachedVector` via `_store_grid`. After normalization,
-# the grid type space for persistent paths is `{_CachedRange, _CachedVector}`,
-# enabling a single 2-arg `_get_h(grid, i)` dispatch surface.
-#
-# Include order: grid_spacing.jl → cached_range.jl → cached_vector.jl → ...
-
-"""
-    _CachedVector{T, Tinv} <: AbstractVector{T}
-
-Vector grid wrapper that caches per-cell spacing (`h`) and reciprocal
-(`inv_h`) for fast O(1) lookup during persistent interpolant evaluation.
-
-# Fields
-- `inner::Vector{T}` — Original grid values (length n). Always a concrete
-  `Vector{T}`. Persistent paths materialize for ownership; one-shot pool
-  paths alias when input is already `Vector{T}`, else pool-acquire +
-  `copyto!` (no heap alloc — see `_cache_axis_pooled` below).
-- `h::Vector{T}` — Cell widths, `h[i] = inner[i+1] - inner[i]` (length n-1).
-  Persistent: fresh heap `Vector{T}`. One-shot: pool-acquired (reused).
-- `inv_h::Vector{Tinv}` — Precomputed reciprocals (length n-1). Same
-  storage rule as `h`.
-
-# Type parameters
-- `T` — Grid element type. Can be `Int`, `Float64`, `ForwardDiff.Dual`,
-  `Measurements.Measurement`, etc. Any type with `-` and `inv` defined.
-- `Tinv` — Reciprocal type, equal to `typeof(inv(oneunit(T)))`. For Float
-  grids `Tinv == T`; for Int grids `Tinv == Float64` (since `inv(::Int)`
-  returns `Float64`).
-
-# Design choice — single concrete inner storage
-All three buffers are pinned to `Vector{_}` (no `I<:AbstractVector{T}` type
-parameter on `inner`). The reason is *not* dispatch cost — `getindex` would
-specialize either way — but **RCU cache key uniformity**: the cubic
-autocache (`CubicSplineCache{T, X, ...}`) keys on the wrapped axis type
-`X`, and if `X = _CachedVector{T, Tinv, I}` flexed per-input (one bank for
-`I=Vector`, another for `I=SubArray`, another for `I=OffsetVector`, …), a
-mixed workload would shard the bank into low-hit-rate buckets. Pinning
-`inner` to `Vector{T}` keeps a single concrete cache key for every user
-input shape. One-shot pool paths preserve zero-alloc for non-`Vector{T}`
-input by pool-acquiring the inner buffer instead of `Vector{T}(x)`.
-
-# Behavior
-- `<: AbstractVector{T}` so existing search and eval kernels accept it
-  transparently — same trick `_CachedRange` uses with `<: AbstractRange`.
-- `Base.getindex(c, i)` forwards to `inner[i]` — zero overhead vs raw `Vector`.
-- `length(c) == length(c.inner)` — same as raw vector.
-- `Base.copy(c)` deep-copies all three fields for ownership.
-
-# Example
-```julia
-x = [0.0, 0.3, 0.7, 1.0]      # non-uniform Float grid
-cv = _CachedVector(x)          # _CachedVector{Float64, Float64}
-
-x_int = [0, 1, 3, 6]           # Int grid
-cv_int = _CachedVector(x_int)  # _CachedVector{Int, Float64}
-```
-"""
-struct _CachedVector{T, Tinv} <: AbstractVector{T}
-    inner::Vector{T}
-    h::Vector{T}        # length n-1
-    inv_h::Vector{Tinv} # length n-1
-end
+# Include order: ... → axis_types.jl → cached_range.jl → cached_vector.jl → ...
 
 # ---------- AbstractVector interface ----------
 Base.size(c::_CachedVector) = (length(c.inner),)
@@ -78,12 +22,6 @@ Base.length(c::_CachedVector) = length(c.inner)
 @inline Base.lastindex(c::_CachedVector) = length(c.inner)
 Base.eltype(::Type{<:_CachedVector{T}}) where {T} = T
 Base.IndexStyle(::Type{<:_CachedVector}) = IndexLinear()
-
-# ---------- Idempotent passthrough ----------
-# `_CachedVector(::_CachedVector)` returns the input unchanged. Mirrors
-# `_to_float(x::_CachedRange{T}, ::Type{T}) = x` (cached_range.jl) — re-wrapping
-# would discard the existing cached `h`/`inv_h` for no reason.
-_CachedVector(c::_CachedVector) = c
 
 # ---------- Wrapper-preserving copy ----------
 # Default `copy(::AbstractVector)` materializes to plain `Vector{T}`, destroying
@@ -152,11 +90,9 @@ end
     return _CachedVector(inner, h, inv_h)
 end
 
-# Range / pre-wrapped passthroughs — no buffer to acquire (Range has cached
-# scalar h, pre-wrapped axes already carry their caches).
-@inline _cache_axis_pooled(_, x::AbstractRange) = _to_float(x, float(eltype(x)))
-@inline _cache_axis_pooled(_, x::_CachedRange) = x
+# Pre-wrapped `_CachedVector` passthrough — cache already built.
 @inline _cache_axis_pooled(_, x::_CachedVector) = x
+# (Range / `_CachedRange` variants live in `cached_range.jl`.)
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 3-arg form: `_cache_axis_pooled(pool, x, Tg)` — target eltype explicit
@@ -243,3 +179,50 @@ end
 # Cubic 1D builds owned cache axes via `_cache_axis(_convert_copy(x, T), bc)`
 # (copy-then-wrap): one buffer copy + eltype conversion, then alias the
 # fresh buffer and build h/inv_h once.
+
+# ========================================
+# `_resolve_axis` — one-shot Vector wrapping
+# ========================================
+# Raw `Vector` is the canonical one-shot form (passthrough); `_CachedVector`
+# round-trips unchanged.
+@inline _resolve_axis(x::AbstractVector) = x
+@inline _resolve_axis(x::AbstractVector, ::AbstractBC) = x
+@inline _resolve_axis(c::_CachedVector) = c
+
+# `:exclusive` raw-input one-shot path — wrap into `_ExclusivePeriodicAxis`.
+@inline function _resolve_axis(x::AbstractVector, bc::PeriodicBC{:exclusive})
+    bc_resolved = _resolve_bc_period(x, bc)
+    return _ExclusivePeriodicAxis(x, bc_resolved.period)
+end
+
+# ========================================
+# `_cache_axis` — persistent-path Vector wrapping
+# ========================================
+# Full DISPATCH TABLE for `_cache_axis(x, bc, Tg)` (cross-input-type) lives in
+# `periodic_axis.jl` as the central reference. Owner-file entries below.
+@inline _cache_axis(x::AbstractVector) = _CachedVector(x)
+@inline _cache_axis(x::AbstractVector, ::AbstractBC) = _CachedVector(x)
+@inline _cache_axis(c::_CachedVector) = c
+@inline _cache_axis(c::_CachedVector, ::AbstractBC) = c
+
+# `:exclusive` 2-arg variants — produce `_ExclusivePeriodicAxis(_CachedVector, ·)`.
+@inline function _cache_axis(x::AbstractVector, bc::PeriodicBC{:exclusive})
+    bc_resolved = _resolve_bc_period(x, bc)
+    return _ExclusivePeriodicAxis(_CachedVector(x), bc_resolved.period)
+end
+@inline function _cache_axis(c::_CachedVector, bc::PeriodicBC{:exclusive})
+    bc_resolved = _resolve_bc_period(c, bc)
+    return _ExclusivePeriodicAxis(c, bc_resolved.period)
+end
+
+# 3-arg Tg-aware. Raw Vector respects Tg via `_to_float` then wraps.
+# Pre-wrapped `_CachedVector` passes through — downstream `_convert_copy(_, Tg)`
+# enforces Tg (intentional contract; see DISPATCH TABLE in `periodic_axis.jl`).
+@inline _cache_axis(x::AbstractVector, bc::AbstractBC, ::Type{Tg}) where {Tg} =
+    _cache_axis(_to_float(x, Tg), bc)
+@inline _cache_axis(c::_CachedVector, bc::AbstractBC, ::Type{Tg}) where {Tg} =
+    _cache_axis(c, bc)
+@inline _cache_axis(x::AbstractVector, bc::PeriodicBC{:exclusive}, ::Type{Tg}) where {Tg} =
+    _cache_axis(_to_float(x, Tg), bc)
+@inline _cache_axis(c::_CachedVector, bc::PeriodicBC{:exclusive}, ::Type{Tg}) where {Tg} =
+    _cache_axis(c, bc)

--- a/src/core/cached_vector.jl
+++ b/src/core/cached_vector.jl
@@ -14,23 +14,20 @@
 # Include order: grid_spacing.jl → cached_range.jl → cached_vector.jl → ...
 
 """
-    _CachedVector{T, Tinv, I} <: AbstractVector{T}
+    _CachedVector{T, Tinv} <: AbstractVector{T}
 
 Vector grid wrapper that caches per-cell spacing (`h`) and reciprocal
 (`inv_h`) for fast O(1) lookup during persistent interpolant evaluation.
 
 # Fields
-- `inner::I` — Original grid values (length n). Storage type varies by
-  construction path: persistent paths materialize to `Vector{T}` for
-  ownership (mutation safety + stable layout); one-shot pool paths alias
-  the caller's input (e.g. `SubArray{T}` view) to avoid an otherwise
-  pointless copy.
+- `inner::Vector{T}` — Original grid values (length n). Always a concrete
+  `Vector{T}`. Persistent paths materialize for ownership; one-shot pool
+  paths alias when input is already `Vector{T}`, else pool-acquire +
+  `copyto!` (no heap alloc — see `_cache_axis_pooled` below).
 - `h::Vector{T}` — Cell widths, `h[i] = inner[i+1] - inner[i]` (length n-1).
-  Persistent path: fresh `Vector{T}` from heap. One-shot path:
-  `acquire!(pool, T, n-1)` returns a `Vector{T}` from the pool's task-local
-  storage (reused across calls — zero-alloc after warmup).
-- `inv_h::Vector{Tinv}` — Precomputed reciprocals (length n-1). Same storage
-  rule as `h`.
+  Persistent: fresh heap `Vector{T}`. One-shot: pool-acquired (reused).
+- `inv_h::Vector{Tinv}` — Precomputed reciprocals (length n-1). Same
+  storage rule as `h`.
 
 # Type parameters
 - `T` — Grid element type. Can be `Int`, `Float64`, `ForwardDiff.Dual`,
@@ -38,36 +35,39 @@ Vector grid wrapper that caches per-cell spacing (`h`) and reciprocal
 - `Tinv` — Reciprocal type, equal to `typeof(inv(oneunit(T)))`. For Float
   grids `Tinv == T`; for Int grids `Tinv == Float64` (since `inv(::Int)`
   returns `Float64`).
-- `I <: AbstractVector{T}` — Concrete inner-storage type. Tracked as a
-  type parameter so `getindex(c, i) = c.inner[i]` specializes on the
-  concrete storage (no runtime dispatch on `SubArray`/`Vector` mix).
-  `h` / `inv_h` are NOT parametrized — they are always `Vector{T}` /
-  `Vector{Tinv}` because `acquire!` returns a `Vector`, not a view.
+
+# Design choice — single concrete inner storage
+All three buffers are pinned to `Vector{_}` (no `I<:AbstractVector{T}` type
+parameter on `inner`). The reason is *not* dispatch cost — `getindex` would
+specialize either way — but **RCU cache key uniformity**: the cubic
+autocache (`CubicSplineCache{T, X, ...}`) keys on the wrapped axis type
+`X`, and if `X = _CachedVector{T, Tinv, I}` flexed per-input (one bank for
+`I=Vector`, another for `I=SubArray`, another for `I=OffsetVector`, …), a
+mixed workload would shard the bank into low-hit-rate buckets. Pinning
+`inner` to `Vector{T}` keeps a single concrete cache key for every user
+input shape. One-shot pool paths preserve zero-alloc for non-`Vector{T}`
+input by pool-acquiring the inner buffer instead of `Vector{T}(x)`.
 
 # Behavior
 - `<: AbstractVector{T}` so existing search and eval kernels accept it
   transparently — same trick `_CachedRange` uses with `<: AbstractRange`.
 - `Base.getindex(c, i)` forwards to `inner[i]` — zero overhead vs raw `Vector`.
 - `length(c) == length(c.inner)` — same as raw vector.
-- `Base.copy(c)` materializes `inner` to `Vector{T}` (ownership contract)
-  regardless of source storage type — so the copy path normalizes one-shot
-  view-backed wrappers into owned `Vector`-backed wrappers suitable for
-  long-lived persistent storage. `h` / `inv_h` are already `Vector`, so
-  `copy` of those is a straight memcpy.
+- `Base.copy(c)` deep-copies all three fields for ownership.
 
 # Example
 ```julia
 x = [0.0, 0.3, 0.7, 1.0]      # non-uniform Float grid
-cv = _CachedVector(x)          # _CachedVector{Float64, Float64, Vector{Float64}}
+cv = _CachedVector(x)          # _CachedVector{Float64, Float64}
 
 x_int = [0, 1, 3, 6]           # Int grid
-cv_int = _CachedVector(x_int)  # _CachedVector{Int, Float64, Vector{Int}}
+cv_int = _CachedVector(x_int)  # _CachedVector{Int, Float64}
 ```
 """
-struct _CachedVector{T, Tinv, I <: AbstractVector{T}} <: AbstractVector{T}
-    inner::I
-    h::Vector{T}        # length n-1; heap (persistent) or pool-acquired (one-shot)
-    inv_h::Vector{Tinv} # length n-1; same storage rule as `h`
+struct _CachedVector{T, Tinv} <: AbstractVector{T}
+    inner::Vector{T}
+    h::Vector{T}        # length n-1
+    inv_h::Vector{Tinv} # length n-1
 end
 
 # ---------- AbstractVector interface ----------
@@ -128,23 +128,28 @@ function _CachedVector(x::AbstractVector{T}) where {T}
 end
 
 # ---------- Pool-backed construction (transient caches) ----------
-# Same shape as the outer ctor, but `h`/`inv_h` come from `pool` (zero-alloc
-# after warmup). UNLIKE the persistent outer ctor, this *aliases* `x` directly
-# — the wrapper lifetime is bounded by the enclosing `@with_pool` scope, so
-# aliasing is safe and avoids materializing a `Vector{T}` from view inputs
-# (e.g. `view(big_grid, k:k+N)`). The `I` type parameter tracks the concrete
-# storage type so downstream `getindex` specializes per concrete inner.
+# Pool-acquired `h` / `inv_h` (reused across calls). For non-`Vector{T}`
+# input (e.g. `view(big, k:k+N)`), the inner buffer is *also* pool-acquired
+# + `copyto!` rather than `Vector{T}(x)` — keeps zero-alloc on view input
+# while preserving the `inner::Vector{T}` invariant.
 @inline function _cache_axis_pooled(pool, x::AbstractVector{T}) where {T}
     n = length(x)
     n >= 2 || throw(ArgumentError("_cache_axis_pooled requires at least 2 grid points, got $n"))
     Tinv = typeof(inv(oneunit(T)))
+    inner = if x isa Vector{T}
+        x
+    else
+        buf = acquire!(pool, T, n)
+        copyto!(buf, x)
+        buf
+    end
     h = acquire!(pool, T, n - 1)
     inv_h = acquire!(pool, Tinv, n - 1)
     @inbounds for i in 1:(n - 1)
-        h[i] = x[i + 1] - x[i]
+        h[i] = inner[i + 1] - inner[i]
         inv_h[i] = inv(h[i])
     end
-    return _CachedVector(x, h, inv_h)
+    return _CachedVector(inner, h, inv_h)
 end
 
 # Range / pre-wrapped passthroughs — no buffer to acquire (Range has cached

--- a/src/core/core.jl
+++ b/src/core/core.jl
@@ -7,8 +7,9 @@ include("bc_types.jl")         # 3. Boundary condition types
 include("interp_method_types.jl") # 3b. Per-axis method specification (CubicMethod, etc.)
 include("coeff_types.jl")         # 3c. AbstractCoeffStrategy, PreCompute, OnTheFly, AutoCoeffs
 include("polyfit_kernels.jl")       # 4. Boundary condition computation kernels (Lagrange, etc.)
-include("cached_range.jl")     # 5. _CachedRange struct + _to_float (Range → _CachedRange normalizer)
-include("cached_vector.jl")    # 5c. _CachedVector struct (Vector grid + cached h/inv_h)
+include("axis_types.jl")       # 4b. Axis struct definitions (_CachedRange / _CachedVector / _ExclusivePeriodicAxis) — central types-first
+include("cached_range.jl")     # 5. _CachedRange methods (_to_float, _get_h, _resolve_axis, _cache_axis*)
+include("cached_vector.jl")    # 5c. _CachedVector methods (build ctor, _get_h, _resolve_axis, _cache_axis*)
 include("search.jl")           # 6. Search policy + interval search
 include("idx_stencil.jl")      # 6a. _IdxStencil{K} — wrap-aware per-axis index stencil
 include("factory.jl")          # 6b. User-facing factory functions (Search, Extrap, Side)

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -831,12 +831,40 @@ end
         q_evals::Tuple{Vararg{Real, N}},
         grids::Tuple{Vararg{AbstractVector, N}},
         searches::Tuple{Vararg{AbstractSearchPolicy, N}},
-        hints::Union{Nothing, Tuple{Vararg{Base.RefValue{Int}, N}}},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
         bcs::Tuple{Vararg{AbstractBC, N}},
     ) where {N}
-    hints_eff = _ensure_hint_nd(hints, Val(N))
-    results = map(_search_axis_stencil, grids, q_evals, searches, hints_eff, bcs)
+    results = map(_search_axis_stencil, grids, q_evals, searches, hints, bcs)
     return _project_search_results(results, _getstencil)
+end
+
+# Nothing-hint overload — scalar oneshot entries only. Batch must use the
+# 5-arg NTuple form (hint allocation hoisted via `_resolve_oneshot_search_nd`).
+@inline function _search_all_intervals_stencil(
+        q_evals::Tuple{Vararg{Real, N}},
+        grids::Tuple{Vararg{AbstractVector, N}},
+        searches::Tuple{Vararg{AbstractSearchPolicy, N}},
+        ::Nothing,
+        bcs::Tuple{Vararg{AbstractBC, N}},
+    ) where {N}
+    hints = _ensure_hint_nd(nothing, Val(N))
+    return _search_all_intervals_stencil(q_evals, grids, searches, hints, bcs)
+end
+
+
+"""
+    _resolve_oneshot_search_nd(search, queries, hint, Val(N)) -> (policies, hints)
+
+Per-axis adaptive policy + persistent hint tuple. Call once outside the
+per-query loop in every ND oneshot batch path. `hint::Nothing` produces a
+fresh `Ref{Int}` per axis; user-supplied Refs pass through unchanged.
+"""
+@inline function _resolve_oneshot_search_nd(
+        search, queries, hint, ::Val{N}
+    ) where {N}
+    policies = _resolve_search_nd(search, Val(N), queries, hint)
+    hints = _ensure_hint_nd(hint, Val(N))
+    return policies, hints
 end
 
 # ========================================

--- a/src/core/periodic_axis.jl
+++ b/src/core/periodic_axis.jl
@@ -575,19 +575,45 @@ end
 # `_promote_grid_float(Float64, Float32) = Float64` then widened `y` to
 # `Float64` too, breaking the documented Float32 promotion.
 #
-# Vector path: `Tg` is unused at the wrap step. Vector eltype is preserved by
-# `_CachedVector(x)`; the inner ctor's wrapper-aware `_convert_copy(c, Tg)`
-# rebuilds with the requested element type. Same for pre-wrapped inputs:
-# the wrapper's eltype passes through unchanged; promotion is the inner
-# constructor's responsibility.
-@inline _cache_axis(x::AbstractVector, bc::AbstractBC, ::Type{Tg}) where {Tg} = _cache_axis(x, bc)
-@inline _cache_axis(x::AbstractVector, bc::PeriodicBC{:exclusive}, ::Type{Tg}) where {Tg} = _cache_axis(x, bc)
+# DISPATCH TABLE (and exactly *which* paths respect `Tg`):
+#
+#   x type                 +  bc                       Tg respected?  result
+#   ───────────────────────────────────────────────────────────────────────────
+#   AbstractVector         +  AbstractBC                ✅            `_CachedVector{Tg}`
+#   AbstractVector         +  PeriodicBC{:exclusive}    ✅            `_ExclusivePeriodicAxis(_CachedVector{Tg}, period)`
+#   AbstractRange          +  AbstractBC                ✅            `_CachedRange{Tg}`
+#   AbstractRange          +  PeriodicBC{:exclusive}    ✅            `_ExclusivePeriodicAxis(_CachedRange{Tg}, period)`
+#   _CachedRange{S}        +  any                       ⚠️ IGNORED    passthrough (eltype S preserved)
+#   _CachedVector{S}       +  any                       ⚠️ IGNORED    passthrough or `:exclusive` wrap (eltype S preserved)
+#   _ExclusivePeriodicAxis +  any                       ⚠️ IGNORED    passthrough (eltype unchanged)
+#
+# Why pre-wrapped paths ignore `Tg` (INTENTIONAL CONTRACT):
+#   Pre-wrapped axes have *already committed* their element type via their
+#   cached `h`/`inv_h` buffers. Re-converting eltype would require dropping
+#   and rebuilding those caches — work that belongs to `_convert_copy(_, Tg)`,
+#   not to `_cache_axis`. The canonical persistent-build pattern is:
+#
+#       xc = _convert_copy(_cache_axis(x, bc, Tg), Tg)
+#
+#   For raw `x`: `_cache_axis` returns a Tg-typed wrapper, then `_convert_copy`
+#   degrades to a same-eltype `Base.copy` (one buffer copy, no eltype work).
+#   For pre-wrapped `x` whose eltype already matches `Tg`: same — passthrough +
+#   identity copy. For pre-wrapped `x` with mismatching eltype: `_cache_axis`
+#   passes it through unchanged, then `_convert_copy(_, Tg)` rebuilds with the
+#   new eltype (one allocation pass — fastest possible for this rare case).
+#
+#   In short: `_cache_axis(x, bc, Tg)` guarantees only that ROOT raw inputs
+#   become `Tg`-typed wrappers. Pre-wrapped inputs round-trip unchanged so the
+#   downstream `_convert_copy` can do the eltype work in a single pass.
+@inline _cache_axis(x::AbstractVector, bc::AbstractBC, ::Type{Tg}) where {Tg} = _cache_axis(_to_float(x, Tg), bc)
+@inline _cache_axis(x::AbstractVector, bc::PeriodicBC{:exclusive}, ::Type{Tg}) where {Tg} = _cache_axis(_to_float(x, Tg), bc)
 @inline _cache_axis(x::AbstractRange, ::AbstractBC, ::Type{Tg}) where {Tg} = _to_float(x, Tg)
 @inline function _cache_axis(x::AbstractRange, bc::PeriodicBC{:exclusive}, ::Type{Tg}) where {Tg}
     bc_resolved = _resolve_bc_period(x, bc)
     return _ExclusivePeriodicAxis(_to_float(x, Tg), bc_resolved.period)
 end
-# Pre-wrapped passthroughs ignore Tg (idempotent — inner ctor handles promotion).
+# Pre-wrapped passthroughs IGNORE Tg by design (see contract above). The
+# `Tg`-typed result is the responsibility of `_convert_copy(_, Tg)` downstream.
 @inline _cache_axis(c::_CachedRange, bc::AbstractBC, ::Type{Tg}) where {Tg} = _cache_axis(c, bc)
 @inline _cache_axis(c::_CachedRange, bc::PeriodicBC{:exclusive}, ::Type{Tg}) where {Tg} = _cache_axis(c, bc)
 @inline _cache_axis(c::_CachedVector, bc::AbstractBC, ::Type{Tg}) where {Tg} = _cache_axis(c, bc)

--- a/src/core/periodic_axis.jl
+++ b/src/core/periodic_axis.jl
@@ -37,136 +37,11 @@
 #
 # Include order: search.jl → periodic.jl → periodic_axis.jl → periodic_data.jl → ...
 
-"""
-    _ExclusivePeriodicAxis{Tg, X<:AbstractVector{Tg}, Tp} <: AbstractVector{Tg}
-
-Representation wrapper for `PeriodicBC{:exclusive, L}` non-uniform Vector
-*axis* grids (companion to `_ExclusivePeriodicData` for the y/data side).
-
-`inner` is the user's raw grid (length n, NO copy). `period` is the period
-span (one period of the user's data). The wrapper reports `length(g) = n+1`
-so search algorithms naturally find the seam cell, but `Base.getindex(g, i)`
-forwards to `inner[i]` WITHOUT any branch — keeping hot search loops at zero
-overhead vs raw `inner`.
-
-Virtual-index access (i.e. `g[n+1]`) is provided through the `_getindex`
-helper (defined below), which branches on the virtual range.
-
-The wrapper also caches `_x_max = inner[1] + period` so `last(g)` is a single
-field read on every query (matches the cost of the legacy `WrapExtrap{T}._x_max`
-field read). This makes the axis a self-sufficient single source of truth for
-the wrap domain `[first(g), last(g))` — `WrapExtrap` itself stays a pure tag
-struct.
-
-# Fields
-- `inner::X` — user's raw non-uniform grid (length n). Can be `Vector{Tg}`
-  or `_CachedVector{Tg, Tinv}`. Range inputs are NOT wrapped — they go
-  directly through `_to_float_adding_endpoint` to a length-(n+1) `_CachedRange`.
-- `period::Tp` — period span. Type independent of `Tg` to allow e.g. `Float64`
-  grids with `Float32` period.
-- `_x_max::Tg` — virtual-endpoint cache (`inner[1] + Tg(period)`); precomputed
-  at construction so `Base.last(g)` is a single field read.
-
-# Example
-```julia
-x = [0.0, 0.25, 0.5, 0.75]                       # raw Vector grid, length 4
-g = _ExclusivePeriodicAxis(x, 1.0)               # presented as length 5
-g[1], g[2], g[3], g[4]                           # 0.0, 0.25, 0.5, 0.75 (raw)
-length(g) == 5                                   # virtual extension
-_getindex(g, 5)                                  # 1.0 (= x[1] + period)
-last(g)                                          # 1.0 (single field read)
-```
-"""
-struct _ExclusivePeriodicAxis{Tg, X <: AbstractVector{Tg}, Tp} <: AbstractVector{Tg}
-    inner::X
-    period::Tp
-    _x_max::Tg
-
-    # Inner constructor: precompute `_x_max = inner[1] + period` (used as the
-    # virtual seam coord and as the upper end of the wrap domain), and validate
-    # `inner[end] < _x_max` (period must exceed the grid span — otherwise the
-    # seam cell would collapse or overlap interior cells). Accepts any
-    # `AbstractVector` inner (`Vector`, `_CachedVector`, `AbstractRange`,
-    # `_CachedRange`) so the same wrapper unifies the `:exclusive` periodic
-    # representation for 1D and ND zero-copy paths.
-    function _ExclusivePeriodicAxis{Tg, X, Tp}(inner::X, period::Tp) where {Tg, X <: AbstractVector{Tg}, Tp}
-        x_max = @inbounds inner[1] + Tg(period)
-        @inbounds inner[end] < x_max || _throw_excl_axis_period_too_small(period, x_max, inner[end])
-        # Cross-validate user period against Range-inferred period (Range inners
-        # only — Vector inners cannot infer). Done once at wrapper construction
-        # so hot-path resolvers (`_resolve_exclusive_period`, `_resolve_bc_period`)
-        # can be trust-mode and pay no per-call validation tax.
-        _validate_exclusive_period(inner, period)
-        return new{Tg, X, Tp}(inner, period, x_max)
-    end
-end
-
-@noinline _throw_excl_axis_period_too_small(period, x_max, last_x) = throw(
-    ArgumentError(
-        "PeriodicBC(:exclusive) period=$period places virtual endpoint at $x_max, " *
-            "not after last grid point x[end]=$last_x"
-    )
-)
-
-# No-op for Vector inners (period unverifiable) — caller's responsibility.
-@inline _validate_exclusive_period(::AbstractVector, _) = nothing
-# Range inners: cross-validate against `step × length` (= total period for the
-# n-cell exclusive form). Tolerance pattern mirrors `_check_periodic_endpoints`
-# in `core/periodic.jl` so the period check and the inclusive-y endpoint check
-# share one numerical contract. Per-eltype dispatch:
-#   - AbstractFloat / Complex{<:AbstractFloat} → `atol = 8*eps, rtol = sqrt(eps)`
-#   - Integer / Rational                       → default `isapprox` (effectively `==`)
-#   - Duck types (Dual, Measurement, ...)      → strict equality on the primal
-@inline _validate_exclusive_period(inner::AbstractRange, period) =
-    _validate_exclusive_period_impl(inner, period, eltype(inner))
-
-@inline function _validate_exclusive_period_impl(
-        inner::AbstractRange, period, ::Type{T}
-    ) where {T <: AbstractFloat}
-    inferred = step(inner) * length(inner)
-    isapprox(T(period), T(inferred); atol = 8 * eps(T), rtol = sqrt(eps(T))) ||
-        _throw_excl_axis_period_mismatch(period, first(inner), inferred)
-    return nothing
-end
-
-@inline function _validate_exclusive_period_impl(
-        inner::AbstractRange, period, ::Type{Complex{T}}
-    ) where {T <: AbstractFloat}
-    inferred = step(inner) * length(inner)
-    isapprox(Complex{T}(period), Complex{T}(inferred); atol = 8 * eps(T), rtol = sqrt(eps(T))) ||
-        _throw_excl_axis_period_mismatch(period, first(inner), inferred)
-    return nothing
-end
-
-@inline function _validate_exclusive_period_impl(
-        inner::AbstractRange, period, ::Type{T}
-    ) where {T <: _PromotableValue}
-    # Integer / Rational grids: exact equality (default isapprox tolerance).
-    inferred = step(inner) * length(inner)
-    isapprox(period, inferred) ||
-        _throw_excl_axis_period_mismatch(period, first(inner), inferred)
-    return nothing
-end
-
-@inline function _validate_exclusive_period_impl(inner::AbstractRange, period, ::Type)
-    # Duck-type fallback (Dual, Measurement, ...): strict equality on primal.
-    inferred = step(inner) * length(inner)
-    _extract_primal(period) == _extract_primal(inferred) ||
-        _throw_excl_axis_period_mismatch(period, first(inner), inferred)
-    return nothing
-end
-
-@noinline _throw_excl_axis_period_mismatch(period, x0, inferred) = throw(
-    ArgumentError(
-        "PeriodicBC's period=$period conflicts with Range-inferred period = " *
-            "$(x0 + inferred) - $x0 = $inferred. " *
-            "Either adjust `period` or omit it for auto-inference."
-    )
-)
-
-# Convenience outer constructor — type params inferred from inputs.
-@inline _ExclusivePeriodicAxis(inner::AbstractVector{Tg}, period) where {Tg} =
-    _ExclusivePeriodicAxis{Tg, typeof(inner), typeof(period)}(inner, period)
+# `_ExclusivePeriodicAxis` struct definition + inner ctor + validation helpers
+# + outer convenience ctor live in `axis_types.jl` (loaded earlier). This file
+# owns the wrapper's behavior: `Base.copy` / `_convert_copy`, AbstractArray
+# interface, `_get_h` / `_get_inv_h` (seam-aware), `_resolve_axis` /
+# `_cache_axis(g::_ExclusivePeriodicAxis, ...)` passthroughs, view, search.
 
 # ---------- Wrapper-preserving copy ----------
 # Default `Base.copy(::AbstractVector)` uses `similar` + `copyto!` which
@@ -450,26 +325,14 @@ end
 # for every method-family.
 
 # ----- Surface (oneshot, zero-alloc) ---------------------------------------
+#
+# Non-`:exclusive` `_resolve_axis` overloads live next to their type definitions
+# (`cached_range.jl` for Range / `_CachedRange`, `cached_vector.jl` for Vector /
+# `_CachedVector`). Below: `:exclusive` overloads (produce `_ExclusivePeriodicAxis`)
+# + the `_ExclusivePeriodicAxis` passthrough.
 
-# 1-arg form: BC-unaware grid normalization. Used by public oneshot API
-# entries that haven't yet inspected `bc` (e.g., `cardinal_interp(x, y, xq; bc)`)
-# and by internal helpers that just need a uniform grid representation.
-# Equivalent to `_resolve_axis(x, NoBC())` but more explicit at the call site.
-@inline _resolve_axis(x::AbstractVector) = x
-@inline _resolve_axis(x::AbstractRange) = _to_float(x, float(eltype(x)))
-
-@inline _resolve_axis(x::AbstractVector, ::AbstractBC) = x
-@inline _resolve_axis(x::AbstractRange, ::AbstractBC) = _to_float(x, float(eltype(x)))
-@inline function _resolve_axis(x::AbstractRange, bc::PeriodicBC{:exclusive})
-    # Wrap the (cached, length-n) Range so the seam-fold idx_R=1 is shared
-    # with the Vector path — uniform behavior in 1D and ND zero-copy.
-    bc_resolved = _resolve_bc_period(x, bc)
-    return _ExclusivePeriodicAxis(_to_float(x, float(eltype(x))), bc_resolved.period)
-end
-@inline function _resolve_axis(x::AbstractVector, bc::PeriodicBC{:exclusive})
-    bc_resolved = _resolve_bc_period(x, bc)
-    return _ExclusivePeriodicAxis(x, bc_resolved.period)
-end
+# `_resolve_axis(::AbstractRange/AbstractVector, ::PeriodicBC{:exclusive})`
+# live in `cached_range.jl` / `cached_vector.jl` (owner files).
 
 @inline _resolve_data(y::AbstractArray, ::AbstractBC) = y
 @inline function _resolve_data(y::AbstractArray, bc::PeriodicBC{:inclusive})
@@ -516,50 +379,12 @@ end
 # are idempotent passthroughs — wrapping is already done; the inner ctor's
 # `_convert_copy` handles ownership transfer + optional type conversion.
 
-# 1-arg form: BC-unaware caching wrap. Mirrors `_resolve_axis(x)` but uses
-# the persistent-storage convention (Vector → `_CachedVector` for cached
-# h/inv_h lookup). Use when the call site is persistent but hasn't yet
-# inspected `bc`. Pre-wrapped inputs pass through idempotently below.
-@inline _cache_axis(x::AbstractVector) = _CachedVector(x)
-@inline _cache_axis(x::AbstractRange) = _to_float(x, float(eltype(x)))
-
-@inline _cache_axis(x::AbstractVector, ::AbstractBC) = _CachedVector(x)
-@inline _cache_axis(x::AbstractRange, ::AbstractBC) = _to_float(x, float(eltype(x)))
-@inline function _cache_axis(x::AbstractRange, bc::PeriodicBC{:exclusive})
-    bc_resolved = _resolve_bc_period(x, bc)
-    return _ExclusivePeriodicAxis(_to_float(x, float(eltype(x))), bc_resolved.period)
-end
-@inline function _cache_axis(x::AbstractVector, bc::PeriodicBC{:exclusive})
-    bc_resolved = _resolve_bc_period(x, bc)
-    return _ExclusivePeriodicAxis(_CachedVector(x), bc_resolved.period)
-end
-# Idempotent passthroughs for pre-wrapped axes. Each wrapper has BOTH a
-# `<:AbstractBC` overload AND an explicit `<:PeriodicBC{:exclusive}` overload
-# to resolve ambiguity against the raw-input entries above
-# (`_CachedRange <: AbstractRange`, `_CachedVector <: AbstractVector`,
-# `_ExclusivePeriodicAxis <: AbstractVector`).
-# Pre-wrapped idempotent passthroughs — both 1-arg and 2-arg forms. The
-# 1-arg passthroughs are critical for `_cache_axis` (without them, the raw
-# `AbstractVector` overload would wrap an already-wrapped axis in a redundant
-# `_CachedVector`). `_resolve_axis` 1-arg is safe via the `AbstractVector`
-# passthrough but explicit overloads are provided for symmetry.
-@inline _resolve_axis(c::_CachedRange) = c
-@inline _resolve_axis(c::_CachedVector) = c
+# `_ExclusivePeriodicAxis`-specific resolvers — wrapper passthroughs.
+# Cross-type `:exclusive` dispatches (raw Range/Vector → wrapper, pre-wrapped
+# `_CachedRange`/`_CachedVector` → wrapper) live in their owner files
+# (`cached_range.jl` / `cached_vector.jl`).
 @inline _resolve_axis(g::_ExclusivePeriodicAxis) = g
-@inline _cache_axis(c::_CachedRange) = c
-@inline _cache_axis(c::_CachedVector) = c
 @inline _cache_axis(g::_ExclusivePeriodicAxis) = g
-
-@inline _cache_axis(c::_CachedRange, ::AbstractBC) = c
-@inline function _cache_axis(c::_CachedRange, bc::PeriodicBC{:exclusive})
-    bc_resolved = _resolve_bc_period(c, bc)
-    return _ExclusivePeriodicAxis(c, bc_resolved.period)
-end
-@inline _cache_axis(c::_CachedVector, ::AbstractBC) = c
-@inline function _cache_axis(c::_CachedVector, bc::PeriodicBC{:exclusive})
-    bc_resolved = _resolve_bc_period(c, bc)
-    return _ExclusivePeriodicAxis(c, bc_resolved.period)
-end
 @inline _cache_axis(g::_ExclusivePeriodicAxis, ::AbstractBC) = g
 @inline _cache_axis(g::_ExclusivePeriodicAxis, ::PeriodicBC{:exclusive}) = g
 
@@ -605,19 +430,9 @@ end
 #   In short: `_cache_axis(x, bc, Tg)` guarantees only that ROOT raw inputs
 #   become `Tg`-typed wrappers. Pre-wrapped inputs round-trip unchanged so the
 #   downstream `_convert_copy` can do the eltype work in a single pass.
-@inline _cache_axis(x::AbstractVector, bc::AbstractBC, ::Type{Tg}) where {Tg} = _cache_axis(_to_float(x, Tg), bc)
-@inline _cache_axis(x::AbstractVector, bc::PeriodicBC{:exclusive}, ::Type{Tg}) where {Tg} = _cache_axis(_to_float(x, Tg), bc)
-@inline _cache_axis(x::AbstractRange, ::AbstractBC, ::Type{Tg}) where {Tg} = _to_float(x, Tg)
-@inline function _cache_axis(x::AbstractRange, bc::PeriodicBC{:exclusive}, ::Type{Tg}) where {Tg}
-    bc_resolved = _resolve_bc_period(x, bc)
-    return _ExclusivePeriodicAxis(_to_float(x, Tg), bc_resolved.period)
-end
-# Pre-wrapped passthroughs IGNORE Tg by design (see contract above). The
-# `Tg`-typed result is the responsibility of `_convert_copy(_, Tg)` downstream.
-@inline _cache_axis(c::_CachedRange, bc::AbstractBC, ::Type{Tg}) where {Tg} = _cache_axis(c, bc)
-@inline _cache_axis(c::_CachedRange, bc::PeriodicBC{:exclusive}, ::Type{Tg}) where {Tg} = _cache_axis(c, bc)
-@inline _cache_axis(c::_CachedVector, bc::AbstractBC, ::Type{Tg}) where {Tg} = _cache_axis(c, bc)
-@inline _cache_axis(c::_CachedVector, bc::PeriodicBC{:exclusive}, ::Type{Tg}) where {Tg} = _cache_axis(c, bc)
+# `_ExclusivePeriodicAxis` passthroughs for 3-arg form.
+# Raw `AbstractRange`/`AbstractVector` + `:exclusive` + Tg, and pre-wrapped
+# `_CachedRange`/`_CachedVector` + `:exclusive` + Tg live in their owner files.
 @inline _cache_axis(g::_ExclusivePeriodicAxis, bc::AbstractBC, ::Type{Tg}) where {Tg} = _cache_axis(g, bc)
 @inline _cache_axis(g::_ExclusivePeriodicAxis, bc::PeriodicBC{:exclusive}, ::Type{Tg}) where {Tg} = _cache_axis(g, bc)
 

--- a/src/core/periodic_axis.jl
+++ b/src/core/periodic_axis.jl
@@ -252,10 +252,26 @@ end
 @inline Base.@propagate_inbounds _get_inv_h(g::_ExclusivePeriodicAxis, idx::Int, xL::Real, xR::Real) =
     idx < length(g.inner) ? _get_inv_h(g.inner, idx, xL, xR) : inv(xR - xL)
 
-# `_alpha_of` for the wrapper: defer to inner so `_CachedRange` uses cached
-# `inv_h` (avoids `(R - L)` cancellation in the denominator).
+# `_alpha_of` for the wrapper: seam-aware so the value computation shares a
+# denominator with the 4-arg `_get_inv_h` at the seam cell.
+#   - Interior cell (`R != g._x_max`): defer to inner so `_CachedRange` uses
+#     its cached `inv_h` field (avoids `(R - L)` cancellation in the denom).
+#   - Seam cell (`R == g._x_max`): use the actual seam width `R - L`,
+#     matching `_get_inv_h(g, idx, xL, xR) = inv(xR - xL)` at `idx == n`.
+#
+# Without the seam branch, a Range inner with an explicit off-tolerance period
+# (within `sqrt(eps)` rtol of `step*length`, accepted by `_validate_exclusive_period`)
+# computed `α` from inner step but derivative from `inv(xR - xL)`, leaving
+# value/derivative on disagreeing denominators. Relative error scales as
+# `n * sqrt(eps)`, so Float32 grids at n ~ 100 or Float64 grids at n ~ 10⁶
+# could show percent-level seam-cell discrepancy.
+#
+# Float equality on `_x_max` is exact: the wrapper ctor enforces
+# `inner[end] < _x_max`, so `inner[idx+1] == _x_max` is unreachable for
+# interior cells. At the seam, the wrapper's `search_interval` returns
+# `xR = g._x_max` by direct field read — bit-equal to the comparand here.
 @inline _alpha_of(q::Real, L::Real, R::Real, g::_ExclusivePeriodicAxis) =
-    _alpha_of(q, L, R, g.inner)
+    R == g._x_max ? (q - L) / float(R - L) : _alpha_of(q, L, R, g.inner)
 
 # ========================================
 # View specialization: preserve wrapper for full-virtual range

--- a/src/core/periodic_axis.jl
+++ b/src/core/periodic_axis.jl
@@ -240,21 +240,17 @@ end
 @inline _wrap_to_domain(xq, g::_ExclusivePeriodicAxis) =
     _wrap_to_domain(xq, @inbounds(g.inner[1]), g._x_max)
 
-# 3-arg `(g, xL, xR)` form for oneshot kernels that already have `xL`/`xR`
-# in registers from search. Delegate to the inner type so `_CachedRange`
-# inners use the cached `h` field (single field load — matches master's
-# perf for non-wrapped Range grids). For `_CachedVector` / `Vector` inners
-# the inner overload computes `xR - xL` directly, same as the wrapper-level
-# fallback would.
-#
-# Seam correctness: at the seam, `xR == g._x_max == inner[1] + period` and
-# `xL == g.inner[n]`. Delegating to `_get_h(_CachedRange, xL, xR) = x.h`
-# returns the cached `step`. For correctly-supplied periods this equals
-# `xR - xL` exactly (the wrapper constructor's cross-validation enforces
-# `period ≈ step × length`); off-bit periods within `sqrt(eps)` rtol differ
-# by ≤1 ULP — numeric noise, well below kernel precision.
-@inline _get_h(g::_ExclusivePeriodicAxis, xL::Real, xR::Real) = _get_h(g.inner, xL, xR)
-@inline _get_inv_h(g::_ExclusivePeriodicAxis, xL::Real, xR::Real) = _get_inv_h(g.inner, xL, xR)
+# 4-arg `(g, idx, xL, xR)` form. Search already produced all four; dispatch
+# picks the per-type cheapest path.
+#   - `idx < length(g.inner)` (interior cell): delegate to inner — uses
+#      `_CachedRange.h`/`_CachedVector.h[idx]` cache.
+#   - `idx == length(g.inner)` (seam cell): inner's idx-lookup would index
+#      out of `inv_h` (length n-1). Use `xR - xL` directly — caller already
+#      has `xR == g._x_max` from search, so this is the natural seam width.
+@inline Base.@propagate_inbounds _get_h(g::_ExclusivePeriodicAxis, idx::Int, xL::Real, xR::Real) =
+    idx < length(g.inner) ? _get_h(g.inner, idx, xL, xR) : xR - xL
+@inline Base.@propagate_inbounds _get_inv_h(g::_ExclusivePeriodicAxis, idx::Int, xL::Real, xR::Real) =
+    idx < length(g.inner) ? _get_inv_h(g.inner, idx, xL, xR) : inv(xR - xL)
 
 # `_alpha_of` for the wrapper: defer to inner so `_CachedRange` uses cached
 # `inv_h` (avoids `(R - L)` cancellation in the denominator).

--- a/src/core/series_utils.jl
+++ b/src/core/series_utils.jl
@@ -20,7 +20,8 @@
 #       and avoids the K-cache-line write jump per query of the Q×K
 #       shape. Wins once NQ or K is large.
 #
-# The crossover is K-dependent (see `scripts/series_threshold_sweep.jl`):
+# The crossover is K-dependent (thresholds empirically tuned on Linear /
+# Constant Series oneshot batch microbenchmarks):
 #   - K ≤ ~100: NQ ≈ 16 is the cleanest break (Q×K wins below, K×Q above).
 #   - K ≥ ~256: Q×K loses at every NQ — the K-inner loop can't SIMD across
 #     K separate output Vectors and the K-cache-line write thrash per

--- a/src/core/series_utils.jl
+++ b/src/core/series_utils.jl
@@ -7,6 +7,35 @@
 #
 
 # ========================================
+# Series one-shot batch loop-order selection
+# ========================================
+# Vector-batch `*_interp!(outs, x, ::Series, xqs)` picks its loop order
+# adaptively from `(NQ, K) = (length(xqs), n_series(s))`:
+#
+#   Q outer × K inner with stack-resident anchor per query.
+#       Tight loop, no pool. Wins on tiny batches (no scratch buffer).
+#
+#   K outer × Q inner with pool-acquired anchor vector.
+#       Inner loop streams one `outputs[k]` Vector — LLVM auto-SIMDs
+#       and avoids the K-cache-line write jump per query of the Q×K
+#       shape. Wins once NQ or K is large.
+#
+# The crossover is K-dependent (see `scripts/series_threshold_sweep.jl`):
+#   - K ≤ ~100: NQ ≈ 16 is the cleanest break (Q×K wins below, K×Q above).
+#   - K ≥ ~256: Q×K loses at every NQ — the K-inner loop can't SIMD across
+#     K separate output Vectors and the K-cache-line write thrash per
+#     query dominates. K×Q wins outright.
+#
+# `_series_use_kq_loop(NQ, K)` codifies both axes: route to the K×Q (pool)
+# path if either NQ exceeds the per-K threshold OR K is large enough that
+# Q×K can never beat the SIMD-friendly inner stream.
+const _SERIES_BATCH_NQ_THRESHOLD = 16
+const _SERIES_BATCH_K_THRESHOLD = 256
+
+@inline _series_use_kq_loop(NQ::Int, K::Int) =
+    NQ > _SERIES_BATCH_NQ_THRESHOLD || K >= _SERIES_BATCH_K_THRESHOLD
+
+# ========================================
 # Output Validation
 # ========================================
 

--- a/src/cubic/cubic_anchor.jl
+++ b/src/cubic/cubic_anchor.jl
@@ -349,8 +349,8 @@ while preserving the full Dual value for weight computation.
     # Compute geometry (cubic-internal concern)
     # h and inv_h are Tg (grid type)
     # dL and dR preserve Dual type for AD (via loc.xq)
-    h = _get_h(x, loc.xL, loc.xR)
-    inv_h = _get_inv_h(x, loc.xL, loc.xR)
+    h = _get_h(x, loc.idx, loc.xL, loc.xR)
+    inv_h = _get_inv_h(x, loc.idx, loc.xL, loc.xR)
     dL = loc.xq - loc.xL
     dR = loc.xR - loc.xq
 

--- a/src/cubic/cubic_cache_pool.jl
+++ b/src/cubic/cubic_cache_pool.jl
@@ -44,13 +44,10 @@ Abstract type for cache entries. Subtypes must have:
 abstract type AbstractCacheEntry{T <: AbstractFloat, X <: AbstractVector{T}} end
 
 # Map user input grid type to the cache's wrapped axis type. Mirrors
-# `_cache_axis(_convert_copy(x, T), bc)` (copy-then-wrap):
-# - Non-periodic / `:inclusive`: Range → `_CachedRange{T, Tinv}`,
-#   Vector → `_CachedVector{T, Tinv}`.
-# - `:exclusive` periodic: extra `_ExclusivePeriodicAxis` wrapper around the
-#   above inner.
-# Cubic always promotes to `T <: AbstractFloat`, so `Tinv == T`; pin it
-# explicitly to keep `EntryType` concrete in the bank.
+# `_cache_axis(_convert_copy(x, T), bc)`: Range → `_CachedRange{T, T}`,
+# Vector → `_CachedVector{T, Tinv}`. `:exclusive` periodic adds an outer
+# `_ExclusivePeriodicAxis` wrapper. Cubic always promotes to float, so pin
+# `Tinv = T` to keep `EntryType` concrete.
 @inline _cached_axis_type(::Type{<:AbstractRange}, ::Type{T}) where {T} = _CachedRange{T, T}
 @inline _cached_axis_type(::Type{<:AbstractVector}, ::Type{T}) where {T} =
     _CachedVector{T, typeof(inv(oneunit(T)))}

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -168,11 +168,12 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
         queries,
         bcs::NTuple{N, AbstractBC},
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
-        policies::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
-        hints,  # Nothing or NTuple{N, Ref{Int}}
-        mono::NTuple{N, Bool},
+        search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}},
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}},
     ) where {Tg, Tv, N}
+    # Resolve here so the fresh Ref tuple stays local to this frame (stack-elidable).
+    policies, hints = _resolve_oneshot_search_nd(search, queries, hint, Val(N))
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
@@ -197,18 +198,16 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
             output[k] = oob_val; continue
         end
         q_evals = _handle_all_extraps(query_k, grids_p, extraps_eff)
-        indices, Ls, _ = _search_all_intervals(q_evals, grids_p, policies, hints, mono)
+        indices, Ls, _ = _search_all_intervals(q_evals, grids_p, policies, hints)
         hs, inv_hs, dLs = _compute_all_local_params(q_evals, grids_p, indices, Ls)
         output[k] = _eval_nd_cell(partials, indices, hs, inv_hs, dLs, ops)
     end
     return output
 end
 
-# Function barrier: forces Julia to runtime-dispatch on the concrete
-# searches tuple type, resolving per-element Union{BinarySearch,LinearBinarySearch} before
-# entering the @with_pool boundary. NOT @inline — specialization requires real call.
-function _cubic_nd_batch_dispatch!(output, grids, data, queries, bcs, extraps, policies, ops, hints, mono)
-    return _cubic_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps, policies, ops, hints, mono)
+# Function barrier — specializes on concrete `search` type.
+function _cubic_nd_batch_dispatch!(output, grids, data, queries, bcs, extraps, ops, search, hint)
+    return _cubic_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps, ops, search, hint)
 end
 
 # ========================================
@@ -239,13 +238,9 @@ function cubic_interp!(
     _validate_nd_grids(grids_typed, data)
 
     bcs = _resolve_bcs_nd(bc, Val(N))
-    policies = _resolve_search_nd(search, Val(N))
-    hints_nd = hint  # pass user hints as-is (nothing or NTuple{N,Ref{Int}})
-    mono = _check_mono_nd(policies, queries)
-
     _validate_nd_bcs!(grids_typed, bcs, data, Val(N))
 
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv_p)
     ops = _resolve_deriv_nd(deriv, Val(N))
-    return _cubic_nd_batch_dispatch!(output, grids_typed, data, queries, bcs, extraps_val, policies, ops, hints_nd, mono)
+    return _cubic_nd_batch_dispatch!(output, grids_typed, data, queries, bcs, extraps_val, ops, search, hint)
 end

--- a/src/hetero/hetero_oneshot.jl
+++ b/src/hetero/hetero_oneshot.jl
@@ -68,11 +68,12 @@ end
         queries,
         methods::Tuple{Vararg{AbstractInterpMethod, N}},
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
-        policies::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
-        hints,  # Nothing or NTuple{N, Ref{Int}}
-        mono::NTuple{N, Bool},
+        search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}},
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}},
     ) where {Tg, N}
+    # Resolve here so the fresh Ref tuple stays local to this frame (stack-elidable).
+    policies, hints = _resolve_oneshot_search_nd(search, queries, hint, Val(N))
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
@@ -102,21 +103,16 @@ end
             continue
         end
         q_eval = _handle_all_extraps(query_k, grids_p, extraps_eff)
-        indices, Ls, _ = _search_all_intervals(q_eval, grids_p, policies, hints, mono)
+        indices, Ls, _ = _search_all_intervals(q_eval, grids_p, policies, hints)
         hs, inv_hs, dLs = _compute_all_local_params(q_eval, grids_p, indices, Ls)
         output[k] = _eval_hetero_nd_cell(partials, indices, hs, inv_hs, dLs, ops, methods)
     end
     return output
 end
 
-# ========================================
-# Function Barrier
-# ========================================
-# Forces search type specialization before entering @with_pool boundary.
-# NOT @inline — specialization requires real call.
-
-function _interp_nd_hetero_batch_dispatch!(output, grids, data, queries, methods, extraps, policies, ops, hints, mono)
-    return _interp_nd_hetero_oneshot_batch!(output, grids, data, queries, methods, extraps, policies, ops, hints, mono)
+# Function barrier — specializes on concrete `search` type.
+function _interp_nd_hetero_batch_dispatch!(output, grids, data, queries, methods, extraps, ops, search, hint)
+    return _interp_nd_hetero_oneshot_batch!(output, grids, data, queries, methods, extraps, ops, search, hint)
 end
 
 # ========================================
@@ -331,8 +327,6 @@ end
     # bc-aware extrap (matches scalar dispatch).
     bcs = map(_bc_for_periodic_check, methods)
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)
-    policies = _resolve_search_nd(search, Val(N))
-    mono = _check_mono_nd(policies, queries)
     ops = _resolve_deriv_nd(deriv, Val(N))
     _validate_axis_methods(grids_typed, methods, extraps_val)
 
@@ -340,18 +334,24 @@ end
         nq = _query_length(queries)
         length(output) == nq || _throw_query_output_mismatch(nq, length(output))
         _query_validate(queries)
-        # Validate inclusive periodic boundary slices ONCE per batch (not per
-        # query). `_interp_nd_oneshot_onthefly` skips the validation since both
-        # callers (here + scalar dispatch) hoist it above their hot path.
+        # Validate inclusive periodic boundary slices ONCE per batch.
         _validate_periodic_slices_nd(data, bcs, Val(N))
+        # OTF batch uses the master shape: pass `search` (unresolved AutoSearch
+        # tuple) + `hints` (as-is) per query. Eager 4-arg resolution + pre-built
+        # hints would propagate Union policies across `_interp_nd_oneshot_onthefly`'s
+        # function boundary — it's too large to inline, so the Union element
+        # boxes into 4 allocs/query (≈ 100 B/query). The architectural fix is a
+        # dedicated OTF batch function that hosts the per-query work locally;
+        # tracked as a follow-up. See `claudedocs/TODO/otf_batch_adaptive_search.md`.
+        searches = _resolve_search_nd(search, Val(N))
         @inbounds for k in 1:nq
             query_k = _extract_query_point(queries, k, Val(N))
-            output[k] = _interp_nd_oneshot_onthefly(grids_typed, data, query_k, methods, extraps_val, policies, ops, hints)
+            output[k] = _interp_nd_oneshot_onthefly(grids_typed, data, query_k, methods, extraps_val, searches, ops, hints)
         end
         return output
     end
 
-    return _interp_nd_hetero_batch_dispatch!(output, grids_typed, data, queries, methods, extraps_val, policies, ops, hints, mono)
+    return _interp_nd_hetero_batch_dispatch!(output, grids_typed, data, queries, methods, extraps_val, ops, search, hints)
 end
 
 # ========================================

--- a/src/hetero/hetero_oneshot.jl
+++ b/src/hetero/hetero_oneshot.jl
@@ -341,8 +341,8 @@ end
         # hints would propagate Union policies across `_interp_nd_oneshot_onthefly`'s
         # function boundary — it's too large to inline, so the Union element
         # boxes into 4 allocs/query (≈ 100 B/query). The architectural fix is a
-        # dedicated OTF batch function that hosts the per-query work locally;
-        # tracked as a follow-up. See `claudedocs/TODO/otf_batch_adaptive_search.md`.
+        # dedicated OTF batch function that hosts the per-query work locally
+        # (follow-up).
         searches = _resolve_search_nd(search, Val(N))
         @inbounds for k in 1:nq
             query_k = _extract_query_point(queries, k, Val(N))

--- a/src/linear/linear_oneshot_series.jl
+++ b/src/linear/linear_oneshot_series.jl
@@ -270,8 +270,8 @@ end
     return outputs
 end
 
-# Adaptive entry. `length(xqs)` selects the loop order — see
-# `_SERIES_BATCH_LOOP_THRESHOLD` docs in `src/core/series_utils.jl`.
+# Adaptive entry. `length(xqs)` and `K` feed `_series_use_kq_loop` to select
+# the loop order — see `src/core/series_utils.jl`.
 @inline function linear_interp!(
         outputs::AbstractVector{<:AbstractVector},
         x::AbstractVector{Tg},

--- a/src/linear/linear_oneshot_series.jl
+++ b/src/linear/linear_oneshot_series.jl
@@ -172,10 +172,106 @@ end
 In-place one-shot linear interpolation at multiple query points.
 `outputs` is a `Vector{<:AbstractVector}` of length `n_series`, each of length `length(xqs)`.
 """
-# Zero-pool vector-batch: Q outer × K inner. Anchor is register-resident for
-# the K-inner loop — no aq_vec scratch, no grid/value extension. Periodic
-# mirrors the scalar helper's wrap-first pattern; non-periodic uses the
-# pair-aware `_anchor_query` (Stage 1) directly.
+# Q outer × K inner — small-NQ fast path. Anchor stack-resident across the
+# K-inner loop. No pool acquired so tiny `xqs` doesn't pay pool-setup
+# overhead. `_is_periodic_bc(bc)` is compile-time-resolved.
+@inline function _linear_series_batch_qk!(
+        outputs::AbstractVector{<:AbstractVector},
+        x::AbstractVector,
+        vecs,
+        xqs::AbstractVector,
+        bc::AbstractBC,
+        op::AbstractEvalOp,
+        extrap::AbstractExtrap,
+        search::AbstractSearchPolicy
+    )
+    K = length(vecs)
+    NQ = length(xqs)
+
+    if _is_periodic_bc(bc)
+        x_eff = _resolve_axis(x, bc)
+        extrap_p = _resolve_extrap(NoExtrap(), bc, x_eff)
+        searcher = _resolve_search(x_eff, xqs, search, nothing, NoBC())
+        @inbounds for j in 1:NQ
+            xq_wrapped = _wrap_to_domain(xqs[j], x_eff)
+            idxL, idxR, xL, _ = search_interval(searcher, x_eff, xq_wrapped)
+            h = _get_h(x_eff, idxL)
+            inv_h = _get_inv_h(x_eff, idxL)
+            alpha = (xq_wrapped - xL) * inv_h
+            aq = _LinearAnchoredQuery(_IdxPair(idxL, idxR), xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
+            for k in 1:K
+                outputs[k][j] = _linear_eval_at_anchor(vecs[k], aq, op, extrap_p)
+            end
+        end
+        return outputs
+    end
+
+    extrap_eff = _check_domain(x, xqs, extrap)
+    searcher = _resolve_search(x, xqs, search, nothing)
+    wrap = extrap_eff isa WrapExtrap
+    @inbounds for j in 1:NQ
+        aq = _anchor_query(x, xqs[j], Val(:linear), wrap, searcher)
+        for k in 1:K
+            outputs[k][j] = _linear_eval_at_anchor(vecs[k], aq, op, extrap_eff)
+        end
+    end
+    return outputs
+end
+
+# K outer × Q inner with pool-acquired anchor vector — large-NQ fast path.
+# Inner loop streams a single `outputs[k]` Vector — LLVM auto-SIMDs and
+# avoids the K-cache-line write jump per query of the Q×K shape.
+@inline @with_pool pool function _linear_series_batch_kq!(
+        outputs::AbstractVector{<:AbstractVector},
+        x::AbstractVector{Tg},
+        vecs,
+        xqs::AbstractVector{Tq},
+        bc::AbstractBC,
+        op::AbstractEvalOp,
+        extrap::AbstractExtrap,
+        search::AbstractSearchPolicy
+    ) where {Tg, Tq <: Real}
+    K = length(vecs)
+    NQ = length(xqs)
+    Tg_actual = eltype(x)
+    Tqp = promote_type(Tg_actual, Tq)
+
+    if _is_periodic_bc(bc)
+        x_eff = _resolve_axis(x, bc)
+        extrap_p = _resolve_extrap(NoExtrap(), bc, x_eff)
+        searcher = _resolve_search(x_eff, xqs, search, nothing, NoBC())
+        aq_vec = acquire!(pool, _LinearAnchoredQuery{Tg_actual, Tqp}, NQ)
+        @inbounds for j in 1:NQ
+            xq_wrapped = _wrap_to_domain(xqs[j], x_eff)
+            idxL, idxR, xL, _ = search_interval(searcher, x_eff, xq_wrapped)
+            h = _get_h(x_eff, idxL)
+            inv_h = _get_inv_h(x_eff, idxL)
+            alpha = (xq_wrapped - xL) * inv_h
+            aq_vec[j] = _LinearAnchoredQuery(_IdxPair(idxL, idxR), xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
+        end
+        @inbounds for k in 1:K
+            for j in 1:NQ
+                outputs[k][j] = _linear_eval_at_anchor(vecs[k], aq_vec[j], op, extrap_p)
+            end
+        end
+        return outputs
+    end
+
+    extrap_eff = _check_domain(x, xqs, extrap)
+    searcher = _resolve_search(x, xqs, search, nothing)
+    wrap = extrap_eff isa WrapExtrap
+    aq_vec = acquire!(pool, _LinearAnchoredQuery{Tg_actual, Tqp}, NQ)
+    _fill_anchors!(aq_vec, x, xqs, Val(:linear), wrap, searcher)
+    @inbounds for k in 1:K
+        for j in 1:NQ
+            outputs[k][j] = _linear_eval_at_anchor(vecs[k], aq_vec[j], op, extrap_eff)
+        end
+    end
+    return outputs
+end
+
+# Adaptive entry. `length(xqs)` selects the loop order — see
+# `_SERIES_BATCH_LOOP_THRESHOLD` docs in `src/core/series_utils.jl`.
 @inline function linear_interp!(
         outputs::AbstractVector{<:AbstractVector},
         x::AbstractVector{Tg},
@@ -192,45 +288,19 @@ In-place one-shot linear interpolation at multiple query points.
     K = n_series(s)
     _validate_series_outputs(outputs, K, length(xqs))
     vecs = _series_vectors(s)
-
-    if _is_periodic_bc(bc)
-        # Per-series `:inclusive` endpoint guarantee. `:exclusive` needs no
-        # per-series check; the anchor's seam pair handles wrap.
-        if bc isa PeriodicBC{:inclusive}
-            @inbounds for k in 1:K
-                _check_periodic_endpoints(bc, vecs[k])
-            end
-        end
-        x_eff = _resolve_axis(x, bc)
-        extrap_p = _resolve_extrap(NoExtrap(), bc, x_eff)
-        searcher = _resolve_search(x_eff, xqs, search, nothing, NoBC())
-        @inbounds for j in eachindex(xqs)
-            xq_wrapped = _wrap_to_domain(xqs[j], x_eff)
-            idxL, idxR, xL, _ = search_interval(searcher, x_eff, xq_wrapped)
-            # Index-based dispatch: `_CachedRange.h` exact step on Range axis,
-            # wrapper's seam width at idx==n. Matches scalar/persistent paths.
-            h = _get_h(x_eff, idxL)
-            inv_h = _get_inv_h(x_eff, idxL)
-            alpha = (xq_wrapped - xL) * inv_h
-            aq = _LinearAnchoredQuery(_IdxPair(idxL, idxR), xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
-            for k in 1:K
-                outputs[k][j] = _linear_eval_at_anchor(vecs[k], aq, deriv, extrap_p)
-            end
-        end
-        return outputs
-    end
-
-    # Non-periodic: `_anchor_query` handles WrapExtrap query-wrap + OOB state.
-    extrap_eff = _check_domain(x, xqs, extrap)
-    searcher = _resolve_search(x, xqs, search, nothing)
-    wrap = extrap_eff isa WrapExtrap
-    @inbounds for j in eachindex(xqs)
-        aq = _anchor_query(x, xqs[j], Val(:linear), wrap, searcher)
-        for k in 1:K
-            outputs[k][j] = _linear_eval_at_anchor(vecs[k], aq, deriv, extrap_eff)
+    # Per-series `:inclusive` endpoint guarantee. `:exclusive` needs no
+    # per-series check; the anchor's seam pair handles wrap.
+    if bc isa PeriodicBC{:inclusive}
+        @inbounds for k in 1:K
+            _check_periodic_endpoints(bc, vecs[k])
         end
     end
-    return outputs
+
+    if _series_use_kq_loop(length(xqs), K)
+        return _linear_series_batch_kq!(outputs, x, vecs, xqs, bc, deriv, extrap, search)
+    else
+        return _linear_series_batch_qk!(outputs, x, vecs, xqs, bc, deriv, extrap, search)
+    end
 end
 
 """

--- a/src/linear/linear_series_interp.jl
+++ b/src/linear/linear_series_interp.jl
@@ -489,15 +489,8 @@ function (sitp::LinearSeriesInterpolant{Tg, Tv, P})(
     return _linear_series_inplace_kernel!(outputs, sitp, xq, searcher, deriv)
 end
 
-# Thin function barrier: ensures the resolved `searcher` (and any hint Ref it
-# may carry) is consumed inside a fresh stack frame, preventing escape-analysis
-# spillover into a 16-byte heap box. No pool needed.
-#
-# Note `@inline` is intentional: the barrier benefit comes from this being a
-# *separate named function* (a clean specialization point for the compiler),
-# not from preventing inlining. Empirically `@noinline` regresses to ~32 B
-# because the forced function-call frame adds arg-passing overhead.
-@inline function _linear_series_inplace_kernel!(
+# Q×K — small-NQ fast path. Stack-resident anchor per query, no pool.
+@inline function _linear_series_qk!(
         outputs::AbstractVector{<:AbstractVector},
         sitp::LinearSeriesInterpolant{Tg},
         xq::AbstractVector,
@@ -512,7 +505,6 @@ end
     extrap = sitp.extrap
     x_min = Tg(first(sitp.x))
     x_max = Tg(last(sitp.x))
-
     @inbounds for j in eachindex(xq)
         aq = _anchor_query(x_grid, xq[j], Val(:linear), wrap, searcher)
         for k in 1:n_ser
@@ -522,6 +514,62 @@ end
         end
     end
     return outputs
+end
+
+# K×Q — large-NQ fast path. Pool-acquired anchor vector, sequential `outputs[k]`
+# inner loop (SIMD-able).
+@inline @with_pool pool function _linear_series_kq!(
+        outputs::AbstractVector{<:AbstractVector},
+        sitp::LinearSeriesInterpolant{Tg},
+        xq::AbstractVector,
+        searcher::Searcher,
+        deriv::DerivOp
+    ) where {Tg}
+    wrap = _should_wrap(sitp)
+    y = sitp.y
+    x_grid = sitp.x
+    n_pts = n_points(sitp)
+    n_ser = n_series(sitp)
+    extrap = sitp.extrap
+    x_min = Tg(first(sitp.x))
+    x_max = Tg(last(sitp.x))
+    NQ = length(xq)
+    Tqp = promote_type(Tg, eltype(xq))
+    aq_vec = acquire!(pool, _LinearAnchoredQuery{Tg, Tqp}, NQ)
+    _fill_anchors!(aq_vec, x_grid, xq, Val(:linear), wrap, searcher)
+    @inbounds for k in 1:n_ser
+        for j in 1:NQ
+            outputs[k][j] = _eval_linear_series_with_extrap(
+                y, x_grid, n_pts, x_min, x_max, k, aq_vec[j], extrap, deriv
+            )
+        end
+    end
+    return outputs
+end
+
+# Thin function barrier: ensures the resolved `searcher` (and any hint Ref it
+# may carry) is consumed inside a fresh stack frame, preventing escape-analysis
+# spillover into a 16-byte heap box.
+#
+# Adaptive: `length(xq)` selects the loop order — see
+# `_SERIES_BATCH_LOOP_THRESHOLD` docs in `src/core/series_utils.jl`.
+#
+# Note `@inline` is intentional: the barrier benefit comes from this being a
+# *separate named function* (a clean specialization point for the compiler),
+# not from preventing inlining. Empirically `@noinline` regresses to ~32 B
+# because the forced function-call frame adds arg-passing overhead.
+@inline function _linear_series_inplace_kernel!(
+        outputs::AbstractVector{<:AbstractVector},
+        sitp::LinearSeriesInterpolant{Tg},
+        xq::AbstractVector,
+        searcher::Searcher,
+        deriv::DerivOp
+    ) where {Tg}
+    if _series_use_kq_loop(length(xq), n_series(sitp))
+        return _linear_series_kq!(outputs, sitp, xq, searcher, deriv)
+    else
+        return _linear_series_qk!(outputs, sitp, xq, searcher, deriv)
+    end
 end
 
 """

--- a/src/linear/linear_series_interp.jl
+++ b/src/linear/linear_series_interp.jl
@@ -551,8 +551,8 @@ end
 # may carry) is consumed inside a fresh stack frame, preventing escape-analysis
 # spillover into a 16-byte heap box.
 #
-# Adaptive: `length(xq)` selects the loop order — see
-# `_SERIES_BATCH_LOOP_THRESHOLD` docs in `src/core/series_utils.jl`.
+# Adaptive: `length(xq)` and `n_series(sitp)` feed `_series_use_kq_loop` to
+# select the loop order — see `src/core/series_utils.jl`.
 #
 # Note `@inline` is intentional: the barrier benefit comes from this being a
 # *separate named function* (a clean specialization point for the compiler),

--- a/src/linear/nd/linear_nd_oneshot.jl
+++ b/src/linear/nd/linear_nd_oneshot.jl
@@ -62,11 +62,9 @@ function _linear_interp_nd_oneshot(
 end
 
 """
-    _linear_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps_val, policies, ops, hints, mono)
+    _linear_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps_val, ops, search, hint)
 
 In-place batch one-shot ND multilinear evaluation.
-Uses query protocol (`_query_length`, `_query_extract`) — works with any query format.
-Writes results into `output`. No heap allocation beyond spacings.
 """
 function _linear_interp_nd_oneshot_batch!(
         output::AbstractVector,
@@ -75,11 +73,12 @@ function _linear_interp_nd_oneshot_batch!(
         queries,
         bcs::NTuple{N, AbstractBC},
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
-        policies::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
-        hints,  # Nothing or NTuple{N, Ref{Int}}
-        mono::NTuple{N, Bool},
+        search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}},
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}},
     ) where {Tg, Tv, N}
+    # Resolve here so the fresh Ref tuple stays local to this frame (stack-elidable).
+    policies, hints = _resolve_oneshot_search_nd(search, queries, hint, Val(N))
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
@@ -103,10 +102,9 @@ function _linear_interp_nd_oneshot_batch!(
     return output
 end
 
-# Function barrier: forces Julia to runtime-dispatch on the concrete
-# searches tuple type before entering the @with_pool boundary.
-function _linear_nd_batch_dispatch!(output, grids, data, queries, bcs, extraps, policies, ops, hints, mono)
-    return _linear_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps, policies, ops, hints, mono)
+# Function barrier — specializes on concrete `search` type.
+function _linear_nd_batch_dispatch!(output, grids, data, queries, bcs, extraps_val, ops, search, hint)
+    return _linear_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps_val, ops, search, hint)
 end
 
 # ========================================
@@ -192,12 +190,8 @@ function linear_interp!(
     grids_typed, _, _, _ = _nd_promote_grids(grids, data)
     _validate_nd_grids(grids_typed, data)
 
-    policies = _resolve_search_nd(search, Val(N))
-    hints_nd = hint
-    mono = _check_mono_nd(policies, queries)
-
     bcs = _resolve_bcs_nd(bc, Val(N))
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)
     ops = _resolve_deriv_nd(deriv, Val(N))
-    return _linear_nd_batch_dispatch!(output, grids_typed, data, queries, bcs, extraps_val, policies, ops, hints_nd, mono)
+    return _linear_nd_batch_dispatch!(output, grids_typed, data, queries, bcs, extraps_val, ops, search, hint)
 end

--- a/src/linear/nd/linear_nd_oneshot.jl
+++ b/src/linear/nd/linear_nd_oneshot.jl
@@ -53,7 +53,11 @@ function _linear_interp_nd_oneshot(
     q_eval = _handle_all_extraps(query, grids_eff, extraps_eff)
     stencils, Ls, Rs = _search_all_intervals_stencil(q_eval, grids_eff, searches, hints, nobcs)
     αs = map(_alpha_of, q_eval, Ls, Rs, grids_eff)
-    inv_hs = map(_get_inv_h, grids_eff, Ls, Rs)
+    # 4-arg `_get_inv_h(g, idx, xL, xR)` — `_CachedVector`/`_CachedRange` use
+    # cached fields (idx-indexed or scalar); raw `Vector` falls back to
+    # `inv(xR - xL)`. `first(stencil)` = idxL for K=2 (linear) stencils.
+    idxLs = map(first, stencils)
+    inv_hs = map(_get_inv_h, grids_eff, idxLs, Ls, Rs)
     return _multilinear_sum(data, stencils, inv_hs, αs, ops, Val(N))
 end
 
@@ -92,7 +96,8 @@ function _linear_interp_nd_oneshot_batch!(
         q_eval = _handle_all_extraps(query_k, grids_eff, extraps_eff)
         stencils, Ls, Rs = _search_all_intervals_stencil(q_eval, grids_eff, policies, hints, nobcs)
         αs = map(_alpha_of, q_eval, Ls, Rs, grids_eff)
-        inv_hs = map(_get_inv_h, grids_eff, Ls, Rs)
+        idxLs = map(first, stencils)
+        inv_hs = map(_get_inv_h, grids_eff, idxLs, Ls, Rs)
         output[k] = _multilinear_sum(data, stencils, inv_hs, αs, ops, Val(N))
     end
     return output

--- a/src/quadratic/nd/quadratic_nd_interpolant.jl
+++ b/src/quadratic/nd/quadratic_nd_interpolant.jl
@@ -85,12 +85,11 @@ function _build_nd_quadratic_interpolant(
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
         searches::NTuple{N, AbstractSearchPolicy}
     ) where {Tg, Tv, N}
-    # Build nodal derivatives using quadratic recurrence. The wrapped grids
-    # carry `h`/`inv_h` directly via `_get_h(itp.grids[d], i)`.
-    nodal_derivs = _build_nd_coeffs_quadratic(grids, data, bcs)
+    # Cache axes for the build phase — inner ctor of `QuadraticInterpolantND`
+    # handles the owned `_convert_copy` separately, so we only wrap (no copy)
+    # here. Already-cached axes pass through idempotently in the ctor.
+    grids_cached = map((g, bc) -> _cache_axis(g, bc, Tg), grids, bcs)
+    nodal_derivs = _build_nd_coeffs_quadratic(grids_cached, data, bcs)
 
-    # Caching wrap (zero-copy of buffer): per-axis `_cache_axis`. Inner ctor's
-    # `_convert_copy(g, Tg)` takes ownership.
-    grids_typed = map(g -> _cache_axis(g, NoBC(), Tg), grids)
-    return QuadraticInterpolantND(grids_typed, nodal_derivs, bcs, extraps_val, searches)
+    return QuadraticInterpolantND(grids_cached, nodal_derivs, bcs, extraps_val, searches)
 end

--- a/src/quadratic/nd/quadratic_nd_interpolant.jl
+++ b/src/quadratic/nd/quadratic_nd_interpolant.jl
@@ -68,10 +68,38 @@ function quadratic_interp(
     bcs = _resolve_bcs_nd(bc, Val(N))
     searches = _resolve_search_nd(search, Val(N))
 
-    # Quadratic only supports inclusive periodic → grid-span equals period →
-    # 5-arg `_resolve_extrap` with BCs is safe (no extension needed).
+    # Quadratic does not support `PeriodicBC` of any flavor — reject before
+    # `_resolve_extrap` (which would project exclusive periodic into a wrap
+    # extrap on a grid the build path cannot consume) and before `_cache_axis`
+    # (which would wrap the axis to virtual `n+1` length, producing a
+    # `DimensionMismatch` instead of the intended `ArgumentError`).
+    _validate_quadratic_bcs_nd(bcs)
     extraps_val = _resolve_extrap(extrap, bcs, grids_typed, Val(N), Tv)
     return _build_nd_quadratic_interpolant(grids_typed, data_typed, bcs, extraps_val, searches)
+end
+
+# ========================================
+# BC validation — reject unsupported BCs upfront
+# ========================================
+#
+# Quadratic ND does not support `PeriodicBC`. Without this guard, the
+# `:inclusive` variant fires `ArgumentError` deep inside `_slope_1d_quadratic!`
+# (via the `AbstractBC` fallback), and the `:exclusive` variant fires a
+# misleading `DimensionMismatch` because `_cache_axis` wraps the grid to
+# virtual `n+1` length before any BC validation runs.
+@noinline _throw_quadratic_periodic_unsupported(axis_idx::Int, bc) = throw(
+    ArgumentError(
+        "Quadratic interpolation does not support PeriodicBC (axis $axis_idx: $(typeof(bc))). " *
+            "Supported: Left(...), Right(...), MinCurvFit, ZeroCurvBC, ZeroSlopeBC, or PolyFit variants."
+    )
+)
+
+@inline function _validate_quadratic_bcs_nd(bcs::NTuple{N, AbstractBC}) where {N}
+    for d in 1:N
+        bc = bcs[d]
+        bc isa PeriodicBC && _throw_quadratic_periodic_unsupported(d, bc)
+    end
+    return nothing
 end
 
 # ========================================

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -35,25 +35,30 @@ Zero-allocation after warmup (pool reuse).
     oob_result = _try_fill_oob(query, grids, extraps_val, ops, @inbounds first(data))
     oob_result !== nothing && return oob_result
 
-    # 1. Pool-allocate partials array (THE KEY: pool instead of heap)
+    # 1. Pool-backed per-axis cache — build phase reuses h/inv_h across slices.
+    # `map` over the tuple dispatches per-element on the concrete axis type
+    # (Range vs Vector); `ntuple(d -> grids[d], ...)` would Union-box.
+    grids_c = map(g -> _cache_axis_pooled(pool, g), grids)
+
+    # 2. Pool-allocate partials array (THE KEY: pool instead of heap)
     # Tz widens Tv with Tg: when grid is Dual, derivatives = data × inv_h → Dual-typed.
     Tz = _output_eltype(Tv, Tg)
     n_partials = 1 << N
     partials = acquire!(pool, Tz, (n_partials, size(data)...))
 
-    # 2. Compute all partial derivatives in-place
-    _compute_nd_partials_quadratic!(partials, grids, data, bcs)
+    # 3. Compute all partial derivatives in-place
+    _compute_nd_partials_quadratic!(partials, grids_c, data, bcs)
 
-    # 3. Materialize WrapExtrap{Nothing} against grids so the eval pipeline never
+    # 4. Materialize WrapExtrap{Nothing} against grids so the eval pipeline never
     # sees the singleton.
-    extraps_eff = map(_resolve_extrap, extraps_val, grids)
+    extraps_eff = map(_resolve_extrap, extraps_val, grids_c)
 
-    # 4. Eval pipeline (axis-only — grids carry `h`/`inv_h` directly)
-    q_eval = _handle_all_extraps(query, grids, extraps_eff)
-    indices, Ls, _ = _search_all_intervals(q_eval, grids, searches, hints)
-    hs, inv_hs, dLs = _compute_all_local_params(q_eval, grids, indices, Ls)
+    # 5. Eval pipeline (axis-only — grids carry `h`/`inv_h` directly)
+    q_eval = _handle_all_extraps(query, grids_c, extraps_eff)
+    indices, Ls, _ = _search_all_intervals(q_eval, grids_c, searches, hints)
+    hs, inv_hs, dLs = _compute_all_local_params(q_eval, grids_c, indices, Ls)
 
-    # 5. Tensor-product kernel evaluation
+    # 6. Tensor-product kernel evaluation
     return _eval_nd_quad_cell(partials, indices, hs, inv_hs, dLs, ops)
 end
 
@@ -81,24 +86,27 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
     _query_validate(queries)
     _validate_nd_domain(grids, queries, extraps_val)
 
+    # Pool-backed per-axis cache — build phase + eval loop reuse h/inv_h.
+    # `map` over the tuple dispatches per-element on concrete axis type;
+    # `ntuple(d -> grids[d], ...)` would Union-box heterogeneous tuples.
+    grids_c = map(g -> _cache_axis_pooled(pool, g), grids)
+
     # Build phase (done once)
     Tz = _output_eltype(Tv, Tg)
     n_partials = 1 << N
     partials = acquire!(pool, Tz, (n_partials, size(data)...))
-    _compute_nd_partials_quadratic!(partials, grids, data, bcs)
-    # Materialize WrapExtrap{Nothing} before the eval loop.
-    extraps_eff = map(_resolve_extrap, extraps_val, grids)
+    _compute_nd_partials_quadratic!(partials, grids_c, data, bcs)
+    extraps_eff = map(_resolve_extrap, extraps_val, grids_c)
 
-    # Eval loop — axis-only helpers read `h`/`inv_h` from `grids`
     @inbounds for k in 1:nq
         query_k = _extract_query_point(queries, k, Val(N))
-        oob_val = _try_fill_oob(query_k, grids, extraps_val, ops, first(data))
+        oob_val = _try_fill_oob(query_k, grids_c, extraps_val, ops, first(data))
         if oob_val !== nothing
             output[k] = oob_val; continue
         end
-        q_eval = _handle_all_extraps(query_k, grids, extraps_eff)
-        indices, Ls, _ = _search_all_intervals(q_eval, grids, policies, hints, mono)
-        hs, inv_hs, dLs = _compute_all_local_params(q_eval, grids, indices, Ls)
+        q_eval = _handle_all_extraps(query_k, grids_c, extraps_eff)
+        indices, Ls, _ = _search_all_intervals(q_eval, grids_c, policies, hints, mono)
+        hs, inv_hs, dLs = _compute_all_local_params(q_eval, grids_c, indices, Ls)
         output[k] = _eval_nd_quad_cell(partials, indices, hs, inv_hs, dLs, ops)
     end
     return output

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -76,11 +76,12 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
         queries,
         bcs::NTuple{N, AbstractBC},
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
-        policies::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
-        hints,  # Nothing or NTuple{N, Ref{Int}}
-        mono::NTuple{N, Bool},
+        search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}},
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}},
     ) where {Tg, Tv, N}
+    # Resolve here so the fresh Ref tuple stays local to this frame (stack-elidable).
+    policies, hints = _resolve_oneshot_search_nd(search, queries, hint, Val(N))
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
@@ -105,17 +106,16 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
             output[k] = oob_val; continue
         end
         q_eval = _handle_all_extraps(query_k, grids_c, extraps_eff)
-        indices, Ls, _ = _search_all_intervals(q_eval, grids_c, policies, hints, mono)
+        indices, Ls, _ = _search_all_intervals(q_eval, grids_c, policies, hints)
         hs, inv_hs, dLs = _compute_all_local_params(q_eval, grids_c, indices, Ls)
         output[k] = _eval_nd_quad_cell(partials, indices, hs, inv_hs, dLs, ops)
     end
     return output
 end
 
-# Function barrier: forces Julia to runtime-dispatch on the concrete
-# searches tuple type before entering the @with_pool boundary.
-function _quadratic_nd_batch_dispatch!(output, grids, data, queries, bcs, extraps, policies, ops, hints, mono)
-    return _quadratic_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps, policies, ops, hints, mono)
+# Function barrier — specializes on concrete `search` type.
+function _quadratic_nd_batch_dispatch!(output, grids, data, queries, bcs, extraps, ops, search, hint)
+    return _quadratic_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps, ops, search, hint)
 end
 
 # ========================================
@@ -233,11 +233,7 @@ function quadratic_interp!(
     _validate_nd_grids(grids_typed, data)
 
     bcs = _resolve_bcs_nd(bc, Val(N))
-    policies = _resolve_search_nd(search, Val(N))
-    hints_nd = hint
-    mono = _check_mono_nd(policies, queries)
-
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)
     ops = _resolve_deriv_nd(deriv, Val(N))
-    return _quadratic_nd_batch_dispatch!(output, grids_typed, data, queries, bcs, extraps_val, policies, ops, hints_nd, mono)
+    return _quadratic_nd_batch_dispatch!(output, grids_typed, data, queries, bcs, extraps_val, ops, search, hint)
 end

--- a/src/quadratic/quadratic_adjoint.jl
+++ b/src/quadratic/quadratic_adjoint.jl
@@ -605,7 +605,7 @@ function quadratic_adjoint(
         bc::QuadraticBC = Left(QuadraticFit()),
         extrap::AbstractExtrap = NoExtrap(),
     )
-    x_p, xq_p, Tg = _promote_adjoint_inputs(x, x_query)
+    x_p, xq_p, _ = _promote_adjoint_inputs(x, x_query)
 
     length(x_p) >= 2 || _throw_adjoint_grid_too_small(length(x_p))
 
@@ -623,10 +623,15 @@ function quadratic_adjoint(
         end
     end
 
-    # Bake anchors directly off the wrapped axis (axis-as-truth).
-    anchors = _bake_quadratic_adjoint_anchors(x_p, xq_p, extrap)
+    # Cache axis for bake loop + per-apply `_compute_mincurv_C` reuse.
+    # `bc::QuadraticBC` (`Left/Right(...)` / `MinCurvFit`) is type-disjoint from
+    # `PeriodicBC{:exclusive}`, so dispatch lands on the
+    # `(::AbstractVector/AbstractRange, ::AbstractBC)` no-wrap overload.
+    x_cached = _cache_axis(x_p, bc)
 
-    return QuadraticAdjoint(anchors, bc, length(x_p), x_p)
+    anchors = _bake_quadratic_adjoint_anchors(x_cached, xq_p, extrap)
+
+    return QuadraticAdjoint(anchors, bc, length(x_cached), x_cached)
 end
 
 # Scalar query convenience

--- a/src/quadratic/quadratic_oneshot.jl
+++ b/src/quadratic/quadratic_oneshot.jl
@@ -146,7 +146,7 @@ vals = quadratic_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_w
     @boundscheck length(y) == length(x) || throw(ArgumentError("x and y must have same length"))
     @boundscheck length(x) >= 2 || throw(ArgumentError("x must have at least 2 elements"))
 
-    x = _resolve_axis(x)
+    x = _cache_axis_pooled(pool, x)
     # Compute coefficients using temporary arrays from pool. The grid `x`
     # carries cached `h`/`inv_h` when wrapped, or computes them on the fly.
     nx = length(x)
@@ -203,7 +203,7 @@ quadratic_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear
     @assert length(output) == length(x_targets) "output must match x_targets length"
     @assert length(x) >= 2 "x must have at least 2 elements"
 
-    x = _resolve_axis(x)
+    x = _cache_axis_pooled(pool, x)
     # Compute coefficients using temporary arrays from pool. The grid `x`
     # carries cached `h`/`inv_h` when wrapped, or computes them on the fly.
     nx = length(x)

--- a/src/quadratic/quadratic_oneshot_series.jl
+++ b/src/quadratic/quadratic_oneshot_series.jl
@@ -23,7 +23,8 @@
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tq <: Real}
     _validate_series_lengths(s, length(x))
-    x = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
+    # Pool-backed cache: K-series loop reuses h/inv_h across all K calls.
+    x = _cache_axis_pooled(pool, x, _promote_grid_float(Tg, _series_eltype(s)))
     _check_domain(x, xq, extrap)
     nx = length(x)
     K = n_series(s)
@@ -61,7 +62,8 @@ end
     ) where {Tg, Tq <: Real}
     _validate_series_lengths(s, length(x))
     length(output) == n_series(s) || _throw_series_dim_mismatch(length(output), n_series(s))
-    x = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
+    # Pool-backed cache: K-series loop reuses h/inv_h.
+    x = _cache_axis_pooled(pool, x, _promote_grid_float(Tg, _series_eltype(s)))
     _check_domain(x, xq, extrap)
     nx = length(x)
     vecs = _series_vectors(s)
@@ -99,7 +101,8 @@ end
         search::AbstractSearchPolicy = AutoSearch()
     ) where {Tg, Tq <: Real}
     _validate_series_lengths(s, length(x))
-    x = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
+    # Pool-backed cache: K-series × Q-query loop reuses h/inv_h.
+    x = _cache_axis_pooled(pool, x, _promote_grid_float(Tg, _series_eltype(s)))
     K = n_series(s)
     _validate_series_outputs(outputs, K, length(xqs))
     # Domain check: NoExtrap → throws if OOB, returns InBounds(); others → pass-through

--- a/test/test_axis_data_resolvers.jl
+++ b/test/test_axis_data_resolvers.jl
@@ -466,7 +466,8 @@ end
 # ─────────────────────────────────────────────────────────────────────────────
 # Dedicated dispatch tests for `_cache_axis` 3-arg Tg form
 # ─────────────────────────────────────────────────────────────────────────────
-# These lock in the dispatch table documented at `periodic_axis.jl:578-607`.
+# These lock in the dispatch table documented in the "Tg-aware 3-arg overloads"
+# section of `src/core/periodic_axis.jl`.
 # They distinguish:
 #   • RAW inputs (Vector/Range) → Tg respected via `_to_float`
 #   • PRE-WRAPPED inputs (_CachedRange/_CachedVector/_ExclusivePeriodicAxis)
@@ -643,6 +644,9 @@ end
     using FastInterpolations: _cache_axis_pooled, _CachedRange, _CachedVector, _to_float
     using AdaptiveArrayPools: @with_pool
 
+    # Assertions live inside the `@with_pool` scope so pool-owned `h`/`inv_h`
+    # buffers never escape — recycled storage would otherwise let stale reads
+    # slip in once a sibling test re-acquires the same slots.
     @with_pool pool function _smoke()
         x_vec = [0.0, 1.0, 2.5, 4.0]
         x_range = 0.0:1.0:3.0
@@ -655,36 +659,38 @@ end
         cr_int_out = _cache_axis_pooled(pool, x_int_range)
         cv_pass = _cache_axis_pooled(pool, cv64)
         cr_pass = _cache_axis_pooled(pool, cr64)
-        return (cv_out, cr_out, cr_int_out, cv_pass, cr_pass, cv64, cr64)
+
+        @testset "Pool wrap / passthrough rules (no Tg)" begin
+            # Vector{Float64} → pool-backed _CachedVector{Float64}
+            @test cv_out isa _CachedVector{Float64}
+            @test eltype(cv_out) === Float64
+            @test length(cv_out.h) == 3                   # n-1
+            @test cv_out.h ≈ [1.0, 1.5, 1.5]
+
+            # Float Range → _CachedRange{Float64}
+            @test cr_out isa _CachedRange{Float64}
+            @test eltype(cr_out) === Float64
+
+            # Int Range → _CachedRange{Float64} (float-defaulted via `float(eltype(x))`)
+            @test cr_int_out isa _CachedRange{Float64}
+            @test eltype(cr_int_out) === Float64
+
+            # Pre-wrapped inputs round-trip unchanged (===)
+            @test cv_pass === cv64
+            @test cr_pass === cr64
+        end
+        return nothing
     end
 
-    @testset "Pool wrap / passthrough rules (no Tg)" begin
-        cv_out, cr_out, cr_int_out, cv_pass, cr_pass, cv64, cr64 = _smoke()
-
-        # Vector{Float64} → pool-backed _CachedVector{Float64}
-        @test cv_out isa _CachedVector{Float64}
-        @test eltype(cv_out) === Float64
-        @test length(cv_out.h) == 3                   # n-1
-        @test cv_out.h ≈ [1.0, 1.5, 1.5]
-
-        # Float Range → _CachedRange{Float64}
-        @test cr_out isa _CachedRange{Float64}
-        @test eltype(cr_out) === Float64
-
-        # Int Range → _CachedRange{Float64} (float-defaulted via `float(eltype(x))`)
-        @test cr_int_out isa _CachedRange{Float64}
-        @test eltype(cr_int_out) === Float64
-
-        # Pre-wrapped inputs round-trip unchanged (===)
-        @test cv_pass === cv64
-        @test cr_pass === cr64
-    end
+    _smoke()
 end
 
 @testitem "_cache_axis_pooled 3-arg Tg respected: raw inputs" begin
     using FastInterpolations: _cache_axis_pooled, _CachedRange, _CachedVector
     using AdaptiveArrayPools: @with_pool
 
+    # Assertions live inside the `@with_pool` scope so pool-owned `h`/`inv_h`
+    # buffers never escape.
     @with_pool pool function _smoke()
         x32 = Float32[0.0, 1.0, 2.0, 3.0]              # raw Vector{Float32}
         r_int = 0:1:3                                  # Int range
@@ -695,25 +701,25 @@ end
         cv_promoted = _cache_axis_pooled(pool, x32, Float64)
         cr_int_promoted = _cache_axis_pooled(pool, r_int, Float32)
         cr_f64_demoted = _cache_axis_pooled(pool, r_f64, Float32)
-        return (cv_promoted, cr_int_promoted, cr_f64_demoted)
+
+        @testset "Vector{Float32} + Tg=Float64 → _CachedVector{Float64}" begin
+            @test cv_promoted isa _CachedVector{Float64}
+            @test eltype(cv_promoted) === Float64
+        end
+
+        @testset "Int range + Tg=Float32 → _CachedRange{Float32}" begin
+            @test cr_int_promoted isa _CachedRange{Float32}
+            @test eltype(cr_int_promoted) === Float32
+        end
+
+        @testset "Float64 range + Tg=Float32 → _CachedRange{Float32} (demotion)" begin
+            @test cr_f64_demoted isa _CachedRange{Float32}
+            @test eltype(cr_f64_demoted) === Float32
+        end
+        return nothing
     end
 
-    cv_promoted, cr_int_promoted, cr_f64_demoted = _smoke()
-
-    @testset "Vector{Float32} + Tg=Float64 → _CachedVector{Float64}" begin
-        @test cv_promoted isa _CachedVector{Float64}
-        @test eltype(cv_promoted) === Float64
-    end
-
-    @testset "Int range + Tg=Float32 → _CachedRange{Float32}" begin
-        @test cr_int_promoted isa _CachedRange{Float32}
-        @test eltype(cr_int_promoted) === Float32
-    end
-
-    @testset "Float64 range + Tg=Float32 → _CachedRange{Float32} (demotion)" begin
-        @test cr_f64_demoted isa _CachedRange{Float32}
-        @test eltype(cr_f64_demoted) === Float32
-    end
+    _smoke()
 end
 
 @testitem "_cache_axis_pooled 3-arg Tg same-eltype identity passthrough" begin
@@ -724,6 +730,8 @@ end
     # `_to_float(::AbstractVector{T}, ::Type{T}) = x` overload (utils.jl:33),
     # so the 3-arg form behaves exactly like the 2-arg form — no conversion,
     # no warning, no extra allocation beyond the 2-arg path's pool work.
+    # Assertions live inside the `@with_pool` scope so pool-owned `h`/`inv_h`
+    # buffers never escape.
     @with_pool pool function _smoke()
         x64 = [0.0, 1.0, 2.0, 3.0]
         r64 = 0.0:1.0:3.0
@@ -734,15 +742,15 @@ end
         cr_a = _cache_axis_pooled(pool, r64, Float64)         # raw range, same Tg
         cv_b = _cache_axis_pooled(pool, cv64, Float64)        # pre-wrapped vector, same Tg
         cr_b = _cache_axis_pooled(pool, cr64, Float64)        # pre-wrapped range, same Tg
-        return (cv_a, cr_a, cv_b, cr_b, cv64, cr64)
+
+        @test cv_a isa _CachedVector{Float64}
+        @test cr_a isa _CachedRange{Float64}
+        @test cv_b === cv64                                   # passthrough
+        @test cr_b === cr64                                   # passthrough
+        return nothing
     end
 
-    cv_a, cr_a, cv_b, cr_b, cv64, cr64 = _smoke()
-
-    @test cv_a isa _CachedVector{Float64}
-    @test cr_a isa _CachedRange{Float64}
-    @test cv_b === cv64                                       # passthrough
-    @test cr_b === cr64                                       # passthrough
+    _smoke()
 end
 
 @testitem "_cache_axis_pooled pool DATA-buffer reuse after warmup" setup = [AllocConstants] begin

--- a/test/test_axis_data_resolvers.jl
+++ b/test/test_axis_data_resolvers.jl
@@ -102,7 +102,7 @@ end
     @testset "Vector + :exclusive → _ExclusivePeriodicAxis{_CachedVector inner}" begin
         x = [0.0, 1.0, 2.0, 3.0]
         ax = _cache_axis(_convert_copy(x, Float64), bc_excl)
-        @test ax isa _ExclusivePeriodicAxis{Float64, _CachedVector{Float64, Float64}, Float64}
+        @test ax isa _ExclusivePeriodicAxis{Float64, _CachedVector{Float64, Float64, Vector{Float64}}, Float64}
         @test ax.inner isa _CachedVector
         @test ax.inner.h ≈ [1.0, 1.0, 1.0]           # inner is cached
         @test ax.period == 4.0
@@ -196,9 +196,9 @@ end
         @inferred f(x_vec, bc_excl, Float64)
         @inferred f(x_rng, bc_no, Float64)
         @inferred f(x_rng, bc_excl, Float64)
-        @test f(x_vec, bc_no, Float64) isa _CachedVector{Float64, Float64}
+        @test f(x_vec, bc_no, Float64) isa _CachedVector{Float64, Float64, Vector{Float64}}
         @test f(x_vec, bc_excl, Float64) isa
-            _ExclusivePeriodicAxis{Float64, _CachedVector{Float64, Float64}}
+            _ExclusivePeriodicAxis{Float64, _CachedVector{Float64, Float64, Vector{Float64}}}
     end
 end
 
@@ -461,4 +461,464 @@ end
     @test g64.inner !== g32.inner               # fresh wrapper
     @test g64.period == 4.0f0                   # period kept (its own type)
     @test collect(g64.inner.inner) == [0.0, 1.0, 2.0, 3.0]
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Dedicated dispatch tests for `_cache_axis` 3-arg Tg form
+# ─────────────────────────────────────────────────────────────────────────────
+# These lock in the dispatch table documented at `periodic_axis.jl:578-607`.
+# They distinguish:
+#   • RAW inputs (Vector/Range) → Tg respected via `_to_float`
+#   • PRE-WRAPPED inputs (_CachedRange/_CachedVector/_ExclusivePeriodicAxis)
+#     → Tg INTENTIONALLY ignored (passthrough; downstream `_convert_copy`
+#     handles the eltype work in the canonical two-step pattern).
+
+@testitem "_cache_axis 3-arg Tg respected: raw Vector (eltype mismatch)" begin
+    using FastInterpolations: _cache_axis, _CachedVector, NoBC, PeriodicBC
+
+    bc_no = NoBC()
+    bc_inc = PeriodicBC(endpoint = :inclusive)
+    bc_excl = PeriodicBC(endpoint = :exclusive, period = 4.0)
+
+    # Suppress the `_warn_type_conversion` one-shot warning that
+    # `_to_float(::AbstractVector, Tg)` emits when broadcasting.
+    x32 = Float32[0.0, 1.0, 2.0, 3.0]
+
+    @testset "Vector{Float32} + Tg=Float64 promotes via _to_float" begin
+        c = _cache_axis(x32, bc_no, Float64)
+        @test c isa _CachedVector{Float64}
+        @test eltype(c) === Float64
+        @test eltype(c.h) === Float64
+        @test eltype(c.inv_h) === Float64
+    end
+
+    @testset "Vector{Float32} + :inclusive + Tg=Float64" begin
+        c = _cache_axis(x32, bc_inc, Float64)
+        @test c isa _CachedVector{Float64}
+        @test eltype(c) === Float64
+    end
+
+    @testset "Vector{Float32} + :exclusive + Tg=Float64" begin
+        ax = _cache_axis(x32, bc_excl, Float64)
+        @test ax isa FastInterpolations._ExclusivePeriodicAxis
+        @test eltype(ax.inner) === Float64           # inner promoted to Tg
+        @test ax.inner isa _CachedVector{Float64}
+    end
+end
+
+@testitem "_cache_axis 3-arg Tg respected: raw Range (eltype mismatch)" begin
+    using FastInterpolations: _cache_axis, _CachedRange, _ExclusivePeriodicAxis, NoBC, PeriodicBC
+
+    bc_no = NoBC()
+    bc_excl = PeriodicBC(endpoint = :exclusive, period = 4.0)
+
+    @testset "Int range + Tg=Float32 → _CachedRange{Float32}" begin
+        r = 0:1:3                                     # eltype Int
+        cr = _cache_axis(r, bc_no, Float32)
+        @test cr isa _CachedRange{Float32}
+        @test eltype(cr) === Float32
+    end
+
+    @testset "Float64 range + Tg=Float32 → _CachedRange{Float32}" begin
+        r = 0.0:1.0:3.0
+        cr = _cache_axis(r, bc_no, Float32)
+        @test cr isa _CachedRange{Float32}
+    end
+
+    @testset "Int range + :exclusive + Tg=Float64" begin
+        r = 0:1:3
+        ax = _cache_axis(r, bc_excl, Float64)
+        @test ax isa _ExclusivePeriodicAxis
+        @test ax.inner isa _CachedRange{Float64}     # inner promoted to Tg
+    end
+end
+
+@testitem "_cache_axis 3-arg Tg INTENTIONALLY IGNORED: pre-wrapped inputs" begin
+    using FastInterpolations:
+        _cache_axis, _CachedRange, _CachedVector, _ExclusivePeriodicAxis,
+        _to_float, NoBC, PeriodicBC
+
+    # CONTRACT LOCK-IN: `_cache_axis(pre-wrapped, bc, Tg)` is a passthrough
+    # regardless of `Tg` — the wrapper's eltype is preserved verbatim. The
+    # canonical persistent pattern is `_convert_copy(_cache_axis(x, bc, Tg), Tg)`
+    # which separates wrapping (this call) from eltype enforcement (`_convert_copy`).
+    # If this passthrough behavior changes silently, every persistent inner ctor
+    # that follows the two-step pattern would acquire a hidden double-conversion.
+    bc_no = NoBC()
+    bc_inc = PeriodicBC(endpoint = :inclusive)
+    bc_excl = PeriodicBC(endpoint = :exclusive, period = 4.0)
+
+    @testset "_CachedRange{Float64} + Tg=Float32 → passthrough (still Float64)" begin
+        cr64 = _to_float(0.0:1.0:3.0, Float64)
+        out = _cache_axis(cr64, bc_no, Float32)
+        @test out === cr64                            # exact identity
+        @test out isa _CachedRange{Float64}
+        @test eltype(out) === Float64                 # NOT Float32 — passthrough
+    end
+
+    @testset "_CachedVector{Float64} + Tg=Float32 → passthrough" begin
+        cv64 = _CachedVector([0.0, 1.0, 2.0, 3.0])
+        out = _cache_axis(cv64, bc_no, Float32)
+        @test out === cv64                            # exact identity
+        @test eltype(out) === Float64
+    end
+
+    @testset "_CachedVector{Float64} + :exclusive + Tg=Float32 wraps but keeps inner eltype" begin
+        cv64 = _CachedVector([0.0, 1.0, 2.0, 3.0])
+        ax = _cache_axis(cv64, bc_excl, Float32)
+        @test ax isa _ExclusivePeriodicAxis
+        @test ax.inner === cv64                       # inner is the SAME wrapper
+        @test eltype(ax.inner) === Float64            # NOT Float32 — passthrough
+    end
+
+    @testset "_CachedRange{Float32} + :inclusive + Tg=Float64 → passthrough" begin
+        cr32 = _to_float(0.0f0:1.0f0:3.0f0, Float32)
+        out = _cache_axis(cr32, bc_inc, Float64)
+        @test out === cr32
+        @test eltype(out) === Float32                 # NOT Float64
+    end
+
+    @testset "_ExclusivePeriodicAxis + Tg → idempotent (Tg ignored)" begin
+        cv32 = _CachedVector(Float32[0.0, 1.0, 2.0, 3.0])
+        g = _ExclusivePeriodicAxis(cv32, 4.0f0)
+        @test _cache_axis(g, bc_no, Float64) === g    # passthrough; eltype Float32 kept
+        @test _cache_axis(g, bc_excl, Float64) === g
+    end
+end
+
+@testitem "_cache_axis canonical two-step pattern enforces Tg" begin
+    using FastInterpolations:
+        _cache_axis, _convert_copy, _CachedVector, _CachedRange, _ExclusivePeriodicAxis,
+        NoBC, PeriodicBC
+
+    # Verify that `_convert_copy(_cache_axis(x, bc, Tg), Tg)` produces a
+    # Tg-typed owned axis for BOTH raw and pre-wrapped inputs. This is the
+    # contract that justifies `_cache_axis` 3-arg's passthrough-on-pre-wrapped
+    # behavior — the eltype enforcement is delegated to `_convert_copy`.
+    bc_no = NoBC()
+    bc_excl = PeriodicBC(endpoint = :exclusive, period = 4.0)
+
+    @testset "Raw Vector{Float32} → Float64 owned _CachedVector" begin
+        x32 = Float32[0.0, 1.0, 2.0, 3.0]
+        xc = _convert_copy(_cache_axis(x32, bc_no, Float64), Float64)
+        @test xc isa _CachedVector{Float64}
+        @test eltype(xc) === Float64
+        @test xc.inner !== x32                        # owned (independent buffer)
+    end
+
+    @testset "Pre-wrapped _CachedVector{Float32} → Float64 owned" begin
+        cv32 = _CachedVector(Float32[0.0, 1.0, 2.0, 3.0])
+        xc = _convert_copy(_cache_axis(cv32, bc_no, Float64), Float64)
+        @test xc isa _CachedVector{Float64}
+        @test eltype(xc) === Float64                  # `_convert_copy` enforced Tg
+        @test xc !== cv32                             # fresh wrapper
+    end
+
+    @testset "Raw Int range → Float64 owned with :exclusive" begin
+        r = 0:1:3
+        ax = _convert_copy(_cache_axis(r, bc_excl, Float64), Float64)
+        @test ax isa _ExclusivePeriodicAxis
+        @test eltype(ax.inner) === Float64
+    end
+
+    @testset "Pre-wrapped _ExclusivePeriodicAxis{Float32} → Float64 owned" begin
+        cv32 = _CachedVector(Float32[0.0, 1.0, 2.0, 3.0])
+        g32 = _ExclusivePeriodicAxis(cv32, 4.0f0)
+        g64 = _convert_copy(_cache_axis(g32, bc_excl, Float64), Float64)
+        @test g64 isa _ExclusivePeriodicAxis
+        @test eltype(g64) === Float64
+        @test g64.inner.inner !== cv32.inner          # fresh user-buffer
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Dedicated dispatch tests for `_cache_axis_pooled` (one-shot variant)
+# ─────────────────────────────────────────────────────────────────────────────
+# These lock in the dispatch table documented at `cached_vector.jl` — the
+# pool-backed twin of `_cache_axis`. Unlike persistent `_cache_axis`, the
+# pooled 3-arg form does NOT have a downstream `_convert_copy` stage, so it
+# threads `Tg` uniformly via `_to_float` (catch-all) for every input type.
+
+@testitem "_cache_axis_pooled 2-arg dispatch table" begin
+    using FastInterpolations: _cache_axis_pooled, _CachedRange, _CachedVector, _to_float
+    using AdaptiveArrayPools: @with_pool
+
+    @with_pool pool function _smoke()
+        x_vec = [0.0, 1.0, 2.5, 4.0]
+        x_range = 0.0:1.0:3.0
+        x_int_range = 0:1:3
+        cr64 = _to_float(x_range, Float64)
+        cv64 = _CachedVector([0.0, 1.0, 2.0, 3.0])
+
+        cv_out = _cache_axis_pooled(pool, x_vec)
+        cr_out = _cache_axis_pooled(pool, x_range)
+        cr_int_out = _cache_axis_pooled(pool, x_int_range)
+        cv_pass = _cache_axis_pooled(pool, cv64)
+        cr_pass = _cache_axis_pooled(pool, cr64)
+        return (cv_out, cr_out, cr_int_out, cv_pass, cr_pass, cv64, cr64)
+    end
+
+    @testset "Pool wrap / passthrough rules (no Tg)" begin
+        cv_out, cr_out, cr_int_out, cv_pass, cr_pass, cv64, cr64 = _smoke()
+
+        # Vector{Float64} → pool-backed _CachedVector{Float64}
+        @test cv_out isa _CachedVector{Float64}
+        @test eltype(cv_out) === Float64
+        @test length(cv_out.h) == 3                   # n-1
+        @test cv_out.h ≈ [1.0, 1.5, 1.5]
+
+        # Float Range → _CachedRange{Float64}
+        @test cr_out isa _CachedRange{Float64}
+        @test eltype(cr_out) === Float64
+
+        # Int Range → _CachedRange{Float64} (float-defaulted via `float(eltype(x))`)
+        @test cr_int_out isa _CachedRange{Float64}
+        @test eltype(cr_int_out) === Float64
+
+        # Pre-wrapped inputs round-trip unchanged (===)
+        @test cv_pass === cv64
+        @test cr_pass === cr64
+    end
+end
+
+@testitem "_cache_axis_pooled 3-arg Tg respected: raw inputs" begin
+    using FastInterpolations: _cache_axis_pooled, _CachedRange, _CachedVector
+    using AdaptiveArrayPools: @with_pool
+
+    @with_pool pool function _smoke()
+        x32 = Float32[0.0, 1.0, 2.0, 3.0]              # raw Vector{Float32}
+        r_int = 0:1:3                                  # Int range
+        r_f64 = 0.0:1.0:3.0                            # Float64 range
+
+        # Suppress repeated warning emission by warmup.
+        _cache_axis_pooled(pool, x32, Float64)         # warms _warn_type_conversion
+        cv_promoted = _cache_axis_pooled(pool, x32, Float64)
+        cr_int_promoted = _cache_axis_pooled(pool, r_int, Float32)
+        cr_f64_demoted = _cache_axis_pooled(pool, r_f64, Float32)
+        return (cv_promoted, cr_int_promoted, cr_f64_demoted)
+    end
+
+    cv_promoted, cr_int_promoted, cr_f64_demoted = _smoke()
+
+    @testset "Vector{Float32} + Tg=Float64 → _CachedVector{Float64}" begin
+        @test cv_promoted isa _CachedVector{Float64}
+        @test eltype(cv_promoted) === Float64
+    end
+
+    @testset "Int range + Tg=Float32 → _CachedRange{Float32}" begin
+        @test cr_int_promoted isa _CachedRange{Float32}
+        @test eltype(cr_int_promoted) === Float32
+    end
+
+    @testset "Float64 range + Tg=Float32 → _CachedRange{Float32} (demotion)" begin
+        @test cr_f64_demoted isa _CachedRange{Float32}
+        @test eltype(cr_f64_demoted) === Float32
+    end
+end
+
+@testitem "_cache_axis_pooled 3-arg Tg same-eltype identity passthrough" begin
+    using FastInterpolations: _cache_axis_pooled, _CachedRange, _CachedVector, _to_float
+    using AdaptiveArrayPools: @with_pool
+
+    # When `Tg == eltype(x)`, the `_to_float` delegation hits the identity
+    # `_to_float(::AbstractVector{T}, ::Type{T}) = x` overload (utils.jl:33),
+    # so the 3-arg form behaves exactly like the 2-arg form — no conversion,
+    # no warning, no extra allocation beyond the 2-arg path's pool work.
+    @with_pool pool function _smoke()
+        x64 = [0.0, 1.0, 2.0, 3.0]
+        r64 = 0.0:1.0:3.0
+        cv64 = _CachedVector([0.0, 1.0, 2.0, 3.0])
+        cr64 = _to_float(r64, Float64)
+
+        cv_a = _cache_axis_pooled(pool, x64, Float64)         # raw vector, same Tg
+        cr_a = _cache_axis_pooled(pool, r64, Float64)         # raw range, same Tg
+        cv_b = _cache_axis_pooled(pool, cv64, Float64)        # pre-wrapped vector, same Tg
+        cr_b = _cache_axis_pooled(pool, cr64, Float64)        # pre-wrapped range, same Tg
+        return (cv_a, cr_a, cv_b, cr_b, cv64, cr64)
+    end
+
+    cv_a, cr_a, cv_b, cr_b, cv64, cr64 = _smoke()
+
+    @test cv_a isa _CachedVector{Float64}
+    @test cr_a isa _CachedRange{Float64}
+    @test cv_b === cv64                                       # passthrough
+    @test cr_b === cr64                                       # passthrough
+end
+
+@testitem "_cache_axis_pooled pool DATA-buffer reuse after warmup" setup = [AllocConstants] begin
+    using FastInterpolations: _cache_axis_pooled, _CachedVector
+    using AdaptiveArrayPools: @with_pool
+
+    # CONTRACT: after warmup, `acquire!(pool, T, n-1)` REUSES the same pool
+    # buffer for `h`/`inv_h` — no fresh n-sized `Vector{T}` per call. Pool
+    # reuse happens ACROSS function invocations (cursor rewinds at scope
+    # exit), so warmups are separate calls of `_measure_*`.
+    #
+    # JIT NOTE: `_measure_*` is defined ONCE at testitem scope so JIT runs
+    # only on the first invocation. Don't wrap `@allocated` in another helper
+    # — that wrapper's first call would pay its own JIT cost (~400 B).
+    #
+    # End-to-end zero-alloc of `quadratic_interp` is enforced by
+    # `test_quadratic.jl`; this test isolates the pool-DATA contract for
+    # `_cache_axis_pooled` standalone.
+
+    # Wrapper aliases pool buffers — MUST NOT escape `@with_pool` scope
+    # (CLAUDE.md "Pool Safety Rules"). Extract a scalar inside the scope.
+    @with_pool pool function _measure_vec(x)
+        c = _cache_axis_pooled(pool, x)
+        return c.h[1] + c.inv_h[1]
+    end
+    @with_pool pool function _measure_range(r)
+        c = _cache_axis_pooled(pool, r)
+        return Float64(c[1])
+    end
+
+    @testset "Raw Vector (n=257) — pool DATA reused (no fresh n-sized Vector)" begin
+        x = [(i - 1) * 1.0 for i in 1:257]
+        _measure_vec(x)                  # warmup 1 (JIT + pool grow)
+        _measure_vec(x)                  # warmup 2 (pool reuses)
+        @test (@allocated _measure_vec(x)) <= ALLOC_THRESHOLD
+    end
+
+    @testset "Raw Range — `_CachedRange` is value-typed (no n-sized alloc)" begin
+        r = 0.0:1.0:256.0
+        _measure_range(r)
+        _measure_range(r)
+        @test (@allocated _measure_range(r)) <= ALLOC_THRESHOLD
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Inner-storage type parameter `I` — view aliasing in one-shot pool
+# ─────────────────────────────────────────────────────────────────────────────
+# `_CachedVector{T, Tinv, I<:AbstractVector{T}}` parametrizes the inner
+# storage so the persistent path keeps `Vector{T}` ownership (mutation safety)
+# while the one-shot pool path aliases whatever the caller passes (SubArray,
+# OffsetVector, etc.) — avoiding an otherwise-pointless `Vector{T}(x)` copy.
+# These tests lock in BOTH halves of that contract.
+
+@testitem "_CachedVector inner-type contract — persistent vs pool" begin
+    using FastInterpolations: _CachedVector, _cache_axis_pooled
+    using AdaptiveArrayPools: @with_pool
+
+    big = [0.0, 1.0, 2.5, 4.0, 6.0, 9.0]
+    vw = @view big[2:5]                              # SubArray{Float64, 1, ...}
+
+    @testset "Persistent ctor materializes inner to Vector{T}" begin
+        c = _CachedVector(vw)
+        @test c.inner isa Vector{Float64}             # NOT SubArray
+        @test c.inner !== vw                          # materialized (independent)
+        @test c.inner == collect(vw)
+    end
+
+    @testset "Pool ctor aliases inner (no materialization)" begin
+        @with_pool pool function _inner()
+            c = _cache_axis_pooled(pool, vw)
+            # `c.inner === vw` proves zero-copy aliasing. After relaxation of
+            # `_CachedVector.inner` from `Vector{T}` to `I<:AbstractVector{T}`,
+            # the pool path no longer materializes view inputs.
+            return c.inner === vw
+        end
+        @test _inner() == true
+    end
+
+    @testset "Pool ctor preserves concrete inner type in `I`" begin
+        @with_pool pool function _inner_type()
+            c_vec = _cache_axis_pooled(pool, [0.0, 1.0, 2.0, 3.0])
+            c_view = _cache_axis_pooled(pool, vw)
+            return (typeof(c_vec).parameters[3], typeof(c_view).parameters[3])
+        end
+        Ivec, Iview = _inner_type()
+        @test Ivec === Vector{Float64}                # Vector → Vector{T}
+        @test Iview <: SubArray{Float64}              # view → SubArray<:AbstractVector{Float64}
+        @test Iview !== Vector{Float64}
+    end
+end
+
+@testitem "_CachedVector view-aliasing — getindex / iteration agree with Vector" begin
+    using FastInterpolations: _cache_axis_pooled
+    using AdaptiveArrayPools: @with_pool
+
+    # Eval kernels access the inner buffer through `getindex(c, i)` and `_get_h`.
+    # With a SubArray inner, both must give the same result as a materialized
+    # Vector wrapper — otherwise eval would silently diverge on view input.
+    big = [0.0, 1.0, 2.5, 4.0, 6.0, 9.0]
+    vw = @view big[2:5]
+    mat = collect(vw)                                 # 1.0, 2.5, 4.0, 6.0
+
+    @with_pool pool function _check()
+        c_view = _cache_axis_pooled(pool, vw)
+        c_mat = _cache_axis_pooled(pool, mat)
+        same_getindex = all(c_view[i] == c_mat[i] for i in 1:4)
+        same_h = c_view.h == c_mat.h
+        same_inv_h = c_view.inv_h == c_mat.inv_h
+        return (same_getindex, same_h, same_inv_h)
+    end
+
+    same_getindex, same_h, same_inv_h = _check()
+    @test same_getindex
+    @test same_h
+    @test same_inv_h
+end
+
+@testitem "_CachedVector copy / _convert_copy normalize view-backed inner to Vector{T}" begin
+    using FastInterpolations: _cache_axis_pooled, _CachedVector, _convert_copy
+    using AdaptiveArrayPools: @with_pool
+
+    # The persistent-path ownership contract: any time we hand a `_CachedVector`
+    # to a long-lived owner (interpolant struct), `copy` and `_convert_copy`
+    # must materialize the inner to `Vector{T}` — otherwise a view-backed
+    # one-shot wrapper could leak into persistent storage and be invalidated
+    # by mutation of the underlying buffer.
+    big = [0.0, 1.0, 2.5, 4.0, 6.0]
+    vw = @view big[1:4]
+
+    @with_pool pool function _make_view_backed()
+        c = _cache_axis_pooled(pool, vw)
+        # Return materialized copies — pool buffers must NOT escape, but
+        # `copy(c)` produces an owned wrapper with heap-allocated inner.
+        return (copy(c), _convert_copy(c, Float64), _convert_copy(c, Float32))
+    end
+
+    c_copy, c_same, c_cross = _make_view_backed()
+
+    @testset "Base.copy: inner materialized to Vector{T}" begin
+        @test c_copy isa _CachedVector{Float64}
+        @test c_copy.inner isa Vector{Float64}        # NOT SubArray
+        @test c_copy.inner == collect(vw)
+    end
+
+    @testset "_convert_copy same-eltype: same materialization as Base.copy" begin
+        @test c_same isa _CachedVector{Float64}
+        @test c_same.inner isa Vector{Float64}
+    end
+
+    @testset "_convert_copy cross-eltype: rebuilds at Tg" begin
+        @test c_cross isa _CachedVector{Float32}
+        @test c_cross.inner isa Vector{Float32}
+        @test c_cross.inner == Float32.(collect(vw))
+    end
+end
+
+@testitem "_cache_axis_pooled view-aliasing — no data-buffer copy" setup = [AllocConstants] begin
+    using FastInterpolations: _cache_axis_pooled
+    using AdaptiveArrayPools: @with_pool
+
+    # CONTRACT: pool-path view input must NOT allocate a `Vector{T}` copy of
+    # the view buffer — `inner::I` aliases the SubArray directly. A regression
+    # to materialization would add `length(vw)*sizeof(T) + header` bytes/call.
+    #
+    # JIT/pool semantics: see "pool DATA-buffer reuse" testitem comment for
+    # the warmup pattern. Wrapper aliases pool buffers, must not escape scope.
+    @with_pool pool function _measure_view(vw)
+        c = _cache_axis_pooled(pool, vw)
+        return c.h[1] + c.inv_h[1]
+    end
+
+    big = [0.0, 1.0, 2.5, 4.0, 6.0, 9.0, 12.0, 15.0]
+    vw = @view big[2:7]
+    _measure_view(vw)                       # warmup 1 (JIT + pool grow)
+    _measure_view(vw)                       # warmup 2 (pool reuses)
+
+    @test (@allocated _measure_view(vw)) <= ALLOC_THRESHOLD
 end

--- a/test/test_axis_data_resolvers.jl
+++ b/test/test_axis_data_resolvers.jl
@@ -102,7 +102,7 @@ end
     @testset "Vector + :exclusive → _ExclusivePeriodicAxis{_CachedVector inner}" begin
         x = [0.0, 1.0, 2.0, 3.0]
         ax = _cache_axis(_convert_copy(x, Float64), bc_excl)
-        @test ax isa _ExclusivePeriodicAxis{Float64, _CachedVector{Float64, Float64, Vector{Float64}}, Float64}
+        @test ax isa _ExclusivePeriodicAxis{Float64, _CachedVector{Float64, Float64}, Float64}
         @test ax.inner isa _CachedVector
         @test ax.inner.h ≈ [1.0, 1.0, 1.0]           # inner is cached
         @test ax.period == 4.0
@@ -196,9 +196,9 @@ end
         @inferred f(x_vec, bc_excl, Float64)
         @inferred f(x_rng, bc_no, Float64)
         @inferred f(x_rng, bc_excl, Float64)
-        @test f(x_vec, bc_no, Float64) isa _CachedVector{Float64, Float64, Vector{Float64}}
+        @test f(x_vec, bc_no, Float64) isa _CachedVector{Float64, Float64}
         @test f(x_vec, bc_excl, Float64) isa
-            _ExclusivePeriodicAxis{Float64, _CachedVector{Float64, Float64, Vector{Float64}}}
+            _ExclusivePeriodicAxis{Float64, _CachedVector{Float64, Float64}}
     end
 end
 
@@ -788,137 +788,36 @@ end
     end
 end
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Inner-storage type parameter `I` — view aliasing in one-shot pool
-# ─────────────────────────────────────────────────────────────────────────────
-# `_CachedVector{T, Tinv, I<:AbstractVector{T}}` parametrizes the inner
-# storage so the persistent path keeps `Vector{T}` ownership (mutation safety)
-# while the one-shot pool path aliases whatever the caller passes (SubArray,
-# OffsetVector, etc.) — avoiding an otherwise-pointless `Vector{T}(x)` copy.
-# These tests lock in BOTH halves of that contract.
-
-@testitem "_CachedVector inner-type contract — persistent vs pool" begin
-    using FastInterpolations: _CachedVector, _cache_axis_pooled
+@testitem "_cache_axis_pooled — view input pool-acquires inner (no heap alloc)" setup = [AllocConstants] begin
+    using FastInterpolations: _cache_axis_pooled, _CachedVector
     using AdaptiveArrayPools: @with_pool
 
-    big = [0.0, 1.0, 2.5, 4.0, 6.0, 9.0]
-    vw = @view big[2:5]                              # SubArray{Float64, 1, ...}
+    # `inner::Vector{T}` is forced for cache-key uniformity. Non-Vector input
+    # (view, OffsetArray, etc.) is copied into a pool-acquired Vector instead
+    # of `Vector{T}(x)`, so view input stays zero-heap after warmup.
+    WRAPPER_OVERHEAD_LIMIT = 512
 
-    @testset "Persistent ctor materializes inner to Vector{T}" begin
-        c = _CachedVector(vw)
-        @test c.inner isa Vector{Float64}             # NOT SubArray
-        @test c.inner !== vw                          # materialized (independent)
-        @test c.inner == collect(vw)
-    end
-
-    @testset "Pool ctor aliases inner (no materialization)" begin
-        @with_pool pool function _inner()
-            c = _cache_axis_pooled(pool, vw)
-            # `c.inner === vw` proves zero-copy aliasing. After relaxation of
-            # `_CachedVector.inner` from `Vector{T}` to `I<:AbstractVector{T}`,
-            # the pool path no longer materializes view inputs.
-            return c.inner === vw
-        end
-        @test _inner() == true
-    end
-
-    @testset "Pool ctor preserves concrete inner type in `I`" begin
-        @with_pool pool function _inner_type()
-            c_vec = _cache_axis_pooled(pool, [0.0, 1.0, 2.0, 3.0])
-            c_view = _cache_axis_pooled(pool, vw)
-            return (typeof(c_vec).parameters[3], typeof(c_view).parameters[3])
-        end
-        Ivec, Iview = _inner_type()
-        @test Ivec === Vector{Float64}                # Vector → Vector{T}
-        @test Iview <: SubArray{Float64}              # view → SubArray<:AbstractVector{Float64}
-        @test Iview !== Vector{Float64}
-    end
-end
-
-@testitem "_CachedVector view-aliasing — getindex / iteration agree with Vector" begin
-    using FastInterpolations: _cache_axis_pooled
-    using AdaptiveArrayPools: @with_pool
-
-    # Eval kernels access the inner buffer through `getindex(c, i)` and `_get_h`.
-    # With a SubArray inner, both must give the same result as a materialized
-    # Vector wrapper — otherwise eval would silently diverge on view input.
-    big = [0.0, 1.0, 2.5, 4.0, 6.0, 9.0]
-    vw = @view big[2:5]
-    mat = collect(vw)                                 # 1.0, 2.5, 4.0, 6.0
-
-    @with_pool pool function _check()
-        c_view = _cache_axis_pooled(pool, vw)
-        c_mat = _cache_axis_pooled(pool, mat)
-        same_getindex = all(c_view[i] == c_mat[i] for i in 1:4)
-        same_h = c_view.h == c_mat.h
-        same_inv_h = c_view.inv_h == c_mat.inv_h
-        return (same_getindex, same_h, same_inv_h)
-    end
-
-    same_getindex, same_h, same_inv_h = _check()
-    @test same_getindex
-    @test same_h
-    @test same_inv_h
-end
-
-@testitem "_CachedVector copy / _convert_copy normalize view-backed inner to Vector{T}" begin
-    using FastInterpolations: _cache_axis_pooled, _CachedVector, _convert_copy
-    using AdaptiveArrayPools: @with_pool
-
-    # The persistent-path ownership contract: any time we hand a `_CachedVector`
-    # to a long-lived owner (interpolant struct), `copy` and `_convert_copy`
-    # must materialize the inner to `Vector{T}` — otherwise a view-backed
-    # one-shot wrapper could leak into persistent storage and be invalidated
-    # by mutation of the underlying buffer.
-    big = [0.0, 1.0, 2.5, 4.0, 6.0]
-    vw = @view big[1:4]
-
-    @with_pool pool function _make_view_backed()
-        c = _cache_axis_pooled(pool, vw)
-        # Return materialized copies — pool buffers must NOT escape, but
-        # `copy(c)` produces an owned wrapper with heap-allocated inner.
-        return (copy(c), _convert_copy(c, Float64), _convert_copy(c, Float32))
-    end
-
-    c_copy, c_same, c_cross = _make_view_backed()
-
-    @testset "Base.copy: inner materialized to Vector{T}" begin
-        @test c_copy isa _CachedVector{Float64}
-        @test c_copy.inner isa Vector{Float64}        # NOT SubArray
-        @test c_copy.inner == collect(vw)
-    end
-
-    @testset "_convert_copy same-eltype: same materialization as Base.copy" begin
-        @test c_same isa _CachedVector{Float64}
-        @test c_same.inner isa Vector{Float64}
-    end
-
-    @testset "_convert_copy cross-eltype: rebuilds at Tg" begin
-        @test c_cross isa _CachedVector{Float32}
-        @test c_cross.inner isa Vector{Float32}
-        @test c_cross.inner == Float32.(collect(vw))
-    end
-end
-
-@testitem "_cache_axis_pooled view-aliasing — no data-buffer copy" setup = [AllocConstants] begin
-    using FastInterpolations: _cache_axis_pooled
-    using AdaptiveArrayPools: @with_pool
-
-    # CONTRACT: pool-path view input must NOT allocate a `Vector{T}` copy of
-    # the view buffer — `inner::I` aliases the SubArray directly. A regression
-    # to materialization would add `length(vw)*sizeof(T) + header` bytes/call.
-    #
-    # JIT/pool semantics: see "pool DATA-buffer reuse" testitem comment for
-    # the warmup pattern. Wrapper aliases pool buffers, must not escape scope.
     @with_pool pool function _measure_view(vw)
         c = _cache_axis_pooled(pool, vw)
-        return c.h[1] + c.inv_h[1]
+        return c.inner[1] + c.h[1] + c.inv_h[1]
     end
 
-    big = [0.0, 1.0, 2.5, 4.0, 6.0, 9.0, 12.0, 15.0]
-    vw = @view big[2:7]
-    _measure_view(vw)                       # warmup 1 (JIT + pool grow)
-    _measure_view(vw)                       # warmup 2 (pool reuses)
+    @testset "View input → inner materialized to Vector{T} (single concrete type)" begin
+        @with_pool pool function _check_type(vw)
+            c = _cache_axis_pooled(pool, vw)
+            return (c isa _CachedVector{Float64, Float64}, c.inner isa Vector{Float64})
+        end
+        big = [0.0, 1.0, 2.5, 4.0, 6.0, 9.0, 12.0, 15.0]
+        is_concrete, inner_is_vector = _check_type(@view big[2:7])
+        @test is_concrete
+        @test inner_is_vector
+    end
 
-    @test (@allocated _measure_view(vw)) <= ALLOC_THRESHOLD
+    @testset "View input — zero heap alloc after warmup (pool reuses inner)" begin
+        big = [0.0, 1.0, 2.5, 4.0, 6.0, 9.0, 12.0, 15.0]
+        vw = @view big[2:7]
+        _measure_view(vw)                       # warmup 1 (pool grow)
+        _measure_view(vw)                       # warmup 2 (pool reuse)
+        @test (@allocated _measure_view(vw)) <= WRAPPER_OVERHEAD_LIMIT
+    end
 end

--- a/test/test_constant_oneshot_series.jl
+++ b/test/test_constant_oneshot_series.jl
@@ -229,4 +229,136 @@
         bc_bad = PeriodicBC(endpoint = :exclusive, period = 2.5)
         @test_throws ArgumentError constant_interp(xv, s, 1.5; bc = bc_bad)
     end
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # K×Q (large-NQ) loop-order path. `_series_use_kq_loop(NQ, K)` returns
+    # true when `NQ > 16` (or `K ≥ 256`), routing to `_constant_series_batch_kq!`
+    # — pool-acquired anchor vector + K-outer×Q-inner stream. The QK helper
+    # (above tests at `Vector query`, `PeriodicBC — vector in-place ...`) only
+    # exercises small NQ; these testsets lock in the KQ branches.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "Vector batch — K×Q loop (NQ=20 > threshold)" begin
+        # NQ=20 triggers the kq! path for any K (since 20 > _SERIES_BATCH_NQ_THRESHOLD=16).
+        NQ = 20
+        xqs = collect(range(0.05, 0.95, NQ))
+        s = Series(y_sin, y_cos, y_exp)
+
+        @testset "Non-periodic NoBC — KQ result == QK reference" begin
+            outputs_kq = [zeros(NQ) for _ in 1:3]
+            constant_interp!(outputs_kq, x, s, xqs)
+            # Cross-check each entry against the scalar oneshot path.
+            for j in eachindex(xqs)
+                ref = constant_interp(x, s, xqs[j])
+                for k in 1:3
+                    @test outputs_kq[k][j] ≈ ref[k] atol = 1.0e-12
+                end
+            end
+        end
+
+        @testset "Non-periodic with WrapExtrap on OOB queries" begin
+            # Include a few OOB queries so `wrap = extrap_eff isa WrapExtrap`
+            # branch fires inside `_constant_series_batch_kq!`.
+            xqs_wrap = vcat(collect(range(0.05, 0.95, NQ - 4)), [-0.2, -0.05, 1.05, 1.2])
+            outputs_kq = [zeros(length(xqs_wrap)) for _ in 1:2]
+            constant_interp!(
+                outputs_kq, x, Series(y_sin, y_cos), xqs_wrap;
+                extrap = WrapExtrap()
+            )
+            for j in eachindex(xqs_wrap)
+                ref = constant_interp(x, Series(y_sin, y_cos), xqs_wrap[j]; extrap = WrapExtrap())
+                @test outputs_kq[1][j] ≈ ref[1] atol = 1.0e-12
+                @test outputs_kq[2][j] ≈ ref[2] atol = 1.0e-12
+            end
+        end
+
+        @testset "PeriodicBC{:inclusive} batch — KQ" begin
+            outputs_kq = [zeros(NQ) for _ in 1:2]
+            constant_interp!(outputs_kq, x, Series(y_sin, y_cos), xqs; bc = PeriodicBC())
+            # Equivalent wrap-by-period query → bit-exact via shared anchor.
+            outputs_kq_wrap = [zeros(NQ) for _ in 1:2]
+            constant_interp!(
+                outputs_kq_wrap, x, Series(y_sin, y_cos), xqs .+ 1.0; bc = PeriodicBC()
+            )
+            @test outputs_kq[1] ≈ outputs_kq_wrap[1] atol = 1.0e-12
+            @test outputs_kq[2] ≈ outputs_kq_wrap[2] atol = 1.0e-12
+        end
+
+        @testset "PeriodicBC{:exclusive} FVM batch — KQ" begin
+            xc = [0.5, 1.5, 2.5]
+            s_fvm = Series([10.0, 20.0, 30.0], [1.0, 2.0, 3.0])
+            bc = PeriodicBC(endpoint = :exclusive, period = 3.0)
+            xqs_fvm = collect(range(0.1, 2.9, NQ))   # NQ=20 across one period
+            outputs_kq = [zeros(NQ), zeros(NQ)]
+            constant_interp!(outputs_kq, xc, s_fvm, xqs_fvm; bc)
+            # Cross-check each entry against the scalar in-place path.
+            out_scalar = zeros(2)
+            for j in eachindex(xqs_fvm)
+                constant_interp!(out_scalar, xc, s_fvm, xqs_fvm[j]; bc)
+                @test outputs_kq[1][j] ≈ out_scalar[1] atol = 1.0e-12
+                @test outputs_kq[2][j] ≈ out_scalar[2] atol = 1.0e-12
+            end
+        end
+
+        @testset "Range grid batch — KQ" begin
+            # Range grid → `_to_float` produces `_CachedRange`. Forces
+            # `_resolve_axis` + `_resolve_search` Range-specific branches
+            # inside the kq! body.
+            x_range = range(0.0, 1.0, 101)
+            outputs_kq = [zeros(NQ) for _ in 1:2]
+            constant_interp!(outputs_kq, x_range, Series(y_sin, y_cos), xqs)
+            for j in eachindex(xqs)
+                ref = constant_interp(x_range, Series(y_sin, y_cos), xqs[j])
+                @test outputs_kq[1][j] ≈ ref[1] atol = 1.0e-12
+                @test outputs_kq[2][j] ≈ ref[2] atol = 1.0e-12
+            end
+        end
+
+        @testset "Float32 grid + Float64 query — KQ Tqp promotion" begin
+            # Hits the `Tqp = promote_type(Tg_actual, Tq)` path inside kq!.
+            x32 = Float32.(x)
+            y32_sin = Float32.(y_sin)
+            y32_cos = Float32.(y_cos)
+            outputs_kq = [zeros(Float64, NQ) for _ in 1:2]
+            constant_interp!(outputs_kq, x32, Series(y32_sin, y32_cos), xqs)
+            for j in eachindex(xqs)
+                ref = constant_interp(x32, Series(y32_sin, y32_cos), xqs[j])
+                @test outputs_kq[1][j] ≈ ref[1] rtol = 1.0e-6
+                @test outputs_kq[2][j] ≈ ref[2] rtol = 1.0e-6
+            end
+        end
+
+        @testset "Derivative op + KQ" begin
+            outputs_kq = [zeros(NQ) for _ in 1:2]
+            constant_interp!(
+                outputs_kq, x, Series(y_sin, y_cos), xqs;
+                deriv = DerivOp(1)
+            )
+            # Constant interp derivative is zero everywhere except at sample
+            # points (where it's a delta); for any non-sample interior query
+            # the result must be zero.
+            for j in eachindex(xqs)
+                @test outputs_kq[1][j] == 0.0
+                @test outputs_kq[2][j] == 0.0
+            end
+        end
+    end
+
+    @testset "Vector batch — K×Q via K threshold (K ≥ 256)" begin
+        # Many small series — `K ≥ 256` triggers kq! regardless of NQ.
+        # Use small NQ=4 so the entry is solely via the K-threshold branch.
+        NQ = 4
+        K = 256
+        xqs = [0.1, 0.37, 0.5, 0.9]
+        ys = [sin.(2π .* x .+ 0.01 * k) for k in 1:K]
+        s = Series(ys)
+        outputs_kq = [zeros(NQ) for _ in 1:K]
+        constant_interp!(outputs_kq, x, s, xqs)
+        # Spot-check a few entries against the scalar oneshot path.
+        for j in eachindex(xqs)
+            ref = constant_interp(x, s, xqs[j])
+            for k in (1, K ÷ 2, K)
+                @test outputs_kq[k][j] ≈ ref[k] atol = 1.0e-12
+            end
+        end
+    end
 end

--- a/test/test_linear_oneshot_series.jl
+++ b/test/test_linear_oneshot_series.jl
@@ -316,4 +316,140 @@
         bc_bad = PeriodicBC(endpoint = :exclusive, period = 2.5)
         @test_throws ArgumentError linear_interp(xv, s, 1.5; bc = bc_bad)
     end
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # K×Q (large-NQ) loop-order path. `_series_use_kq_loop(NQ, K)` returns
+    # true when `NQ > 16` (or `K ≥ 256`), routing to `_linear_series_batch_kq!`
+    # — pool-acquired anchor vector + K-outer×Q-inner stream. Existing
+    # `Vector query` / `PeriodicBC — vector in-place ...` tests use NQ ≤ 4
+    # and hit only the QK helper; these testsets lock in the KQ branches.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "Vector batch — K×Q loop (NQ=20 > threshold)" begin
+        NQ = 20
+        xqs = collect(range(0.05, 0.95, NQ))
+        s = Series(y_sin, y_cos, y_exp)
+
+        @testset "Non-periodic NoBC — KQ result == scalar reference" begin
+            outputs_kq = [zeros(NQ) for _ in 1:3]
+            linear_interp!(outputs_kq, x, s, xqs)
+            for j in eachindex(xqs)
+                ref = linear_interp(x, s, xqs[j])
+                for k in 1:3
+                    @test outputs_kq[k][j] ≈ ref[k] atol = 1.0e-12
+                end
+            end
+        end
+
+        @testset "Non-periodic with WrapExtrap on OOB queries" begin
+            # OOB queries force `wrap = extrap_eff isa WrapExtrap` true inside
+            # the non-periodic kq! branch.
+            xqs_wrap = vcat(collect(range(0.05, 0.95, NQ - 4)), [-0.2, -0.05, 1.05, 1.2])
+            outputs_kq = [zeros(length(xqs_wrap)) for _ in 1:2]
+            linear_interp!(
+                outputs_kq, x, Series(y_sin, y_cos), xqs_wrap;
+                extrap = WrapExtrap()
+            )
+            for j in eachindex(xqs_wrap)
+                ref = linear_interp(x, Series(y_sin, y_cos), xqs_wrap[j]; extrap = WrapExtrap())
+                @test outputs_kq[1][j] ≈ ref[1] atol = 1.0e-12
+                @test outputs_kq[2][j] ≈ ref[2] atol = 1.0e-12
+            end
+        end
+
+        @testset "Non-periodic with ClampExtrap on OOB queries — KQ" begin
+            xqs_clamp = vcat(collect(range(0.05, 0.95, NQ - 2)), [-0.5, 1.5])
+            outputs_kq = [zeros(length(xqs_clamp)) for _ in 1:2]
+            linear_interp!(
+                outputs_kq, x, Series(y_sin, y_cos), xqs_clamp;
+                extrap = ClampExtrap()
+            )
+            # Clamped OOB → boundary value.
+            @test outputs_kq[1][end - 1] ≈ y_sin[1] atol = 1.0e-12
+            @test outputs_kq[1][end] ≈ y_sin[end] atol = 1.0e-12
+        end
+
+        @testset "PeriodicBC{:inclusive} batch — KQ" begin
+            outputs_kq = [zeros(NQ) for _ in 1:2]
+            linear_interp!(outputs_kq, x, Series(y_sin, y_cos), xqs; bc = PeriodicBC())
+            # Shifted-by-period query must produce the same result (bit-exact via shared anchor).
+            outputs_kq_wrap = [zeros(NQ) for _ in 1:2]
+            linear_interp!(
+                outputs_kq_wrap, x, Series(y_sin, y_cos), xqs .+ 1.0; bc = PeriodicBC()
+            )
+            @test outputs_kq[1] ≈ outputs_kq_wrap[1] atol = 1.0e-12
+            @test outputs_kq[2] ≈ outputs_kq_wrap[2] atol = 1.0e-12
+        end
+
+        @testset "PeriodicBC{:exclusive} FVM batch — KQ" begin
+            xc = [0.5, 1.5, 2.5]
+            s_fvm = Series([10.0, 20.0, 30.0], [1.0, 2.0, 3.0])
+            bc = PeriodicBC(endpoint = :exclusive, period = 3.0)
+            xqs_fvm = collect(range(0.1, 2.9, NQ))
+            outputs_kq = [zeros(NQ), zeros(NQ)]
+            linear_interp!(outputs_kq, xc, s_fvm, xqs_fvm; bc)
+            out_scalar = zeros(2)
+            for j in eachindex(xqs_fvm)
+                linear_interp!(out_scalar, xc, s_fvm, xqs_fvm[j]; bc)
+                @test outputs_kq[1][j] ≈ out_scalar[1] atol = 1.0e-12
+                @test outputs_kq[2][j] ≈ out_scalar[2] atol = 1.0e-12
+            end
+        end
+
+        @testset "Range grid batch — KQ" begin
+            # Range grid → `_to_float` produces `_CachedRange`. Exercises the
+            # Range-specific `_resolve_axis`/`_resolve_search` paths inside kq!.
+            x_range = range(0.0, 1.0, 101)
+            outputs_kq = [zeros(NQ) for _ in 1:2]
+            linear_interp!(outputs_kq, x_range, Series(y_sin, y_cos), xqs)
+            for j in eachindex(xqs)
+                ref = linear_interp(x_range, Series(y_sin, y_cos), xqs[j])
+                @test outputs_kq[1][j] ≈ ref[1] atol = 1.0e-12
+                @test outputs_kq[2][j] ≈ ref[2] atol = 1.0e-12
+            end
+        end
+
+        @testset "Float32 grid + Float64 query — KQ Tqp promotion" begin
+            x32 = Float32.(x)
+            y32_sin = Float32.(y_sin)
+            y32_cos = Float32.(y_cos)
+            outputs_kq = [zeros(Float64, NQ) for _ in 1:2]
+            linear_interp!(outputs_kq, x32, Series(y32_sin, y32_cos), xqs)
+            for j in eachindex(xqs)
+                ref = linear_interp(x32, Series(y32_sin, y32_cos), xqs[j])
+                @test outputs_kq[1][j] ≈ ref[1] rtol = 1.0e-6
+                @test outputs_kq[2][j] ≈ ref[2] rtol = 1.0e-6
+            end
+        end
+
+        @testset "DerivOp(1) + KQ — slope at each query matches scalar" begin
+            outputs_kq = [zeros(NQ) for _ in 1:2]
+            linear_interp!(
+                outputs_kq, x, Series(y_sin, y_cos), xqs;
+                deriv = DerivOp(1)
+            )
+            for j in eachindex(xqs)
+                ref = linear_interp(x, Series(y_sin, y_cos), xqs[j]; deriv = DerivOp(1))
+                @test outputs_kq[1][j] ≈ ref[1] atol = 1.0e-12
+                @test outputs_kq[2][j] ≈ ref[2] atol = 1.0e-12
+            end
+        end
+    end
+
+    @testset "Vector batch — K×Q via K threshold (K ≥ 256)" begin
+        # Many small series — `K ≥ 256` triggers kq! regardless of NQ.
+        # Use small NQ=4 so the dispatch entry is solely via the K threshold.
+        NQ = 4
+        K = 256
+        xqs = [0.1, 0.37, 0.5, 0.9]
+        ys = [sin.(2π .* x .+ 0.01 * k) for k in 1:K]
+        s = Series(ys)
+        outputs_kq = [zeros(NQ) for _ in 1:K]
+        linear_interp!(outputs_kq, x, s, xqs)
+        for j in eachindex(xqs)
+            ref = linear_interp(x, s, xqs[j])
+            for k in (1, K ÷ 2, K)
+                @test outputs_kq[k][j] ≈ ref[k] atol = 1.0e-12
+            end
+        end
+    end
 end

--- a/test/test_nd_autosearch_peraxis.jl
+++ b/test/test_nd_autosearch_peraxis.jl
@@ -1,6 +1,8 @@
 @testitem "ND Per-Axis Adaptive AutoSearch Resolution" begin
+    using Random: MersenneTwister
     using FastInterpolations: _resolve_search_nd, _resolve_search_policy,
         _is_axis_likely_monotone, _check_mono_nd, _query_extract, _query_length,
+        _resolve_oneshot_search_nd,
         AutoSearch, BinarySearch, LinearBinarySearch
 
     # ========================================
@@ -98,6 +100,115 @@
         result = _resolve_search_nd(AutoSearch(), Val(2), (sorted, sorted), hints)
         @test result[1] isa LinearBinarySearch
         @test result[2] isa LinearBinarySearch
+    end
+
+    # ========================================
+    # Oneshot batch resolution — `_resolve_oneshot_search_nd`
+    # ========================================
+    # Single resolution point hoisted outside the per-query loop. Verifies
+    # the (policies, hints) shape across (sort/random × hint/no-hint) combos.
+
+    @testset "Oneshot ND batch resolution — `_resolve_oneshot_search_nd`" begin
+        sorted = collect(1.0:50.0)
+        random = [
+            3.0, 1.0, 4.0, 1.0, 5.0, 9.0, 2.0, 6.0, 5.0, 3.0,
+            7.0, 8.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0,
+        ]
+
+        @testset "no-hint, sort × sort → both LB + fresh persistent Refs" begin
+            policies, hints = _resolve_oneshot_search_nd(
+                AutoSearch(), (sorted, sorted), nothing, Val(2)
+            )
+            @test policies[1] isa LinearBinarySearch
+            @test policies[2] isa LinearBinarySearch
+            @test hints[1] isa Base.RefValue{Int}
+            @test hints[2] isa Base.RefValue{Int}
+            @test hints[1][] == 1 && hints[2][] == 1  # fresh start at idx=1
+        end
+
+        @testset "no-hint, rand × rand → both Binary (no walk overhead)" begin
+            policies, _hints = _resolve_oneshot_search_nd(
+                AutoSearch(), (random, random), nothing, Val(2)
+            )
+            @test policies[1] isa BinarySearch
+            @test policies[2] isa BinarySearch
+        end
+
+        @testset "no-hint, mixed → per-axis (LB, Binary)" begin
+            policies, _hints = _resolve_oneshot_search_nd(
+                AutoSearch(), (sorted, random), nothing, Val(2)
+            )
+            @test policies[1] isa LinearBinarySearch
+            @test policies[2] isa BinarySearch
+        end
+
+        @testset "user-supplied hint → preserved, random axis still LB" begin
+            # With explicit hint, "caller wants locality" → both axes LB.
+            user_hint = (Ref(7), Ref(13))
+            policies, hints = _resolve_oneshot_search_nd(
+                AutoSearch(), (random, random), user_hint, Val(2)
+            )
+            @test policies[1] isa LinearBinarySearch
+            @test policies[2] isa LinearBinarySearch
+            @test hints === user_hint
+            @test hints[1][] == 7 && hints[2][] == 13
+        end
+
+        @testset "explicit BinarySearch passthrough" begin
+            policies, _hints = _resolve_oneshot_search_nd(
+                BinarySearch(), (sorted, sorted), nothing, Val(2)
+            )
+            @test policies[1] isa BinarySearch
+            @test policies[2] isa BinarySearch
+        end
+
+        @testset "3D mixed: (sort, rand, descending) → (LB, Binary, LB)" begin
+            descending = collect(50.0:-1.0:1.0)
+            policies, hints = _resolve_oneshot_search_nd(
+                AutoSearch(), (sorted, random, descending), nothing, Val(3)
+            )
+            @test policies[1] isa LinearBinarySearch
+            @test policies[2] isa BinarySearch
+            @test policies[3] isa LinearBinarySearch
+            @test length(hints) == 3
+        end
+    end
+
+    @testset "Behavioral equivalence: AutoSearch (no hint) ≡ LB + persistent user hint" begin
+        # AutoSearch on sorted queries must produce bit-identical output to an
+        # explicit `search=LinearBinarySearch()` + user-supplied persistent Ref.
+        xs = collect(range(0.0, 10.0, 51))
+        ys = collect(range(0.0, 10.0, 51))
+        data = [Float64(x + y) for x in xs, y in ys]
+
+        sorted_xq = collect(0.1:0.1:9.9)
+        sorted_yq = collect(0.1:0.1:9.9)
+        nq = length(sorted_xq)
+        out_auto = Vector{Float64}(undef, nq)
+        out_lb_hint = Vector{Float64}(undef, nq)
+
+        linear_interp!(out_auto, (xs, ys), data, (sorted_xq, sorted_yq))
+        linear_interp!(out_lb_hint, (xs, ys), data, (sorted_xq, sorted_yq);
+                       search=LinearBinarySearch(), hint=(Ref(1), Ref(1)))
+        @test out_auto == out_lb_hint   # bit-exact: same algorithm, same hints semantics
+    end
+
+    @testset "Behavioral equivalence: random AutoSearch ≡ explicit BinarySearch" begin
+        # Random queries must produce bit-identical output to explicit BinarySearch.
+        xs = collect(range(0.0, 10.0, 51))
+        ys = collect(range(0.0, 10.0, 51))
+        data = [Float64(x + y) for x in xs, y in ys]
+
+        rng = MersenneTwister(0x1234abcd)
+        random_xq = rand(rng, 100) .* 9.9
+        random_yq = rand(rng, 100) .* 9.9
+        nq = length(random_xq)
+        out_auto = Vector{Float64}(undef, nq)
+        out_binary = Vector{Float64}(undef, nq)
+
+        linear_interp!(out_auto, (xs, ys), data, (random_xq, random_yq))
+        linear_interp!(out_binary, (xs, ys), data, (random_xq, random_yq); search=BinarySearch())
+        @test out_auto == out_binary
     end
 
     # ========================================

--- a/test/test_nd_autosearch_peraxis.jl
+++ b/test/test_nd_autosearch_peraxis.jl
@@ -188,8 +188,10 @@
         out_lb_hint = Vector{Float64}(undef, nq)
 
         linear_interp!(out_auto, (xs, ys), data, (sorted_xq, sorted_yq))
-        linear_interp!(out_lb_hint, (xs, ys), data, (sorted_xq, sorted_yq);
-                       search=LinearBinarySearch(), hint=(Ref(1), Ref(1)))
+        linear_interp!(
+            out_lb_hint, (xs, ys), data, (sorted_xq, sorted_yq);
+            search = LinearBinarySearch(), hint = (Ref(1), Ref(1))
+        )
         @test out_auto == out_lb_hint   # bit-exact: same algorithm, same hints semantics
     end
 
@@ -207,7 +209,7 @@
         out_binary = Vector{Float64}(undef, nq)
 
         linear_interp!(out_auto, (xs, ys), data, (random_xq, random_yq))
-        linear_interp!(out_binary, (xs, ys), data, (random_xq, random_yq); search=BinarySearch())
+        linear_interp!(out_binary, (xs, ys), data, (random_xq, random_yq); search = BinarySearch())
         @test out_auto == out_binary
     end
 

--- a/test/test_nd_quadratic.jl
+++ b/test/test_nd_quadratic.jl
@@ -444,7 +444,7 @@
             # Exclusive PeriodicBC: must also raise `ArgumentError`, not a
             # misleading `AssertionError`/`DimensionMismatch` from the wrapped
             # virtual-`n+1` grid being passed through `_cache_axis` before BC
-            # validation runs. (Regression guard for #140 Copilot review.)
+            # validation runs.
             @test_throws ArgumentError quadratic_interp(
                 (x, y), data;
                 bc = PeriodicBC(endpoint = :exclusive)

--- a/test/test_nd_quadratic.jl
+++ b/test/test_nd_quadratic.jl
@@ -435,9 +435,30 @@
 
         @testset "unsupported BC" begin
             data = rand(11, 6)
+            # Inclusive PeriodicBC: rejected at `_slope_1d_quadratic!` fallback
+            # via clear `ArgumentError("Unsupported boundary condition ...")`.
             @test_throws ArgumentError quadratic_interp(
                 (x, y), data;
                 bc = PeriodicBC()
+            )
+            # Exclusive PeriodicBC: must also raise `ArgumentError`, not a
+            # misleading `AssertionError`/`DimensionMismatch` from the wrapped
+            # virtual-`n+1` grid being passed through `_cache_axis` before BC
+            # validation runs. (Regression guard for #140 Copilot review.)
+            @test_throws ArgumentError quadratic_interp(
+                (x, y), data;
+                bc = PeriodicBC(endpoint = :exclusive)
+            )
+            # Same exclusive guard with per-axis BC tuple — must also raise
+            # `ArgumentError`, regardless of whether the unsupported BC is on
+            # the first axis or a later one.
+            @test_throws ArgumentError quadratic_interp(
+                (x, y), data;
+                bc = (PeriodicBC(endpoint = :exclusive), Left(QuadraticFit()))
+            )
+            @test_throws ArgumentError quadratic_interp(
+                (x, y), data;
+                bc = (Left(QuadraticFit()), PeriodicBC(endpoint = :exclusive))
             )
         end
     end

--- a/test/test_periodic_exclusive.jl
+++ b/test/test_periodic_exclusive.jl
@@ -979,3 +979,73 @@ end
     end
 
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Seam-width consistency between value (`_alpha_of`) and derivative
+# (`_get_inv_h`) for `_ExclusivePeriodicAxis` with `_CachedRange` inner.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Regression guard for the divergence introduced when `_get_h`/`_get_inv_h`
+# moved to the 4-arg `(g, idx, xL, xR)` form and started using the actual seam
+# width `xR - xL` at the seam cell, while `_alpha_of(::_ExclusivePeriodicAxis)`
+# was left delegating to `g.inner` (which uses the inner's cached step on
+# `_CachedRange` — NOT the actual seam width).
+#
+# For Range inners with a period that passes the `sqrt(eps)` cross-validation
+# tolerance but is not exactly `step * length`, the two seam widths differ by
+# more than 1 ULP. Linear eval (`_alpha_of`) then computes a value whose
+# implicit denominator disagrees with the derivative's denominator, breaking
+# the `Range inner` vs `Vector inner` numerical parity that holds elsewhere.
+@testitem "Linear PeriodicBC(:exclusive) — Range/Vector seam parity for off-bit period" begin
+    using FastInterpolations: linear_interp, PeriodicBC, DerivOp
+
+    # Logically identical grids in Range vs Vector form. Vector form's
+    # `_alpha_of` uses `(q - L) / (R - L)`; Range form delegates to
+    # `_CachedRange.inv_h` (= `inv(step)`), which is what diverges from the
+    # actual seam width.
+    r = range(0.0, step = 1.0, length = 4)        # [0.0, 1.0, 2.0, 3.0]
+    v = collect(r)
+    y = Float64[10, 20, 30, 40]
+
+    # Period off-bit from `step*length = 4.0` but well within
+    # `sqrt(eps(Float64)) ≈ 1.49e-8` relative tolerance, so wrapper
+    # construction's cross-validation accepts it.
+    delta = 3.0e-8
+    period_off = 4.0 + delta
+    bc = PeriodicBC(endpoint = :exclusive, period = period_off)
+
+    # Query in middle of seam cell — most sensitive to seam-width handling.
+    xq_seam = 3.5
+
+    @testset "value at seam — Range inner ↔ Vector inner agree" begin
+        val_r = linear_interp(r, y, xq_seam; bc = bc)
+        val_v = linear_interp(v, y, xq_seam; bc = bc)
+        # The buggy Range path uses inner step (1.0) as the seam-cell inv_h,
+        # while the Vector path uses the actual seam width (≈ 1 + delta).
+        # Expected discrepancy ≈ 0.5 × 30 × delta ≈ 4.5e-7 — comfortably
+        # above the rtol below if val/deriv stay consistent.
+        @test val_r ≈ val_v rtol = 1.0e-12
+    end
+
+    @testset "derivative at seam — Range inner ↔ Vector inner agree" begin
+        # Derivative already uses the 4-arg `_get_inv_h` → `inv(xR - xL)` at
+        # the seam on BOTH Range and Vector inners; this guard locks that in
+        # so a future regression to inner-delegation gets flagged.
+        d_r = linear_interp(r, y, xq_seam; bc = bc, deriv = DerivOp(1))
+        d_v = linear_interp(v, y, xq_seam; bc = bc, deriv = DerivOp(1))
+        @test d_r ≈ d_v rtol = 1.0e-12
+    end
+
+    @testset "val/deriv internal consistency — Range inner" begin
+        # Independent of any Vector reference: the val and deriv at the seam
+        # must share a denominator. Finite-difference check across the seam
+        # cell — if the two paths use different inv_h, the FD slope at the
+        # cell midpoint will diverge from the analytic deriv by O(delta).
+        h = 1.0e-3                                # FD step inside seam cell
+        val_lo = linear_interp(r, y, xq_seam - h; bc = bc)
+        val_hi = linear_interp(r, y, xq_seam + h; bc = bc)
+        d_mid = linear_interp(r, y, xq_seam; bc = bc, deriv = DerivOp(1))
+        @test (val_hi - val_lo) / (2h) ≈ d_mid rtol = 1.0e-10
+    end
+end
+

--- a/test/test_periodic_exclusive.jl
+++ b/test/test_periodic_exclusive.jl
@@ -1048,4 +1048,3 @@ end
         @test (val_hi - val_lo) / (2h) ≈ d_mid rtol = 1.0e-10
     end
 end
-


### PR DESCRIPTION
## Summary

**Series oneshot batch.** PR #127 inverted the 1D Series vector-batch loop from K-outer × Q-inner (v0.4.9) to Q-outer × K-inner; the flip was benchmarked at NQ=8 but cost 50–110 % at NQ ≥ 100 and 100 %+ at K ≥ 1000 (K-inner loop loses auto-SIMD across separate `outputs[k]` Vectors). Fix routes per call on `(NQ, K)` — Q×K kept for the tiny-N case PR #127 optimised, K×Q + pool restored otherwise — and extracts the two shapes into named helpers so the small-batch path no longer pays `@with_pool` setup.

**ND oneshot batch.** `{linear,constant,quadratic,cubic,hetero}_interp(grids, data, queries)` ignored its `AutoSearch` policy and always dispatched `LinearBinarySearch` with a fresh `Ref(1)` per query. Fix hoists `_resolve_oneshot_search_nd(search, queries, hint, Val(N))` into each `*_interp_nd_oneshot_batch!` so policies + hints stay local to a single inlined frame.

**Size**: 10 commits, 22 files, +1188 / −509.

## Coverage

| Path | Status |
|---|---|
| 1D Linear / Constant Series oneshot batch + persistent callable | ✅ adaptive Q×K↔K×Q |
| Quadratic / Cubic Series batch | ✅ unchanged — structurally K-outer (per-series solver), untouched by PR #127 |
| PCHIP / Cardinal / Akima / Hermite Series | N/A — no Series API |
| ND oneshot batch Linear / Constant / Quadratic / Cubic / Hetero PreCompute | ✅ per-axis adaptive |
| Hetero `coeffs=OnTheFly()` batch | ⏳ master shape — see Out of scope |

## Implementation

- **`_series_use_kq_loop(NQ, K) = NQ > 16 || K ≥ 256`** in `src/core/series_utils.jl`. NQ axis catches typical regimes; K axis catches K-very-large where Q×K can never beat the SIMD-friendly inner stream.
- **Per-method helpers** in `{constant,linear}/{*_oneshot_series.jl,*_series_interp.jl}`: Q×K helper is plain `@inline`; K×Q helper is `@inline @with_pool pool`. Both branch internally on `_is_periodic_bc(bc)` (compile-time resolved). Entry function validates inputs once, then dispatches.
- **`_resolve_oneshot_search_nd`** in `src/core/nd_utils.jl` called at the top of each `*_interp_nd_oneshot_batch!`; resolved `policies` + `hints` stay local. OnTheFly stays on master-shape — Union policies box across the un-inlinable `_interp_nd_oneshot_onthefly` boundary (tracked in `claudedocs/TODO/otf_batch_adaptive_search.md`).
- **Refactor support** (5 prior commits on this branch) unifies the per-axis storage so the ND hoist applies uniformly across methods: `_CachedVector` parametric `inner::I`, Quadratic axis paths onto `_cache_axis` + pool, `_get_h` / `_get_inv_h` 4-arg `(grid, idx, xL, xR)`, axis struct centralization.

## Performance

### Series oneshot batch — Constant, Vector grid, random queries, min µs

| (NQ, K)       | v0.4.9 | master | this PR |
|---------------|-------:|-------:|--------:|
| (8, 8)        |   0.12 |   0.12 |    0.12 |
| (1000, 8)     |  12.4  |  29.2  |   13.0  |
| (16, 1000)    |  13.5  |  26.5  |   14.9  |
| (1000, 1000)  |  690   |  4809  |   717   |

Linear Series matches within ±3 % of these numbers.

### ND oneshot grid × query — 2D Vector × Vector, NQ=1000, min µs

| Path                | v0.4.9 | master | this PR |
|---------------------|-------:|-------:|--------:|
| bilinear sort×sort  |  20.4  |  20.5  |   3.25  |
| bilinear sort×rand  |  11.0  |  19.4  |   7.96  |
| bilinear rand×rand  |  11.6  |  19.6  |  11.4   |
| bicubic  sort×sort  |  55.6  |  47.4  |  41.3   |
| bicubic  sort×rand  |  51.6  |  47.4  |  49.3   |
| bicubic  rand×rand  |  51.6  |  47.5  |  52.7   |

bilinear `sort×sort` (6.3 × faster than master) is the headline: per-axis adaptive search was already broken on v0.4.9 too — every batch call collapsed to the rand×rand cost regardless of query pattern. This PR is the first to honour the per-axis policy.

## Benchmark sensors (`benchmark/ci_benchmark.jl`)

- **group 13** `_nd_oneshot_gridquery` — Linear + Cubic 2D Vector × Vector × {sort×sort, rand×rand, sort×rand}. Mixed `sort×rand` flags any future regression that collapses per-axis policies.
- **group 14** `_series_oneshot_batch` — Linear / Constant Series oneshot batch in-place, K=8, NQ=1000, Vector grid, random queries. In-place form chosen so the timing reflects pure computation — cv ~3 % instead of 440 % on the allocating form.