### PR TITLE
(fix): Close the right boundary of `WrapExtrap`'s domain

### DIFF
--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -278,13 +278,8 @@ end
         y::AbstractVector, x_last, aq::_ConstantAnchoredQuery,
         op::AbstractEvalOp, side_param::AbstractSide, ::AbstractExtrap
     )
-    # Right-edge short-circuit: at `aq.xq == x_last`, return the right corner
-    # value `y[aq.idxR]` so this works uniformly for both non-periodic axes
-    # (idxR == n; `y[idxR] == y[end]`) and `_ExclusivePeriodicAxis` (idxR == 1;
-    # `y[idxR] == y[1]`, the cyclic wrap at the seam). Using `y[end]` was
-    # silently correct under half-open `_wrap_to_domain` (which wrapped seam
-    # queries to x_min before this point fired); closed semantics keeps
-    # `aq.xq` at the seam, so we route through the search-resolved idxR.
+    # Right-edge short-circuit: `y[aq.idxR]` resolves to `y[end]` for non-periodic
+    # (idxR == n) and to the cyclic `y[1]` for `_ExclusivePeriodicAxis` (idxR == 1).
     aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[aq.idxR]) : 0 * first(y))
     @inbounds return _constant_kernel(op, y[aq.idxL], y[aq.idxR], aq.h, aq.dL, side_param)
 end
@@ -295,13 +290,8 @@ end
         op::AbstractEvalOp, side_param::AbstractSide, ::NoExtrap
     )
     aq.state != IN_DOMAIN && throw(DomainError(aq.xq, "query point outside domain"))
-    # Right-edge short-circuit: at `aq.xq == x_last`, return the right corner
-    # value `y[aq.idxR]` so this works uniformly for both non-periodic axes
-    # (idxR == n; `y[idxR] == y[end]`) and `_ExclusivePeriodicAxis` (idxR == 1;
-    # `y[idxR] == y[1]`, the cyclic wrap at the seam). Using `y[end]` was
-    # silently correct under half-open `_wrap_to_domain` (which wrapped seam
-    # queries to x_min before this point fired); closed semantics keeps
-    # `aq.xq` at the seam, so we route through the search-resolved idxR.
+    # Right-edge short-circuit: `y[aq.idxR]` resolves to `y[end]` for non-periodic
+    # (idxR == n) and to the cyclic `y[1]` for `_ExclusivePeriodicAxis` (idxR == 1).
     aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[aq.idxR]) : 0 * first(y))
     @inbounds return _constant_kernel(op, y[aq.idxL], y[aq.idxR], aq.h, aq.dL, side_param)
 end
@@ -315,13 +305,8 @@ end
         y_bnd = aq.state == OOB_LEFT ? first(y) : last(y)
         return _eval_extrapolation(op, y_bnd, extrap, aq.xq)
     end
-    # Right-edge short-circuit: at `aq.xq == x_last`, return the right corner
-    # value `y[aq.idxR]` so this works uniformly for both non-periodic axes
-    # (idxR == n; `y[idxR] == y[end]`) and `_ExclusivePeriodicAxis` (idxR == 1;
-    # `y[idxR] == y[1]`, the cyclic wrap at the seam). Using `y[end]` was
-    # silently correct under half-open `_wrap_to_domain` (which wrapped seam
-    # queries to x_min before this point fired); closed semantics keeps
-    # `aq.xq` at the seam, so we route through the search-resolved idxR.
+    # Right-edge short-circuit: `y[aq.idxR]` resolves to `y[end]` for non-periodic
+    # (idxR == n) and to the cyclic `y[1]` for `_ExclusivePeriodicAxis` (idxR == 1).
     aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[aq.idxR]) : 0 * first(y))
     @inbounds return _constant_kernel(op, y[aq.idxL], y[aq.idxR], aq.h, aq.dL, side_param)
 end
@@ -349,10 +334,8 @@ end
         x_min, x_max = first(itp.x), last(itp.x)
         throw(DomainError(aq.xq, "query point outside domain [$x_min, $x_max]"))
     end
-    # Right-edge short-circuit uses idxR (search-resolved). For persistent
-    # ConstantInterpolant on `:exclusive` PeriodicBC the build path extends
-    # the grid, so `itp.y[end] == itp.y[1]` cyclically and `y[idxR] == y[end]`
-    # — same value, idxR form keeps parity with `_constant_eval_at_anchor`.
+    # Right-edge short-circuit: `idxR` resolves to `n` for non-periodic and to
+    # `n+1` (cyclic `y[1]`) on `:exclusive` PeriodicBC's extended-grid persistent path.
     if aq.xq == last(itp.x)
         return op isa EvalValue ? (@inbounds itp.y[aq.idxR]) : zero(T)
     end

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -278,7 +278,14 @@ end
         y::AbstractVector, x_last, aq::_ConstantAnchoredQuery,
         op::AbstractEvalOp, side_param::AbstractSide, ::AbstractExtrap
     )
-    aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[end]) : 0 * first(y))
+    # Right-edge short-circuit: at `aq.xq == x_last`, return the right corner
+    # value `y[aq.idxR]` so this works uniformly for both non-periodic axes
+    # (idxR == n; `y[idxR] == y[end]`) and `_ExclusivePeriodicAxis` (idxR == 1;
+    # `y[idxR] == y[1]`, the cyclic wrap at the seam). Using `y[end]` was
+    # silently correct under half-open `_wrap_to_domain` (which wrapped seam
+    # queries to x_min before this point fired); closed semantics keeps
+    # `aq.xq` at the seam, so we route through the search-resolved idxR.
+    aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[aq.idxR]) : 0 * first(y))
     @inbounds return _constant_kernel(op, y[aq.idxL], y[aq.idxR], aq.h, aq.dL, side_param)
 end
 
@@ -288,7 +295,14 @@ end
         op::AbstractEvalOp, side_param::AbstractSide, ::NoExtrap
     )
     aq.state != IN_DOMAIN && throw(DomainError(aq.xq, "query point outside domain"))
-    aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[end]) : 0 * first(y))
+    # Right-edge short-circuit: at `aq.xq == x_last`, return the right corner
+    # value `y[aq.idxR]` so this works uniformly for both non-periodic axes
+    # (idxR == n; `y[idxR] == y[end]`) and `_ExclusivePeriodicAxis` (idxR == 1;
+    # `y[idxR] == y[1]`, the cyclic wrap at the seam). Using `y[end]` was
+    # silently correct under half-open `_wrap_to_domain` (which wrapped seam
+    # queries to x_min before this point fired); closed semantics keeps
+    # `aq.xq` at the seam, so we route through the search-resolved idxR.
+    aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[aq.idxR]) : 0 * first(y))
     @inbounds return _constant_kernel(op, y[aq.idxL], y[aq.idxR], aq.h, aq.dL, side_param)
 end
 
@@ -301,7 +315,14 @@ end
         y_bnd = aq.state == OOB_LEFT ? first(y) : last(y)
         return _eval_extrapolation(op, y_bnd, extrap, aq.xq)
     end
-    aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[end]) : 0 * first(y))
+    # Right-edge short-circuit: at `aq.xq == x_last`, return the right corner
+    # value `y[aq.idxR]` so this works uniformly for both non-periodic axes
+    # (idxR == n; `y[idxR] == y[end]`) and `_ExclusivePeriodicAxis` (idxR == 1;
+    # `y[idxR] == y[1]`, the cyclic wrap at the seam). Using `y[end]` was
+    # silently correct under half-open `_wrap_to_domain` (which wrapped seam
+    # queries to x_min before this point fired); closed semantics keeps
+    # `aq.xq` at the seam, so we route through the search-resolved idxR.
+    aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[aq.idxR]) : 0 * first(y))
     @inbounds return _constant_kernel(op, y[aq.idxL], y[aq.idxR], aq.h, aq.dL, side_param)
 end
 
@@ -328,8 +349,12 @@ end
         x_min, x_max = first(itp.x), last(itp.x)
         throw(DomainError(aq.xq, "query point outside domain [$x_min, $x_max]"))
     end
+    # Right-edge short-circuit uses idxR (search-resolved). For persistent
+    # ConstantInterpolant on `:exclusive` PeriodicBC the build path extends
+    # the grid, so `itp.y[end] == itp.y[1]` cyclically and `y[idxR] == y[end]`
+    # — same value, idxR form keeps parity with `_constant_eval_at_anchor`.
     if aq.xq == last(itp.x)
-        return op isa EvalValue ? (@inbounds itp.y[end]) : zero(T)
+        return op isa EvalValue ? (@inbounds itp.y[aq.idxR]) : zero(T)
     end
     @inbounds return _constant_kernel(op, itp.y[aq.idxL], itp.y[aq.idxR], aq.h, aq.dL, itp.side)
 end

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -94,7 +94,7 @@ Create an anchored query for ultra-fast constant interpolation at a fixed point.
 - `x`: Grid points (must match grid used for interpolant construction)
 - `xq`: Query point (scalar)
 - `::Val{:constant}`: Type tag to distinguish from other anchor types
-- `wrap`: If true, wrap `xq` to domain [x[1], x[end]) before anchoring.
+- `wrap`: If true, wrap `xq` to closed domain [x[1], x[end]] before anchoring.
           Used for `extrap=WrapExtrap()` mode.
 
 # Returns
@@ -136,7 +136,7 @@ the grid used for interpolant construction.
 - `x`: Grid points (must match interpolant's grid)
 - `xq`: Query points (any Real type, auto-promoted to T)
 - `::Val{:constant}`: Type tag
-- `wrap`: If true, wrap query points to domain [x[1], x[end]) before anchoring.
+- `wrap`: If true, wrap query points to closed domain [x[1], x[end]] before anchoring.
 
 # Example
 ```julia
@@ -179,7 +179,7 @@ the caller reuses `buffer`. Writes `length(xq)` entries.
 - `x::AbstractVector{T}`: Grid points (must match interpolant's grid)
 - `xq::AbstractVector`: Query points (any Real type, auto-promoted to T)
 - `::Val{:constant}`: Type tag for constant interpolation
-- `wrap::Bool=false`: If true, wrap query points to domain [x[1], x[end])
+- `wrap::Bool=false`: If true, wrap query points to closed domain [x[1], x[end]]
 
 # Returns
 The same `buffer` object, filled with anchored queries.

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -87,7 +87,7 @@ end
     return _constant_eval_at_point(x, y, xi, InBounds(), side, op, searcher)
 end
 
-# WrapExtrap: wrap query to domain → search + kernel.
+# WrapExtrap: wrap query to domain → right-edge short-circuit → search + kernel.
 # `_wrap_to_domain(xi, x, ::WrapExtrap)` reads `(first(x), last(x))` from the
 # axis — `_ExclusivePeriodicAxis` exposes the precomputed virtual endpoint via
 # `last(g)`, so the wrap domain naturally spans one period for `:exclusive`.
@@ -101,6 +101,14 @@ end
         searcher::S
     ) where {Tg, Tv, Tq <: Real, S <: Searcher}
     xi_wrapped = _wrap_to_domain(xi, x)
+    # Right-edge short-circuit (closed-domain): `xi == last(x)` collapses
+    # uniformly to `last(y)`, bypassing side semantics. Mirrors the InBounds
+    # core's identical guard and the persistent anchor path's `aq.xq == x_last`
+    # short-circuit so scalar oneshot agrees with the persistent interpolant at
+    # the exact boundary. `last(_ExclusivePeriodicData) = inner[1]` so `:exclusive`
+    # cyclic wrap is preserved; raw Vector yields `y[n]`.
+    _extract_primal(xi_wrapped) == _extract_primal(last(x)) &&
+        return op isa EvalValue ? last(y) : 0 * first(y)
     idx, idx_R, xL, xR = search_interval(searcher, x, xi_wrapped)
     dL = xi_wrapped - xL
     # Unwrap data once: `search_interval` already resolved the seam (idx_R = 1

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -137,7 +137,7 @@ Constant (step/piecewise constant) interpolation at a single point.
   - `NoExtrap()` (default): throws DomainError if outside domain
   - `ClampExtrap()`: clamp to boundary values
   - `ExtendExtrap()`: same as ClampExtrap (slope=0)
-  - `WrapExtrap()`: wrap to [x_min, x_max)
+  - `WrapExtrap()`: wrap to closed domain [x_min, x_max] (xq==x_max returns y[end])
 - `side::AbstractSide`: Side selection
   - `NearestSide()` (default): nearest neighbor (left tie-breaking at midpoint)
   - `LeftSide()`: always use left value

--- a/src/core/anchor_common.jl
+++ b/src/core/anchor_common.jl
@@ -81,8 +81,11 @@ Dual type. The interval search uses `_extract_primal(xq)` for comparisons.
     xq_primal = _extract_primal(xq)
 
     # Handle wrapping (for extrap=WrapExtrap() or periodic mode)
-    # Generic _wrap_to_domain handles AD primal extraction and returns Tg
-    if wrap && (xq_primal < x_min || xq_primal >= x_max)
+    # Generic _wrap_to_domain handles AD primal extraction and returns Tg.
+    # Closed-domain convention: `xq == x_max` is in-domain — no wrap needed.
+    # Only strictly-OOB queries (`xq < x_min` or `xq > x_max`) take the slow
+    # `mod()` path inside `_wrap_to_domain` (which itself uses `xi <= x_max`).
+    if wrap && (xq_primal < x_min || xq_primal > x_max)
         xq = _wrap_to_domain(xq, x_min, x_max)
         xq_primal = xq  # xq is now Tg, no need for _extract_primal
     end

--- a/src/core/eval_ops.jl
+++ b/src/core/eval_ops.jl
@@ -290,8 +290,12 @@ using modular arithmetic. For periodic data.
 Closed-domain convention: `xq == last(x)` is an in-domain boundary query
 (returns the right-corner value, e.g. `y[end]` for non-periodic data); only
 strictly-OOB queries take the `mod()` path. Matches `ClampExtrap`/`FillExtrap`'s
-closed convention. `:inclusive` PeriodicBC is invariant (validated `y[1] ≈ y[end]`);
-`:exclusive` PeriodicBC is invariant via the seam-aware
+closed convention. `:inclusive` PeriodicBC: forward **value** is invariant
+(validated `y[1] ≈ y[end]`), but **adjoint** sensitivity at `xq == last(x)`
+now scatters to slot `n` instead of slot `1` — delta-equivalent under the
+`:inclusive` cycle constraint, but observably different if downstream code
+does not enforce `y[1] == y[end]` on `f_bar`. `:exclusive` PeriodicBC is
+fully invariant (forward + adjoint) via the seam-aware
 `_ExclusivePeriodicAxis.search_interval` returning `idx_R = 1` at `xq >= inner[n]`.
 
 Tag struct with no fields: the wrap domain is read directly from the axis at

--- a/src/core/eval_ops.jl
+++ b/src/core/eval_ops.jl
@@ -284,8 +284,15 @@ struct ExtendExtrap <: AbstractExtrap end
 """
     WrapExtrap <: AbstractExtrap
 
-Wrap extrapolation — wraps queries into the domain `[first(x), last(x))` using
-modular arithmetic. For periodic data.
+Wrap extrapolation — wraps queries into the closed domain `[first(x), last(x)]`
+using modular arithmetic. For periodic data.
+
+Closed-domain convention: `xq == last(x)` is an in-domain boundary query
+(returns the right-corner value, e.g. `y[end]` for non-periodic data); only
+strictly-OOB queries take the `mod()` path. Matches `ClampExtrap`/`FillExtrap`'s
+closed convention. `:inclusive` PeriodicBC is invariant (validated `y[1] ≈ y[end]`);
+`:exclusive` PeriodicBC is invariant via the seam-aware
+`_ExclusivePeriodicAxis.search_interval` returning `idx_R = 1` at `xq >= inner[n]`.
 
 Tag struct with no fields: the wrap domain is read directly from the axis at
 query time via `first(x)` / `last(x)`. After the surface-API axis resolution
@@ -307,7 +314,7 @@ itp = linear_interp(x, y; extrap=WrapExtrap())
 struct WrapExtrap <: AbstractExtrap end
 
 # Backward-compat: previous API was `WrapExtrap(x)` materializing the wrap
-# domain `[first(x), last(x))` into the struct's `_x_min`/`_x_max` fields.
+# domain `[first(x), last(x)]` into the struct's `_x_min`/`_x_max` fields.
 # After the tag-struct refactor (axis IS the source of truth for the wrap
 # domain), the axis-passing form is redundant — the kernel reads `(first(x),
 # last(x))` directly via `_wrap_to_domain(xq, x)`. This shim accepts and

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -14,8 +14,16 @@
 """
     _wrap_to_domain(xi::FT, x_min::FT, x_max::FT) where {FT<:AbstractFloat}
 
-Wrap a query point `xi` to the domain [x_min, x_max).
+Wrap a query point `xi` to the domain [x_min, x_max].
 Used for periodic boundary conditions and extrap=WrapExtrap().
+
+Closed-domain convention: `xi == x_max` is an in-domain boundary query
+(returns `xi` unchanged); only strictly-OOB queries (`xi < x_min` or
+`xi > x_max`) take the cold `mod()` path. See `claudedocs/TODO/DONE/
+wrapextrap_closed_semantics.md` for the design discussion. `:inclusive`
+PeriodicBC is invariant (validated `y[1] ≈ y[end]`); `:exclusive`
+PeriodicBC is invariant (seam-aware `_ExclusivePeriodicAxis.search_interval`
+returns `idx_R = 1` at `xq >= inner[n]`).
 
 Optimized: skips expensive `mod()` when xi is already in domain.
 """
@@ -25,7 +33,7 @@ Optimized: skips expensive `mod()` when xi is already in domain.
     # bloat the caller (every WrapExtrap eval kernel) with mod-related
     # asm. On constant rng+perEx persistent (3-4 ns baseline, 138 lines
     # before split), this collapses the eval kernel to ~75 lines.
-    if (xi >= x_min) && (xi < x_max)
+    if (xi >= x_min) && (xi <= x_max)
         return xi
     end
     return _wrap_to_domain_slow(xi, x_min, x_max)
@@ -37,7 +45,7 @@ end
 @inline function _wrap_to_domain(xi::Real, x_min::Tg, x_max::Tg) where {Tg}
     xi_primal = _extract_primal(xi)
     # Fast path: already in domain, return original xi (preserves Dual type for AD)
-    if (xi_primal >= x_min) && (xi_primal < x_max)
+    if (xi_primal >= x_min) && (xi_primal <= x_max)
         return xi
     end
     return _wrap_to_domain_slow(xi, x_min, x_max)

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -19,11 +19,10 @@ Used for periodic boundary conditions and extrap=WrapExtrap().
 
 Closed-domain convention: `xi == x_max` is an in-domain boundary query
 (returns `xi` unchanged); only strictly-OOB queries (`xi < x_min` or
-`xi > x_max`) take the cold `mod()` path. See `claudedocs/TODO/DONE/
-wrapextrap_closed_semantics.md` for the design discussion. `:inclusive`
-PeriodicBC is invariant (validated `y[1] ≈ y[end]`); `:exclusive`
-PeriodicBC is invariant (seam-aware `_ExclusivePeriodicAxis.search_interval`
-returns `idx_R = 1` at `xq >= inner[n]`).
+`xi > x_max`) take the cold `mod()` path. `PeriodicBC{:inclusive}` is
+invariant because `y[1] ≈ y[end]` by construction; `:exclusive` is
+invariant because `_ExclusivePeriodicAxis.search_interval` already returns
+`idx_R = 1` for `xq >= inner[n]` at the seam.
 
 Optimized: skips expensive `mod()` when xi is already in domain.
 """

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -20,9 +20,11 @@ Used for periodic boundary conditions and extrap=WrapExtrap().
 Closed-domain convention: `xi == x_max` is an in-domain boundary query
 (returns `xi` unchanged); only strictly-OOB queries (`xi < x_min` or
 `xi > x_max`) take the cold `mod()` path. `PeriodicBC{:inclusive}` is
-invariant because `y[1] ≈ y[end]` by construction; `:exclusive` is
-invariant because `_ExclusivePeriodicAxis.search_interval` already returns
-`idx_R = 1` for `xq >= inner[n]` at the seam.
+forward-**value**-invariant because `y[1] ≈ y[end]` by construction; the
+adjoint sensitivity at the seam now scatters to slot `n` instead of slot `1`
+(delta-equivalent under the cycle constraint). `:exclusive` is fully invariant
+(forward + adjoint) because `_ExclusivePeriodicAxis.search_interval` already
+returns `idx_R = 1` for `xq >= inner[n]` at the seam.
 
 Optimized: skips expensive `mod()` when xi is already in domain.
 """

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -491,22 +491,17 @@ end
 "No-op vector domain check for non-NoExtrap modes: pass-through extrap."
 @inline _check_domain(::AbstractVector, ::AbstractVector{<:Real}, extrap::AbstractExtrap) = extrap
 
-# Clamp / Fill batch fast path: closed `[first, last]` — `last` is in-domain
-# for clamp/fill semantics (no clamping or filling at the boundary).
+# Closed-domain batch fast path: every OOB policy (`ClampExtrap`, `FillExtrap`,
+# `WrapExtrap`) treats `[first(x), last(x)]` as the in-domain interval, so they
+# share one batch promotion. Previously `WrapExtrap` used a `_is_all_inbounds_halfopen`
+# variant (strict `<` on `x_max`) to keep queries at `last(x)` in the wrap-needed
+# set; with closed semantics (PR refac/wrap_closed) it joins the closed Union and
+# returns `y[end]` at the exact boundary instead of wrapping to `y[1]`.
 @inline function _check_domain(
         x::AbstractVector, xi::AbstractVector{<:Real},
-        e::Union{ClampExtrap, FillExtrap}
+        e::Union{ClampExtrap, FillExtrap, WrapExtrap}
     )
     return _is_all_inbounds(x, xi) ? InBounds() : e
-end
-
-# WrapExtrap batch fast path: half-open `[first, last)` — `last` wraps to
-# `first` per `_wrap_to_domain`'s `xi < x_max` fast-path check. Promoting a
-# batch containing `last(x)` to InBounds would skip that wrap and return
-# `y[last]` instead of `y[first]` (silent semantic regression). The
-# half-open variant uses strict `<` to keep `last` in the wrap-needed set.
-@inline function _check_domain(x::AbstractVector, xi::AbstractVector{<:Real}, e::WrapExtrap)
-    return _is_all_inbounds_halfopen(x, xi) ? InBounds() : e
 end
 
 """
@@ -544,19 +539,6 @@ end
 @inline function _is_all_inbounds(x::_CachedRange, queries::AbstractVector{<:Real})
     isempty(queries) && return true
     return minimum(queries) >= x.domain_lo && maximum(queries) <= x.domain_hi
-end
-
-# Half-open variant for WrapExtrap: `last(x)` belongs to the wrap-needed
-# set because `_wrap_to_domain`'s fast path uses strict `xi < x_max`.
-@inline function _is_all_inbounds_halfopen(x::AbstractVector, queries::AbstractVector{<:Real})
-    isempty(queries) && return true
-    return minimum(queries) >= _extract_primal(first(x)) &&
-        maximum(queries) < _extract_primal(last(x))
-end
-
-@inline function _is_all_inbounds_halfopen(x::_CachedRange, queries::AbstractVector{<:Real})
-    isempty(queries) && return true
-    return minimum(queries) >= x.domain_lo && maximum(queries) < x.domain_hi
 end
 
 # ========================================

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -493,10 +493,7 @@ end
 
 # Closed-domain batch fast path: every OOB policy (`ClampExtrap`, `FillExtrap`,
 # `WrapExtrap`) treats `[first(x), last(x)]` as the in-domain interval, so they
-# share one batch promotion. Previously `WrapExtrap` used a `_is_all_inbounds_halfopen`
-# variant (strict `<` on `x_max`) to keep queries at `last(x)` in the wrap-needed
-# set; with closed semantics (PR refac/wrap_closed) it joins the closed Union and
-# returns `y[end]` at the exact boundary instead of wrapping to `y[1]`.
+# share one batch promotion to `InBounds()`.
 @inline function _check_domain(
         x::AbstractVector, xi::AbstractVector{<:Real},
         e::Union{ClampExtrap, FillExtrap, WrapExtrap}

--- a/src/cubic/cubic_adjoint.jl
+++ b/src/cubic/cubic_adjoint.jl
@@ -505,7 +505,7 @@ function _build_cubic_adjoint_periodic(
     # promoted :exclusive, :inclusive for direct user input.
     cache = _get_cubic_cache(x_ext, _bc_after_extend(bc), _effective_autocache(autocache, Tg))
 
-    # Build anchored queries with wrapping (queries outside domain → wrap to [x[1], x[end]))
+    # Build anchored queries with wrapping (queries outside closed domain → wrap to [x[1], x[end]])
     anchors = _anchor_query(cache.x, xq, Val(:cubic), true)
 
     return CubicAdjoint(cache, anchors, cache.bc)

--- a/src/cubic/cubic_anchor.jl
+++ b/src/cubic/cubic_anchor.jl
@@ -192,7 +192,7 @@ Create an anchored query for ultra-fast cubic spline evaluation at a fixed point
 - `x`: Grid points (must match grid used for interpolant construction)
 - `xq`: Query point (scalar, can be Float or ForwardDiff.Dual for AD)
 - `::Val{:cubic}`: Type tag to distinguish from other anchor types
-- `wrap`: If true, wrap `xq` to domain [x[1], x[end]) before anchoring.
+- `wrap`: If true, wrap `xq` to closed domain [x[1], x[end]] before anchoring.
           Used for `extrap=WrapExtrap()` mode. Distinct from `PeriodicBC` (boundary condition).
 
 # Returns
@@ -243,7 +243,7 @@ the grid used for interpolant construction.
 - `x`: Grid points (must match interpolant's grid)
 - `xq`: Query points (any Real type, auto-promoted to T)
 - `::Val{:cubic}`: Type tag to distinguish from other anchor types
-- `wrap`: If true, wrap query points to domain [x[1], x[end]) before anchoring.
+- `wrap`: If true, wrap query points to closed domain [x[1], x[end]] before anchoring.
           Used for `extrap=WrapExtrap()` mode. Distinct from `PeriodicBC` (boundary condition).
 
 # Example
@@ -292,7 +292,7 @@ In-place version of `_anchor_query(x, xq, Val(:cubic))` for zero-allocation pool
 - `x::AbstractVector{Tg}`: Grid points (must match interpolant's grid)
 - `xq::AbstractVector{Tq}`: Query points (must match buffer's query type)
 - `::Val{:cubic}`: Type tag for cubic interpolation
-- `wrap::Bool=false`: If true, wrap query points to domain [x[1], x[end])
+- `wrap::Bool=false`: If true, wrap query points to closed domain [x[1], x[end]]
 
 # Returns
 The same `buffer` object, filled with anchored queries.
@@ -363,7 +363,7 @@ while preserving the full Dual value for weight computation.
     # `_anchor_loc` discards `idx_R` from `search_interval`'s 4-tuple, so this
     # path always assumes `idxR = idxL + 1`. Valid only for:
     #   - non-periodic queries (no seam dispatch in the searcher),
-    #   - `WrapExtrap` queries (wrap maps into `[first(x), last(x))`, no seam),
+    #   - `WrapExtrap` queries (wrap maps into `[first(x), last(x)]`, no seam),
     #   - periodic queries on a *post-extension* (n+1) grid (idxL+1 ≤ n+1).
     # Periodic-exclusive callers on a raw n-size grid MUST bypass this path
     # and build the anchor from `search_interval`'s 4-tuple to preserve the

--- a/src/linear/linear_anchor.jl
+++ b/src/linear/linear_anchor.jl
@@ -157,7 +157,7 @@ Create an anchored query for ultra-fast linear interpolation at a fixed point.
 - `x`: Grid points (must match grid used for interpolant construction)
 - `xq`: Query point (scalar)
 - `::Val{:linear}`: Type tag to distinguish from cubic anchor
-- `wrap`: If true, wrap `xq` to domain [x[1], x[end]) before anchoring.
+- `wrap`: If true, wrap `xq` to closed domain [x[1], x[end]] before anchoring.
           Used for `extrap=WrapExtrap()` mode.
 
 # Returns
@@ -239,7 +239,7 @@ the caller reuses `buffer`. Writes `length(xq)` entries.
 - `x::AbstractVector{Tg}`: Grid points (must match interpolant's grid)
 - `xq::AbstractVector`: Query points (any Real type)
 - `::Val{:linear}`: Type tag for linear interpolation
-- `wrap::Bool=false`: If true, wrap query points to domain [x[1], x[end])
+- `wrap::Bool=false`: If true, wrap query points to closed domain [x[1], x[end]]
 
 # Precision Preservation
 The outer `_LinearAnchoredQuery` constructor promotes via `promote_type(S, Tg)`,

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -124,8 +124,11 @@ end
     x_min, x_max = first(x), last(x)
     qmin, qmax = minimum(x_targets), maximum(x_targets)
 
-    if qmin >= x_min && qmax < x_max
-        # Fast path: all queries inside domain — use extension (no wrap overhead)
+    if qmin >= x_min && qmax <= x_max
+        # Fast path: all queries inside the closed domain `[first(x), last(x)]`
+        # — use extension (no wrap overhead). Exact `qmax == x_max` is in-domain
+        # under closed semantics (PR refac/wrap_closed); `_wrap_to_domain` would
+        # be a no-op for those anyway, so route them straight into the fast path.
         @inbounds for i in eachindex(x_targets, output)
             output[i] = _linear_eval_at_point(x, y, x_targets[i], ExtendExtrap(), op, searcher)
         end

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -115,7 +115,7 @@ end
         op::O,
         searcher::S
     ) where {Tg, O <: AbstractEvalOp, S <: Searcher}
-    # Wrap domain comes directly from the axis: `[first(x), last(x))`. For
+    # Wrap domain comes directly from the axis: `[first(x), last(x)]`. For
     # `_ExclusivePeriodicAxis`, `last(x)` is the precomputed virtual endpoint
     # (`inner[1] + period`), so the domain extends one period beyond the raw
     # grid as required for `:exclusive` periodic. Hoisting once outside the
@@ -126,9 +126,8 @@ end
 
     if qmin >= x_min && qmax <= x_max
         # Fast path: all queries inside the closed domain `[first(x), last(x)]`
-        # — use extension (no wrap overhead). Exact `qmax == x_max` is in-domain
-        # under closed semantics (PR refac/wrap_closed); `_wrap_to_domain` would
-        # be a no-op for those anyway, so route them straight into the fast path.
+        # — use extension (no wrap overhead). Exact `qmax == x_max` is in-domain,
+        # so `_wrap_to_domain` would be a no-op anyway — route straight in.
         @inbounds for i in eachindex(x_targets, output)
             output[i] = _linear_eval_at_point(x, y, x_targets[i], ExtendExtrap(), op, searcher)
         end

--- a/src/quadratic/quadratic_anchor.jl
+++ b/src/quadratic/quadratic_anchor.jl
@@ -76,7 +76,7 @@ Create an anchored query for ultra-fast quadratic interpolation at a fixed point
 - `x`: Grid points (must match grid used for interpolant construction)
 - `xq`: Query point (scalar, can be Float or ForwardDiff.Dual for AD)
 - `::Val{:quadratic}`: Type tag to distinguish from other anchor types
-- `wrap`: If true, wrap `xq` to domain [x[1], x[end]) before anchoring.
+- `wrap`: If true, wrap `xq` to closed domain [x[1], x[end]] before anchoring.
           Used for `extrap=WrapExtrap()` mode.
 
 # Returns
@@ -116,7 +116,7 @@ the grid used for interpolant construction.
 - `x`: Grid points (must match interpolant's grid)
 - `xq`: Query points (any Real type, auto-promoted to T)
 - `::Val{:quadratic}`: Type tag
-- `wrap`: If true, wrap query points to domain [x[1], x[end]) before anchoring.
+- `wrap`: If true, wrap query points to closed domain [x[1], x[end]] before anchoring.
 
 # Example
 ```julia
@@ -161,7 +161,7 @@ In-place version of `_anchor_query(x, xq, Val(:quadratic))` for zero-allocation 
 - `x::AbstractVector{T}`: Grid points (must match interpolant's grid)
 - `xq::AbstractVector`: Query points (any Real type, auto-promoted to T)
 - `::Val{:quadratic}`: Type tag for quadratic interpolation
-- `wrap::Bool=false`: If true, wrap query points to domain [x[1], x[end])
+- `wrap::Bool=false`: If true, wrap query points to closed domain [x[1], x[end]]
 
 # Returns
 The same `buffer` object, filled with anchored queries.

--- a/test/test_anchor_common.jl
+++ b/test/test_anchor_common.jl
@@ -61,12 +61,22 @@
         @test loc_right.state == FI.IN_DOMAIN
     end
 
-    @testset "_anchor_loc — wrap at x_max" begin
+    @testset "_anchor_loc — closed boundary at x_max (no wrap)" begin
         x = collect(range(0.0, 1.0, 11))
-        # xq == x_max with wrap → should wrap to x_min
+        # Closed semantics: xq == x_max stays in-domain, lands on the last cell.
         loc = FI._anchor_loc(x, 1.0, true)
         @test loc.state == FI.IN_DOMAIN
-        @test loc.xq ≈ 0.0
+        @test loc.xq ≈ 1.0
+        @test loc.idx == length(x) - 1   # last cell (n-1)
+        @test loc.xR ≈ 1.0
+    end
+
+    @testset "_anchor_loc — strictly OOB right still wraps" begin
+        x = collect(range(0.0, 1.0, 11))
+        # q = 1.25 = x_min + 1.25*period → wraps to 0.25
+        loc = FI._anchor_loc(x, 1.25, true)
+        @test loc.state == FI.IN_DOMAIN
+        @test loc.xq ≈ 0.25
     end
 
     # ========================================

--- a/test/test_constant.jl
+++ b/test/test_constant.jl
@@ -155,7 +155,9 @@ end
         @test constant_interp(x, y, -1.0; extrap = ExtendExtrap()) == 10.0
         @test constant_interp(x, y, 5.0; extrap = ExtendExtrap()) == 50.0
 
-        @test constant_interp(x, y, 4.0; extrap = WrapExtrap()) == 10.0
+        # Closed `[first(x), last(x)]` (PR refac/wrap_closed): exact last(x) is in-domain,
+        # returns y[end]. Strictly-OOB queries still wrap.
+        @test constant_interp(x, y, 4.0; extrap = WrapExtrap()) == 50.0
         @test constant_interp(x, y, 4.5; extrap = WrapExtrap()) == 10.0
 
         @test constant_interp(x, y, -1.0; extrap = ClampExtrap(), deriv = DerivOp(1)) == 0.0
@@ -223,7 +225,8 @@ end
         itp_left = constant_interp(x_int, y_int; side = LeftSide())
         @test itp_left(0.9) == 10.0
         itp_wrap = constant_interp(x_int, y_int; extrap = WrapExtrap())
-        @test itp_wrap(4.0) == 10.0
+        # Closed-domain: xq == last(x) returns y[end]; was y[1] under prior half-open.
+        @test itp_wrap(4.0) == 50
     end
 
     @testset "ConstantInterpolant - 2-arg form" begin
@@ -259,7 +262,8 @@ end
 
     @testset "ConstantInterpolant - Options" begin
         itp_wrap = constant_interp(x, y; extrap = WrapExtrap())
-        @test itp_wrap(4.0) == 10.0
+        # Closed-domain: xq == last(x) returns y[end].
+        @test itp_wrap(4.0) == 50.0
 
         itp_const = constant_interp(x, y; extrap = ClampExtrap())
         @test itp_const(-1.0) == 10.0
@@ -503,16 +507,24 @@ end
     end
 
     @testset "Edge: xi == x[end] with extrap modes" begin
+        # Closed-domain (PR refac/wrap_closed): every extrap policy now agrees
+        # at the exact right boundary — xq == last(x) returns y[end].
         @test constant_interp(x, y, 4.0; extrap = NoExtrap()) == 50.0
         @test constant_interp(x, y, 4.0; extrap = ClampExtrap()) == 50.0
         @test constant_interp(x, y, 4.0; extrap = ExtendExtrap()) == 50.0
-        @test constant_interp(x, y, 4.0; extrap = WrapExtrap()) == 10.0
+        @test constant_interp(x, y, 4.0; extrap = WrapExtrap()) == 50.0
     end
 
     @testset "Edge: Wrap boundary cases" begin
-        @test constant_interp(x, y, 4.0; extrap = WrapExtrap(), side = LeftSide()) == 10.0
-        @test constant_interp(x, y, 4.0; extrap = WrapExtrap(), side = RightSide()) == 10.0
-        @test constant_interp(x, y, 4.0; extrap = WrapExtrap(), side = NearestSide()) == 10.0
+        # Closed `[first(x), last(x)]`: xq == last(x) returns y[end] via the
+        # x_last short-circuit in `_constant_eval_at_anchor` (which now uses
+        # `y[aq.idxR]`; idxR == n for non-periodic). Side flag is irrelevant
+        # at the exact right edge because both LeftSide/RightSide/NearestSide
+        # collapse onto the single boundary point.
+        @test constant_interp(x, y, 4.0; extrap = WrapExtrap(), side = LeftSide()) == 50.0
+        @test constant_interp(x, y, 4.0; extrap = WrapExtrap(), side = RightSide()) == 50.0
+        @test constant_interp(x, y, 4.0; extrap = WrapExtrap(), side = NearestSide()) == 50.0
+        # Strictly-OOB queries still wrap as before.
         @test constant_interp(x, y, 4.5; extrap = WrapExtrap(), side = NearestSide()) == 10.0
         @test constant_interp(x, y, 5.0; extrap = WrapExtrap(), side = NearestSide()) == 20.0
     end

--- a/test/test_constant_periodic.jl
+++ b/test/test_constant_periodic.jl
@@ -710,10 +710,14 @@
         @test out_at_n[2] == 4.0
 
         # Series↔non-series alignment at the exclusive right endpoint.
-        # `_wrap_to_domain` sends xq = x[1] + period back onto the base domain
-        # [x[1], x[1]+period), so the resolved value is `y[1]` (the wrapped
-        # endpoint), not `y[n]`. Before this refactor the pool-extended series
-        # path returned `y[n]` here instead; the assertion pins down the fix.
+        # Under closed-domain semantics (PR refac/wrap_closed), `_wrap_to_domain`
+        # does NOT wrap `xq == x[1]+period` (closed `[x_min, x_max]` includes both
+        # endpoints). Instead, `_ExclusivePeriodicAxis.search_interval` seam fast
+        # path returns `idx_R = 1` for `xq >= inner[n]`, so the eval kernel reads
+        # `y[idx_R=1]` cyclically. The series-anchor short-circuit `aq.xq == x_last`
+        # was updated to route through `y[aq.idxR]` (was `y[end]`) so both raw
+        # `_ExclusivePeriodicAxis` (idxR==1 → y[1]) and persistent extended paths
+        # (idxR==n+1 → y[end]==y[1]) yield the same answer.
         out_endpoint = constant_interp(x, s, 4.0; bc = bc)
         @test out_endpoint[1] == constant_interp(x, y1, 4.0; bc = bc) == y1[1]
         @test out_endpoint[2] == constant_interp(x, y2, 4.0; bc = bc) == y2[1]

--- a/test/test_hermite_1d.jl
+++ b/test/test_hermite_1d.jl
@@ -126,11 +126,13 @@
         # WrapExtrap — wraps to domain
         val_wrap = hermite_interp(x, y, dy, 3.2; extrap = WrapExtrap())
         @test isfinite(val_wrap)
-        # WrapExtrap — vector fast-path includes x_max (no unnecessary wrap overhead)
+        # WrapExtrap — vector fast-path includes x_max (closed `[first(x), last(x)]`;
+        # PR refac/wrap_closed). Exact `x[end]` is in-domain → returns `y[end]`
+        # (was wrap-to-`y[1]` under prior half-open semantics).
         xq_boundary = [x[end]]
         out_boundary = similar(xq_boundary)
         hermite_interp!(out_boundary, x, y, dy, xq_boundary; extrap = WrapExtrap())
-        @test isfinite(out_boundary[1])
+        @test out_boundary[1] == y[end]
 
         # Callable with extrap
         itp = hermite_interp(x, y, dy; extrap = ClampExtrap())

--- a/test/test_periodic_bc.jl
+++ b/test/test_periodic_bc.jl
@@ -30,7 +30,7 @@
             @test result[2] ≈ sin(0.5) atol = 1.0e-3  # 2π + 0.5 wraps to 0.5
             @test result[3] ≈ sin(2π - 0.5) atol = 1.0e-3  # -0.5 wraps to 2π - 0.5 = -sin(0.5)
 
-            # Fast path: all queries inside domain [x_min, x_max) → uses extension path
+            # Fast path: all queries inside closed domain [x_min, x_max] → uses extension path
             inside_query = [0.5, 1.0, 2.0]
             inside_result = linear_interp(x, y, inside_query; extrap = WrapExtrap())
             @test inside_result ≈ sin.(inside_query) atol = 1.0e-3

--- a/test/test_periodic_bc.jl
+++ b/test/test_periodic_bc.jl
@@ -365,8 +365,11 @@
     end
 
     @testset "_check_periodic_endpoints validation (Cubic only)" begin
-        # NOTE: Linear interpolation with extrap=WrapExtrap() does NOT check endpoints!
-        # Only cubic bc=PeriodicBC() checks that y[1] ≈ y[end] (isapprox for _PromotableValue)
+        # NOTE: Linear interpolation with extrap=WrapExtrap() does NOT check endpoints.
+        # Under closed-domain semantics (PR refac/wrap_closed), `xq == last(x)` is an
+        # in-domain boundary query that returns `y[end]` via the search path — no
+        # `y[1] ≈ y[end]` validation is needed for plain WrapExtrap. Only Cubic
+        # bc=PeriodicBC() checks endpoint match (required for the periodic Thomas solve).
         x = range(0.0, 2π, 101)
 
         @testset "Valid periodic data — exact endpoints (Float64)" begin

--- a/test/test_wrap_to_domain_closed.jl
+++ b/test/test_wrap_to_domain_closed.jl
@@ -19,3 +19,18 @@ end
     # Float xi on Int-like Float bounds
     @test _wrap_to_domain(4.0, 0.0, 4.0) == 4.0
 end
+
+@testitem "_check_domain batch — WrapExtrap returns InBounds at exact last(x)" begin
+    using FastInterpolations: _check_domain, WrapExtrap, InBounds
+    x = collect(range(0.0, 1.0, 11))
+    xq = [0.0, 0.5, 1.0]  # includes both endpoints
+    # Closed semantics: all three are in-domain → InBounds()
+    @test _check_domain(x, xq, WrapExtrap()) isa InBounds
+end
+
+@testitem "_check_domain batch — WrapExtrap returns extrap when OOB" begin
+    using FastInterpolations: _check_domain, WrapExtrap
+    x = collect(range(0.0, 1.0, 11))
+    xq = [0.0, 0.5, 1.25]  # 1.25 is strictly OOB
+    @test _check_domain(x, xq, WrapExtrap()) === WrapExtrap()
+end

--- a/test/test_wrap_to_domain_closed.jl
+++ b/test/test_wrap_to_domain_closed.jl
@@ -1,0 +1,21 @@
+@testitem "_wrap_to_domain — closed boundary (Float64)" begin
+    using FastInterpolations: _wrap_to_domain
+    # Interior — unchanged
+    @test _wrap_to_domain(0.5, 0.0, 1.0) == 0.5
+    # Exact right boundary — was wrap, now passthrough
+    @test _wrap_to_domain(1.0, 0.0, 1.0) == 1.0
+    # Exact left boundary — unchanged
+    @test _wrap_to_domain(0.0, 0.0, 1.0) == 0.0
+    # Strictly OOB right — still wraps
+    @test _wrap_to_domain(1.25, 0.0, 1.0) ≈ 0.25
+    # Strictly OOB left — still wraps
+    @test _wrap_to_domain(-0.25, 0.0, 1.0) ≈ 0.75
+end
+
+@testitem "_wrap_to_domain — closed boundary (generic Real / Int)" begin
+    using FastInterpolations: _wrap_to_domain
+    # Int xi on Float bounds — exact right boundary
+    @test _wrap_to_domain(4, 0.0, 4.0) == 4
+    # Float xi on Int-like Float bounds
+    @test _wrap_to_domain(4.0, 0.0, 4.0) == 4.0
+end

--- a/test/test_wrapextrap_closed_boundary.jl
+++ b/test/test_wrapextrap_closed_boundary.jl
@@ -164,10 +164,10 @@ end
     @test interp((gx, gy), data, corner; method = (CubicInterp(), LinearInterp()), extrap = ext_both) ≈
         expected atol = 1.0e-12
     let itp = interp(
-                (gx, gy), data;
-                method = (CubicInterp(), LinearInterp()),
-                extrap = ext_both, coeffs = PreCompute(),
-            )
+            (gx, gy), data;
+            method = (CubicInterp(), LinearInterp()),
+            extrap = ext_both, coeffs = PreCompute(),
+        )
         @test itp(corner) ≈ expected atol = 1.0e-12
     end
 
@@ -179,10 +179,10 @@ end
         extrap = ext_both,
     ) ≈ expected atol = 1.0e-12
     let itp = interp(
-                (gx, gy), data;
-                method = (CardinalInterp(), CardinalInterp()),
-                extrap = ext_both, coeffs = OnTheFly(),
-            )
+            (gx, gy), data;
+            method = (CardinalInterp(), CardinalInterp()),
+            extrap = ext_both, coeffs = OnTheFly(),
+        )
         @test itp(corner) ≈ expected atol = 1.0e-12
     end
 

--- a/test/test_wrapextrap_closed_boundary.jl
+++ b/test/test_wrapextrap_closed_boundary.jl
@@ -1,10 +1,136 @@
-@testitem "Linear batch WrapExtrap — exact last(x) takes fast path" begin
+# ════════════════════════════════════════════════════════════════════════════
+# WrapExtrap closed-domain `[first(x), last(x)]` semantic guards
+#
+# After the closed-domain conversion (PR refac/wrap_closed), queries at
+# exactly `last(x)` are treated as in-domain boundary queries (return
+# `y[end]`) instead of wrapping to `first(x)`. This file pins down that
+# behavior across 1D methods × extrap policies × grid types, plus the ND
+# axis-level analog and the :exclusive/:inclusive PeriodicBC invariants.
+# ════════════════════════════════════════════════════════════════════════════
+
+@testitem "Closed boundary — Linear 1D × every extrap × every grid type" begin
+    using FastInterpolations
+    for x in (collect(range(0.0, 1.0, 11)), range(0.0, 1.0, 11))
+        y = collect(1.0:11.0)
+        # Scalar — every extrap at exact last(x) returns y[end]
+        @test linear_interp(x, y, 1.0; extrap = WrapExtrap()) == y[end]
+        @test linear_interp(x, y, 1.0; extrap = ClampExtrap()) == y[end]
+        @test linear_interp(x, y, 1.0; extrap = FillExtrap(-1.0)) == y[end]
+        @test linear_interp(x, y, 1.0; extrap = NoExtrap()) == y[end]
+        # Batch (exercises the linear_oneshot fast path)
+        @test linear_interp(x, y, [1.0]; extrap = WrapExtrap())[1] == y[end]
+        @test linear_interp(x, y, [0.5, 1.0]; extrap = WrapExtrap())[end] == y[end]
+        # Strictly OOB still wraps to the correct in-domain cell
+        @test linear_interp(x, y, 1.25; extrap = WrapExtrap()) ≈
+            linear_interp(x, y, 0.25; extrap = NoExtrap())  atol = 1.0e-12
+    end
+end
+
+@testitem "Closed boundary — Constant 1D × every extrap" begin
     using FastInterpolations
     x = collect(range(0.0, 1.0, 11))
     y = collect(1.0:11.0)
-    xq = [0.0, 0.5, 1.0]
-    out = linear_interp(x, y, xq; extrap=WrapExtrap())
-    # Closed: last entry should be y[end] = 11.0, NOT y[1] = 1.0
-    @test out[end] == y[end]
-    @test out[1] == y[1]
+    @test constant_interp(x, y, 1.0; extrap = WrapExtrap()) == y[end]
+    @test constant_interp(x, y, [1.0]; extrap = WrapExtrap())[1] == y[end]
+    @test constant_interp(x, y, 1.0; extrap = ClampExtrap()) == y[end]
+end
+
+@testitem "Closed boundary — Cubic 1D × WrapExtrap × every grid type" begin
+    using FastInterpolations
+    for x in (collect(range(0.0, 1.0, 11)), range(0.0, 1.0, 11))
+        y = sin.(x)
+        @test cubic_interp(x, y, 1.0; extrap = WrapExtrap()) ≈ y[end] atol = 1.0e-12
+        @test cubic_interp(x, y, [1.0]; extrap = WrapExtrap())[1] ≈ y[end] atol = 1.0e-12
+    end
+end
+
+@testitem "Closed boundary — Quadratic 1D × WrapExtrap" begin
+    using FastInterpolations
+    x = collect(range(0.0, 1.0, 11))
+    y = x .^ 2
+    @test quadratic_interp(x, y, 1.0; extrap = WrapExtrap()) ≈ y[end] atol = 1.0e-12
+    @test quadratic_interp(x, y, [1.0]; extrap = WrapExtrap())[1] ≈ y[end] atol = 1.0e-12
+end
+
+@testitem "Closed boundary — Hermite (precomputed dy) × WrapExtrap" begin
+    using FastInterpolations
+    x = collect(range(0.0, 1.0, 11))
+    y = sin.(x)
+    dy = cos.(x)
+    @test hermite_interp(x, y, dy, 1.0; extrap = WrapExtrap()) ≈ y[end] atol = 1.0e-12
+    @test hermite_interp(x, y, dy, [1.0]; extrap = WrapExtrap())[1] ≈ y[end] atol = 1.0e-12
+end
+
+@testitem "Closed boundary — Hermite OnTheFly (PCHIP/Cardinal/Akima) × WrapExtrap" begin
+    using FastInterpolations
+    x = collect(range(0.0, 1.0, 11))
+    y = sin.(x)
+    @test pchip_interp(x, y, 1.0; extrap = WrapExtrap()) ≈ y[end] atol = 1.0e-12
+    @test cardinal_interp(x, y, 1.0; tension = 0.0, extrap = WrapExtrap()) ≈ y[end] atol = 1.0e-12
+    @test akima_interp(x, y, 1.0; extrap = WrapExtrap()) ≈ y[end] atol = 1.0e-12
+end
+
+@testitem "Closed boundary — :inclusive PeriodicBC still returns y[1] (= y[end])" begin
+    using FastInterpolations
+    x = collect(range(0.0, 2π, 11))
+    y = sin.(x)
+    y[end] = y[1]   # enforce closed cycle
+    # Validation guarantees y[1] == y[end], so closed eval at xq=last(x)
+    # (search returns last interval, α=1, eval = y[end]) gives the same value
+    # as the old wrap-to-x_min path (search returns interval 1, α=0).
+    @test cubic_interp(x, y, 2π; bc = PeriodicBC()) ≈ y[1] atol = 1.0e-12
+    @test cubic_interp(x, y, [2π]; bc = PeriodicBC())[1] ≈ y[1] atol = 1.0e-12
+    @test linear_interp(x, y, 2π; bc = PeriodicBC()) ≈ y[1] atol = 1.0e-12
+end
+
+@testitem "Closed boundary — :exclusive PeriodicBC: seam search returns y[1] without wrap" begin
+    using FastInterpolations
+    x = range(0.5, step = 1.0, length = 3)       # FVM cell-centered grid
+    y = [10.0, 20.0, 30.0]
+    bc = PeriodicBC(endpoint = :exclusive, period = 3.0)
+    # Virtual endpoint x[1] + period = 3.5
+    # Old (half-open): _wrap_to_domain(3.5) → 0.5 → search → y[1]=10.0
+    # New (closed):    no wrap; seam search → (n=3, idx_R=1, ...), α=1 → y[idx_R=1] = y[1]
+    @test linear_interp(x, y, 3.5; bc = bc) == 10.0
+    @test linear_interp(x, y, [3.5]; bc = bc)[1] == 10.0
+    @test constant_interp(x, y, 3.5; bc = bc) == 10.0
+end
+
+@testitem "Closed boundary — :exclusive PeriodicBC series oneshot at virtual endpoint" begin
+    using FastInterpolations
+    # Pin the bug exposed by closed semantics: constant series oneshot
+    # _constant_eval_at_anchor short-circuit was using y[end] (=y[n]) instead
+    # of y[aq.idxR] (=y[1] for _ExclusivePeriodicAxis seam fold).
+    x = collect(0.0:3.0)
+    y1 = [10.0, 20.0, 30.0, 40.0]
+    y2 = [1.0, 2.0, 3.0, 4.0]
+    s = Series(y1, y2)
+    bc = PeriodicBC(endpoint = :exclusive, period = 4.0)
+    out = constant_interp(x, s, 4.0; bc = bc)
+    @test out[1] == y1[1]                                        # cyclic, NOT y1[end]
+    @test out[2] == y2[1]
+    # Series ↔ non-series alignment
+    @test out[1] == constant_interp(x, y1, 4.0; bc = bc)
+    @test out[2] == constant_interp(x, y2, 4.0; bc = bc)
+end
+
+@testitem "Closed boundary — ND per-axis WrapExtrap at last(grid)" begin
+    using FastInterpolations
+    gx = collect(range(0.0, 1.0, 11))
+    gy = collect(range(0.0, 2.0, 21))
+    data = [Float64(i + 10j) for i in 1:length(gx), j in 1:length(gy)]
+    # Scalar query at the corner (last(gx), last(gy)) on BOTH axes
+    val = interp(
+        (gx, gy), data, (1.0, 2.0);
+        method = (LinearInterp(), LinearInterp()),
+        extrap = (WrapExtrap(), WrapExtrap()),
+    )
+    @test val == data[end, end]
+    # Batch (SoA) query at the corner
+    out = interp(
+        (gx, gy), data, ([1.0], [2.0]);
+        method = (LinearInterp(), LinearInterp()),
+        extrap = (WrapExtrap(), WrapExtrap()),
+    )
+    @test out[1] == data[end, end]
 end

--- a/test/test_wrapextrap_closed_boundary.jl
+++ b/test/test_wrapextrap_closed_boundary.jl
@@ -265,6 +265,49 @@ end
     end
 end
 
+@testitem "Closed boundary — :inclusive PeriodicBC adjoint at last(x) lands at f_bar[end]" begin
+    using FastInterpolations
+    # Companion to the WrapExtrap adjoint test above for :inclusive PeriodicBC.
+    # Under v0.4.9 (half-open) the seam wrapped to first(x) and adjoint
+    # sensitivity scattered to f_bar[1]; under v0.4.10 (closed) it now lands
+    # at f_bar[end]. Forward value stays invariant (y[1] ≈ y[end] by the
+    # :inclusive cycle constraint), but the adjoint slot location does not —
+    # equivalent only after a y[1] = y[end] re-projection on f_bar.
+    x = collect(range(0.0, 2π, 11))
+    y = sin.(x)
+    y[end] = y[1]   # enforce :inclusive cycle (constructor validates this)
+    y_bar = [1.0]
+    bc = PeriodicBC(endpoint = :inclusive)
+
+    # Linear: exact at nodes — gradient = δ_{k,end}, no cyclic coupling
+    let adj = linear_adjoint(x, [last(x)]; bc = bc), f_bar = adj(y_bar)
+        @test f_bar[end] == 1.0
+        @test f_bar[1] == 0.0
+        @test all(f_bar[2:(end - 1)] .== 0.0)
+    end
+    # Cubic: Sherman-Morrison transpose solve, but the spline is exact at every
+    # node, so d itp(x[n]) / d y[k] = δ_{k,n} for any BC. Data-independent adjoint.
+    let adj = cubic_adjoint(x, [last(x)]; bc = bc), f_bar = adj(y_bar)
+        @test f_bar[end] ≈ 1.0 atol = 1.0e-10
+        @test f_bar[1] ≈ 0.0 atol = 1.0e-10
+    end
+    # PCHIP / Akima: closed-cycle slope adjoint via mod1 cyclic stencil, but
+    # Hermite slope basis evaluates to 0 at α=1, so gradient still concentrates
+    # at f_bar[end] — cyclic slope propagation contributes nothing at the node.
+    let adj = pchip_adjoint(x, y, [last(x)]; bc = bc), f_bar = adj(y_bar)
+        @test f_bar[end] ≈ 1.0 atol = 1.0e-10
+        @test f_bar[1] ≈ 0.0 atol = 1.0e-10
+    end
+    let adj = cardinal_adjoint(x, [last(x)]; tension = 0.0, bc = bc), f_bar = adj(y_bar)
+        @test f_bar[end] ≈ 1.0 atol = 1.0e-10
+        @test f_bar[1] ≈ 0.0 atol = 1.0e-10
+    end
+    let adj = akima_adjoint(x, y, [last(x)]; bc = bc), f_bar = adj(y_bar)
+        @test f_bar[end] ≈ 1.0 atol = 1.0e-10
+        @test f_bar[1] ≈ 0.0 atol = 1.0e-10
+    end
+end
+
 @testitem "Closed boundary — zero alloc on new WrapExtrap fast paths" setup = [AllocConstants] begin
     using FastInterpolations
     # The closed-domain conversion added (1) a constant scalar oneshot right-edge

--- a/test/test_wrapextrap_closed_boundary.jl
+++ b/test/test_wrapextrap_closed_boundary.jl
@@ -1,0 +1,10 @@
+@testitem "Linear batch WrapExtrap — exact last(x) takes fast path" begin
+    using FastInterpolations
+    x = collect(range(0.0, 1.0, 11))
+    y = collect(1.0:11.0)
+    xq = [0.0, 0.5, 1.0]
+    out = linear_interp(x, y, xq; extrap=WrapExtrap())
+    # Closed: last entry should be y[end] = 11.0, NOT y[1] = 1.0
+    @test out[end] == y[end]
+    @test out[1] == y[1]
+end

--- a/test/test_wrapextrap_closed_boundary.jl
+++ b/test/test_wrapextrap_closed_boundary.jl
@@ -134,3 +134,198 @@ end
     )
     @test out[1] == data[end, end]
 end
+
+@testitem "Closed boundary — ND hetero corner × WrapExtrap (homo + mixed method tuples)" begin
+    using FastInterpolations
+    # Splines interpolate exactly at every node, so the corner query
+    # `(last(gx), last(gy))` must return `data[end, end]` for every supported
+    # ND method combination under per-axis WrapExtrap. Covers method-tuple
+    # branches not exercised by the Linear×Linear corner above:
+    #   - homo Cubic×Cubic, Quadratic×Quadratic
+    #   - hetero Cubic×Linear (different families per axis)
+    #   - 3D Cubic×Cubic×Cubic (N > 2 corner)
+    #   - OnTheFly Hermite via Cardinal×Cardinal (cell-local `_collapse_dims` path)
+    gx = collect(range(0.0, 1.0, 11))
+    gy = collect(range(0.0, 2.0, 21))
+    data = [sin(xi) + cos(yj) for xi in gx, yj in gy]
+    corner = (1.0, 2.0)
+    ext_both = (WrapExtrap(), WrapExtrap())
+    expected = data[end, end]
+
+    # Homogeneous high-order at the corner
+    @test interp((gx, gy), data, corner; method = (CubicInterp(), CubicInterp()), extrap = ext_both) ≈
+        expected atol = 1.0e-12
+    @test interp(
+        (gx, gy), data, corner;
+        method = (QuadraticInterp(), QuadraticInterp()), extrap = ext_both
+    ) ≈ expected atol = 1.0e-12
+
+    # Hetero: different families per axis (oneshot and persistent)
+    @test interp((gx, gy), data, corner; method = (CubicInterp(), LinearInterp()), extrap = ext_both) ≈
+        expected atol = 1.0e-12
+    let itp = interp(
+                (gx, gy), data;
+                method = (CubicInterp(), LinearInterp()),
+                extrap = ext_both, coeffs = PreCompute(),
+            )
+        @test itp(corner) ≈ expected atol = 1.0e-12
+    end
+
+    # OnTheFly Hermite via Cardinal×Cardinal — exercises the cell-local
+    # `_collapse_dims` window-aware path from PR #112.
+    @test interp(
+        (gx, gy), data, corner;
+        method = (CardinalInterp(), CardinalInterp()),
+        extrap = ext_both,
+    ) ≈ expected atol = 1.0e-12
+    let itp = interp(
+                (gx, gy), data;
+                method = (CardinalInterp(), CardinalInterp()),
+                extrap = ext_both, coeffs = OnTheFly(),
+            )
+        @test itp(corner) ≈ expected atol = 1.0e-12
+    end
+
+    # 3D corner (N > 2): Cubic×Cubic×Cubic, all-WrapExtrap
+    gz = collect(range(0.0, 0.5, 7))
+    data3 = [sin(xi) + cos(yj) + zk for xi in gx, yj in gy, zk in gz]
+    corner3 = (1.0, 2.0, 0.5)
+    @test interp(
+        (gx, gy, gz), data3, corner3;
+        method = (CubicInterp(), CubicInterp(), CubicInterp()),
+        extrap = (WrapExtrap(), WrapExtrap(), WrapExtrap()),
+    ) ≈ data3[end, end, end] atol = 1.0e-12
+end
+
+@testitem "Closed boundary — persistent (callable) interpolant at last(x) × WrapExtrap" begin
+    using FastInterpolations
+    # Spline interpolates exactly at every node, so itp(last(x)) must return
+    # y[end] for every method family. Pins the closed-domain contract on the
+    # `_anchor_loc`-driven persistent path (distinct from the search-driven
+    # oneshot path covered above).
+    for x in (collect(range(0.0, 1.0, 11)), range(0.0, 1.0, 11))
+        y = sin.(x)
+        @test linear_interp(x, y; extrap = WrapExtrap())(1.0) ≈ y[end] atol = 1.0e-14
+        @test constant_interp(x, y; extrap = WrapExtrap())(1.0) ≈ y[end] atol = 1.0e-14
+        @test cubic_interp(x, y; extrap = WrapExtrap())(1.0) ≈ y[end] atol = 1.0e-12
+        @test quadratic_interp(x, y; extrap = WrapExtrap())(1.0) ≈ y[end] atol = 1.0e-12
+        @test pchip_interp(x, y; extrap = WrapExtrap())(1.0) ≈ y[end] atol = 1.0e-14
+        @test cardinal_interp(x, y; tension = 0.0, extrap = WrapExtrap())(1.0) ≈ y[end] atol = 1.0e-14
+        @test akima_interp(x, y; extrap = WrapExtrap())(1.0) ≈ y[end] atol = 1.0e-14
+        # Hermite with explicit slopes
+        dy = cos.(x)
+        @test hermite_interp(x, y, dy; extrap = WrapExtrap())(1.0) ≈ y[end] atol = 1.0e-14
+    end
+end
+
+@testitem "Closed boundary — adjoint at last(x) lands at f_bar[end] × WrapExtrap" begin
+    using FastInterpolations
+    # Under closed semantics, xq == last(x) lands at α=1 in interval n-1.
+    # Spline interpolates exactly at every node, so d itp(last(x)) / d y[i]
+    # is the indicator δ_{i, end}. Old half-open semantics wrapped to first(x),
+    # giving δ_{i, 1} — this test pins the gradient location.
+    x = collect(range(0.0, 1.0, 11))
+    y = sin.(x)
+    y_bar = [1.0]
+
+    # Linear: closed-form weights, exact at nodes
+    let adj = linear_adjoint(x, [1.0]; extrap = WrapExtrap()), f_bar = adj(y_bar)
+        @test f_bar[end] == 1.0
+        @test f_bar[1] == 0.0
+        @test all(f_bar[2:(end - 1)] .== 0.0)
+    end
+    # Cubic, Quadratic: data-independent adjoint (no y arg)
+    let adj = cubic_adjoint(x, [1.0]; extrap = WrapExtrap()), f_bar = adj(y_bar)
+        @test f_bar[end] ≈ 1.0 atol = 1.0e-12
+        @test f_bar[1] ≈ 0.0 atol = 1.0e-12
+    end
+    let adj = quadratic_adjoint(x, [1.0]; extrap = WrapExtrap()), f_bar = adj(y_bar)
+        @test f_bar[end] ≈ 1.0 atol = 1.0e-12
+        @test f_bar[1] ≈ 0.0 atol = 1.0e-12
+    end
+    # OnTheFly Hermite families: slopes are data-dependent, so adjoint takes (x, y, xq)
+    let adj = pchip_adjoint(x, y, [1.0]; extrap = WrapExtrap()), f_bar = adj(y_bar)
+        @test f_bar[end] ≈ 1.0 atol = 1.0e-12
+        @test f_bar[1] ≈ 0.0 atol = 1.0e-12
+    end
+    # Cardinal adjoint: data-independent (linear in y), so no y arg
+    let adj = cardinal_adjoint(x, [1.0]; tension = 0.0, extrap = WrapExtrap()),
+            f_bar = adj(y_bar)
+        @test f_bar[end] ≈ 1.0 atol = 1.0e-12
+        @test f_bar[1] ≈ 0.0 atol = 1.0e-12
+    end
+    let adj = akima_adjoint(x, y, [1.0]; extrap = WrapExtrap()), f_bar = adj(y_bar)
+        @test f_bar[end] ≈ 1.0 atol = 1.0e-12
+        @test f_bar[1] ≈ 0.0 atol = 1.0e-12
+    end
+    # Hermite (user-supplied slopes): adjoint is data-independent (x, xq) only
+    let adj = hermite_adjoint(x, [1.0]; extrap = WrapExtrap()), f_bar = adj(y_bar)
+        @test f_bar[end] ≈ 1.0 atol = 1.0e-12
+        @test f_bar[1] ≈ 0.0 atol = 1.0e-12
+    end
+end
+
+@testitem "Closed boundary — zero alloc on new WrapExtrap fast paths" setup = [AllocConstants] begin
+    using FastInterpolations
+    # The closed-domain conversion added (1) a constant scalar oneshot right-edge
+    # short-circuit and (2) widened the linear batch fast-path predicate to `<=`.
+    # Both must stay within `ALLOC_THRESHOLD` (0 on Julia ≥ 1.12, ~240 B on LTS).
+
+    # Function-barrier pattern: setup + warmup + @allocated all inside one fn,
+    # so the @testset try/catch doesn't taint type inference of locals.
+    function _alloc_constant_oneshot_at_xmax()
+        x = collect(range(0.0, 1.0, 11))
+        y = collect(1.0:11.0)
+        # warmup
+        constant_interp(x, y, 1.0; extrap = WrapExtrap())
+        return @allocated constant_interp(x, y, 1.0; extrap = WrapExtrap())
+    end
+
+    function _alloc_linear_batch_at_xmax()
+        x = collect(range(0.0, 1.0, 11))
+        y = collect(1.0:11.0)
+        out = Vector{Float64}(undef, 3)
+        targets = [0.25, 0.5, 1.0]
+        # warmup
+        linear_interp!(out, x, y, targets; extrap = WrapExtrap())
+        return @allocated linear_interp!(out, x, y, targets; extrap = WrapExtrap())
+    end
+
+    @test _alloc_constant_oneshot_at_xmax() <= ALLOC_THRESHOLD
+    @test _alloc_linear_batch_at_xmax() <= ALLOC_THRESHOLD
+end
+
+@testitem "Closed boundary — derivative at last(x) matches last-segment slope × WrapExtrap" begin
+    using FastInterpolations
+    # Under closed semantics, xq == last(x) lands in cell n-1 at α=1, so
+    # `deriv=DerivOp(1)` must return the last-segment slope. Under the old
+    # half-open convention it would have wrapped to xq=first(x) and returned
+    # the FIRST-segment slope — a discontinuity at the seam. Asymmetric data
+    # exposes the difference.
+    x = collect(range(0.0, 1.0, 11))
+    h = x[2] - x[1]
+    # Asymmetric so first-segment slope ≠ last-segment slope
+    y = exp.(x)
+    last_slope = (y[end] - y[end - 1]) / h
+    first_slope = (y[2] - y[1]) / h
+    @test last_slope ≉ first_slope            # data is asymmetric (sanity)
+
+    # Linear: analytical — derivative is exactly the segment slope
+    @test linear_interp(x, y, 1.0; extrap = WrapExtrap(), deriv = DerivOp(1)) ≈
+        last_slope atol = 1.0e-12
+
+    # Cubic/Quadratic/Hermite: derivative is continuous; verify it matches the
+    # limit from inside the domain (closed-domain seam continuity, not a wrap jump)
+    for method_call in (
+            x_ -> cubic_interp(x, y, x_; extrap = WrapExtrap(), deriv = DerivOp(1)),
+            x_ -> quadratic_interp(x, y, x_; extrap = WrapExtrap(), deriv = DerivOp(1)),
+            x_ -> pchip_interp(x, y, x_; extrap = WrapExtrap(), deriv = DerivOp(1)),
+            x_ -> akima_interp(x, y, x_; extrap = WrapExtrap(), deriv = DerivOp(1)),
+        )
+        d_at_max = method_call(1.0)
+        d_just_below = method_call(1.0 - 1.0e-7)
+        @test d_at_max ≈ d_just_below rtol = 1.0e-4
+        # And NOT equal to the first-segment slope (would be the case under old wrap)
+        @test !isapprox(d_at_max, first_slope; rtol = 1.0e-3)
+    end
+end


### PR DESCRIPTION
## Summary

`WrapExtrap`'s in-domain interval is now closed: `[first(x), last(x)]`. Previously it was half-open `[first(x), last(x))`, so a query at exactly `xq == last(x)` wrapped to the left edge and returned `y[1]`. With closed semantics it stays at the right edge and returns `y[end]`.

This is a behavioral change at exactly one point — `xq == last(x)` under plain `WrapExtrap`. All other queries (`xq < last(x)`, `xq > last(x)`, `xq < first(x)`) are unchanged.

`PeriodicBC` users are observably unaffected:
- `:inclusive` requires `y[1] == y[end]` by construction, so the new return value at the seam is equal to the old one.
- `:exclusive` reaches the seam through `_ExclusivePeriodicAxis.search_interval`, which already used an inclusive `xq >= x[n]` predicate — its fast path returns the cyclic value (`y[1]`) regardless of the wrap-predicate change.
