### PR TITLE
(fix + perf): Restore + extend batch InBounds fast path (1D + ND)

### DIFF
--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -16,18 +16,19 @@
 # _eval_extrapolation helper is defined in core/utils.jl (shared by all methods).
 # _get_h(x, xL, xR) dispatches to x.h (_CachedRange) or xR-xL (Vector).
 
-# NoExtrap / InBounds: domain check + search + kernel.
-# (OOB impossible: NoExtrap throws, InBounds guarantees in-domain)
+# Core in-bounds path: `last(x) == xi` seam handling + search + kernel.
+# All non-InBounds extrap overloads delegate here after preprocessing — see
+# cubic_eval.jl for the same `InBounds = core fast path` pattern. WrapExtrap
+# uses a separate periodic-seam-aware core (`_raw(y)`) below.
 @inline function _constant_eval_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         xi::Tq,
-        extrap::AbstractExtrap,
+        ::InBounds,
         side::AbstractSide,
         op::AbstractEvalOp,
         searcher::S
     ) where {Tg, Tv, Tq <: Real, S <: Searcher}
-    @boundscheck _check_domain(x, xi, extrap)
     if _extract_primal(xi) == _extract_primal(last(x))
         # `last(x)` for `_ExclusivePeriodicAxis` is the *virtual* `inner[1] + period`
         # (the seam right endpoint). The corresponding y at that virtual slot is
@@ -41,8 +42,23 @@
     @inbounds return _constant_kernel(op, y[idx], y[idx_R], _get_h(x, idx, xL, xR), dL, side)
 end
 
-# ExtendExtrap: constant function has zero slope → extend = clamp.
-# Cannot use catch-all because kernel is side-dependent and OOB dL > h gives wrong side.
+# NoExtrap / others matching AbstractExtrap: domain check → delegate.
+@inline function _constant_eval_at_point(
+        x::AbstractVector{Tg},
+        y::AbstractVector{Tv},
+        xi::Tq,
+        extrap::AbstractExtrap,
+        side::AbstractSide,
+        op::AbstractEvalOp,
+        searcher::S
+    ) where {Tg, Tv, Tq <: Real, S <: Searcher}
+    @boundscheck _check_domain(x, xi, extrap)
+    return _constant_eval_at_point(x, y, xi, InBounds(), side, op, searcher)
+end
+
+# ExtendExtrap: constant has zero slope → extend = clamp. Route through
+# ClampExtrap so OOB queries return the boundary value (in-bounds case
+# eventually reaches the InBounds core).
 @inline function _constant_eval_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
@@ -55,7 +71,7 @@ end
     return _constant_eval_at_point(x, y, xi, ClampExtrap(), side, op, searcher)
 end
 
-# ClampExtrap / FillExtrap: boundary check → extrap value or kernel.
+# ClampExtrap / FillExtrap: boundary check → extrap value or delegate.
 @inline function _constant_eval_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
@@ -68,12 +84,7 @@ end
     xi_primal = _extract_primal(xi)
     xi_primal < _extract_primal(first(x)) && return _eval_extrapolation(op, first(y), extrap, xi)
     xi_primal > _extract_primal(last(x)) && return _eval_extrapolation(op, last(y), extrap, xi)
-    if xi_primal == _extract_primal(last(x))
-        return op isa EvalValue ? last(y) : 0 * first(y)
-    end
-    idx, idx_R, xL, xR = search_interval(searcher, x, xi)
-    dL = xi - xL
-    @inbounds return _constant_kernel(op, y[idx], y[idx_R], _get_h(x, idx, xL, xR), dL, side)
+    return _constant_eval_at_point(x, y, xi, InBounds(), side, op, searcher)
 end
 
 # WrapExtrap: wrap query to domain → search + kernel.

--- a/src/constant/nd/constant_nd_eval.jl
+++ b/src/constant/nd/constant_nd_eval.jl
@@ -97,15 +97,18 @@ end
 # CELL LOCATION (locate once, evaluate many)
 # ========================================
 
-# Generic N-dimensional
+# Generic N-dimensional. `extraps` carries batch-level InBounds promotion
+# from `_check_domain_nd` when applicable; scalar callers route via the
+# 5-arg forwarder (interpolant_protocol.jl) injecting `itp.extraps`.
 @inline function _locate_cell(
         itp::ConstantInterpolantND{Tg, Tv, N},
         query::Tuple{Vararg{Real, N}},
+        extraps::Tuple{Vararg{AbstractExtrap, N}},
         policies::NTuple{N, AbstractSearchPolicy},
         hints::Tuple{Vararg{Base.RefValue{Int}, N}},
         mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
-    q_eval = _handle_all_extraps(query, itp.grids, itp.extraps)
+    q_eval = _handle_all_extraps(query, itp.grids, extraps)
     indices, Ls, _ = _search_all_intervals(q_eval, itp.grids, policies, hints, mono)
     # h-lift: the kernel now takes precomputed `hs` instead of computing
     # `_get_h(grids[d], indices[d])` inside the @generated body. Persistent
@@ -121,12 +124,13 @@ end
 @inline function _locate_cell(
         itp::ConstantInterpolantND{Tg, Tv, 2},
         query::Tuple{Vararg{Real, 2}},
+        extraps::Tuple{AbstractExtrap, AbstractExtrap},
         policies::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
         hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
         mono::Tuple{Bool, Bool},
     ) where {Tg, Tv}
     x_eval, y_eval, ix, iy, xL, yL = _locate_cell_2d_preamble(
-        query, itp.grids, itp.extraps, policies, hints, mono
+        query, itp.grids, extraps, policies, hints, mono
     )
     # Lift h + wrap indices into stencils, matching the generic-N path.
     hx = _get_h(itp.grids[1], ix)

--- a/src/constant/nd/constant_nd_eval.jl
+++ b/src/constant/nd/constant_nd_eval.jl
@@ -23,75 +23,23 @@
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
     mono = _scalar_mono(hint, Val(N))
-    val = _eval_constant_nd(itp, resolved, ops, policies, hints, mono)
+    val = _eval_nd_at_point(itp, resolved, ops, policies, hints, mono)
     Tq = promote_type(map(typeof, query)...)
     return convert(_output_eltype(itp, Tq), val)
 end
 
 # In-place + allocating batch use the inherited `AbstractInterpolantND`
 # protocol; output eltype comes from the `_output_eltype(itp, Tq)` trait
-# overridden in `constant_nd_types.jl`.
-
-# Zero-fill for any derivative is handled by _deriv_zero_fill trait below.
+# overridden in `constant_nd_types.jl`. Scalar evaluation routes through
+# the generic `_eval_nd_at_point` in interpolant_protocol.jl — Constant's
+# "any derivative → 0" rule is wired via the `_deriv_zero_fill` trait below.
 
 # Derivative zero-fill trait: constant has zero derivative at all orders
 @inline _deriv_zero_fill(::ConstantInterpolantND, ops::NTuple{N, AbstractEvalOp}, ::Val{N}) where {N} =
     _has_any_derivative(ops, Val(N))
 
-# ========================================
-# Core Evaluation Logic
-# ========================================
-
-"""
-    _eval_constant_nd(itp, query, ops, search_tuple)
-
-Evaluate ConstantInterpolantND at a single point.
-
-For constant interpolation:
-- If any derivative order > 0, return zero via `0 * y` (duck-typing compatible)
-- Otherwise, find interval and select corner based on side mode
-"""
 # Zero-ref for fill-value derivative computation (duck-typed zero via 0 * data_element)
 @inline _zero_ref(itp::ConstantInterpolantND) = @inbounds first(itp.data)
-
-# Generic N-dimensional version (uses _locate_cell + _eval_at_cell)
-@inline function _eval_constant_nd(
-        itp::ConstantInterpolantND{Tg, Tv, N},
-        query::Tuple{Vararg{Real, N}},
-        ops::NTuple{N, AbstractEvalOp},
-        policies::NTuple{N, AbstractSearchPolicy},
-        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
-        mono::NTuple{N, Bool},
-    ) where {Tg, Tv, N}
-    _validate_nd_domain(itp.grids, query, itp.extraps)
-    oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
-    oob_result !== nothing && return oob_result
-    if _has_any_derivative(ops, Val(N))
-        return 0 * first(itp.data)
-    end
-    cell = _locate_cell(itp, query, policies, hints, mono)
-    return _eval_at_cell(itp, cell, ops)
-end
-
-# N=2 specialization: dispatches to N=2 _locate_cell via type
-@inline function _eval_constant_nd(
-        itp::ConstantInterpolantND{Tg, Tv, 2},
-        query::Tuple{Vararg{Real, 2}},
-        ops::NTuple{2, AbstractEvalOp},
-        policies::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
-        hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
-        mono::Tuple{Bool, Bool},
-    ) where {Tg, Tv}
-    _validate_nd_domain(itp.grids, query, itp.extraps)
-    oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
-    oob_result !== nothing && return oob_result
-    op_x, op_y = ops
-    if !(op_x isa EvalValue) || !(op_y isa EvalValue)
-        return 0 * first(itp.data)
-    end
-    cell = _locate_cell(itp, query, policies, hints, mono)
-    return _eval_at_cell(itp, cell, ops)
-end
 
 # ========================================
 # CELL LOCATION (locate once, evaluate many)

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -72,11 +72,14 @@ function _constant_interp_nd_oneshot_batch!(
     _query_validate(queries)
     grids_eff = map(_resolve_axis, grids, bcs)
     nobcs = ntuple(_ -> NoBC(), Val(N))
-    _validate_nd_domain(grids_eff, queries, extraps_val)
     extraps_eff = _resolve_extrap(extraps_val, bcs, grids_eff, data, Val(N))
+    # Batch-level InBounds promotion: see cubic_nd_oneshot.jl / linear_nd_oneshot.jl
+    # for the same pattern. Replaces `_validate_nd_domain` (throw via 1D
+    # `_check_domain`'s `@boundscheck`) and shrinks `fill_dims` at compile time.
+    extraps_eff = _check_domain_nd(grids_eff, queries, extraps_eff)
     @inbounds for k in 1:nq
         query_k = _extract_query_point(queries, k, Val(N))
-        oob_val = _try_fill_oob(query_k, grids_eff, extraps_val, EvalValue(), first(data))
+        oob_val = _try_fill_oob(query_k, grids_eff, extraps_eff, EvalValue(), first(data))
         if oob_val !== nothing
             output[k] = oob_val; continue
         end

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -122,6 +122,7 @@ end
         output::AbstractVector,
         itp::AbstractInterpolantND{Tg, Tv, N},
         queries,
+        extraps_eff::Tuple{Vararg{AbstractExtrap, N}},
         ops::NTuple{N, AbstractEvalOp},
         policies::Tuple{Vararg{AbstractSearchPolicy, N}},
         hints::Tuple{Vararg{Base.RefValue{Int}, N}},
@@ -130,16 +131,31 @@ end
     zref = _zero_ref(itp)
     @inbounds for k in 1:_query_length(queries)
         query_k = _extract_query_point(queries, k, Val(N))
-        oob_val = _try_fill_oob(query_k, itp.grids, itp.extraps, ops, zref)
+        # `extraps_eff` carries per-axis `InBounds()` from `_check_domain_nd`
+        # when all batch queries on that axis are in-bounds (1D `_check_domain`
+        # union-split per axis via the heterogeneous `map`). `_try_fill_oob` and
+        # `_locate_cell` compile away the wrap/clamp/fill per-query branches on
+        # the InBounds axes — see `_handle_axis_extrap(::InBounds) = q` and
+        # `_is_fill_oob`'s @generated `fill_dims` filtering.
+        oob_val = _try_fill_oob(query_k, itp.grids, extraps_eff, ops, zref)
         if oob_val !== nothing
             output[k] = oob_val
             continue
         end
-        cell = _locate_cell(itp, query_k, policies, hints, mono)
+        cell = _locate_cell(itp, query_k, extraps_eff, policies, hints, mono)
         output[k] = _eval_at_cell(itp, cell, ops)
     end
     return output
 end
+
+# Scalar-path forwarder: vector_calculus and per-method scalar `_eval_*_nd`
+# call the 5-arg form; we inject `itp.extraps` so the canonical 6-arg
+# `_locate_cell` works uniformly. The 6-arg form is the source of truth —
+# batch callers (`_interp_nd_batch!`) and the windowed/hetero paths can pass
+# a different `extraps_eff` (e.g., InBounds-promoted) without affecting
+# scalar callers. Pure `getfield` body — Julia elides this trivially.
+@inline _locate_cell(itp::AbstractInterpolantND, q, policies, hints, mono) =
+    _locate_cell(itp, q, itp.extraps, policies, hints, mono)
 
 # ========================================
 # ND Scalar: Vector query → tuple conversion
@@ -189,7 +205,12 @@ function (itp::AbstractInterpolantND{Tg, Tv, N})(
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
-    _validate_nd_domain(itp.grids, queries, itp.extraps)
+    # Batch-level InBounds promotion: SoA queries get per-axis InBounds when
+    # every query on that axis is in-bounds; AoS/generic stays original.
+    # Subsumes the NoExtrap throw via 1D `_check_domain`'s `@boundscheck
+    # _is_all_inbounds || _throw_batch_oob`, so the separate `_validate_nd_domain`
+    # call is no longer needed.
+    extraps_eff = _check_domain_nd(itp.grids, queries, itp.extraps)
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
     mono = _check_mono_nd(policies, queries)
@@ -197,7 +218,7 @@ function (itp::AbstractInterpolantND{Tg, Tv, N})(
         fill!(output, zero(eltype(output)))
         return output
     end
-    _interp_nd_batch!(output, itp, queries, ops, policies, hints, mono)
+    _interp_nd_batch!(output, itp, queries, extraps_eff, ops, policies, hints, mono)
     return output
 end
 

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -181,6 +181,7 @@ end
         hints::Tuple{Vararg{Base.RefValue{Int}, N}},
         mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
+    # NoExtrap throw must precede FillExtrap short-circuit (mixed-extrap configs).
     _validate_nd_domain(itp.grids, query, itp.extraps)
     oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
     oob_result !== nothing && return oob_result

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -148,14 +148,46 @@ end
     return output
 end
 
-# Scalar-path forwarder: vector_calculus and per-method scalar `_eval_*_nd`
-# call the 5-arg form; we inject `itp.extraps` so the canonical 6-arg
+# Scalar-path forwarder: vector_calculus and per-method scalar paths call
+# the 5-arg form; we inject `itp.extraps` so the canonical 6-arg
 # `_locate_cell` works uniformly. The 6-arg form is the source of truth —
 # batch callers (`_interp_nd_batch!`) and the windowed/hetero paths can pass
 # a different `extraps_eff` (e.g., InBounds-promoted) without affecting
 # scalar callers. Pure `getfield` body — Julia elides this trivially.
 @inline _locate_cell(itp::AbstractInterpolantND, q, policies, hints, mono) =
     _locate_cell(itp, q, itp.extraps, policies, hints, mono)
+
+# ========================================
+# Unified Scalar Interpolant Evaluation (Generic ND)
+# ========================================
+#
+# Single scalar entry point for AbstractInterpolantND subtypes whose eval
+# structure matches `validate → try_fill_oob → deriv_zero_fill → locate →
+# eval` (Cubic / Linear / Constant / Quadratic). Each method's callable
+# resolves search/hints/ops then delegates here.
+#
+# Trait dispatch: `_deriv_zero_fill(itp, ops, Val(N))` (Linear: 2nd+ deriv,
+# Constant: any deriv, Cubic/Quadratic default false). `_zero_ref(itp)`
+# supplies the per-method zero element (data first / partials first).
+#
+# Hetero is *not* routed through here — its callable has GridIdx/NoInterp
+# branches and `_eval_hetero_nd` uses a non-`_locate_cell` path (recursive
+# `_collapse_dims` / `_eval_hetero_precomputed`).
+@inline function _eval_nd_at_point(
+        itp::AbstractInterpolantND{Tg, Tv, N},
+        query::Tuple{Vararg{Real, N}},
+        ops::NTuple{N, AbstractEvalOp},
+        policies::NTuple{N, AbstractSearchPolicy},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
+        mono::NTuple{N, Bool},
+    ) where {Tg, Tv, N}
+    _validate_nd_domain(itp.grids, query, itp.extraps)
+    oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
+    oob_result !== nothing && return oob_result
+    _deriv_zero_fill(itp, ops, Val(N)) && return 0 * _zero_ref(itp)
+    cell = _locate_cell(itp, query, policies, hints, mono)
+    return _eval_at_cell(itp, cell, ops)
+end
 
 # ========================================
 # ND Scalar: Vector query → tuple conversion

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -49,7 +49,10 @@
     ) where {Tg, Tv}
     grid = _itp_grid(itp)
     extrap = _itp_extrap(itp)
-    @boundscheck _check_domain(grid, xq, extrap)
+    # Domain check is delegated to the per-method `_eval_*_at_point` callable
+    # below — NoExtrap throws via that path's `@boundscheck _check_domain`,
+    # while Clamp/Fill/Wrap handle OOB inside their specialized eval methods
+    # without ever calling `_check_domain`. Outer redundancy removed.
     searcher = _resolve_search(grid, xq, search, hint)
     val = _itp_eval_scalar(itp, xq, extrap, deriv, searcher)
     return convert(_output_eltype(itp, typeof(xq)), val)

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -559,8 +559,12 @@ end
     return q
 end
 
-@inline function _handle_axis_extrap(q, axis::AbstractVector, extrap::WrapExtrap)
+@inline function _handle_axis_extrap(q, axis::AbstractVector, ::WrapExtrap)
     return _wrap_to_domain(q, axis)
+end
+
+@inline function _handle_axis_extrap(q, axis::AbstractVector, ::InBounds)
+    return q
 end
 
 # ========================================

--- a/src/core/query_protocol.jl
+++ b/src/core/query_protocol.jl
@@ -162,3 +162,56 @@ function _validate_nd_domain(
     end
     return nothing
 end
+
+# ── Batch-level domain check returning per-axis InBounds-or-original ──
+#
+# ND analog of 1D `_check_domain(x, xi::AbstractVector, extrap) -> InBounds | extrap`.
+# Per-axis: if all queries on axis d are in-bounds, return `InBounds()` for that
+# axis; otherwise keep the original extrap. Result is `NTuple{N, AbstractExtrap}`
+# where each slot is `Union{InBounds, original}` — Julia specializes the map per
+# axis (heterogeneous map, no boxing) into a concrete tuple type.
+#
+# Downstream `_handle_axis_extrap(q, axis, ::InBounds) = q` (nd_utils.jl) is a
+# no-op for InBounds axes, eliding wrap/clamp/fill per-query branches when all
+# queries are in-bounds. Fixes Julia 1.10+ deep-`@inbounds`-non-propagation
+# overhead (ND NoExtrap batch N=2 Nq=1000: 2000 calls → 0 calls expected).
+#
+# SoA only — AoS/generic fallback returns `extraps` unchanged (per-axis min/max
+# would require a linear pass via `_query_extract`; deferred follow-up).
+
+# SoA batch: reuse 1D vector `_check_domain` per axis. NoExtrap throws via the
+# 1D `@boundscheck _is_all_inbounds || _throw_batch_oob`; Wrap/Clamp/Fill return
+# `InBounds()` when all in-bounds, original extrap otherwise; ExtendExtrap (and
+# any fallback) returns itself unchanged.
+@inline function _check_domain_nd(
+        grids::NTuple{N, AbstractVector},
+        queries::Tuple{AbstractVector{<:Real}, Vararg{AbstractVector{<:Real}}},
+        extraps::Tuple{Vararg{AbstractExtrap, N}}
+    ) where {N}
+    isempty(first(queries)) && return extraps
+    return map(_check_domain, grids, queries, extraps)
+end
+
+# Scalar point: no batch-level promotion to do — defer to per-axis `_check_domain`
+# inside the eval path. Validate via existing `_validate_nd_domain` then return
+# `extraps` unchanged.
+@inline function _check_domain_nd(
+        grids::NTuple{N, AbstractVector},
+        query::Tuple{Vararg{Real, N}},
+        extraps::Tuple{Vararg{AbstractExtrap, N}}
+    ) where {N}
+    _validate_nd_domain(grids, query, extraps)
+    return extraps
+end
+
+# Generic / AoS: deferred — single linear pass with per-axis min/max accumulators
+# could enable AoS promotion later. For now, validate (NoExtrap throw) and
+# return `extraps` unchanged so the inner per-query path handles each axis.
+@inline function _check_domain_nd(
+        grids::NTuple{N, AbstractVector},
+        queries,
+        extraps::Tuple{Vararg{AbstractExtrap, N}}
+    ) where {N}
+    _validate_nd_domain(grids, queries, extraps)
+    return extraps
+end

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -515,15 +515,21 @@ Uses two `&&`-chained reductions rather than `extrema`:
 1.13 fixes the SIMD issue, but the short-circuit advantage remains for
 the OOB slow-path, so this form stays preferred even post-1.10-LTS.
 """
+# `_extract_primal` is required on `first(x)` / `last(x)` here because
+# ForwardDiff's `Real <= Dual` comparison includes partial-sign tie-breaking
+# at equal primals — so a Float query exactly at the boundary against a
+# Dual grid endpoint can flip in/out of bounds based on the partial sign
+# alone (see `test/ext/test_linear_dual_grid.jl` "Domain boundary:
+# primal-based NoExtrap check (partial-independent)"). Inline calls keep
+# the `&&` short-circuit intact.
 @inline function _is_all_inbounds(x::AbstractVector, queries::AbstractVector{<:Real})
-    return minimum(queries) >= first(x) && maximum(queries) <= last(x)
+    return minimum(queries) >= _extract_primal(first(x)) &&
+        maximum(queries) <= _extract_primal(last(x))
 end
 
-# `_CachedRange`: use `domain_lo`/`domain_hi` (≈1 ULP wider than `lo`/`hi`
-# on x86_64 TwicePrecision normalization) for safe bounds, mirroring
-# `_check_domain(::_CachedRange, ::NoExtrap)`. The fields are typed
-# `T <: AbstractFloat` per `_CachedRange{T, Tinv}`, so no `_extract_primal`
-# is needed.
+# `_CachedRange`: `domain_lo`/`domain_hi` (≈1 ULP wider than `lo`/`hi` on
+# x86_64 TwicePrecision normalization) for safe bounds. Fields are typed
+# `T <: AbstractFloat` per the struct, so no `_extract_primal` is needed.
 @inline function _is_all_inbounds(x::_CachedRange, queries::AbstractVector{<:Real})
     return minimum(queries) >= x.domain_lo && maximum(queries) <= x.domain_hi
 end

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -497,6 +497,14 @@ end
     return _is_all_inbounds(x, xi) ? InBounds() : WrapExtrap()
 end
 
+# ClampExtrap / FillExtrap: same batch-check pattern. When all queries are
+# in-domain, the per-query `<first / >last` branches inside `_eval_*_at_point`
+# are elided via the InBounds dispatch (worth ~20-30% on the in-domain hot
+# path). Returns Union{InBounds, <original>}.
+@inline function _check_domain(x::AbstractVector, xi::AbstractVector{<:Real}, e::_ClampOrFill)
+    return _is_all_inbounds(x, xi) ? InBounds() : e
+end
+
 """
 True iff every element of `queries` lies in the closed domain
 `[first(x), last(x)]`. Enables batch-level fast paths that elide per-query

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -500,10 +500,11 @@ end
 end
 
 """
-True iff every element of `queries` lies in the half-open domain
-`[first(x), last(x))`. Enables batch-level fast paths that elide per-query
-domain handling (e.g. `_wrap_to_domain` for PeriodicBC) when no element
-is OOB.
+True iff every element of `queries` lies in the closed domain
+`[first(x), last(x)]`. Enables batch-level fast paths that elide per-query
+domain handling (e.g. `_wrap_to_domain` for PeriodicBC, which only needs
+to apply when a query is strictly outside `[first, last]`) when no
+element is OOB.
 
 Uses two `&&`-chained reductions rather than `extrema`:
 - pre-1.13 `extrema` carries a (min, max) tuple dep across the loop that
@@ -515,7 +516,16 @@ Uses two `&&`-chained reductions rather than `extrema`:
 the OOB slow-path, so this form stays preferred even post-1.10-LTS.
 """
 @inline function _is_all_inbounds(x::AbstractVector, queries::AbstractVector{<:Real})
-    return minimum(queries) >= first(x) && maximum(queries) < last(x)
+    return minimum(queries) >= first(x) && maximum(queries) <= last(x)
+end
+
+# `_CachedRange`: use `domain_lo`/`domain_hi` (≈1 ULP wider than `lo`/`hi`
+# on x86_64 TwicePrecision normalization) for safe bounds, mirroring
+# `_check_domain(::_CachedRange, ::NoExtrap)`. The fields are typed
+# `T <: AbstractFloat` per `_CachedRange{T, Tinv}`, so no `_extract_primal`
+# is needed.
+@inline function _is_all_inbounds(x::_CachedRange, queries::AbstractVector{<:Real})
+    return minimum(queries) >= x.domain_lo && maximum(queries) <= x.domain_hi
 end
 
 # ========================================

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -491,17 +491,22 @@ end
 "No-op vector domain check for non-NoExtrap modes: pass-through extrap."
 @inline _check_domain(::AbstractVector, ::AbstractVector{<:Real}, extrap::AbstractExtrap) = extrap
 
-# Wrap / Clamp / Fill batch fast path: when all queries are in-domain, the
-# per-query OOB handling inside `_eval_*_at_point` (`_wrap_to_domain` for
-# WrapExtrap, `<first / >last` branches for `_ClampOrFill`) is elided via
-# the `InBounds` dispatch. Returns `Union{InBounds, typeof(e)}` — Julia
-# specializes per concrete `e`, so callers get a narrow 2-singleton Union
-# that splits cleanly without dynamic dispatch.
+# Clamp / Fill batch fast path: closed `[first, last]` — `last` is in-domain
+# for clamp/fill semantics (no clamping or filling at the boundary).
 @inline function _check_domain(
         x::AbstractVector, xi::AbstractVector{<:Real},
-        e::Union{WrapExtrap, ClampExtrap, FillExtrap}
+        e::Union{ClampExtrap, FillExtrap}
     )
     return _is_all_inbounds(x, xi) ? InBounds() : e
+end
+
+# WrapExtrap batch fast path: half-open `[first, last)` — `last` wraps to
+# `first` per `_wrap_to_domain`'s `xi < x_max` fast-path check. Promoting a
+# batch containing `last(x)` to InBounds would skip that wrap and return
+# `y[last]` instead of `y[first]` (silent semantic regression). The
+# half-open variant uses strict `<` to keep `last` in the wrap-needed set.
+@inline function _check_domain(x::AbstractVector, xi::AbstractVector{<:Real}, e::WrapExtrap)
+    return _is_all_inbounds_halfopen(x, xi) ? InBounds() : e
 end
 
 """
@@ -528,6 +533,7 @@ the OOB slow-path, so this form stays preferred even post-1.10-LTS.
 # primal-based NoExtrap check (partial-independent)"). Inline calls keep
 # the `&&` short-circuit intact.
 @inline function _is_all_inbounds(x::AbstractVector, queries::AbstractVector{<:Real})
+    isempty(queries) && return true
     return minimum(queries) >= _extract_primal(first(x)) &&
         maximum(queries) <= _extract_primal(last(x))
 end
@@ -536,7 +542,21 @@ end
 # x86_64 TwicePrecision normalization) for safe bounds. Fields are typed
 # `T <: AbstractFloat` per the struct, so no `_extract_primal` is needed.
 @inline function _is_all_inbounds(x::_CachedRange, queries::AbstractVector{<:Real})
+    isempty(queries) && return true
     return minimum(queries) >= x.domain_lo && maximum(queries) <= x.domain_hi
+end
+
+# Half-open variant for WrapExtrap: `last(x)` belongs to the wrap-needed
+# set because `_wrap_to_domain`'s fast path uses strict `xi < x_max`.
+@inline function _is_all_inbounds_halfopen(x::AbstractVector, queries::AbstractVector{<:Real})
+    isempty(queries) && return true
+    return minimum(queries) >= _extract_primal(first(x)) &&
+        maximum(queries) <  _extract_primal(last(x))
+end
+
+@inline function _is_all_inbounds_halfopen(x::_CachedRange, queries::AbstractVector{<:Real})
+    isempty(queries) && return true
+    return minimum(queries) >= x.domain_lo && maximum(queries) < x.domain_hi
 end
 
 # ========================================

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -497,8 +497,10 @@ end
 # the `InBounds` dispatch. Returns `Union{InBounds, typeof(e)}` — Julia
 # specializes per concrete `e`, so callers get a narrow 2-singleton Union
 # that splits cleanly without dynamic dispatch.
-@inline function _check_domain(x::AbstractVector, xi::AbstractVector{<:Real},
-        e::Union{WrapExtrap, ClampExtrap, FillExtrap})
+@inline function _check_domain(
+        x::AbstractVector, xi::AbstractVector{<:Real},
+        e::Union{WrapExtrap, ClampExtrap, FillExtrap}
+    )
     return _is_all_inbounds(x, xi) ? InBounds() : e
 end
 

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -551,7 +551,7 @@ end
 @inline function _is_all_inbounds_halfopen(x::AbstractVector, queries::AbstractVector{<:Real})
     isempty(queries) && return true
     return minimum(queries) >= _extract_primal(first(x)) &&
-        maximum(queries) <  _extract_primal(last(x))
+        maximum(queries) < _extract_primal(last(x))
 end
 
 @inline function _is_all_inbounds_halfopen(x::_CachedRange, queries::AbstractVector{<:Real})

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -468,26 +468,24 @@ end
 # scan is skipped but the extrap conversion still happens.
 # ----------------------------------------
 
-"Vector domain check for NoExtrap: validate batch, return InBounds()."
+"""
+Vector domain check for NoExtrap: validate batch, return `InBounds()`.
+
+Delegates the batch in-domain test to `_is_all_inbounds`, which dispatches
+on axis type (using `domain_lo/hi` for `_CachedRange`'s wider TwicePrecision
+bracket on x86_64) and is partial-sign-safe under ForwardDiff. Throw
+message uses `first(x)/last(x)` — exact endpoints, not the widened bracket.
+"""
 @inline function _check_domain(x::AbstractVector, xi::AbstractVector{<:Real}, ::NoExtrap)
-    @boundscheck begin
-        x_min, x_max = _extract_primal(first(x)), _extract_primal(last(x))
-        xq_min, xq_max = minimum(xi), maximum(xi)
-        (xq_min < x_min || xq_max > x_max) &&
-            _throw_domain_error(xq_min < x_min ? xq_min : xq_max, x_min, x_max)
-    end
+    @boundscheck _is_all_inbounds(x, xi) || _throw_batch_oob(x, xi)
     return InBounds()
 end
 
-# _CachedRange: use domain_lo/domain_hi for vector domain checks.
-@inline function _check_domain(x::_CachedRange, xi::AbstractVector{<:Real}, ::NoExtrap)
-    @boundscheck begin
-        lo, hi = _extract_primal(x.domain_lo), _extract_primal(x.domain_hi)
-        xq_min, xq_max = minimum(xi), maximum(xi)
-        (xq_min < lo || xq_max > hi) &&
-            _throw_domain_error(xq_min < lo ? xq_min : xq_max, _extract_primal(x.lo), _extract_primal(x.hi))
-    end
-    return InBounds()
+@noinline function _throw_batch_oob(x::AbstractVector, xi::AbstractVector{<:Real})
+    qmin, qmax = minimum(xi), maximum(xi)
+    x_min = _extract_primal(first(x))
+    x_max = _extract_primal(last(x))
+    _throw_domain_error(qmin < x_min ? qmin : qmax, x_min, x_max)
 end
 
 "No-op vector domain check for non-NoExtrap modes: pass-through extrap."

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -493,6 +493,31 @@ end
 "No-op vector domain check for non-NoExtrap modes: pass-through extrap."
 @inline _check_domain(::AbstractVector, ::AbstractVector{<:Real}, extrap::AbstractExtrap) = extrap
 
+# WrapExtrap: batch in-domain check converts to InBounds() when wrap is unneeded.
+# Returns Union{InBounds, WrapExtrap}; caller must handle both via Union splitting.
+@inline function _check_domain(x::AbstractVector, xi::AbstractVector{<:Real}, ::WrapExtrap)
+    return _is_all_inbounds(x, xi) ? InBounds() : WrapExtrap()
+end
+
+"""
+True iff every element of `queries` lies in the half-open domain
+`[first(x), last(x))`. Enables batch-level fast paths that elide per-query
+domain handling (e.g. `_wrap_to_domain` for PeriodicBC) when no element
+is OOB.
+
+Uses two `&&`-chained reductions rather than `extrema`:
+- pre-1.13 `extrema` carries a (min, max) tuple dep across the loop that
+  blocks LLVM auto-vectorization (~30× slower on Vector{Float64} N=1000)
+- `&&` short-circuits when `minimum` is already OOB, skipping the
+  `maximum` scan entirely — strictly ≤ `extrema`'s work in all cases
+
+1.13 fixes the SIMD issue, but the short-circuit advantage remains for
+the OOB slow-path, so this form stays preferred even post-1.10-LTS.
+"""
+@inline function _is_all_inbounds(x::AbstractVector, queries::AbstractVector{<:Real})
+    return minimum(queries) >= first(x) && maximum(queries) < last(x)
+end
+
 # ========================================
 # Extrapolation value helpers (shared by all interpolation methods)
 # ========================================

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -491,17 +491,14 @@ end
 "No-op vector domain check for non-NoExtrap modes: pass-through extrap."
 @inline _check_domain(::AbstractVector, ::AbstractVector{<:Real}, extrap::AbstractExtrap) = extrap
 
-# WrapExtrap: batch in-domain check converts to InBounds() when wrap is unneeded.
-# Returns Union{InBounds, WrapExtrap}; caller must handle both via Union splitting.
-@inline function _check_domain(x::AbstractVector, xi::AbstractVector{<:Real}, ::WrapExtrap)
-    return _is_all_inbounds(x, xi) ? InBounds() : WrapExtrap()
-end
-
-# ClampExtrap / FillExtrap: same batch-check pattern. When all queries are
-# in-domain, the per-query `<first / >last` branches inside `_eval_*_at_point`
-# are elided via the InBounds dispatch (worth ~20-30% on the in-domain hot
-# path). Returns Union{InBounds, <original>}.
-@inline function _check_domain(x::AbstractVector, xi::AbstractVector{<:Real}, e::_ClampOrFill)
+# Wrap / Clamp / Fill batch fast path: when all queries are in-domain, the
+# per-query OOB handling inside `_eval_*_at_point` (`_wrap_to_domain` for
+# WrapExtrap, `<first / >last` branches for `_ClampOrFill`) is elided via
+# the `InBounds` dispatch. Returns `Union{InBounds, typeof(e)}` — Julia
+# specializes per concrete `e`, so callers get a narrow 2-singleton Union
+# that splits cleanly without dynamic dispatch.
+@inline function _check_domain(x::AbstractVector, xi::AbstractVector{<:Real},
+        e::Union{WrapExtrap, ClampExtrap, FillExtrap})
     return _is_all_inbounds(x, xi) ? InBounds() : e
 end
 

--- a/src/cubic/cubic_eval.jl
+++ b/src/cubic/cubic_eval.jl
@@ -19,20 +19,22 @@
 # (`WrapExtrap` vs others), which `_resolve_extrap` materializes from `cache.bc`
 # at construction time.
 
-# NoExtrap / ExtendExtrap: direct search + kernel.
+# Core in-bounds path: search + kernel only. All other extrap overloads do
+# their preprocessing (boundary check / wrap / OOB return) and then delegate
+# here once the query is known to be inside the domain. `_resolve_grididx`
+# is called here as well so direct InBounds-dispatch callers (e.g., the
+# `_cubic_vector_loop!` Union-splitting fast path) get GridIdx resolution
+# without going through a preprocess overload.
 @inline function _eval_cubic_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         z::AbstractVector,
         xq::Tq,
-        extrap::AbstractExtrap,
+        ::InBounds,
         op::O,
         searcher::S
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
-    # Resolve bare `GridIdx(k)` (carries `val=NaN` until bound) to its grid
-    # coordinate so subsequent arithmetic sees a real value.
     xq = _resolve_grididx(xq, x)
-    @boundscheck _check_domain(x, xq, extrap)
     idx, idx_R, xL, xR = search_interval(searcher, x, xq)
     dL = xq - xL
     dR = xR - xq
@@ -45,7 +47,23 @@
     return _cubic_kernel(op, zL, zR, yL, yR, h, inv_h, dL, dR)
 end
 
-# ClampExtrap / FillExtrap: boundary check → extrap value or kernel.
+# NoExtrap / ExtendExtrap / others matching AbstractExtrap: domain check
+# (no-op for non-NoExtrap fallback, throws for NoExtrap on OOB) → delegate.
+@inline function _eval_cubic_at_point(
+        x::AbstractVector{Tg},
+        y::AbstractVector{Tv},
+        z::AbstractVector,
+        xq::Tq,
+        extrap::AbstractExtrap,
+        op::O,
+        searcher::S
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    xq = _resolve_grididx(xq, x)
+    @boundscheck _check_domain(x, xq, extrap)
+    return _eval_cubic_at_point(x, y, z, xq, InBounds(), op, searcher)
+end
+
+# ClampExtrap / FillExtrap: boundary check → extrap value or delegate.
 @inline function _eval_cubic_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
@@ -59,41 +77,21 @@ end
     xq_primal = _extract_primal(xq)
     xq_primal < first(x) && return _eval_extrapolation(op, first(y), extrap, xq)
     xq_primal > last(x) && return _eval_extrapolation(op, last(y), extrap, xq)
-    idx, idx_R, xL, xR = search_interval(searcher, x, xq)
-    dL = xq - xL
-    dR = xR - xq
-    h = _get_h(x, idx)
-    inv_h = _get_inv_h(x, idx)
-    @inbounds begin
-        zL = z[idx]; zR = z[idx_R]
-        yL = y[idx]; yR = y[idx_R]
-    end
-    return _cubic_kernel(op, zL, zR, yL, yR, h, inv_h, dL, dR)
+    return _eval_cubic_at_point(x, y, z, xq, InBounds(), op, searcher)
 end
 
-# WrapExtrap: wrap query to domain → search + kernel.
-# Wrap domain `[first(x), last(x))` is read directly from the (possibly-wrapped) axis.
+# WrapExtrap: wrap query to domain → delegate with wrapped value.
 @inline function _eval_cubic_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         z::AbstractVector,
         xq::Tq,
-        extrap::WrapExtrap,
+        ::WrapExtrap,
         op::O,
         searcher::S
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
-    xq = _resolve_grididx(xq, x)
-    xq_wrapped = _wrap_to_domain(xq, x)
-    idx, idx_R, xL, xR = search_interval(searcher, x, xq_wrapped)
-    dL = xq_wrapped - xL
-    dR = xR - xq_wrapped
-    h = _get_h(x, idx)
-    inv_h = _get_inv_h(x, idx)
-    @inbounds begin
-        zL = z[idx]; zR = z[idx_R]
-        yL = y[idx]; yR = y[idx_R]
-    end
-    return _cubic_kernel(op, zL, zR, yL, yR, h, inv_h, dL, dR)
+    xq_wrapped = _wrap_to_domain(_resolve_grididx(xq, x), x)
+    return _eval_cubic_at_point(x, y, z, xq_wrapped, InBounds(), op, searcher)
 end
 
 # ========================================

--- a/src/cubic/cubic_eval.jl
+++ b/src/cubic/cubic_eval.jl
@@ -96,7 +96,6 @@ end
     return _cubic_kernel(op, zL, zR, yL, yR, h, inv_h, dL, dR)
 end
 
-
 # ========================================
 # Vector Loop Function
 # ========================================

--- a/src/cubic/cubic_eval.jl
+++ b/src/cubic/cubic_eval.jl
@@ -149,6 +149,8 @@ Uses task-local pool for workspace allocation.
 
     searcher = _resolve_search(cache.x, x_query, search, hint)
     extrap_eff = _resolve_extrap(extrap, cache.bc, cache.x)
-    @boundscheck _check_domain(cache.x, x_query, extrap_eff)
+    # Domain check delegated to `_eval_cubic_at_point(::AbstractExtrap)`
+    # below — its inner `@boundscheck _check_domain` handles NoExtrap throw,
+    # while Clamp/Fill/Wrap specialized methods handle OOB without checking.
     _eval_cubic_at_point(cache.x, y, z, x_query, extrap_eff, deriv, searcher)
 end

--- a/src/cubic/nd/cubic_nd_eval.jl
+++ b/src/cubic/nd/cubic_nd_eval.jl
@@ -45,12 +45,13 @@ itp((1.0, 0.5); deriv=(DerivOp(1), EvalValue()))  # ∂f/∂x only
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
     mono = _scalar_mono(hint, Val(N))
-    return _eval_nd_hermite(itp, resolved, ops, policies, hints, mono)
+    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono)
 end
 
 # In-place batch evaluation (SoA + AoS) is handled by the unified
 # AbstractInterpolantND callable in nd_interpolant_protocol.jl.
-# CubicInterpolantND has no special batch logic (no zero-fill trait).
+# Scalar evaluation routes through the generic `_eval_nd_at_point` defined
+# there — Cubic exposes only the `_locate_cell` + `_eval_at_cell` traits.
 
 # ========================================
 # CELL LOCATION (locate once, evaluate many)
@@ -111,44 +112,8 @@ end
     return _eval_nd_cell(partials, indices, hs, inv_hs, dLs, ops)
 end
 
-# ========================================
-# CORE HERMITE EVALUATION
-# ========================================
-
 # Zero-ref for fill-value derivative computation (duck-typed zero via 0 * data_element)
 @inline _zero_ref(itp::CubicInterpolantND) = @inbounds first(itp.nodal_derivs.partials)
-
-# Generic N-dimensional (uses _locate_cell + _eval_at_cell)
-@inline function _eval_nd_hermite(
-        itp::CubicInterpolantND{Tg, Tv, N},
-        query::Tuple{Vararg{Real, N}},
-        ops::NTuple{N, AbstractEvalOp},
-        policies::NTuple{N, AbstractSearchPolicy},
-        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
-        mono::NTuple{N, Bool},
-    ) where {Tg, Tv, N}
-    _validate_nd_domain(itp.grids, query, itp.extraps)
-    oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
-    oob_result !== nothing && return oob_result
-    cell = _locate_cell(itp, query, policies, hints, mono)
-    return _eval_at_cell(itp, cell, ops)
-end
-
-# N=2 specialization: dispatches to N=2 _locate_cell via type
-@inline function _eval_nd_hermite(
-        itp::CubicInterpolantND{Tg, Tv, 2},
-        query::Tuple{Vararg{Real, 2}},
-        ops::Tuple{<:AbstractEvalOp, <:AbstractEvalOp},
-        policies::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
-        hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
-        mono::Tuple{Bool, Bool},
-    ) where {Tg, Tv}
-    _validate_nd_domain(itp.grids, query, itp.extraps)
-    oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
-    oob_result !== nothing && return oob_result
-    cell = _locate_cell(itp, query, policies, hints, mono)
-    return _eval_at_cell(itp, cell, ops)
-end
 
 # ========================================
 # @GENERATED TENSOR PRODUCT KERNEL

--- a/src/cubic/nd/cubic_nd_eval.jl
+++ b/src/cubic/nd/cubic_nd_eval.jl
@@ -63,15 +63,18 @@ end
 # functions (gradient, hessian, laplacian) to search intervals ONCE and
 # evaluate the kernel multiple times with different derivative ops.
 
-# Generic N-dimensional
+# Generic N-dimensional. `extraps` is the per-axis effective extrap tuple —
+# batch callers pass an InBounds-promoted version from `_check_domain_nd`;
+# scalar callers go through the 5-arg forwarder which injects `itp.extraps`.
 @inline function _locate_cell(
         itp::CubicInterpolantND{Tg, Tv, N},
         query::Tuple{Vararg{Real, N}},
+        extraps::Tuple{Vararg{AbstractExtrap, N}},
         policies::NTuple{N, AbstractSearchPolicy},
         hints::Tuple{Vararg{Base.RefValue{Int}, N}},
         mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
-    q_evals = _handle_all_extraps(query, itp.grids, itp.extraps)
+    q_evals = _handle_all_extraps(query, itp.grids, extraps)
     indices, Ls, _ = _search_all_intervals(q_evals, itp.grids, policies, hints, mono)
     hs, inv_hs, dLs = _compute_all_local_params(q_evals, itp.grids, indices, Ls)
 
@@ -82,12 +85,13 @@ end
 @inline function _locate_cell(
         itp::CubicInterpolantND{Tg, Tv, 2},
         query::Tuple{Vararg{Real, 2}},
+        extraps::Tuple{AbstractExtrap, AbstractExtrap},
         policies::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
         hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
         mono::Tuple{Bool, Bool},
     ) where {Tg, Tv}
     x_eval, y_eval, ix, iy, xL, yL = _locate_cell_2d_preamble(
-        query, itp.grids, itp.extraps, policies, hints, mono
+        query, itp.grids, extraps, policies, hints, mono
     )
 
     hx = _get_h(itp.grids[1], ix);  hy = _get_h(itp.grids[2], iy)

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -177,13 +177,17 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
-    _validate_nd_domain(grids, queries, extraps_val)
 
     # Build phase (same as scalar, done once)
     grids_p, data_p, bcs_p = _prepare_periodic_nd_pooled(pool, grids, data, bcs)
     # Per-axis materialization of extraps against the (possibly extended) grid.
     # Post-extension: grid-span IS the wrap domain → 2-arg primitive per-axis.
     extraps_eff = map(_resolve_extrap, extraps_val, grids_p)
+    # Batch-level InBounds promotion: per-axis if all queries are in-bounds,
+    # axis gets `InBounds()` so per-query `_try_fill_oob` / `_handle_all_extraps`
+    # branches compile away. Subsumes the prior `_validate_nd_domain` throw
+    # (NoExtrap path goes through 1D `_check_domain`'s `@boundscheck`).
+    extraps_eff = _check_domain_nd(grids_p, queries, extraps_eff)
     Tz = _output_eltype(Tv, Tg)
     n_partials = 1 << N
     partials = acquire!(pool, Tz, (n_partials, size(data_p)...))
@@ -193,7 +197,7 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
     # `h`/`inv_h` directly from `grids_p` (no transient pool spacings).
     @inbounds for k in 1:nq
         query_k = _extract_query_point(queries, k, Val(N))
-        oob_val = _try_fill_oob(query_k, grids_p, extraps_val, ops, first(data_p))
+        oob_val = _try_fill_oob(query_k, grids_p, extraps_eff, ops, first(data_p))
         if oob_val !== nothing
             output[k] = oob_val; continue
         end

--- a/src/hermite/hermite_eval.jl
+++ b/src/hermite/hermite_eval.jl
@@ -11,7 +11,28 @@
 # ║                  PRECOMPUTED SLOPES (dy::AbstractVector)                  ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
-# NoExtrap / ExtendExtrap / generic: direct search + kernel
+# Core in-bounds path: search + kernel. All non-InBounds extrap overloads
+# delegate here after preprocessing — see cubic_eval.jl for the same
+# `InBounds = core fast path` pattern.
+@inline function _hermite_eval_at_point(
+        x::AbstractVector{Tg},
+        y::AbstractVector{Tv},
+        dy::AbstractVector,
+        xq::Tq,
+        ::InBounds,
+        op::O,
+        searcher::S
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    xq = _resolve_grididx(xq, x)
+    idx, idx_R, xL, _ = search_interval(searcher, x, xq)
+    dL = xq - xL
+    h = _get_h(x, idx)
+    inv_h = _get_inv_h(x, idx)
+    @inbounds return _hermite_kernel_1d(op, y[idx], y[idx_R], dy[idx], dy[idx_R], h, inv_h, dL)
+end
+
+# NoExtrap / ExtendExtrap / others matching AbstractExtrap: domain check
+# → delegate.
 @inline function _hermite_eval_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
@@ -23,14 +44,10 @@
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq = _resolve_grididx(xq, x)
     @boundscheck _check_domain(x, xq, extrap)
-    idx, idx_R, xL, _ = search_interval(searcher, x, xq)
-    dL = xq - xL
-    h = _get_h(x, idx)
-    inv_h = _get_inv_h(x, idx)
-    @inbounds return _hermite_kernel_1d(op, y[idx], y[idx_R], dy[idx], dy[idx_R], h, inv_h, dL)
+    return _hermite_eval_at_point(x, y, dy, xq, InBounds(), op, searcher)
 end
 
-# ClampExtrap / FillExtrap: boundary check → extrap value or kernel
+# ClampExtrap / FillExtrap: boundary check → extrap value or delegate.
 @inline function _hermite_eval_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
@@ -47,30 +64,21 @@ end
     elseif xq_primal > _extract_primal(last(x))
         return _eval_extrapolation(op, last(y), extrap, xq)
     end
-    idx, idx_R, xL, _ = search_interval(searcher, x, xq)
-    dL = xq - xL
-    h = _get_h(x, idx)
-    inv_h = _get_inv_h(x, idx)
-    @inbounds return _hermite_kernel_1d(op, y[idx], y[idx_R], dy[idx], dy[idx_R], h, inv_h, dL)
+    return _hermite_eval_at_point(x, y, dy, xq, InBounds(), op, searcher)
 end
 
-# WrapExtrap: wrap query to domain → search + kernel
+# WrapExtrap: wrap query to domain → delegate with wrapped value.
 @inline function _hermite_eval_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         dy::AbstractVector,
         xq::Tq,
-        extrap::WrapExtrap,
+        ::WrapExtrap,
         op::O,
         searcher::S
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
-    xq = _resolve_grididx(xq, x)
-    xq_wrapped = _wrap_to_domain(xq, x)
-    idx, idx_R, xL, _ = search_interval(searcher, x, xq_wrapped)
-    dL = xq_wrapped - xL
-    h = _get_h(x, idx)
-    inv_h = _get_inv_h(x, idx)
-    @inbounds return _hermite_kernel_1d(op, y[idx], y[idx_R], dy[idx], dy[idx_R], h, inv_h, dL)
+    xq_wrapped = _wrap_to_domain(_resolve_grididx(xq, x), x)
+    return _hermite_eval_at_point(x, y, dy, xq_wrapped, InBounds(), op, searcher)
 end
 
 # Vector loop — generic. WrapExtrap fast/slow path is routed by
@@ -99,6 +107,30 @@ end
 # ║              ON-THE-FLY SLOPES (sm::AbstractSlopeMethod)                  ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
+# Core in-bounds path (slope method): search + local-slope + kernel. All
+# non-InBounds overloads delegate here after preprocessing — same pattern
+# as the pre-baked-slopes variant above.
+@inline function _hermite_eval_at_point(
+        x::AbstractVector{Tg},
+        y::AbstractVector{Tv},
+        sm::AbstractSlopeMethod,
+        xq::Tq,
+        ::InBounds,
+        op::O,
+        searcher::S
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    xq = _resolve_grididx(xq, x)
+    idx, idx_R, xL, _ = search_interval(searcher, x, xq)
+    n = _data_length(x)
+    dyL = _local_slope(sm, x, y, idx, n)
+    dyR = _local_slope(sm, x, y, idx_R, n)
+    dL = xq - xL
+    h = _get_h(x, idx)
+    inv_h = _get_inv_h(x, idx)
+    yr = _raw(y)
+    @inbounds return _hermite_kernel_1d(op, yr[idx], yr[idx_R], dyL, dyR, h, inv_h, dL)
+end
+
 @inline function _hermite_eval_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
@@ -110,15 +142,7 @@ end
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq = _resolve_grididx(xq, x)
     @boundscheck _check_domain(x, xq, extrap)
-    idx, idx_R, xL, _ = search_interval(searcher, x, xq)
-    n = _data_length(x)
-    dyL = _local_slope(sm, x, y, idx, n)
-    dyR = _local_slope(sm, x, y, idx_R, n)
-    dL = xq - xL
-    h = _get_h(x, idx)
-    inv_h = _get_inv_h(x, idx)
-    yr = _raw(y)
-    @inbounds return _hermite_kernel_1d(op, yr[idx], yr[idx_R], dyL, dyR, h, inv_h, dL)
+    return _hermite_eval_at_point(x, y, sm, xq, InBounds(), op, searcher)
 end
 
 @inline function _hermite_eval_at_point(
@@ -137,15 +161,7 @@ end
     elseif xq_primal > _extract_primal(last(x))
         return _eval_extrapolation(op, last(y), extrap, xq)
     end
-    idx, idx_R, xL, _ = search_interval(searcher, x, xq)
-    n = _data_length(x)
-    dyL = _local_slope(sm, x, y, idx, n)
-    dyR = _local_slope(sm, x, y, idx_R, n)
-    dL = xq - xL
-    h = _get_h(x, idx)
-    inv_h = _get_inv_h(x, idx)
-    yr = _raw(y)
-    @inbounds return _hermite_kernel_1d(op, yr[idx], yr[idx_R], dyL, dyR, h, inv_h, dL)
+    return _hermite_eval_at_point(x, y, sm, xq, InBounds(), op, searcher)
 end
 
 @inline function _hermite_eval_at_point(
@@ -153,21 +169,12 @@ end
         y::AbstractVector{Tv},
         sm::AbstractSlopeMethod,
         xq::Tq,
-        extrap::WrapExtrap,
+        ::WrapExtrap,
         op::O,
         searcher::S
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
-    xq = _resolve_grididx(xq, x)
-    xq_wrapped = _wrap_to_domain(xq, x)
-    idx, idx_R, xL, _ = search_interval(searcher, x, xq_wrapped)
-    n = _data_length(x)
-    dyL = _local_slope(sm, x, y, idx, n)
-    dyR = _local_slope(sm, x, y, idx_R, n)
-    dL = xq_wrapped - xL
-    h = _get_h(x, idx)
-    inv_h = _get_inv_h(x, idx)
-    yr = _raw(y)
-    @inbounds return _hermite_kernel_1d(op, yr[idx], yr[idx_R], dyL, dyR, h, inv_h, dL)
+    xq_wrapped = _wrap_to_domain(_resolve_grididx(xq, x), x)
+    return _hermite_eval_at_point(x, y, sm, xq_wrapped, InBounds(), op, searcher)
 end
 
 # Vector loop — generic (slope method). Same `_check_domain` routing as

--- a/src/hermite/hermite_eval.jl
+++ b/src/hermite/hermite_eval.jl
@@ -73,7 +73,11 @@ end
     @inbounds return _hermite_kernel_1d(op, y[idx], y[idx_R], dy[idx], dy[idx_R], h, inv_h, dL)
 end
 
-# Vector loop — generic
+# Vector loop — generic. WrapExtrap fast/slow path is routed by
+# `_check_domain(::WrapExtrap, ::AbstractVector)`, which returns `InBounds()`
+# when no element needs wrapping. Union splitting + LLVM loop unswitching
+# generate the same two monomorphic loop bodies as a hand-specialized
+# overload would.
 @inline function _hermite_vector_loop!(
         output::AbstractVector,
         x::AbstractVector{Tg},
@@ -87,33 +91,6 @@ end
     extrap = _check_domain(x, xq, extrap)
     @inbounds for i in eachindex(xq, output)
         output[i] = _hermite_eval_at_point(x, y, dy, xq[i], extrap, deriv, searcher)
-    end
-    return output
-end
-
-# Vector loop — WrapExtrap specialization (2-stage: bulk-wrap + ExtendExtrap kernel)
-@inline function _hermite_vector_loop!(
-        output::AbstractVector,
-        x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        dy::AbstractVector,
-        xq::AbstractVector{<:Real},
-        extrap::WrapExtrap,
-        deriv::O,
-        searcher::P
-    ) where {Tg, Tv, O <: AbstractEvalOp, P <: Searcher}
-    x_min, x_max = first(x), last(x)
-    qmin, qmax = minimum(xq), maximum(xq)
-
-    if qmin >= x_min && qmax < x_max
-        @inbounds for i in eachindex(xq, output)
-            output[i] = _hermite_eval_at_point(x, y, dy, xq[i], ExtendExtrap(), deriv, searcher)
-        end
-    else
-        @inbounds for i in eachindex(xq, output)
-            xi_wrapped = _wrap_to_domain(xq[i], x)
-            output[i] = _hermite_eval_at_point(x, y, dy, xi_wrapped, ExtendExtrap(), deriv, searcher)
-        end
     end
     return output
 end
@@ -193,7 +170,8 @@ end
     @inbounds return _hermite_kernel_1d(op, yr[idx], yr[idx_R], dyL, dyR, h, inv_h, dL)
 end
 
-# Vector loop — generic (slope method)
+# Vector loop — generic (slope method). Same `_check_domain` routing as
+# the pre-baked-slopes variant above.
 @inline function _hermite_vector_loop!(
         output::AbstractVector,
         x::AbstractVector{Tg},
@@ -207,33 +185,6 @@ end
     extrap = _check_domain(x, xq, extrap)
     @inbounds for i in eachindex(xq, output)
         output[i] = _hermite_eval_at_point(x, y, sm, xq[i], extrap, deriv, searcher)
-    end
-    return output
-end
-
-# Vector loop — WrapExtrap specialization (slope method)
-@inline function _hermite_vector_loop!(
-        output::AbstractVector,
-        x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        sm::AbstractSlopeMethod,
-        xq::AbstractVector{<:Real},
-        extrap::WrapExtrap,
-        deriv::O,
-        searcher::P
-    ) where {Tg, Tv, O <: AbstractEvalOp, P <: Searcher}
-    x_min, x_max = first(x), last(x)
-    qmin, qmax = minimum(xq), maximum(xq)
-
-    if qmin >= x_min && qmax < x_max
-        @inbounds for i in eachindex(xq, output)
-            output[i] = _hermite_eval_at_point(x, y, sm, xq[i], ExtendExtrap(), deriv, searcher)
-        end
-    else
-        @inbounds for i in eachindex(xq, output)
-            xi_wrapped = _wrap_to_domain(xq[i], x)
-            output[i] = _hermite_eval_at_point(x, y, sm, xi_wrapped, ExtendExtrap(), deriv, searcher)
-        end
     end
     return output
 end

--- a/src/hetero/hetero_eval.jl
+++ b/src/hetero/hetero_eval.jl
@@ -415,11 +415,12 @@ end
 @inline function _locate_cell(
         itp::HeteroInterpolantND{Tg, Tv, N, G, M, E, P, <:Array},
         query::Tuple{Vararg{Real, N}},
+        extraps::Tuple{Vararg{AbstractExtrap, N}},
         policies::NTuple{N, AbstractSearchPolicy},
         hints::Tuple{Vararg{Base.RefValue{Int}, N}},
         mono::NTuple{N, Bool},
     ) where {Tg, Tv, N, G, M, E, P}
-    q_eval = _handle_all_extraps(query, itp.grids, itp.extraps)
+    q_eval = _handle_all_extraps(query, itp.grids, extraps)
 
     # Periodic wrap-aware path: build the wrap-aware cell ONCE here so the
     # generic `_gradient_generic` / `_hessian_generic` / `_laplacian_generic`
@@ -439,6 +440,10 @@ end
     if _has_any_windowable_method(itp.methods) && !_has_grididx(typeof(query))
         data_local, grids_local, rel_windows = _build_windowed_cell(itp, q_eval, policies, hints, mono)
         # Inner kernel uses policies for fiber re-search on sliced grids.
+        # Pass user-facing `itp.extraps` here (not InBounds-promoted `extraps`):
+        # the recursive 1D collapse runs its own per-axis `_check_domain` and
+        # benefits from the 1D-level InBounds promotion — promotion happens
+        # naturally inside each 1D oneshot call.
         return (data_local, grids_local, itp.methods, itp.extraps, q_eval, policies, nothing, rel_windows)
     end
 
@@ -465,11 +470,12 @@ end
 @inline function _locate_cell(
         itp::HeteroInterpolantND{Tg, Tv, N, G, M, E, P, <:_HeteroPartials},
         query::Tuple{Vararg{Real, N}},
+        extraps::Tuple{Vararg{AbstractExtrap, N}},
         policies::NTuple{N, AbstractSearchPolicy},
         hints::Tuple{Vararg{Base.RefValue{Int}, N}},
         mono::NTuple{N, Bool},
     ) where {Tg, Tv, N, G, M, E, P}
-    q_eval = _handle_all_extraps(query, itp.grids, itp.extraps)
+    q_eval = _handle_all_extraps(query, itp.grids, extraps)
     indices, Ls, _ = _search_all_intervals(q_eval, itp.grids, policies, hints, mono)
     hs, inv_hs, dLs = _compute_all_local_params(q_eval, itp.grids, indices, Ls)
     return (itp.data.partials, indices, hs, inv_hs, dLs)

--- a/src/hetero/hetero_oneshot.jl
+++ b/src/hetero/hetero_oneshot.jl
@@ -77,7 +77,6 @@ end
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
-    _validate_nd_domain(grids, queries, extraps_val)
 
     # Build phase (ONE-TIME)
     bcs_periodic = map(_bc_for_periodic_check, methods)
@@ -86,6 +85,8 @@ end
     # Per-axis materialization against the (possibly extended) grid.
     # Post-extension: grid-span IS the wrap domain → 2-arg primitive per-axis.
     extraps_eff = map(_resolve_extrap, extraps_val, grids_p)
+    # Batch-level InBounds promotion: see cubic_nd_oneshot.jl for pattern.
+    extraps_eff = _check_domain_nd(grids_p, queries, extraps_eff)
 
     Tv = _value_type(eltype(data), Tg)
     Tz = _output_eltype(Tv, Tg)
@@ -97,7 +98,7 @@ end
     # Eval loop (per query) — axis-only helpers read `h`/`inv_h` from `grids_p`
     @inbounds for k in 1:nq
         query_k = _extract_query_point(queries, k, Val(N))
-        oob_val = _try_fill_oob(query_k, grids_p, extraps_val, ops, first(data_p))
+        oob_val = _try_fill_oob(query_k, grids_p, extraps_eff, ops, first(data_p))
         if oob_val !== nothing
             output[k] = oob_val
             continue

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -120,6 +120,7 @@ end
     # (`inner[1] + period`), so the domain extends one period beyond the raw
     # grid as required for `:exclusive` periodic. Hoisting once outside the
     # loop keeps inner-loop cost identical to the legacy `_x_min/_x_max` read.
+    isempty(x_targets) && return output
     x_min, x_max = first(x), last(x)
     qmin, qmax = minimum(x_targets), maximum(x_targets)
 

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -230,21 +230,19 @@ For ForwardDiff compatibility, `xq` can be a Dual type:
 # `_locate_cell` design — exact at knots is sacrificed for query-time speed
 # (1 ULP off possible at right knots; oneshot path remains exact).
 
-# NoExtrap / ExtendExtrap / other: direct search + kernel.
-# _check_domain(::NoExtrap) throws if OOB; all others are no-ops.
+# Core in-bounds path: search + kernel. All non-InBounds extrap overloads
+# delegate here after their preprocessing — see cubic_eval.jl for the same
+# `InBounds = core fast path` pattern. WrapExtrap uses a periodic-seam-aware
+# core overload below (`_raw(y)`) to avoid the data wrapper's cyclic branch.
 @inline function _linear_eval_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         xq::Tq,
-        extrap::AbstractExtrap,
+        ::InBounds,
         op::O,
         searcher::S
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
-    # Resolve bare `GridIdx(k)` (which carries `val=NaN` until bound) into
-    # its grid coordinate so all subsequent arithmetic sees a real value.
-    # Real queries pass through unchanged.
     xq = _resolve_grididx(xq, x)
-    @boundscheck _check_domain(x, xq, extrap)
     idx, idx_R, xL, xR = search_interval(searcher, x, xq)
     # Independent computation of `α` and `inv_h`. The kernel uses only one
     # (EvalValue → α, `DerivOp(1)` → inv_h, `DerivOp(2)` → neither), so the
@@ -256,7 +254,22 @@ For ForwardDiff compatibility, `xq` can be a Dual type:
     @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, idx), α)
 end
 
-# ClampExtrap / FillExtrap: boundary check → extrap value or kernel.
+# NoExtrap / ExtendExtrap / others matching AbstractExtrap: domain check
+# (NoExtrap throws on OOB; others are no-op fallbacks) → delegate.
+@inline function _linear_eval_at_point(
+        x::AbstractVector{Tg},
+        y::AbstractVector{Tv},
+        xq::Tq,
+        extrap::AbstractExtrap,
+        op::O,
+        searcher::S
+    ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
+    xq = _resolve_grididx(xq, x)
+    @boundscheck _check_domain(x, xq, extrap)
+    return _linear_eval_at_point(x, y, xq, InBounds(), op, searcher)
+end
+
+# ClampExtrap / FillExtrap: boundary check → extrap value or delegate.
 @inline function _linear_eval_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
@@ -272,32 +285,26 @@ end
     elseif xq_primal > last(x)
         return _eval_extrapolation(op, last(y), extrap, xq)
     end
-    idx, idx_R, xL, xR = search_interval(searcher, x, xq)
-    α = _alpha_of(xq, xL, xR, x)
-    @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, idx), α)
+    return _linear_eval_at_point(x, y, xq, InBounds(), op, searcher)
 end
 
-# WrapExtrap: wrap query to domain → search + kernel.
+# WrapExtrap: wrap query to domain → search + kernel using `_raw(y)`.
 # Pass original xq (may be Dual) to _wrap_to_domain to preserve AD derivatives.
-# The wrap domain is `[first(x), last(x))`, read directly from the axis —
-# `_ExclusivePeriodicAxis` exposes the virtual endpoint via `last(g)` so the
-# domain naturally spans one period beyond the raw grid for `:exclusive` periodic.
+# `search_interval` already resolves seam wrap-around (idx_R = 1 for the seam
+# cell), so `yi[idx_R]` is safe via the raw inner — no need for the data
+# wrapper's per-call cyclic branch. Cannot delegate to the generic InBounds
+# core because that uses `y[idx]` (data wrapper); inline the kernel here.
 @inline function _linear_eval_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         xq::Tq,
-        extrap::WrapExtrap,
+        ::WrapExtrap,
         op::O,
         searcher::S
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
-    xq = _resolve_grididx(xq, x)
-    xq_wrapped = _wrap_to_domain(xq, x)
+    xq_wrapped = _wrap_to_domain(_resolve_grididx(xq, x), x)
     idx, idx_R, xL, xR = search_interval(searcher, x, xq_wrapped)
     α = _alpha_of(xq_wrapped, xL, xR, x)
-    # `search_interval` already resolves seam wrap-around (idx_R = 1 for the
-    # seam cell), so `yi[idx_R]` is safe via the raw inner — no need for the
-    # data wrapper's per-call cyclic branch. `_get_inv_h(x, idx)` keeps the
-    # wrapper for seam-aware (idx == n) cell width.
     yi = _raw(y)
     @inbounds return _linear_kernel(op, yi[idx], yi[idx_R], _get_inv_h(x, idx), α)
 end

--- a/src/linear/nd/linear_nd_eval.jl
+++ b/src/linear/nd/linear_nd_eval.jl
@@ -40,15 +40,18 @@ end
 # CELL LOCATION (locate once, evaluate many)
 # ========================================
 
-# Generic N-dimensional
+# Generic N-dimensional. `extraps` is the per-axis effective extrap tuple —
+# batch callers pass InBounds-promoted; scalar callers route through the
+# 5-arg forwarder (interpolant_protocol.jl) which injects `itp.extraps`.
 @inline function _locate_cell(
         itp::LinearInterpolantND{Tg, Tv, N},
         query::Tuple{Vararg{Real, N}},
+        extraps::Tuple{Vararg{AbstractExtrap, N}},
         policies::NTuple{N, AbstractSearchPolicy},
         hints::Tuple{Vararg{Base.RefValue{Int}, N}},
         mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
-    q_eval = _handle_all_extraps(query, itp.grids, itp.extraps)
+    q_eval = _handle_all_extraps(query, itp.grids, extraps)
     indices, Ls, _ = _search_all_intervals(q_eval, itp.grids, policies, hints, mono)
     inv_hs = map(_get_inv_h, itp.grids, indices)
     αs = map(_alpha_of, q_eval, Ls, inv_hs)
@@ -60,12 +63,13 @@ end
 @inline function _locate_cell(
         itp::LinearInterpolantND{Tg, Tv, 2},
         query::Tuple{Vararg{Real, 2}},
+        extraps::Tuple{AbstractExtrap, AbstractExtrap},
         policies::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
         hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
         mono::Tuple{Bool, Bool},
     ) where {Tg, Tv}
     x_eval, y_eval, ix, iy, xL, yL = _locate_cell_2d_preamble(
-        query, itp.grids, itp.extraps, policies, hints, mono
+        query, itp.grids, extraps, policies, hints, mono
     )
 
     inv_hx = _get_inv_h(itp.grids[1], ix)

--- a/src/linear/nd/linear_nd_eval.jl
+++ b/src/linear/nd/linear_nd_eval.jl
@@ -25,12 +25,13 @@
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
     mono = _scalar_mono(hint, Val(N))
-    return _eval_linear_nd(itp, resolved, ops, policies, hints, mono)
+    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono)
 end
 
 # In-place batch evaluation (SoA + AoS) is handled by the unified
-# AbstractInterpolantND callable in nd_interpolant_protocol.jl.
-# Zero-fill for 2nd+ derivatives is handled by _deriv_zero_fill trait below.
+# AbstractInterpolantND callable in nd_interpolant_protocol.jl. Scalar
+# evaluation routes through the generic `_eval_nd_at_point` there —
+# 2nd+ derivative zero-fill is wired via the `_deriv_zero_fill` trait below.
 
 # Derivative zero-fill trait: linear has zero 2nd+ derivative
 @inline _deriv_zero_fill(::LinearInterpolantND, ops::NTuple{N, AbstractEvalOp}, ::Val{N}) where {N} =
@@ -92,51 +93,8 @@ end
     return _multilinear_sum(data, stencils, inv_hs, αs, ops, Val(N))
 end
 
-# ========================================
-# Core Evaluation Logic
-# ========================================
-
 # Zero-ref for fill-value derivative computation (duck-typed zero via 0 * data_element)
 @inline _zero_ref(itp::LinearInterpolantND) = @inbounds first(itp.data)
-
-# Generic N-dimensional version (uses _locate_cell + _eval_at_cell)
-@inline function _eval_linear_nd(
-        itp::LinearInterpolantND{Tg, Tv, N},
-        query::Tuple{Vararg{Real, N}},
-        ops::NTuple{N, AbstractEvalOp},
-        policies::NTuple{N, AbstractSearchPolicy},
-        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
-        mono::NTuple{N, Bool},
-    ) where {Tg, Tv, N}
-    _validate_nd_domain(itp.grids, query, itp.extraps)
-    oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
-    oob_result !== nothing && return oob_result
-    if _has_second_or_higher_derivative(ops, Val(N))
-        return 0 * first(itp.data)
-    end
-    cell = _locate_cell(itp, query, policies, hints, mono)
-    return _eval_at_cell(itp, cell, ops)
-end
-
-# N=2 specialization: dispatches to N=2 _locate_cell via type
-@inline function _eval_linear_nd(
-        itp::LinearInterpolantND{Tg, Tv, 2},
-        query::Tuple{Vararg{Real, 2}},
-        ops::NTuple{2, AbstractEvalOp},
-        policies::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
-        hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
-        mono::Tuple{Bool, Bool},
-    ) where {Tg, Tv}
-    _validate_nd_domain(itp.grids, query, itp.extraps)
-    oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
-    oob_result !== nothing && return oob_result
-    op_x, op_y = ops
-    if op_x isa EvalDeriv2 || op_x isa EvalDeriv3 || op_y isa EvalDeriv2 || op_y isa EvalDeriv3
-        return 0 * first(itp.data)
-    end
-    cell = _locate_cell(itp, query, policies, hints, mono)
-    return _eval_at_cell(itp, cell, ops)
-end
 
 # ========================================
 # Derivative Check
@@ -223,8 +181,9 @@ end
 @inline _linear_weight(::EvalDeriv1, α, inv_h, ::Val{0}) = -inv_h
 @inline _linear_weight(::EvalDeriv1, α, inv_h, ::Val{1}) = inv_h
 
-# Second and higher derivatives are zero (handled by early return in _eval_linear_nd)
-# But define them for completeness if somehow called
+# Second and higher derivatives are zero (handled by `_deriv_zero_fill` trait
+# routing the scalar/batch entry points to a zero return before kernel reaches
+# here). Defined for completeness in case `_eval_at_cell` is invoked directly.
 @inline _linear_weight(::EvalDeriv2, α, inv_h, ::Val{B}) where {B} = zero(α)
 @inline _linear_weight(::EvalDeriv3, α, inv_h, ::Val{B}) where {B} = zero(α)
 

--- a/src/linear/nd/linear_nd_oneshot.jl
+++ b/src/linear/nd/linear_nd_oneshot.jl
@@ -84,11 +84,14 @@ function _linear_interp_nd_oneshot_batch!(
     _query_validate(queries)
     grids_eff = map(_resolve_axis, grids, bcs)
     nobcs = ntuple(_ -> NoBC(), Val(N))
-    _validate_nd_domain(grids_eff, queries, extraps_val)
     extraps_eff = _resolve_extrap(extraps_val, bcs, grids_eff, data, Val(N))
+    # Batch-level InBounds promotion: replaces `_validate_nd_domain` throw +
+    # elides per-query wrap/clamp/fill on in-bounds axes via the @generated
+    # `_is_fill_oob` and `_handle_axis_extrap(::InBounds)` no-op.
+    extraps_eff = _check_domain_nd(grids_eff, queries, extraps_eff)
     @inbounds for k in 1:nq
         query_k = _extract_query_point(queries, k, Val(N))
-        oob_val = _try_fill_oob(query_k, grids_eff, extraps_val, ops, first(data))
+        oob_val = _try_fill_oob(query_k, grids_eff, extraps_eff, ops, first(data))
         if oob_val !== nothing
             output[k] = oob_val; continue
         end

--- a/src/quadratic/nd/quadratic_nd_eval.jl
+++ b/src/quadratic/nd/quadratic_nd_eval.jl
@@ -70,12 +70,13 @@ itp((1.0, 0.5); deriv=(DerivOp(1), EvalValue()))      # ∂f/∂x only
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
     mono = _scalar_mono(hint, Val(N))
-    return _eval_nd_quadratic(itp, resolved, ops, policies, hints, mono)
+    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono)
 end
 
 # In-place batch evaluation (SoA + AoS) is handled by the unified
-# AbstractInterpolantND callable in nd_utils.jl.
-# QuadraticInterpolantND has no special batch logic (no zero-fill trait).
+# AbstractInterpolantND callable in interpolant_protocol.jl. Scalar
+# evaluation routes through the generic `_eval_nd_at_point` there —
+# QuadraticInterpolantND has no zero-fill trait (default false).
 
 # ========================================
 # CELL LOCATION (locate once, evaluate many)
@@ -132,44 +133,8 @@ end
     return _eval_nd_quad_cell(partials, indices, hs, inv_hs, dLs, ops)
 end
 
-# ========================================
-# CORE QUADRATIC EVALUATION
-# ========================================
-
 # Zero-ref for fill-value derivative computation (duck-typed zero via 0 * data_element)
 @inline _zero_ref(itp::QuadraticInterpolantND) = @inbounds first(itp.nodal_derivs.partials)
-
-# Generic N-dimensional (uses _locate_cell + _eval_at_cell)
-@inline function _eval_nd_quadratic(
-        itp::QuadraticInterpolantND{Tg, Tv, N},
-        query::Tuple{Vararg{Real, N}},
-        ops::NTuple{N, AbstractEvalOp},
-        policies::NTuple{N, AbstractSearchPolicy},
-        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
-        mono::NTuple{N, Bool},
-    ) where {Tg, Tv, N}
-    _validate_nd_domain(itp.grids, query, itp.extraps)
-    oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
-    oob_result !== nothing && return oob_result
-    cell = _locate_cell(itp, query, policies, hints, mono)
-    return _eval_at_cell(itp, cell, ops)
-end
-
-# N=2 specialization: dispatches to N=2 _locate_cell via type
-@inline function _eval_nd_quadratic(
-        itp::QuadraticInterpolantND{Tg, Tv, 2},
-        query::Tuple{Vararg{Real, 2}},
-        ops::Tuple{<:AbstractEvalOp, <:AbstractEvalOp},
-        policies::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
-        hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
-        mono::Tuple{Bool, Bool},
-    ) where {Tg, Tv}
-    _validate_nd_domain(itp.grids, query, itp.extraps)
-    oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
-    oob_result !== nothing && return oob_result
-    cell = _locate_cell(itp, query, policies, hints, mono)
-    return _eval_at_cell(itp, cell, ops)
-end
 
 # ========================================
 # @GENERATED TENSOR PRODUCT KERNEL (Quadratic)

--- a/src/quadratic/nd/quadratic_nd_eval.jl
+++ b/src/quadratic/nd/quadratic_nd_eval.jl
@@ -81,15 +81,18 @@ end
 # CELL LOCATION (locate once, evaluate many)
 # ========================================
 
-# Generic N-dimensional
+# Generic N-dimensional. `extraps` carries batch-level InBounds promotion
+# from `_check_domain_nd` when applicable; scalar callers route via the
+# 5-arg forwarder (interpolant_protocol.jl) injecting `itp.extraps`.
 @inline function _locate_cell(
         itp::QuadraticInterpolantND{Tg, Tv, N},
         query::Tuple{Vararg{Real, N}},
+        extraps::Tuple{Vararg{AbstractExtrap, N}},
         policies::NTuple{N, AbstractSearchPolicy},
         hints::Tuple{Vararg{Base.RefValue{Int}, N}},
         mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
-    q_evals = _handle_all_extraps(query, itp.grids, itp.extraps)
+    q_evals = _handle_all_extraps(query, itp.grids, extraps)
     # Wrapped grids carry cached `h`/`inv_h` directly — use the spacings-free
     # overloads (5-arg `_search_all_intervals`, 4-arg `_compute_all_local_params`)
     # shared with Linear/Constant/Hetero ND.
@@ -103,12 +106,13 @@ end
 @inline function _locate_cell(
         itp::QuadraticInterpolantND{Tg, Tv, 2},
         query::Tuple{Vararg{Real, 2}},
+        extraps::Tuple{AbstractExtrap, AbstractExtrap},
         policies::Tuple{<:AbstractSearchPolicy, <:AbstractSearchPolicy},
         hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
         mono::Tuple{Bool, Bool},
     ) where {Tg, Tv}
     x_eval, y_eval, ix, iy, xL, yL = _locate_cell_2d_preamble(
-        query, itp.grids, itp.extraps, policies, hints, mono
+        query, itp.grids, extraps, policies, hints, mono
     )
 
     hx = _get_h(itp.grids[1], ix);  hy = _get_h(itp.grids[2], iy)

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -85,7 +85,6 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
-    _validate_nd_domain(grids, queries, extraps_val)
 
     # Pool-backed per-axis cache — build phase + eval loop reuse h/inv_h.
     # `map` over the tuple dispatches per-element on concrete axis type;
@@ -98,10 +97,14 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
     partials = acquire!(pool, Tz, (n_partials, size(data)...))
     _compute_nd_partials_quadratic!(partials, grids_c, data, bcs)
     extraps_eff = map(_resolve_extrap, extraps_val, grids_c)
+    # Batch-level InBounds promotion (see cubic_nd_oneshot.jl). Subsumes
+    # `_validate_nd_domain` and elides per-query wrap/clamp/fill branches on
+    # in-bounds axes.
+    extraps_eff = _check_domain_nd(grids_c, queries, extraps_eff)
 
     @inbounds for k in 1:nq
         query_k = _extract_query_point(queries, k, Val(N))
-        oob_val = _try_fill_oob(query_k, grids_c, extraps_val, ops, first(data))
+        oob_val = _try_fill_oob(query_k, grids_c, extraps_eff, ops, first(data))
         if oob_val !== nothing
             output[k] = oob_val; continue
         end

--- a/src/quadratic/quadratic_oneshot.jl
+++ b/src/quadratic/quadratic_oneshot.jl
@@ -21,8 +21,26 @@
 # Core eval: extrap dispatch → search → kernel (no intermediate layers)
 # ========================================
 
-# NoExtrap / ExtendExtrap / other: direct search + kernel.
-# _check_domain(::NoExtrap) throws if OOB; search_interval clamps idx for ExtendExtrap.
+# Core in-bounds path: search + kernel. All non-InBounds extrap overloads
+# delegate here after preprocessing — see cubic_eval.jl for the same
+# `InBounds = core fast path` pattern.
+@inline function _quadratic_eval_at_point(
+        x::AbstractVector{Tg},
+        y::AbstractVector{Tv},
+        a::AbstractVector{Tc},
+        d::AbstractVector{Tc},
+        xq::Tq,
+        ::InBounds,
+        op::AbstractEvalOp,
+        searcher::S
+    ) where {Tg, Tv, Tc, Tq, S <: Searcher}
+    idx, _, xL, _ = search_interval(searcher, x, xq)
+    dt = xq - xL  # Can be Dual for AD
+    @inbounds return _quadratic_kernel(op, a[idx], d[idx], y[idx], dt)
+end
+
+# NoExtrap / ExtendExtrap / others matching AbstractExtrap: domain check
+# → delegate. `_check_domain(::NoExtrap)` throws on OOB; others are no-op.
 @inline function _quadratic_eval_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
@@ -34,12 +52,10 @@
         searcher::S
     ) where {Tg, Tv, Tc, Tq, S <: Searcher}
     @boundscheck _check_domain(x, xq, extrap)
-    idx, _, xL, _ = search_interval(searcher, x, xq)
-    dt = xq - xL  # Can be Dual for AD
-    @inbounds return _quadratic_kernel(op, a[idx], d[idx], y[idx], dt)
+    return _quadratic_eval_at_point(x, y, a, d, xq, InBounds(), op, searcher)
 end
 
-# ClampExtrap / FillExtrap: boundary check → extrap value or kernel.
+# ClampExtrap / FillExtrap: boundary check → extrap value or delegate.
 @inline function _quadratic_eval_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
@@ -53,27 +69,22 @@ end
     xq_primal = _extract_primal(xq)
     xq_primal < _extract_primal(first(x)) && return _eval_extrapolation(op, first(y), extrap, xq)
     xq_primal > _extract_primal(last(x)) && return _eval_extrapolation(op, last(y), extrap, xq)
-    idx, _, xL, _ = search_interval(searcher, x, xq)
-    dt = xq - xL
-    @inbounds return _quadratic_kernel(op, a[idx], d[idx], y[idx], dt)
+    return _quadratic_eval_at_point(x, y, a, d, xq, InBounds(), op, searcher)
 end
 
-# WrapExtrap: wrap query to domain → search + kernel.
-# Wrap domain `[first(x), last(x))` is read directly from the axis.
+# WrapExtrap: wrap query to domain → delegate with wrapped value.
 @inline function _quadratic_eval_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         a::AbstractVector{Tc},
         d::AbstractVector{Tc},
         xq::Tq,
-        extrap::WrapExtrap,
+        ::WrapExtrap,
         op::AbstractEvalOp,
         searcher::S
     ) where {Tg, Tv, Tc, Tq, S <: Searcher}
     xq_wrapped = _wrap_to_domain(xq, x)
-    idx, _, xL, _ = search_interval(searcher, x, xq_wrapped)
-    dt = xq_wrapped - xL
-    @inbounds return _quadratic_kernel(op, a[idx], d[idx], y[idx], dt)
+    return _quadratic_eval_at_point(x, y, a, d, xq_wrapped, InBounds(), op, searcher)
 end
 
 


### PR DESCRIPTION
## Summary

PR #134 introduced a generic loop but removed the BC-specialized fast path for `WrapExtrap`. This caused a ~36% performance regression for Cubic + PeriodicBC vector evaluation. 

This PR restores the v0.4.9 fast path in a method-agnostic way. The batch entry now tests bounds once and demotes the extrapolation to an `InBounds` singleton. Per-query handlers then process `InBounds` as a fast no-op. 

This pattern is also extended to `ClampExtrap`, `FillExtrap`, and `NoExtrap` across the full ND batch pipeline. When a batch is fully in-domain, all per-query boundary checks are elided. 

Additionally, two correctness bugs uncovered during refactoring are fixed:
- A boundary logic bug where `WrapExtrap` incorrectly returned `y[end]` instead of `y[1]` when `xq == last(x)`.
- An `ArgumentError` caused by calling `minimum`/`maximum` on empty batches.

## Implementation

- **1D Dispatch Elision**: `_check_domain` now returns `InBounds()` if all queries are valid. This pays the cost of a single `minimum`/`maximum` scan to skip per-query checks. `NoExtrap` still properly throws for out-of-bounds.
- **1D Delegate Refactor**: Collapsed seven `_eval_*_at_point` families into a 4-overload pattern (an `InBounds` core + preprocessors). This removes redundant code while standardizing behavior.
- **ND Batch Promotion**: Added `_check_domain_nd` to independently promote each axis to `InBounds` (for SoA paths), covering all five oneshot batch loops.
- **ND Scalar Unification**: Unified eight `_eval_*_nd` overloads into a single generic `_eval_nd_at_point`. `Hetero` retains specialization due to its recursive requirements.
- **Correctness Fixes**: 
  - `WrapExtrap` now uses half-open bounds `[first, last)` via `_is_all_inbounds_halfopen`.
  - Empty batches safely return empty arrays instead of throwing `ArgumentError`.

## Performance

Measured on M1 Pro, Julia 1.12.6, in-bounds batches.

### 1D Cubic + PeriodicBC(:exclusive), persistent eval

| Grid type | v0.4.9 | master | this PR | Δ vs master |
|---|---:|---:|---:|---:|
| Range  | 2.46 μs | 2.50 μs | 2.44 μs | noise |
| Vector | 1.85 μs | 2.61 μs | **1.85 μs** | **−29 %** |

`Vector` grids regressed because the generic loop forced repeated `first`/`last` calls. The `InBounds` promotion completely bypasses this, restoring v0.4.9 parity.

### 2D ND, persistent batch eval, in-bounds SoA

| Method | Grid | master | this PR | Δ vs master |
|---|---|---:|---:|---:|
| LinearND | Range | 3.45 μs | 3.04 μs | −12 % |
| LinearND | Vector| 3.84 μs | 3.45 μs | −10 % |
| CubicND  | Range | 7.41 μs | 7.05 μs |  −5 % |
| CubicND  | Vector| 7.17 μs | 6.92 μs |  −3 % |

*(Note: The large v0.4.9 gap seen previously was a fixed bug from PR #140)*

## Out of scope

- **Adjoint paths**: Using `_check_domain_nd` here caused closure-capture regressions. The planned fix is tracked in `nd_extrap_validate_unification.md`.
- **Outer `_validate_nd_domain` removal**: Cannot be safely dropped in ND due to mixed-extrap hazards.
- **WrapExtrap semantics**: The codebase keeps Interpolations.jl's half-open `[first, last)`. Switching to closed bounds is discussed in `wrapextrap_closed_semantics.md`.
- **Cubic + PeriodicBC oneshot regression**: Oneshot vector eval regressed due to the new `_ExclusivePeriodicAxis` wrapper. Tracked for a separate follow-up PR.