### PR TITLE
(fix + refac): Method-aware output-eltype via kernel-shape op trait

### DIFF
--- a/src/akima/akima_oneshot.jl
+++ b/src/akima/akima_oneshot.jl
@@ -177,7 +177,7 @@ function akima_interp(
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, Tq <: Real}
-    Tr = _output_eltype(Tv, _promote_grid_float(Tg, Tv), Tq)
+    Tr = _output_eltype(_arithmetic_kernel_shape, _promote_grid_float(Tg, Tv), Tv, Tq)
     output = Vector{Tr}(undef, length(x_query))
     akima_interp!(output, x, y, x_query; bc = bc, coeffs = coeffs, extrap = extrap, deriv = deriv, search = search, hint = hint)
     return output

--- a/src/cardinal/cardinal_oneshot.jl
+++ b/src/cardinal/cardinal_oneshot.jl
@@ -199,7 +199,7 @@ function cardinal_interp(
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, Tq <: Real}
-    Tr = _output_eltype(Tv, _promote_grid_float(Tg, Tv), Tq)
+    Tr = _output_eltype(_arithmetic_kernel_shape, _promote_grid_float(Tg, Tv), Tv, Tq)
     output = Vector{Tr}(undef, length(x_query))
     cardinal_interp!(output, x, y, x_query; bc = bc, coeffs = coeffs, tension = tension, extrap = extrap, deriv = deriv, search = search, hint = hint)
     return output

--- a/src/constant/constant_adjoint.jl
+++ b/src/constant/constant_adjoint.jl
@@ -229,8 +229,8 @@ function constant_adjoint(
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
     ) where {Tg}
-    # Selection kernel → raw eltype contract (cubic/linear/… keep using the
-    # shared `_promote_adjoint_inputs` for their Float-promotion needs).
+    # Grid stays raw `Tg` (no `_promote_adjoint_inputs` Float widening).
+    # Adjoint buffer eltype comes from the protocol's `_output_eltype`.
     x_p = x
     xq_p = _promote_query_typed(x_query, Tg)
 

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -360,7 +360,7 @@ function (itp::ConstantInterpolant{Tg, Tv})(
         aq_vec::AbstractVector{<:_ConstantAnchoredQuery{Tg, Tq}};
         deriv::DerivOp = EvalValue()
     ) where {Tg, Tv, Tq <: Real}
-    T_out = _output_eltype(Tv, Tg, Tq)
+    T_out = _output_eltype(_constant_kernel_shape, Tv, Tq)
     output = Vector{T_out}(undef, length(aq_vec))
     @inbounds for i in eachindex(aq_vec)
         output[i] = _constant_eval_with_anchor(itp, aq_vec[i], deriv)

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -356,11 +356,12 @@ end
 Evaluate constant interpolant at multiple anchored query points.
 Returns newly allocated vector.
 """
-function (itp::ConstantInterpolant{T})(
-        aq_vec::AbstractVector{<:_ConstantAnchoredQuery{T}};
+function (itp::ConstantInterpolant{Tg, Tv})(
+        aq_vec::AbstractVector{<:_ConstantAnchoredQuery{Tg, Tq}};
         deriv::DerivOp = EvalValue()
-    ) where {T}
-    output = Vector{T}(undef, length(aq_vec))
+    ) where {Tg, Tv, Tq <: Real}
+    T_out = _output_eltype(Tv, Tg, Tq)
+    output = Vector{T_out}(undef, length(aq_vec))
     @inbounds for i in eachindex(aq_vec)
         output[i] = _constant_eval_with_anchor(itp, aq_vec[i], deriv)
     end

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -360,7 +360,7 @@ function (itp::ConstantInterpolant{Tg, Tv})(
         aq_vec::AbstractVector{<:_ConstantAnchoredQuery{Tg, Tq}};
         deriv::DerivOp = EvalValue()
     ) where {Tg, Tv, Tq <: Real}
-    T_out = _output_eltype(_constant_kernel_shape, Tv, Tq)
+    T_out = _output_eltype(_constant_kernel_shape, Tg, Tv, Tq)
     output = Vector{T_out}(undef, length(aq_vec))
     @inbounds for i in eachindex(aq_vec)
         output[i] = _constant_eval_with_anchor(itp, aq_vec[i], deriv)

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -273,14 +273,14 @@ end
 # Canonical evaluation functions that take raw y vector + explicit params.
 # Used by both interpolant anchor dispatch AND series one-shot evaluation.
 
-# Default case (extension, wrap, inbounds): kernel with right-boundary check
+# Default case (extension, wrap, inbounds): kernel with right-boundary check.
+# Short-circuits use `* one(aq.xq)` to match the kernel's `* one(dL)` carrier
+# propagation — without it, Int y + Float xq returns Union{Int,Float}.
 @inline function _constant_eval_at_anchor(
         y::AbstractVector, x_last, aq::_ConstantAnchoredQuery,
         op::AbstractEvalOp, side_param::AbstractSide, ::AbstractExtrap
     )
-    # Right-edge short-circuit: `y[aq.idxR]` resolves to `y[end]` for non-periodic
-    # (idxR == n) and to the cyclic `y[1]` for `_ExclusivePeriodicAxis` (idxR == 1).
-    aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[aq.idxR]) : 0 * first(y))
+    aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[aq.idxR] * one(aq.xq)) : 0 * first(y) * one(aq.xq))
     @inbounds return _constant_kernel(op, y[aq.idxL], y[aq.idxR], aq.h, aq.dL, side_param)
 end
 
@@ -290,9 +290,7 @@ end
         op::AbstractEvalOp, side_param::AbstractSide, ::NoExtrap
     )
     aq.state != IN_DOMAIN && throw(DomainError(aq.xq, "query point outside domain"))
-    # Right-edge short-circuit: `y[aq.idxR]` resolves to `y[end]` for non-periodic
-    # (idxR == n) and to the cyclic `y[1]` for `_ExclusivePeriodicAxis` (idxR == 1).
-    aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[aq.idxR]) : 0 * first(y))
+    aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[aq.idxR] * one(aq.xq)) : 0 * first(y) * one(aq.xq))
     @inbounds return _constant_kernel(op, y[aq.idxL], y[aq.idxR], aq.h, aq.dL, side_param)
 end
 
@@ -305,9 +303,7 @@ end
         y_bnd = aq.state == OOB_LEFT ? first(y) : last(y)
         return _eval_extrapolation(op, y_bnd, extrap, aq.xq)
     end
-    # Right-edge short-circuit: `y[aq.idxR]` resolves to `y[end]` for non-periodic
-    # (idxR == n) and to the cyclic `y[1]` for `_ExclusivePeriodicAxis` (idxR == 1).
-    aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[aq.idxR]) : 0 * first(y))
+    aq.xq == x_last && return (op isa EvalValue ? (@inbounds y[aq.idxR] * one(aq.xq)) : 0 * first(y) * one(aq.xq))
     @inbounds return _constant_kernel(op, y[aq.idxL], y[aq.idxR], aq.h, aq.dL, side_param)
 end
 
@@ -334,10 +330,8 @@ end
         x_min, x_max = first(itp.x), last(itp.x)
         throw(DomainError(aq.xq, "query point outside domain [$x_min, $x_max]"))
     end
-    # Right-edge short-circuit: `idxR` resolves to `n` for non-periodic and to
-    # `n+1` (cyclic `y[1]`) on `:exclusive` PeriodicBC's extended-grid persistent path.
     if aq.xq == last(itp.x)
-        return op isa EvalValue ? (@inbounds itp.y[aq.idxR]) : zero(T)
+        return op isa EvalValue ? (@inbounds itp.y[aq.idxR] * one(aq.xq)) : zero(T) * one(aq.xq)
     end
     @inbounds return _constant_kernel(op, itp.y[aq.idxL], itp.y[aq.idxR], aq.h, aq.dL, itp.side)
 end

--- a/src/constant/constant_interpolant.jl
+++ b/src/constant/constant_interpolant.jl
@@ -21,12 +21,14 @@ end
 end
 
 # Constant declares its kernel shape — selection (`y * one(dL)`, no division).
-# Trait infers the exact return type via `promote_op`, so scalar/batch agree
-# (Int×Int×Int → Int; SVector × Dual → SVector{Dual}; etc.).
-@inline _constant_kernel_shape(yv, q) = yv * one(q)
+# Args mirror the real kernel: `(xL, yv, xq)` so `xq - xL` exposes the actual
+# `dL` carrier (e.g. `Dual` grid + `Float` xq → `Dual` dL). Trait infers the
+# exact return type via `promote_op`, so scalar/batch agree (Int×Int×Int → Int;
+# SVector × Dual → SVector{Dual}; Float y × Dual grid → Dual; etc.).
+@inline _constant_kernel_shape(xL, yv, xq) = yv * one(xq - xL)
 
 @inline _output_eltype(::ConstantInterpolant{Tg, Tv}, ::Type{Tq}) where {Tg, Tv, Tq} =
-    _output_eltype(_constant_kernel_shape, Tv, Tq)
+    _output_eltype(_constant_kernel_shape, Tg, Tv, Tq)
 
 # ─────────────────────────────────────────────────────────────
 # Vector loop (function barrier)

--- a/src/constant/constant_interpolant.jl
+++ b/src/constant/constant_interpolant.jl
@@ -20,16 +20,6 @@ end
     return _constant_vector_loop!(output, itp.x, itp.y, xq, extrap, itp.side, op, searcher)
 end
 
-# ========================================
-# Selection-kernel output eltype trait
-# ========================================
-# Override the shared `_output_eltype(itp, Tq)` trait so the protocol's scalar
-# + batch callables keep raw `Tv` for plain numeric queries (selection kernel)
-# and only widen for duck-typed queries (Dual, …) so AD carriers round-trip.
-# Single source of truth — no callable overrides needed.
-@inline _output_eltype(::ConstantInterpolant{Tg, Tv}, ::Type{Tq}) where {Tg, Tv, Tq} =
-    Tq <: _PromotableValue ? Tv : promote_type(Tv, Tq)
-
 # ─────────────────────────────────────────────────────────────
 # Vector loop (function barrier)
 # Julia specializes on concrete Searcher type P, eliminating Union-split

--- a/src/constant/constant_interpolant.jl
+++ b/src/constant/constant_interpolant.jl
@@ -100,8 +100,9 @@ end
 # ========================================
 # Generic Constructor (User API)
 # ========================================
-# Selection kernel → raw eltype contract (Int in → Int out). Signature
-# parametrized directly on `{Tg, Tv}` — no `_promote_grid_float` indirection.
+# Storage parametrized on `{Tg, Tv}` directly — no `_promote_grid_float`
+# indirection. Return type widens via the kernel's `* one(dL)` carrier
+# propagation (handled per-callable, not at construction).
 @inline function constant_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv};

--- a/src/constant/constant_interpolant.jl
+++ b/src/constant/constant_interpolant.jl
@@ -20,6 +20,14 @@ end
     return _constant_vector_loop!(output, itp.x, itp.y, xq, extrap, itp.side, op, searcher)
 end
 
+# Constant declares its kernel shape — selection (`y * one(dL)`, no division).
+# Trait infers the exact return type via `promote_op`, so scalar/batch agree
+# (Int×Int×Int → Int; SVector × Dual → SVector{Dual}; etc.).
+@inline _constant_kernel_shape(yv, q) = yv * one(q)
+
+@inline _output_eltype(::ConstantInterpolant{Tg, Tv}, ::Type{Tq}) where {Tg, Tv, Tq} =
+    _output_eltype(_constant_kernel_shape, Tv, Tq)
+
 # ─────────────────────────────────────────────────────────────
 # Vector loop (function barrier)
 # Julia specializes on concrete Searcher type P, eliminating Union-split

--- a/src/constant/constant_kernels.jl
+++ b/src/constant/constant_kernels.jl
@@ -17,7 +17,11 @@
 # AD Support:
 # - dL can be ForwardDiff.Dual for automatic differentiation
 # - Comparisons use _extract_primal(dL) to get Float value
-# - Output is always Tv (no AD propagation through constant interp - derivative is 0)
+# - Multiplying the selection by `one(dL)` propagates `Tq`'s carrier (Dual,
+#   Float, …) into the result while keeping the value unchanged — aligns
+#   in-domain type with `_promote_extrap_val`'s OOB output. Derivative
+#   branches use `0 * y_left * one(dL)` so they only require `*(::Int, ::Tv)`
+#   and `*(::Tv, ::Real)` (no `zero(::Tv)` assumption beyond master's).
 #
 # Grid point behavior: When dL == 0 (exactly at grid point),
 # all side modes return y_left (the value at that grid point).
@@ -30,7 +34,7 @@ Always returns the left boundary value `y_left`.
 dL can be any Real (including ForwardDiff.Dual for AD).
 """
 @inline function _constant_kernel(::EvalValue, y_left::Tv, ::Tv, ::Tg, dL::Td, ::LeftSide) where {Tv, Tg, Td <: Real}
-    return y_left
+    return y_left * one(dL)
 end
 
 """
@@ -43,7 +47,8 @@ dL can be any Real (including ForwardDiff.Dual for AD).
 @inline function _constant_kernel(::EvalValue, y_left::Tv, y_right::Tv, ::Tg, dL::Td, ::RightSide) where {Tv, Tg, Td <: Real}
     # Use primal value for comparison (supports ForwardDiff.Dual)
     dL_primal = _extract_primal(dL)
-    return iszero(dL_primal) ? y_left : y_right
+    selected = iszero(dL_primal) ? y_left : y_right
+    return selected * one(dL)
 end
 
 """
@@ -56,7 +61,8 @@ dL can be any Real (including ForwardDiff.Dual for AD).
 @inline function _constant_kernel(::EvalValue, y_left::Tv, y_right::Tv, h::Tg, dL::Td, ::NearestSide) where {Tv, Tg, Td <: Real}
     # Use primal value for comparison (supports ForwardDiff.Dual)
     dL_primal = _extract_primal(dL)
-    return dL_primal <= h / 2 ? y_left : y_right
+    selected = dL_primal <= h / 2 ? y_left : y_right
+    return selected * one(dL)
 end
 
 """
@@ -67,7 +73,7 @@ Always returns zero (constant function has no slope).
 Uses `0 * y_left` for duck-typing support and NaN propagation.
 """
 @inline function _constant_kernel(::EvalDeriv1, y_left::Tv, ::Tv, ::Tg, dL::Td, ::AbstractSide) where {Tv, Tg, Td <: Real}
-    return 0 * y_left
+    return 0 * y_left * one(dL)
 end
 
 """
@@ -77,7 +83,7 @@ Second derivative of constant interpolation.
 Always returns zero (constant function has no curvature).
 """
 @inline function _constant_kernel(::EvalDeriv2, y_left::Tv, ::Tv, ::Tg, dL::Td, ::AbstractSide) where {Tv, Tg, Td <: Real}
-    return 0 * y_left
+    return 0 * y_left * one(dL)
 end
 
 """
@@ -86,12 +92,12 @@ end
 Third derivative of constant interpolation is always zero.
 """
 @inline function _constant_kernel(::EvalDeriv3, y_left::Tv, ::Tv, ::Tg, dL::Td, ::AbstractSide) where {Tv, Tg, Td <: Real}
-    return 0 * y_left
+    return 0 * y_left * one(dL)
 end
 
 """Generic fallback: N-th derivative of degree-0 (constant) is zero for N ≥ 1."""
-@inline function _constant_kernel(::DerivOp{N}, y_left::Tv, ::Tv, ::Tg, ::Td, ::AbstractSide) where {N, Tv, Tg, Td <: Real}
-    return 0 * y_left
+@inline function _constant_kernel(::DerivOp{N}, y_left::Tv, ::Tv, ::Tg, dL::Td, ::AbstractSide) where {N, Tv, Tg, Td <: Real}
+    return 0 * y_left * one(dL)
 end
 
 # ========================================

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -276,9 +276,8 @@ sorted_queries = sort(rand(1000))
 vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_window=8))
 ```
 """
-# Unified allocating vector one-shot. Output eltype = `eltype(y)` for plain
-# numeric queries (raw Tv contract); widens to `promote_type(Tv, Tq)` for
-# duck-typed queries (Dual, Measurement, …) so AD carriers aren't stripped.
+# Sample-first allocation: kernel return type drives the container eltype,
+# which faithfully handles cases where `promote_type` is non-concrete.
 function constant_interp(
         x::AbstractVector,
         y::AbstractVector,
@@ -289,10 +288,15 @@ function constant_interp(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
     )
-    Tv = eltype(y)
-    Tq = eltype(x_targets)
-    T_out = Tq <: _PromotableValue ? Tv : promote_type(Tv, Tq)
-    output = Vector{T_out}(undef, length(x_targets))
+    n = length(x_targets)
+    if n == 0
+        return Vector{_output_eltype(eltype(y), eltype(x), eltype(x_targets))}(undef, 0)
+    end
+    first_val = constant_interp(
+        x, y, @inbounds(x_targets[begin]);
+        bc, side, extrap, deriv, search
+    )
+    output = Vector{typeof(first_val)}(undef, n)
     constant_interp!(output, x, y, x_targets; bc, extrap, side, deriv, search)
     return output
 end

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -30,12 +30,10 @@
         searcher::S
     ) where {Tg, Tv, Tq <: Real, S <: Searcher}
     if _extract_primal(xi) == _extract_primal(last(x))
-        # `last(x)` for `_ExclusivePeriodicAxis` is the *virtual* `inner[1] + period`
-        # (the seam right endpoint). The corresponding y at that virtual slot is
-        # `last(y) = inner[1]` for `_ExclusivePeriodicData` — cyclic via the data
-        # wrapper. For raw vectors both `last`s are the user's last entry.
-        # Single uniform `last(y)` handles both cases — no `_resolve_idx` needed.
-        return op isa EvalValue ? last(y) : 0 * first(y)
+        # `last(y)` covers both raw vectors and `_ExclusivePeriodicData` (cyclic
+        # `inner[1]`). `* one(xi)` propagates Tq carrier to match the kernel
+        # path below (without it, Int y + Float xq returns Union{Int,Float}).
+        return op isa EvalValue ? last(y) * one(xi) : 0 * first(y) * one(xi)
     end
     idx, idx_R, xL, xR = search_interval(searcher, x, xi)
     dL = xi - xL
@@ -108,7 +106,7 @@ end
     # the exact boundary. `last(_ExclusivePeriodicData) = inner[1]` so `:exclusive`
     # cyclic wrap is preserved; raw Vector yields `y[n]`.
     _extract_primal(xi_wrapped) == _extract_primal(last(x)) &&
-        return op isa EvalValue ? last(y) : 0 * first(y)
+        return op isa EvalValue ? last(y) * one(xi_wrapped) : 0 * first(y) * one(xi_wrapped)
     idx, idx_R, xL, xR = search_interval(searcher, x, xi_wrapped)
     dL = xi_wrapped - xL
     # Unwrap data once: `search_interval` already resolved the seam (idx_R = 1

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -274,8 +274,9 @@ sorted_queries = sort(rand(1000))
 vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_window=8))
 ```
 """
-# Sample-first allocation: kernel return type drives the container eltype,
-# which faithfully handles cases where `promote_type` is non-concrete.
+# Buffer eltype from the unified `_output_eltype` — same natural-promotion
+# rule as every other method (Int chains widen to Float; duck `SVector × Dual`
+# resolves via `Base.promote_op` fallback).
 function constant_interp(
         x::AbstractVector,
         y::AbstractVector,
@@ -286,15 +287,9 @@ function constant_interp(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
     )
-    n = length(x_targets)
-    if n == 0
-        return Vector{_output_eltype(eltype(y), eltype(x), eltype(x_targets))}(undef, 0)
-    end
-    first_val = constant_interp(
-        x, y, @inbounds(x_targets[begin]);
-        bc, side, extrap, deriv, search
+    output = Vector{_output_eltype(eltype(y), eltype(x), eltype(x_targets))}(
+        undef, length(x_targets)
     )
-    output = Vector{typeof(first_val)}(undef, n)
     constant_interp!(output, x, y, x_targets; bc, extrap, side, deriv, search)
     return output
 end

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -275,8 +275,9 @@ vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_wi
 ```
 """
 # Buffer eltype via Constant's kernel shape — Julia infers the return type
-# from `_constant_kernel_shape(yv, q) = yv * one(q)`, matching the actual
-# kernel reality (Int×Int×Int → Int; SVector × Dual → SVector{Dual}).
+# from `_constant_kernel_shape(xL, yv, xq) = yv * one(xq - xL)`, matching the
+# actual kernel reality (Int×Int×Int → Int; SVector × Dual → SVector{Dual};
+# Float y × Dual grid → Dual carrier via `xq - xL`).
 function constant_interp(
         x::AbstractVector,
         y::AbstractVector,
@@ -287,7 +288,7 @@ function constant_interp(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
     )
-    output = Vector{_output_eltype(_constant_kernel_shape, eltype(y), eltype(x_targets))}(
+    output = Vector{_output_eltype(_constant_kernel_shape, eltype(x), eltype(y), eltype(x_targets))}(
         undef, length(x_targets)
     )
     constant_interp!(output, x, y, x_targets; bc, extrap, side, deriv, search)

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -274,9 +274,9 @@ sorted_queries = sort(rand(1000))
 vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_window=8))
 ```
 """
-# Buffer eltype from the unified `_output_eltype` — same natural-promotion
-# rule as every other method (Int chains widen to Float; duck `SVector × Dual`
-# resolves via `Base.promote_op` fallback).
+# Buffer eltype via Constant's kernel shape — Julia infers the return type
+# from `_constant_kernel_shape(yv, q) = yv * one(q)`, matching the actual
+# kernel reality (Int×Int×Int → Int; SVector × Dual → SVector{Dual}).
 function constant_interp(
         x::AbstractVector,
         y::AbstractVector,
@@ -287,7 +287,7 @@ function constant_interp(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
     )
-    output = Vector{_output_eltype(eltype(y), eltype(x), eltype(x_targets))}(
+    output = Vector{_output_eltype(_constant_kernel_shape, eltype(y), eltype(x_targets))}(
         undef, length(x_targets)
     )
     constant_interp!(output, x, y, x_targets; bc, extrap, side, deriv, search)

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -155,8 +155,8 @@ Constant (step/piecewise constant) interpolation at a single point.
   - `LinearBinarySearch(linear_window=8)`: Linear search within window, then binary fallback
 
 # Returns
-- Interpolated value, eltype `eltype(y)` (raw Tv; widens to `promote_type(Tv, Tq)`
-  only for duck-typed queries).
+- Interpolated value, eltype `promote_type(eltype(y), eltype(xq))` (the
+  kernel's `* one(dL)` carrier propagation; fully-Int chain preserves Int).
 
 # Example
 ```julia

--- a/src/constant/constant_oneshot_series.jl
+++ b/src/constant/constant_oneshot_series.jl
@@ -78,9 +78,7 @@ end
     x = _to_float(x, Tg)
     K = n_series(s)
     Tv = _series_eltype(s)
-    # Duck-typed Tq routes through `_output_eltype` (Base.promote_op fallback);
-    # promotable Tq preserves raw Tv. Mirrors ConstantSeriesInterpolant.
-    Tv_out = Tq <: _PromotableValue ? Tv : _output_eltype(Tv, Tq)
+    Tv_out = _output_eltype(_constant_kernel_shape, Tg, Tv, Tq)
     output = Vector{Tv_out}(undef, K)
     if _is_periodic_bc(bc)
         # Helper wraps `x` via `_resolve_axis(x, bc)` and searches against the
@@ -286,8 +284,7 @@ function constant_interp(
     ) where {Tg, Tq <: Real}
     K = n_series(s)
     Tv = _series_eltype(s)
-    # Same Tv_out rule as the scalar series oneshot — duck queries widen.
-    Tv_out = Tq <: _PromotableValue ? Tv : _output_eltype(Tv, Tq)
+    Tv_out = _output_eltype(_constant_kernel_shape, Tg, Tv, Tq)
     outputs = [Vector{Tv_out}(undef, length(xqs)) for _ in 1:K]
     constant_interp!(outputs, x, s, xqs; bc, side, extrap, deriv, search)
     return outputs

--- a/src/constant/constant_oneshot_series.jl
+++ b/src/constant/constant_oneshot_series.jl
@@ -78,9 +78,9 @@ end
     x = _to_float(x, Tg)
     K = n_series(s)
     Tv = _series_eltype(s)
-    # Duck-typed queries (Dual, …) widen to keep AD carrier; plain queries
-    # preserve raw Tv. Mirrors ConstantSeriesInterpolant scalar callable.
-    Tv_out = Tq <: _PromotableValue ? Tv : promote_type(Tv, Tq)
+    # Duck-typed Tq routes through `_output_eltype` (Base.promote_op fallback);
+    # promotable Tq preserves raw Tv. Mirrors ConstantSeriesInterpolant.
+    Tv_out = Tq <: _PromotableValue ? Tv : _output_eltype(Tv, Tq)
     output = Vector{Tv_out}(undef, K)
     if _is_periodic_bc(bc)
         # Helper wraps `x` via `_resolve_axis(x, bc)` and searches against the
@@ -287,7 +287,7 @@ function constant_interp(
     K = n_series(s)
     Tv = _series_eltype(s)
     # Same Tv_out rule as the scalar series oneshot — duck queries widen.
-    Tv_out = Tq <: _PromotableValue ? Tv : promote_type(Tv, Tq)
+    Tv_out = Tq <: _PromotableValue ? Tv : _output_eltype(Tv, Tq)
     outputs = [Vector{Tv_out}(undef, length(xqs)) for _ in 1:K]
     constant_interp!(outputs, x, s, xqs; bc, side, extrap, deriv, search)
     return outputs

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -394,7 +394,9 @@ Returns a vector of values, one per y-series.
 
 # AD Support
 Plain queries (`Tq <: _PromotableValue`) → output eltype `Tv` unchanged.
-Duck-typed queries (e.g. `ForwardDiff.Dual`) widen to `promote_type(Tv, Tq)`.
+Duck-typed queries (e.g. `ForwardDiff.Dual`) route through `_output_eltype`
+(`Base.promote_op` on the kernel shape) so carriers like `SVector × Dual`
+resolve correctly instead of collapsing to `Vector{Any}`.
 """
 function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
         xq::Tq;

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -393,9 +393,11 @@ Returns a vector of values, one per y-series.
 - `deriv=DerivOp(1),DerivOp(2)`: Returns zeros (step function derivative is zero everywhere)
 
 # AD Support
-Plain queries (`Tq <: _PromotableValue`) → output eltype `Tv` unchanged.
-Duck-typed queries (e.g. `ForwardDiff.Dual`) route through `_output_eltype`
-(`Base.promote_op` on the kernel shape) so carriers like `SVector × Dual`
+Output eltype routes through the kernel-shape trait
+`_output_eltype(_constant_kernel_shape, Tg, Tv, Tq)`. `Base.promote_op` on
+`yv * one(xq - xL)` jointly considers grid (Tg), value (Tv) and query (Tq),
+so duck carriers on either Tg (e.g. `Dual` grid + `Float` xq) or Tq (`Float`
+grid + `Dual` xq) propagate uniformly. Carriers like `SVector × Dual`
 resolve correctly instead of collapsing to `Vector{Any}`.
 """
 function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
@@ -404,10 +406,7 @@ function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, P, Tq <: Real}
-    # Container element sized as `Tv` for promotable Tq (kernel result converts
-    # on assign). Duck Tq (Dual, …) routes through `_output_eltype` so SVector
-    # × Dual resolves via `Base.promote_op` instead of collapsing to `Vector{Any}`.
-    T_out = Tq <: _PromotableValue ? Tv : _output_eltype(Tv, Tq)
+    T_out = _output_eltype(_constant_kernel_shape, Tg, Tv, Tq)
     out = Vector{T_out}(undef, n_series(sitp))
     return sitp(out, xq; deriv = deriv, search = search, hint = hint)
 end
@@ -459,8 +458,7 @@ function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
     n_query = length(xq_typed)
     n_ser = n_series(sitp)
 
-    # Raw-Tv contract for promotable Tq; duck Tq (Dual, …) carrier-propagates.
-    T_out = Tq <: _PromotableValue ? Tv : _output_eltype(Tv, Tq)
+    T_out = _output_eltype(_constant_kernel_shape, Tg, Tv, Tq)
     outputs = Vector{Vector{T_out}}(undef, n_ser)
     @inbounds for k in 1:n_ser
         outputs[k] = Vector{T_out}(undef, n_query)

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -402,12 +402,10 @@ function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, P, Tq <: Real}
-    # Selection kernel returns `y[idx]::Tv` — Tv flows through unchanged for
-    # plain numerical queries. Duck-typed queries (Dual, …) get the legacy
-    # `promote_type(Tv, Tq)` widening so AD callers keep their input-Dual →
-    # output-Dual API contract (the partial wrt xq is 0 for constant, but the
-    # carrier type must match).
-    T_out = Tq <: _PromotableValue ? Tv : promote_type(Tv, Tq)
+    # Selection kernel returns `y[idx]::Tv` for promotable Tq (raw-Tv contract).
+    # Duck-typed Tq (Dual, …) routes through `_output_eltype` so SVector × Dual
+    # resolves via `Base.promote_op` instead of collapsing to `Vector{Any}`.
+    T_out = Tq <: _PromotableValue ? Tv : _output_eltype(Tv, Tq)
     out = Vector{T_out}(undef, n_series(sitp))
     return sitp(out, xq; deriv = deriv, search = search, hint = hint)
 end
@@ -459,10 +457,11 @@ function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
     n_query = length(xq_typed)
     n_ser = n_series(sitp)
 
-    # Explicit Vector{Vector{Tv}} for type stability on Julia LTS
-    outputs = Vector{Vector{Tv}}(undef, n_ser)
+    # Raw-Tv contract for promotable Tq; duck Tq (Dual, …) carrier-propagates.
+    T_out = Tq <: _PromotableValue ? Tv : _output_eltype(Tv, Tq)
+    outputs = Vector{Vector{T_out}}(undef, n_ser)
     @inbounds for k in 1:n_ser
-        outputs[k] = Vector{Tv}(undef, n_query)
+        outputs[k] = Vector{T_out}(undef, n_query)
     end
     sitp(outputs, xq_typed; deriv = deriv, search = search, hint = hint)
 

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -485,7 +485,7 @@ query on the stack and reused for all K series, staying in registers across
 the K evals. No pool, no `aq_vec` scratch.
 """
 function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
-        outputs::AbstractVector{<:AbstractVector{Tv}},
+        outputs::AbstractVector{<:AbstractVector},
         xq::AbstractVector{<:Real};
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = sitp.search_policy,

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -402,9 +402,9 @@ function (sitp::ConstantSeriesInterpolant{Tg, Tv, P})(
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, P, Tq <: Real}
-    # Selection kernel returns `y[idx]::Tv` for promotable Tq (raw-Tv contract).
-    # Duck-typed Tq (Dual, …) routes through `_output_eltype` so SVector × Dual
-    # resolves via `Base.promote_op` instead of collapsing to `Vector{Any}`.
+    # Container element sized as `Tv` for promotable Tq (kernel result converts
+    # on assign). Duck Tq (Dual, …) routes through `_output_eltype` so SVector
+    # × Dual resolves via `Base.promote_op` instead of collapsing to `Vector{Any}`.
     T_out = Tq <: _PromotableValue ? Tv : _output_eltype(Tv, Tq)
     out = Vector{T_out}(undef, n_series(sitp))
     return sitp(out, xq; deriv = deriv, search = search, hint = hint)

--- a/src/constant/constant_types.jl
+++ b/src/constant/constant_types.jl
@@ -61,9 +61,8 @@ struct ConstantInterpolant{Tg, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector{
     search_policy::P  # Default search policy (immutable, thread-safe)
 
     # Inner: `_cache_axis` (insurance) then `_convert_copy` for ownership.
-    # `{Tg, Tv}` parametrized directly — selection kernel → raw eltype
-    # contract (Int in → Int out), unlike arithmetic methods that thread
-    # `_promote_grid_float(TX, TY)` through here.
+    # `{Tg, Tv}` parametrized directly — no `_promote_grid_float(TX, TY)`
+    # indirection (storage stays raw; the kernel handles return-type widening).
     function ConstantInterpolant(
             x::AbstractVector{Tg}, y::AbstractVector{Tv}, ev::E, sv::SD, search::P;
             bc::AbstractBC = NoBC()

--- a/src/constant/nd/constant_nd_adjoint.jl
+++ b/src/constant/nd/constant_nd_adjoint.jl
@@ -240,7 +240,8 @@ end
 @inline function _constant_adjoint_dispatch(
         grids::NTuple{N, AbstractVector}, queries, bc, side, extrap
     ) where {N}
-    # Selection-kernel adjoint: raw eltype contract (no `float()` widening).
+    # Grid stays raw (no `float()` widening); adjoint buffer eltype comes
+    # from the protocol's `_output_eltype`.
     Tg = _promote_grid_eltype(grids)
     grids_typed = _convert_grids_typed(grids, Tg)
 

--- a/src/constant/nd/constant_nd_eval.jl
+++ b/src/constant/nd/constant_nd_eval.jl
@@ -9,9 +9,6 @@
 # Callable Interface
 # ========================================
 
-# Scalar tuple query — wraps the selection-kernel value in `convert` against
-# the `_output_eltype(itp, Tq)` trait so plain numeric queries keep raw `Tv`
-# while duck-typed queries (Dual, …) get their carrier preserved.
 @inline function (itp::ConstantInterpolantND{Tg, Tv, N})(
         query::Tuple{Vararg{Real, N}};
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
@@ -23,9 +20,7 @@
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
     mono = _scalar_mono(hint, Val(N))
-    val = _eval_nd_at_point(itp, resolved, ops, policies, hints, mono)
-    Tq = promote_type(map(typeof, query)...)
-    return convert(_output_eltype(itp, Tq), val)
+    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono)
 end
 
 # In-place + allocating batch use the inherited `AbstractInterpolantND`
@@ -195,7 +190,9 @@ paths share this signature.
     end
     idx_expr = Expr(:tuple, idx_parts...)
 
-    push!(exprs, :(@inbounds data[$idx_expr...]))
+    # Per-axis `* one(dL_d)` propagates each axis's `Tq` carrier (mirrors 1D).
+    ones_expr = Expr(:call, :*, [:(one($(Symbol("dL_", d)))) for d in 1:N]...)
+    push!(exprs, :(@inbounds data[$idx_expr...] * $ones_expr))
 
     return Expr(:block, :(Base.@_inline_meta), exprs...)
 end

--- a/src/constant/nd/constant_nd_eval.jl
+++ b/src/constant/nd/constant_nd_eval.jl
@@ -24,8 +24,9 @@
 end
 
 # In-place + allocating batch use the inherited `AbstractInterpolantND`
-# protocol (sample-first allocator). Scalar routes through `_eval_nd_at_point`;
-# Constant's "any derivative → 0" rule is wired via `_deriv_zero_fill` below.
+# protocol (trait-sized allocator via `_output_eltype`). Scalar routes
+# through `_eval_nd_at_point`; Constant's "any derivative → 0" rule is
+# wired via `_deriv_zero_fill` below.
 
 # Derivative zero-fill trait: constant has zero derivative at all orders
 @inline _deriv_zero_fill(::ConstantInterpolantND, ops::NTuple{N, AbstractEvalOp}, ::Val{N}) where {N} =

--- a/src/constant/nd/constant_nd_eval.jl
+++ b/src/constant/nd/constant_nd_eval.jl
@@ -24,10 +24,8 @@
 end
 
 # In-place + allocating batch use the inherited `AbstractInterpolantND`
-# protocol; output eltype comes from the `_output_eltype(itp, Tq)` trait
-# overridden in `constant_nd_types.jl`. Scalar evaluation routes through
-# the generic `_eval_nd_at_point` in interpolant_protocol.jl — Constant's
-# "any derivative → 0" rule is wired via the `_deriv_zero_fill` trait below.
+# protocol (sample-first allocator). Scalar routes through `_eval_nd_at_point`;
+# Constant's "any derivative → 0" rule is wired via `_deriv_zero_fill` below.
 
 # Derivative zero-fill trait: constant has zero derivative at all orders
 @inline _deriv_zero_fill(::ConstantInterpolantND, ops::NTuple{N, AbstractEvalOp}, ::Val{N}) where {N} =

--- a/src/constant/nd/constant_nd_eval.jl
+++ b/src/constant/nd/constant_nd_eval.jl
@@ -94,10 +94,11 @@ end
         cell::Tuple,
         ops::NTuple{N, AbstractEvalOp}
     ) where {Tg, Tv, N}
-    if _has_any_derivative(ops, Val(N))
-        return 0 * first(itp.data)
-    end
     data, stencils, hs, sides, q_eval, Ls = cell
+    if _has_any_derivative(ops, Val(N))
+        # `prod(one, q_eval)` folds carrier over every axis.
+        return 0 * first(itp.data) * prod(one, q_eval)
+    end
     return _constant_nd_kernel(data, stencils, hs, sides, q_eval, Ls)
 end
 

--- a/src/constant/nd/constant_nd_interpolant.jl
+++ b/src/constant/nd/constant_nd_interpolant.jl
@@ -57,9 +57,9 @@ function constant_interp(
     # Validate grid dimensions
     _validate_nd_grids(grids, data)
 
-    # Selection kernel → raw eltype contract (Int in → Int out), N-axis
-    # generalization of the 1D policy: `Tg = promote_type(eltype.(grids)...)`
-    # without Float widening, `Tv = eltype(data)`.
+    # Raw storage (no Float widening): `Tg = promote_type(eltype.(grids)...)`,
+    # `Tv = eltype(data)`. Kernel handles return-type widening via per-axis
+    # `* one(dL_d)`.
     grids_typed, _, Tv = _nd_promote_grids_raw(grids, data)
     data_typed = data
 

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -105,10 +105,9 @@ function _constant_interp_nd_oneshot_batch(
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}},
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}},
     ) where {Tg, Tv, N}
-    # Unified trait: natural promotion (Int→Float upgrade for promotable Tq;
-    # duck `SVector × Dual` resolves via `Base.promote_op` fallback).
+    # Buffer eltype via Constant's kernel shape (mirrors 1D oneshot wrapper).
     Tq = _query_eltype(queries)
-    output = Vector{_output_eltype(Tv, Tg, Tq)}(undef, _query_length(queries))
+    output = Vector{_output_eltype(_constant_kernel_shape, Tv, Tq)}(undef, _query_length(queries))
     return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps_val, side_vals, search, hint)
 end
 

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -105,7 +105,18 @@ function _constant_interp_nd_oneshot_batch(
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}},
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}},
     ) where {Tg, Tv, N}
-    output = Vector{Tv}(undef, _query_length(queries))
+    nq = _query_length(queries)
+    if nq == 0
+        return Vector{Tv}(undef, 0)
+    end
+    # Sample-first: Constant's `y * one(dL)` kernel produces a type that depends
+    # on the query carrier (Int×Float→Float, SVector×Dual→SVector{Dual}); the
+    # trait would over-predict via the Float upgrade so we read the actual
+    # kernel return type from a single scalar eval.
+    policies, _ = _resolve_oneshot_search_nd(search, queries, hint, Val(N))
+    first_q = _extract_query_point(queries, 1, Val(N))
+    first_val = _constant_interp_nd_oneshot(grids, data, first_q, bcs, extraps_val, side_vals, policies, nothing)
+    output = Vector{typeof(first_val)}(undef, nq)
     return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps_val, side_vals, search, hint)
 end
 
@@ -181,10 +192,6 @@ function constant_interp(
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
-    if _is_any_deriv(deriv)
-        return zeros(Tv, _query_length(queries))
-    end
-
     grids_typed, _, _ = _nd_promote_grids_raw(grids, data)
     _validate_nd_grids(grids_typed, data)
 
@@ -192,9 +199,17 @@ function constant_interp(
     sides = _resolve_side_nd(side, Val(N))
 
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)
+    if _is_any_deriv(deriv)
+        # Derivative is identically zero; size with the actual kernel output
+        # type via a single sample so Tq carrier (Dual, etc.) propagates.
+        nq = _query_length(queries)
+        nq == 0 && return Vector{Tv}(undef, 0)
+        zero_sample = 0 * first(data) * one(eltype(_extract_query_point(queries, 1, Val(N))[1]))
+        return fill(zero_sample, nq)
+    end
     return _constant_nd_batch_dispatch(
         grids_typed, data, queries, bcs, extraps_val, sides, search, hint
-    )::Vector{Tv}
+    )
 end
 
 # ========================================

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -193,9 +193,13 @@ function constant_interp(
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)
     if _is_any_deriv(deriv)
         # `prod(one, first_q)` folds carrier over every axis (mirrors the
-        # scalar deriv branch above and the forward kernel).
+        # scalar deriv branch above and the forward kernel). Empty path
+        # uses the kernel-shape trait so eltype matches the non-empty
+        # branch (query carrier preserved).
         nq = _query_length(queries)
-        nq == 0 && return Vector{Tv}(undef, 0)
+        Tg_grid = eltype(grids_typed[1])
+        Tq = _query_eltype(queries)
+        nq == 0 && return Vector{_output_eltype(_constant_kernel_shape, Tg_grid, Tv, Tq)}(undef, 0)
         first_q = _extract_query_point(queries, 1, Val(N))
         zero_sample = 0 * first(data) * prod(one, first_q)
         return fill(zero_sample, nq)

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -105,18 +105,10 @@ function _constant_interp_nd_oneshot_batch(
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}},
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}},
     ) where {Tg, Tv, N}
-    nq = _query_length(queries)
-    if nq == 0
-        return Vector{Tv}(undef, 0)
-    end
-    # Sample-first: Constant's `y * one(dL)` kernel produces a type that depends
-    # on the query carrier (Int×Float→Float, SVector×Dual→SVector{Dual}); the
-    # trait would over-predict via the Float upgrade so we read the actual
-    # kernel return type from a single scalar eval.
-    policies, _ = _resolve_oneshot_search_nd(search, queries, hint, Val(N))
-    first_q = _extract_query_point(queries, 1, Val(N))
-    first_val = _constant_interp_nd_oneshot(grids, data, first_q, bcs, extraps_val, side_vals, policies, nothing)
-    output = Vector{typeof(first_val)}(undef, nq)
+    # Unified trait: natural promotion (Int→Float upgrade for promotable Tq;
+    # duck `SVector × Dual` resolves via `Base.promote_op` fallback).
+    Tq = _query_eltype(queries)
+    output = Vector{_output_eltype(Tv, Tg, Tq)}(undef, _query_length(queries))
     return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps_val, side_vals, search, hint)
 end
 

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -107,7 +107,7 @@ function _constant_interp_nd_oneshot_batch(
     ) where {Tg, Tv, N}
     # Buffer eltype via Constant's kernel shape (mirrors 1D oneshot wrapper).
     Tq = _query_eltype(queries)
-    output = Vector{_output_eltype(_constant_kernel_shape, Tv, Tq)}(undef, _query_length(queries))
+    output = Vector{_output_eltype(_constant_kernel_shape, Tg, Tv, Tq)}(undef, _query_length(queries))
     return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps_val, side_vals, search, hint)
 end
 

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -156,9 +156,10 @@ function constant_interp(
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
-    # Any derivative of constant interpolation is zero
+    # `prod(one, query)` folds `one(::Tq_axis_d)` over every axis (mirrors
+    # forward kernel's per-axis `* one(dL_d)`); identity for plain Float.
     if _is_any_deriv(deriv)
-        return 0 * first(data)
+        return 0 * first(data) * prod(one, query)
     end
 
     grids_typed, _, _ = _nd_promote_grids_raw(grids, data)
@@ -200,11 +201,12 @@ function constant_interp(
 
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)
     if _is_any_deriv(deriv)
-        # Derivative is identically zero; size with the actual kernel output
-        # type via a single sample so Tq carrier (Dual, etc.) propagates.
+        # `prod(one, first_q)` folds carrier over every axis (mirrors the
+        # scalar deriv branch above and the forward kernel).
         nq = _query_length(queries)
         nq == 0 && return Vector{Tv}(undef, 0)
-        zero_sample = 0 * first(data) * one(eltype(_extract_query_point(queries, 1, Val(N))[1]))
+        first_q = _extract_query_point(queries, 1, Val(N))
+        zero_sample = 0 * first(data) * prod(one, first_q)
         return fill(zero_sample, nq)
     end
     return _constant_nd_batch_dispatch(

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -160,7 +160,7 @@ function constant_interp(
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)
     return _constant_interp_nd_oneshot(
         grids_typed, data, query, bcs, extraps_val, sides, searches, hint
-    )::Tv
+    )
 end
 
 """

--- a/src/constant/nd/constant_nd_types.jl
+++ b/src/constant/nd/constant_nd_types.jl
@@ -79,3 +79,8 @@ end
 # Type introspection
 @inline grid_type(::ConstantInterpolantND{Tg}) where {Tg} = Tg
 @inline value_type(::ConstantInterpolantND{Tg, Tv}) where {Tg, Tv} = Tv
+
+# Mirrors the 1D override: trait routes to `_constant_kernel_shape` so the
+# inferred return matches the kernel's actual `y * one(dL)` shape.
+@inline _output_eltype(::ConstantInterpolantND{Tg, Tv, N}, ::Type{Tq}) where {Tg, Tv, N, Tq} =
+    _output_eltype(_constant_kernel_shape, Tv, Tq)

--- a/src/constant/nd/constant_nd_types.jl
+++ b/src/constant/nd/constant_nd_types.jl
@@ -83,4 +83,4 @@ end
 # Mirrors the 1D override: trait routes to `_constant_kernel_shape` so the
 # inferred return matches the kernel's actual `y * one(dL)` shape.
 @inline _output_eltype(::ConstantInterpolantND{Tg, Tv, N}, ::Type{Tq}) where {Tg, Tv, N, Tq} =
-    _output_eltype(_constant_kernel_shape, Tv, Tq)
+    _output_eltype(_constant_kernel_shape, Tg, Tv, Tq)

--- a/src/constant/nd/constant_nd_types.jl
+++ b/src/constant/nd/constant_nd_types.jl
@@ -79,9 +79,3 @@ end
 # Type introspection
 @inline grid_type(::ConstantInterpolantND{Tg}) where {Tg} = Tg
 @inline value_type(::ConstantInterpolantND{Tg, Tv}) where {Tg, Tv} = Tv
-
-# Selection-kernel output eltype trait — raw `Tv` for plain queries, widen
-# only for duck queries (Dual, Measurement, …). Mirrors the 1D override in
-# `constant_interpolant.jl`.
-@inline _output_eltype(::ConstantInterpolantND{Tg, Tv, N}, ::Type{Tq}) where {Tg, Tv, N, Tq} =
-    Tq <: _PromotableValue ? Tv : promote_type(Tv, Tq)

--- a/src/core/adjoint_protocol.jl
+++ b/src/core/adjoint_protocol.jl
@@ -112,7 +112,7 @@ function (adj::AbstractAdjoint1D{Tg})(
     ) where {Tg}
     nq = _n_queries(adj)
     length(y_bar) == nq || _throw_adjoint_dim_mismatch("y_bar", length(y_bar), nq)
-    Tv = promote_type(eltype(y_bar), Tg)
+    Tv = _output_eltype(eltype(y_bar), Tg)
     f_bar = zeros(Tv, _adjoint_internal_length(adj))
     _adjoint_1d_apply!(f_bar, adj, y_bar, deriv)
     return _adjoint_1d_finalize(f_bar, adj)
@@ -122,7 +122,7 @@ function (adj::AbstractAdjoint1D{Tg})(
         y_bar::Real; deriv::DerivOp = EvalValue(), _extra...
     ) where {Tg}
     _n_queries(adj) == 1 || _throw_adjoint_dim_mismatch("y_bar", 1, _n_queries(adj))
-    Tv = promote_type(typeof(y_bar), Tg)
+    Tv = _output_eltype(typeof(y_bar), Tg)
     f_bar = zeros(Tv, _adjoint_internal_length(adj))
     _adjoint_1d_apply!(f_bar, adj, (y_bar,), deriv)
     return _adjoint_1d_finalize(f_bar, adj)
@@ -133,7 +133,7 @@ function (adj::AbstractAdjoint1D{Tg})(
     ) where {Tg}
     nq = _n_queries(adj)
     length(y_bar) == nq || _throw_adjoint_dim_mismatch("y_bar", length(y_bar), nq)
-    Tv = promote_type(eltype(y_bar), Tg)
+    Tv = _output_eltype(eltype(y_bar), Tg)
     f_bar = zeros(Tv, _adjoint_internal_length(adj))
     _adjoint_1d_apply!(f_bar, adj, y_bar, deriv)
     return _adjoint_1d_finalize(f_bar, adj)
@@ -350,7 +350,7 @@ function (adj::AbstractAdjointND{Tg, N})(
     ops = _resolve_deriv_nd(deriv, Val(N))
     nq = _n_queries(adj)
     length(y_bar) == nq || _throw_adjoint_dim_mismatch("y_bar", length(y_bar), nq)
-    Tv = promote_type(eltype(y_bar), Tg)
+    Tv = _output_eltype(eltype(y_bar), Tg)
     f_bar = zeros(Tv, _grid_size(adj)...)
     _adjoint_nd_apply!(f_bar, adj, y_bar, ops)
     return _adjoint_nd_finalize(f_bar, adj)
@@ -365,7 +365,7 @@ function (adj::AbstractAdjointND{Tg, N})(
     ) where {Tg, N}
     ops = _resolve_deriv_nd(deriv, Val(N))
     _n_queries(adj) == 1 || _throw_adjoint_dim_mismatch("y_bar", 1, _n_queries(adj))
-    Tv = promote_type(typeof(y_bar), Tg)
+    Tv = _output_eltype(typeof(y_bar), Tg)
     f_bar = zeros(Tv, _grid_size(adj)...)
     _adjoint_nd_apply!(f_bar, adj, y_bar, ops)
     return _adjoint_nd_finalize(f_bar, adj)
@@ -381,7 +381,7 @@ function (adj::AbstractAdjointND{Tg, N})(
     ops = _resolve_deriv_nd(deriv, Val(N))
     nq = _n_queries(adj)
     length(y_bar) == nq || _throw_adjoint_dim_mismatch("y_bar", length(y_bar), nq)
-    Tv = promote_type(eltype(y_bar), Tg)
+    Tv = _output_eltype(eltype(y_bar), Tg)
     f_bar = zeros(Tv, _grid_size(adj)...)
     _adjoint_nd_apply!(f_bar, adj, y_bar, ops)
     return _adjoint_nd_finalize(f_bar, adj)

--- a/src/core/adjoint_protocol.jl
+++ b/src/core/adjoint_protocol.jl
@@ -112,7 +112,7 @@ function (adj::AbstractAdjoint1D{Tg})(
     ) where {Tg}
     nq = _n_queries(adj)
     length(y_bar) == nq || _throw_adjoint_dim_mismatch("y_bar", length(y_bar), nq)
-    Tv = _output_eltype(eltype(y_bar), Tg)
+    Tv = _output_eltype(_arithmetic_kernel_shape, Tg, eltype(y_bar), Tg)
     f_bar = zeros(Tv, _adjoint_internal_length(adj))
     _adjoint_1d_apply!(f_bar, adj, y_bar, deriv)
     return _adjoint_1d_finalize(f_bar, adj)
@@ -122,7 +122,7 @@ function (adj::AbstractAdjoint1D{Tg})(
         y_bar::Real; deriv::DerivOp = EvalValue(), _extra...
     ) where {Tg}
     _n_queries(adj) == 1 || _throw_adjoint_dim_mismatch("y_bar", 1, _n_queries(adj))
-    Tv = _output_eltype(typeof(y_bar), Tg)
+    Tv = _output_eltype(_arithmetic_kernel_shape, Tg, typeof(y_bar), Tg)
     f_bar = zeros(Tv, _adjoint_internal_length(adj))
     _adjoint_1d_apply!(f_bar, adj, (y_bar,), deriv)
     return _adjoint_1d_finalize(f_bar, adj)
@@ -133,7 +133,7 @@ function (adj::AbstractAdjoint1D{Tg})(
     ) where {Tg}
     nq = _n_queries(adj)
     length(y_bar) == nq || _throw_adjoint_dim_mismatch("y_bar", length(y_bar), nq)
-    Tv = _output_eltype(eltype(y_bar), Tg)
+    Tv = _output_eltype(_arithmetic_kernel_shape, Tg, eltype(y_bar), Tg)
     f_bar = zeros(Tv, _adjoint_internal_length(adj))
     _adjoint_1d_apply!(f_bar, adj, y_bar, deriv)
     return _adjoint_1d_finalize(f_bar, adj)
@@ -350,7 +350,7 @@ function (adj::AbstractAdjointND{Tg, N})(
     ops = _resolve_deriv_nd(deriv, Val(N))
     nq = _n_queries(adj)
     length(y_bar) == nq || _throw_adjoint_dim_mismatch("y_bar", length(y_bar), nq)
-    Tv = _output_eltype(eltype(y_bar), Tg)
+    Tv = _output_eltype(_arithmetic_kernel_shape, Tg, eltype(y_bar), Tg)
     f_bar = zeros(Tv, _grid_size(adj)...)
     _adjoint_nd_apply!(f_bar, adj, y_bar, ops)
     return _adjoint_nd_finalize(f_bar, adj)
@@ -365,7 +365,7 @@ function (adj::AbstractAdjointND{Tg, N})(
     ) where {Tg, N}
     ops = _resolve_deriv_nd(deriv, Val(N))
     _n_queries(adj) == 1 || _throw_adjoint_dim_mismatch("y_bar", 1, _n_queries(adj))
-    Tv = _output_eltype(typeof(y_bar), Tg)
+    Tv = _output_eltype(_arithmetic_kernel_shape, Tg, typeof(y_bar), Tg)
     f_bar = zeros(Tv, _grid_size(adj)...)
     _adjoint_nd_apply!(f_bar, adj, y_bar, ops)
     return _adjoint_nd_finalize(f_bar, adj)
@@ -381,7 +381,7 @@ function (adj::AbstractAdjointND{Tg, N})(
     ops = _resolve_deriv_nd(deriv, Val(N))
     nq = _n_queries(adj)
     length(y_bar) == nq || _throw_adjoint_dim_mismatch("y_bar", length(y_bar), nq)
-    Tv = _output_eltype(eltype(y_bar), Tg)
+    Tv = _output_eltype(_arithmetic_kernel_shape, Tg, eltype(y_bar), Tg)
     f_bar = zeros(Tv, _grid_size(adj)...)
     _adjoint_nd_apply!(f_bar, adj, y_bar, ops)
     return _adjoint_nd_finalize(f_bar, adj)

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -185,7 +185,8 @@ end
     _validate_nd_domain(itp.grids, query, itp.extraps)
     oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _zero_ref(itp))
     oob_result !== nothing && return oob_result
-    _deriv_zero_fill(itp, ops, Val(N)) && return 0 * _zero_ref(itp)
+    # `prod(one, query)` folds carrier over every axis; identity for plain Float.
+    _deriv_zero_fill(itp, ops, Val(N)) && return 0 * _zero_ref(itp) * prod(one, query)
     cell = _locate_cell(itp, query, policies, hints, mono)
     return _eval_at_cell(itp, cell, ops)
 end

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -25,11 +25,11 @@
 @inline _itp_search(itp::AbstractInterpolant1D) = itp.search_policy
 
 # ── Output eltype trait ──
-# Used as the empty-batch fallback type. Scalar callables return the kernel
-# result directly; allocating-batch callables sample the kernel for the
-# container eltype.
+# Default: arithmetic kernels (Linear/Cubic/Quadratic) divide by `h`, so route
+# through the shared `_arithmetic_kernel_shape` for Julia inference. Selection
+# kernels (Constant) and Hermite-family (with `dy`) override this default.
 @inline _output_eltype(::AbstractInterpolant1D{Tg, Tv}, ::Type{Tq}) where {Tg, Tv, Tq} =
-    _output_eltype(Tv, Tg, Tq)
+    _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)
 
 # ========================================
 # 1D Scalar Call — Hot Path
@@ -106,7 +106,7 @@ end
 
 # ── Output eltype trait (ND) — mirrors the 1D version. ──
 @inline _output_eltype(::AbstractInterpolantND{Tg, Tv, N}, ::Type{Tq}) where {Tg, Tv, N, Tq} =
-    _output_eltype(Tv, Tg, Tq)
+    _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)
 
 # ========================================
 # Unified Batch Interpolant Evaluation (Generic ND)

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -25,13 +25,9 @@
 @inline _itp_search(itp::AbstractInterpolant1D) = itp.search_policy
 
 # ── Output eltype trait ──
-# Arithmetic kernels (Linear, Cubic, …) widen via `_output_eltype(Tv, Tg, Tq)`
-# because the kernel produces a wider result from the arithmetic. Selection
-# kernels (Constant) override this to keep raw `Tv` for plain queries and
-# only widen for duck-typed queries (Dual, Measurement, …) so AD carriers
-# round-trip. Both scalar and batch protocol callables go through this single
-# trait; on the scalar path the result is wrapped in `convert(...)` (identity
-# when the kernel already produced the trait's type).
+# Used as the empty-batch fallback type. Scalar callables return the kernel
+# result directly; allocating-batch callables sample the kernel for the
+# container eltype.
 @inline _output_eltype(::AbstractInterpolant1D{Tg, Tv}, ::Type{Tq}) where {Tg, Tv, Tq} =
     _output_eltype(Tv, Tg, Tq)
 
@@ -54,15 +50,14 @@
     # while Clamp/Fill/Wrap handle OOB inside their specialized eval methods
     # without ever calling `_check_domain`. Outer redundancy removed.
     searcher = _resolve_search(grid, xq, search, hint)
-    val = _itp_eval_scalar(itp, xq, extrap, deriv, searcher)
-    return convert(_output_eltype(itp, typeof(xq)), val)
+    return _itp_eval_scalar(itp, xq, extrap, deriv, searcher)
 end
 
 # ========================================
 # 1D Vector Call — Allocating
 # ========================================
-# Output eltype: trait `_output_eltype(itp, Tq)` — defaults to widening
-# `promote_type(Tv, Tg, Tq)`; Constant overrides for raw-Tv contract.
+# Sample-first: kernel return type drives the container eltype. Required when
+# `promote_type(Tv, Tg, Tq)` is non-concrete (e.g., `SVector × Dual`).
 
 function (itp::AbstractInterpolant1D{Tg, Tv})(
         xq::AbstractVector{Tq};
@@ -72,8 +67,13 @@ function (itp::AbstractInterpolant1D{Tg, Tv})(
     ) where {Tg, Tv, Tq <: Real}
     grid = _itp_grid(itp)
     extrap = _itp_extrap(itp)
-    output = Vector{_output_eltype(itp, Tq)}(undef, length(xq))
+    n = length(xq)
+    if n == 0
+        return Vector{_output_eltype(itp, Tq)}(undef, 0)
+    end
     searcher = _resolve_search(grid, xq, search, hint)
+    first_val = _itp_eval_scalar(itp, @inbounds(xq[begin]), extrap, deriv, searcher)
+    output = Vector{typeof(first_val)}(undef, n)
     _itp_vector_loop!(output, itp, xq, extrap, deriv, searcher)
     return output
 end
@@ -258,7 +258,7 @@ end
 # ========================================
 # ND Allocating Batch — Unified
 # ========================================
-# Allocates output via protocol, delegates to in-place above.
+# Sample-first: kernel return type drives the container eltype (see 1D variant).
 
 function (itp::AbstractInterpolantND{Tg, Tv, N})(
         queries;
@@ -267,6 +267,13 @@ function (itp::AbstractInterpolantND{Tg, Tv, N})(
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
     Tq = _query_eltype(queries)
-    output = Vector{_output_eltype(itp, Tq)}(undef, _query_length(queries))
+    nq = _query_length(queries)
+    if nq == 0
+        return Vector{_output_eltype(itp, Tq)}(undef, 0)
+    end
+    first_query = _extract_query_point(queries, 1, Val(N))
+    first_val = itp(first_query; deriv = deriv, search = search, hint = hint)
+    output = Vector{typeof(first_val)}(undef, nq)
+    @inbounds output[1] = first_val
     return itp(output, queries; deriv = deriv, search = search, hint = hint)
 end

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -56,8 +56,10 @@ end
 # ========================================
 # 1D Vector Call — Allocating
 # ========================================
-# Sample-first: kernel return type drives the container eltype. Required when
-# `promote_type(Tv, Tg, Tq)` is non-concrete (e.g., `SVector × Dual`).
+# Buffer eltype comes from the `_output_eltype(itp, Tq)` trait — generic for
+# arithmetic kernels (Int→Float upgrade) and `_select_output_eltype` for
+# selection kernels (Constant). Duck `SVector × Dual` resolves via the
+# trait's `Base.promote_op` fallback.
 
 function (itp::AbstractInterpolant1D{Tg, Tv})(
         xq::AbstractVector{Tq};
@@ -67,13 +69,8 @@ function (itp::AbstractInterpolant1D{Tg, Tv})(
     ) where {Tg, Tv, Tq <: Real}
     grid = _itp_grid(itp)
     extrap = _itp_extrap(itp)
-    n = length(xq)
-    if n == 0
-        return Vector{_output_eltype(itp, Tq)}(undef, 0)
-    end
+    output = Vector{_output_eltype(itp, Tq)}(undef, length(xq))
     searcher = _resolve_search(grid, xq, search, hint)
-    first_val = _itp_eval_scalar(itp, @inbounds(xq[begin]), extrap, deriv, searcher)
-    output = Vector{typeof(first_val)}(undef, n)
     _itp_vector_loop!(output, itp, xq, extrap, deriv, searcher)
     return output
 end
@@ -259,7 +256,8 @@ end
 # ========================================
 # ND Allocating Batch — Unified
 # ========================================
-# Sample-first: kernel return type drives the container eltype (see 1D variant).
+# Buffer eltype from `_output_eltype(itp, Tq)` (see 1D variant for kernel-
+# type rationale); delegates to in-place — no sample-first eval.
 
 function (itp::AbstractInterpolantND{Tg, Tv, N})(
         queries;
@@ -268,13 +266,6 @@ function (itp::AbstractInterpolantND{Tg, Tv, N})(
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
     Tq = _query_eltype(queries)
-    nq = _query_length(queries)
-    if nq == 0
-        return Vector{_output_eltype(itp, Tq)}(undef, 0)
-    end
-    first_query = _extract_query_point(queries, 1, Val(N))
-    first_val = itp(first_query; deriv = deriv, search = search, hint = hint)
-    output = Vector{typeof(first_val)}(undef, nq)
-    @inbounds output[1] = first_val
+    output = Vector{_output_eltype(itp, Tq)}(undef, _query_length(queries))
     return itp(output, queries; deriv = deriv, search = search, hint = hint)
 end

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -121,11 +121,21 @@ Determine the output value type from y element type and grid type.
 """
     _output_eltype(::Type{Tv}, types...) -> Type
 
-Output element type for arithmetic-kernel allocators (Linear/Cubic/Quadratic
-/Hermite). Concrete `promote_type` gets Int→Float upgrade (these kernels
-divide — Int chains widen naturally); otherwise queries `Base.promote_op`
-on `_kernel_shape_op` to see through duck carriers like `SVector × Dual`.
-Falls back to `Tv` if the op is undefined.
+Generic output-eltype probe via the universal arithmetic kernel shape
+`y*q + y` (`_kernel_shape_op`). Currently used by:
+
+- Internal coefficient eltype (Cubic `Tz`, Quadratic `Tc`).
+- Adjoint allocators (`adjoint_protocol.jl`).
+- Hetero ND legacy paths and a few series callsites.
+
+Concrete `promote_type` gets Int→Float upgrade (arithmetic kernels divide
+— Int chains widen naturally); duck carriers (e.g. `SVector × Dual`) fall
+through to `Base.promote_op` on `_kernel_shape_op`, with final fallback
+to `Tv` if the op is undefined.
+
+For method-aware output-buffer sizing (Linear/Cubic/Quadratic/Constant/
+Hermite), prefer the kernel-op overload below — it predicts the method's
+exact kernel return type via `Base.promote_op`.
 """
 @inline function _output_eltype(::Type{Tv}, types::Type...) where {Tv}
     Tr = promote_type(Tv, types...)

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -122,9 +122,10 @@ Determine the output value type from y element type and grid type.
     _output_eltype(::Type{Tv}, types...) -> Type
 
 Output element type for one-shot batch allocation. Concrete `promote_type`
-result gets Int→Float upgrade; otherwise queries `Base.promote_op` on
-`_kernel_shape_op` (constant-folded at compile time) to see through duck
-carriers like `SVector × Dual`. Falls back to `Tv` if the op is undefined.
+result gets Int→Float upgrade (natural promotion — arithmetic kernels divide,
+selection kernel accepts the same widening at allocation time); otherwise
+queries `Base.promote_op` on `_kernel_shape_op` to see through duck carriers
+like `SVector × Dual`. Falls back to `Tv` if the op is undefined.
 """
 @inline function _output_eltype(::Type{Tv}, types::Type...) where {Tv}
     Tr = promote_type(Tv, types...)

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -155,7 +155,7 @@ Method-aware output element type via `Base.promote_op` on the method's own
 kernel shape. Lets Julia inference predict the kernel's exact return type
 — no hand-coded Float upgrade, no `_PromotableValue` enumeration. Use this
 overload from a method that declares its kernel shape (e.g., Constant's
-`_constant_kernel_shape(yv, q) = yv * one(q)`).
+`_constant_kernel_shape(xL, yv, xq) = yv * one(xq - xL)`).
 """
 @inline function _output_eltype(kernel_op::F, ::Type{Tv}, types::Type...) where {F, Tv}
     Top = Base.promote_op(kernel_op, Tv, types...)

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -130,24 +130,27 @@ In that case, falls back to Tv since the kernel always returns Tv.
     return isconcretetype(Tout) ? Tout : Tv
 end
 
+# Universal kernel-shape op: every interp kernel produces `Tv + α·Tv` where α
+# carries Tq. Used as the inference probe in the `_output_eltype` duck fallback.
+@inline _kernel_shape_op(yv, q) = yv * q + yv
+
 """
     _output_eltype(::Type{Tv}, types...) -> Type
 
-Compute output element type for ND one-shot batch evaluation.
-
-Uses `promote_type(Tv, types...)` for standard numerics. For custom/duck
-types where `promote_type` falls back to a non-concrete type (e.g., `Any`),
-returns `Tv` directly since the interpolation kernel always returns `Tv`.
-
-Same logic as `_series_output_type` but accepts varargs for ND promotion
-chains like `promote_type(Tv, Tg, Tq)`.
+Output element type for one-shot batch allocation. Concrete `promote_type`
+result gets Int→Float upgrade; otherwise queries `Base.promote_op` on
+`_kernel_shape_op` (constant-folded at compile time) to see through duck
+carriers like `SVector × Dual`. Falls back to `Tv` if the op is undefined.
 """
 @inline function _output_eltype(::Type{Tv}, types::Type...) where {Tv}
     Tr = promote_type(Tv, types...)
-    Tc = isconcretetype(Tr) ? Tr : Tv
-    # Ensure standard numerics produce Float coefficients (Int→Float64).
-    # Duck types (MyStruct etc.) pass through — float() would MethodError.
-    return (Tc <: _PromotableValue && !(Tc <: AbstractFloat)) ? float(Tc) : Tc
+    if isconcretetype(Tr)
+        return (Tr <: _PromotableValue && !(Tr <: AbstractFloat)) ? float(Tr) : Tr
+    end
+    Tq = length(types) == 0 ? Tv : promote_type(types...)
+    Top = Base.promote_op(_kernel_shape_op, Tv, Tq)
+    (Top === Union{} || Top === Any) && return Tv
+    return Top
 end
 
 """

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -121,11 +121,11 @@ Determine the output value type from y element type and grid type.
 """
     _output_eltype(::Type{Tv}, types...) -> Type
 
-Output element type for one-shot batch allocation. Concrete `promote_type`
-result gets Int→Float upgrade (natural promotion — arithmetic kernels divide,
-selection kernel accepts the same widening at allocation time); otherwise
-queries `Base.promote_op` on `_kernel_shape_op` to see through duck carriers
-like `SVector × Dual`. Falls back to `Tv` if the op is undefined.
+Output element type for arithmetic-kernel allocators (Linear/Cubic/Quadratic
+/Hermite). Concrete `promote_type` gets Int→Float upgrade (these kernels
+divide — Int chains widen naturally); otherwise queries `Base.promote_op`
+on `_kernel_shape_op` to see through duck carriers like `SVector × Dual`.
+Falls back to `Tv` if the op is undefined.
 """
 @inline function _output_eltype(::Type{Tv}, types::Type...) where {Tv}
     Tr = promote_type(Tv, types...)
@@ -134,6 +134,21 @@ like `SVector × Dual`. Falls back to `Tv` if the op is undefined.
     end
     Tq = length(types) == 0 ? Tv : promote_type(types...)
     Top = Base.promote_op(_kernel_shape_op, Tv, Tq)
+    (Top === Union{} || Top === Any) && return Tv
+    return Top
+end
+
+"""
+    _output_eltype(kernel_op, ::Type{Tv}, types...) -> Type
+
+Method-aware output element type via `Base.promote_op` on the method's own
+kernel shape. Lets Julia inference predict the kernel's exact return type
+— no hand-coded Float upgrade, no `_PromotableValue` enumeration. Use this
+overload from a method that declares its kernel shape (e.g., Constant's
+`_constant_kernel_shape(yv, q) = yv * one(q)`).
+"""
+@inline function _output_eltype(kernel_op::F, ::Type{Tv}, types::Type...) where {F, Tv}
+    Top = Base.promote_op(kernel_op, Tv, types...)
     (Top === Union{} || Top === Any) && return Tv
     return Top
 end

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -153,6 +153,11 @@ overload from a method that declares its kernel shape (e.g., Constant's
     return Top
 end
 
+# Shared kernel shape for arithmetic methods (Linear/Cubic/Quadratic/Hermite):
+# `y + y * (dL/h)` captures the division-by-`h` that drives the Int→Float
+# widening — Julia inference predicts the exact kernel return type.
+@inline _arithmetic_kernel_shape(yv, dL, h) = yv + yv * (dL / h)
+
 """
     _promote_query_eltype(::Type{Tv}, q::Tuple) -> Type
 

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -113,25 +113,9 @@ Determine the output value type from y element type and grid type.
 # values are not promoted to grid type (no grid-parameter partials in y).
 @inline _value_type(::Type{T}, ::Type{Tg}) where {T, Tg} = T
 
-"""
-    _series_output_type(::Type{Tv}, ::Type{Tq}) -> Type
-
-Compute output element type for series evaluation.
-
-For standard numerics, uses `promote_type(Tv, Tq)` to widen correctly
-(e.g., Float64 + Dual → Dual for AD support).
-
-For custom Tv without `promote_rule`, `promote_type` falls back to an
-abstract typejoin (e.g., Number), which makes the output vector untyped.
-In that case, falls back to Tv since the kernel always returns Tv.
-"""
-@inline function _series_output_type(::Type{Tv}, ::Type{Tq}) where {Tv, Tq}
-    Tout = promote_type(Tv, Tq)
-    return isconcretetype(Tout) ? Tout : Tv
-end
-
-# Universal kernel-shape op: every interp kernel produces `Tv + α·Tv` where α
-# carries Tq. Used as the inference probe in the `_output_eltype` duck fallback.
+# Inference probe for `_output_eltype` duck fallback. Standard kernels
+# (Linear/Cubic/Quadratic/Hermite) produce `Tv + α·Tv` shapes; Constant's
+# `Tv * one(Tq)` lives in the same promotion space.
 @inline _kernel_shape_op(yv, q) = yv * q + yv
 
 """

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -155,8 +155,10 @@ end
 
 # Shared kernel shape for arithmetic methods (Linear/Cubic/Quadratic/Hermite):
 # `y + y * (dL/h)` captures the division-by-`h` that drives the Int→Float
-# widening — Julia inference predicts the exact kernel return type.
-@inline _arithmetic_kernel_shape(yv, dL, h) = yv + yv * (dL / h)
+# widening — Julia inference predicts the exact kernel return type. Args are
+# ordered `(Tg, Tv, Tq)` so callers use `_output_eltype(shape, Tg, Tv, Tq)`,
+# matching the codebase's standard type-parameter order.
+@inline _arithmetic_kernel_shape(h, yv, dL) = yv + yv * (dL / h)
 
 """
     _promote_query_eltype(::Type{Tv}, q::Tuple) -> Type

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -569,8 +569,13 @@ end
 # Named _promote_extrap_val (not _promote_extrap) to avoid collision with the struct
 # promoter in eval_ops.jl which promotes FillExtrap fill_value at construction time.
 @inline _promote_extrap_val(val::Number, xq::Number) = val + zero(xq) * zero(val)
+# AbstractArray Tv (e.g. `SVector` y) — broadcast the carrier-propagating
+# pattern so scalar OOB matches in-domain kernel's `y * one(dL)` shape and
+# agrees with batch path's trait-sized buffer.
+@inline _promote_extrap_val(val::AbstractArray, xq::Number) = val .+ zero(xq) .* zero(eltype(val))
 @inline _promote_extrap_val(val, xq) = val
 @inline _promote_extrap_zero(val::Number, xq::Number) = zero(xq) * zero(val)
+@inline _promote_extrap_zero(val::AbstractArray, xq::Number) = 0 .* val .+ zero(xq) .* zero(eltype(val))
 @inline _promote_extrap_zero(val, xq) = 0 * val
 
 # Generic: any derivative order → zero (flat extrapolation has zero derivatives)

--- a/src/cubic/cubic_oneshot.jl
+++ b/src/cubic/cubic_oneshot.jl
@@ -327,7 +327,7 @@ function cubic_interp(
         search::AbstractSearchPolicy = AutoSearch()
     ) where {Tg, Tv}
     Tq = eltype(x_query)
-    Tr = _output_eltype(Tv, Tg, Tq)
+    Tr = _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)
     output = Vector{Tr}(undef, length(x_query))
     cubic_interp!(output, x, y, x_query; bc, extrap, autocache, deriv, search)
     return output

--- a/src/cubic/cubic_oneshot.jl
+++ b/src/cubic/cubic_oneshot.jl
@@ -283,7 +283,7 @@ function cubic_interp(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
     ) where {Tg, Tv, Tq <: Real}
-    Tr = _output_eltype(Tv, eltype(cache.x), Tq)
+    Tr = _output_eltype(_arithmetic_kernel_shape, eltype(cache.x), Tv, Tq)
     output = Vector{Tr}(undef, length(x_query))
     cubic_interp!(output, cache, y, x_query; extrap = extrap, deriv = deriv, search = search)
     return output

--- a/src/cubic/cubic_oneshot_series.jl
+++ b/src/cubic/cubic_oneshot_series.jl
@@ -201,7 +201,7 @@ Build cache once → anchor once → solve+eval per y-vector with z-buffer reuse
     _is_periodic_bc(bc) || _check_domain(x, xq, extrap)
     K = n_series(s)
     Tg_actual = eltype(x)
-    output = Vector{_series_output_type(_output_eltype(_series_eltype(s), Tg_actual), Tq)}(undef, K)
+    output = Vector{_output_eltype(_series_eltype(s), Tg_actual, Tq)}(undef, K)
     # Periodic helper searches against `cache.x` (wrapped from the cache pool),
     # so axis-level dispatch handles seam — no `bc` thread into the Searcher.
     searcher = _resolve_search(x, xq, search, hint)
@@ -313,7 +313,7 @@ function cubic_interp(
     ) where {Tg, Tq <: Real}
     K = n_series(s)
     Tg_float = _promote_grid_float(Tg, _series_eltype(s))
-    Tv = _series_output_type(_output_eltype(_series_eltype(s), Tg_float), Tq)
+    Tv = _output_eltype(_series_eltype(s), Tg_float, Tq)
     outputs = [Vector{Tv}(undef, length(xqs)) for _ in 1:K]
     cubic_interp!(outputs, x, s, xqs; bc, extrap, autocache, deriv, search)
     return outputs

--- a/src/cubic/cubic_oneshot_series.jl
+++ b/src/cubic/cubic_oneshot_series.jl
@@ -201,7 +201,7 @@ Build cache once → anchor once → solve+eval per y-vector with z-buffer reuse
     _is_periodic_bc(bc) || _check_domain(x, xq, extrap)
     K = n_series(s)
     Tg_actual = eltype(x)
-    output = Vector{_output_eltype(_series_eltype(s), Tg_actual, Tq)}(undef, K)
+    output = Vector{_output_eltype(_arithmetic_kernel_shape, Tg_actual, _series_eltype(s), Tq)}(undef, K)
     # Periodic helper searches against `cache.x` (wrapped from the cache pool),
     # so axis-level dispatch handles seam — no `bc` thread into the Searcher.
     searcher = _resolve_search(x, xq, search, hint)
@@ -313,7 +313,7 @@ function cubic_interp(
     ) where {Tg, Tq <: Real}
     K = n_series(s)
     Tg_float = _promote_grid_float(Tg, _series_eltype(s))
-    Tv = _output_eltype(_series_eltype(s), Tg_float, Tq)
+    Tv = _output_eltype(_arithmetic_kernel_shape, Tg_float, _series_eltype(s), Tq)
     outputs = [Vector{Tv}(undef, length(xqs)) for _ in 1:K]
     cubic_interp!(outputs, x, s, xqs; bc, extrap, autocache, deriv, search)
     return outputs

--- a/src/cubic/cubic_series_interp.jl
+++ b/src/cubic/cubic_series_interp.jl
@@ -745,7 +745,7 @@ function (sitp::CubicSeriesInterpolant{Tg, Tv})(
     ) where {Tg, Tv, Tq <: Real}
     # Promote for anchor: Int→Float, Int-backed Dual→Float-backed Dual (no-op for Float/Float-backed Dual)
     xq_promoted = _promote_for_anchor(xq, Tg)
-    T_out = _series_output_type(_output_eltype(Tv, Tg), typeof(xq_promoted))
+    T_out = _output_eltype(Tv, Tg, typeof(xq_promoted))
     output = Vector{T_out}(undef, n_series(sitp))
 
     # Build anchor preserving Dual type in xq
@@ -805,7 +805,7 @@ function (sitp::CubicSeriesInterpolant{Tg, Tv})(
     ) where {Tg, Tv, Tq <: Real}
     n_query = length(xq)
     n_ser = n_series(sitp)
-    T_out = _series_output_type(_output_eltype(Tv, Tg), Tq)
+    T_out = _output_eltype(Tv, Tg, Tq)
 
     # Explicit Vector{Vector{T_out}} for type stability on Julia LTS
     outputs = Vector{Vector{T_out}}(undef, n_ser)

--- a/src/cubic/cubic_series_interp.jl
+++ b/src/cubic/cubic_series_interp.jl
@@ -745,7 +745,7 @@ function (sitp::CubicSeriesInterpolant{Tg, Tv})(
     ) where {Tg, Tv, Tq <: Real}
     # Promote for anchor: Int→Float, Int-backed Dual→Float-backed Dual (no-op for Float/Float-backed Dual)
     xq_promoted = _promote_for_anchor(xq, Tg)
-    T_out = _output_eltype(Tv, Tg, typeof(xq_promoted))
+    T_out = _output_eltype(_arithmetic_kernel_shape, Tg, Tv, typeof(xq_promoted))
     output = Vector{T_out}(undef, n_series(sitp))
 
     # Build anchor preserving Dual type in xq
@@ -805,7 +805,7 @@ function (sitp::CubicSeriesInterpolant{Tg, Tv})(
     ) where {Tg, Tv, Tq <: Real}
     n_query = length(xq)
     n_ser = n_series(sitp)
-    T_out = _output_eltype(Tv, Tg, Tq)
+    T_out = _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)
 
     # Explicit Vector{Vector{T_out}} for type stability on Julia LTS
     outputs = Vector{Vector{T_out}}(undef, n_ser)

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -80,7 +80,7 @@ function cubic_interp(
     ) where {Tv, N}
     _, Tg, _, _ = _nd_promote_grids(grids, data)
     Tq = _query_eltype(queries)
-    Tr = _output_eltype(Tv, Tg, Tq)
+    Tr = _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)
     output = Vector{Tr}(undef, _query_length(queries))
     cubic_interp!(output, grids, data, queries; deriv, bc, extrap, search, coeffs, hint)
     return output

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -37,9 +37,9 @@ function cubic_interp(
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
     # Type promotion + validation (same as constructor path)
-    grids_typed, Tg, Tv_p, Tz = _nd_promote_grids(grids, data)
+    grids_typed, Tg, Tv_p, _ = _nd_promote_grids(grids, data)
     _validate_nd_grids(grids_typed, data)
-    Tr = _output_eltype(Tv_p, Tg, typeof.(query)...)
+    Tr = _output_eltype(_arithmetic_kernel_shape, Tg, Tv, promote_type(typeof.(query)...))
 
     bcs = _resolve_bcs_nd(bc, Val(N))
     searches = _resolve_search_nd(search, Val(N), query)  # NTuple{N,Real} <: Tuple → BinarySearch/axis

--- a/src/hermite/hermite_interpolant.jl
+++ b/src/hermite/hermite_interpolant.jl
@@ -22,6 +22,18 @@ end
     return _hermite_vector_loop!(output, itp.x, itp.y, itp.dy, xq, extrap, op, searcher)
 end
 
+# Hermite-family kernel mixes `y` and `dy` (`h00·y0 + h01·y1 + h10·h·dy0 + h11·h·dy1`).
+# Two-call pattern over `_arithmetic_kernel_shape` keeps `Tv` and `eltype(dy)` in
+# disjoint promote chains so a duck-typed `dy` (e.g., Float64 y + Vector{Dual} dy
+# for AD on slopes) widens the result without poisoning the `y` chain.
+@inline function _output_eltype(itp::AbstractHermiteInterpolant1D{Tg, Tv}, ::Type{Tq}) where {Tg, Tv, Tq}
+    Tdy = eltype(itp.dy)
+    return promote_type(
+        _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq),
+        _output_eltype(_arithmetic_kernel_shape, Tg, Tdy, Tq),
+    )
+end
+
 # ========================================
 # Outer Constructor: typed inputs only
 # ========================================

--- a/src/hermite/hermite_oneshot.jl
+++ b/src/hermite/hermite_oneshot.jl
@@ -90,7 +90,9 @@ function hermite_interp(
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing,
     ) where {Tg, Tv, Tq <: Real}
-    Tr = _output_eltype(Tv, _promote_grid_float(Tg, Tv), Tq, eltype(dy))
+    # `eltype(dy)` dropped: it usually equals Tv, and including it can collapse
+    # the trait's internal `promote_type(...)` to `Any` on duck inputs.
+    Tr = _output_eltype(Tv, _promote_grid_float(Tg, Tv), Tq)
     output = Vector{Tr}(undef, length(x_query))
     hermite_interp!(output, x, y, dy, x_query; extrap = extrap, deriv = deriv, search = search, hint = hint)
     return output

--- a/src/hermite/hermite_oneshot.jl
+++ b/src/hermite/hermite_oneshot.jl
@@ -90,10 +90,15 @@ function hermite_interp(
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing,
     ) where {Tg, Tv, Tq <: Real}
-    # Disjoint chains for `Tv` and `eltype(dy)` — a 4-arg call would let SVector
-    # `eltype(dy)` collapse the duck-Tq fallback to `Any`.
+    # Disjoint chains for `Tv` and `eltype(dy)` over the shared kernel shape —
+    # a single trait call would let SVector `eltype(dy)` collapse the duck-Tq
+    # fallback to `Any`. Mirrors the `AbstractHermiteInterpolant1D` persistent
+    # override that pulls `eltype(itp.dy)` at the type level.
     Tg_p = _promote_grid_float(Tg, Tv)
-    Tr = promote_type(_output_eltype(Tv, Tg_p, Tq), _output_eltype(eltype(dy), Tg_p, Tq))
+    Tr = promote_type(
+        _output_eltype(_arithmetic_kernel_shape, Tg_p, Tv, Tq),
+        _output_eltype(_arithmetic_kernel_shape, Tg_p, eltype(dy), Tq),
+    )
     output = Vector{Tr}(undef, length(x_query))
     hermite_interp!(output, x, y, dy, x_query; extrap = extrap, deriv = deriv, search = search, hint = hint)
     return output

--- a/src/hermite/hermite_oneshot.jl
+++ b/src/hermite/hermite_oneshot.jl
@@ -90,9 +90,10 @@ function hermite_interp(
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing,
     ) where {Tg, Tv, Tq <: Real}
-    # `eltype(dy)` dropped: it usually equals Tv, and including it can collapse
-    # the trait's internal `promote_type(...)` to `Any` on duck inputs.
-    Tr = _output_eltype(Tv, _promote_grid_float(Tg, Tv), Tq)
+    # Disjoint chains for `Tv` and `eltype(dy)` — a 4-arg call would let SVector
+    # `eltype(dy)` collapse the duck-Tq fallback to `Any`.
+    Tg_p = _promote_grid_float(Tg, Tv)
+    Tr = promote_type(_output_eltype(Tv, Tg_p, Tq), _output_eltype(eltype(dy), Tg_p, Tq))
     output = Vector{Tr}(undef, length(x_query))
     hermite_interp!(output, x, y, dy, x_query; extrap = extrap, deriv = deriv, search = search, hint = hint)
     return output

--- a/src/linear/linear_anchor.jl
+++ b/src/linear/linear_anchor.jl
@@ -419,7 +419,7 @@ function (itp::LinearInterpolant{Tg, Tv})(
         aq_vec::AbstractVector{<:_LinearAnchoredQuery{Tg, Tq}};
         deriv::DerivOp = EvalValue()
     ) where {Tg, Tv, Tq <: Real}
-    T_out = _output_eltype(Tv, Tg, Tq)
+    T_out = _output_eltype(_arithmetic_kernel_shape, Tv, Tq, Tg)
     output = Vector{T_out}(undef, length(aq_vec))
     @inbounds for i in eachindex(aq_vec)
         output[i] = _linear_eval_with_anchor(itp, aq_vec[i], deriv)

--- a/src/linear/linear_anchor.jl
+++ b/src/linear/linear_anchor.jl
@@ -419,7 +419,7 @@ function (itp::LinearInterpolant{Tg, Tv})(
         aq_vec::AbstractVector{<:_LinearAnchoredQuery{Tg, Tq}};
         deriv::DerivOp = EvalValue()
     ) where {Tg, Tv, Tq <: Real}
-    T_out = _output_eltype(_arithmetic_kernel_shape, Tv, Tq, Tg)
+    T_out = _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)
     output = Vector{T_out}(undef, length(aq_vec))
     @inbounds for i in eachindex(aq_vec)
         output[i] = _linear_eval_with_anchor(itp, aq_vec[i], deriv)

--- a/src/linear/linear_interpolant.jl
+++ b/src/linear/linear_interpolant.jl
@@ -19,6 +19,11 @@ end
     return _linear_vector_loop!(output, itp.x, itp.y, xq, extrap, op, searcher)
 end
 
+# Linear's kernel divides by `h` (`y0 + (y1-y0)*(dL/h)`); shared
+# `_arithmetic_kernel_shape` drives type inference for the output buffer.
+@inline _output_eltype(::LinearInterpolant{Tg, Tv}, ::Type{Tq}) where {Tg, Tv, Tq} =
+    _output_eltype(_arithmetic_kernel_shape, Tv, Tq, Tg)
+
 # ========================================
 # Vector Loop (Function Barrier)
 # ========================================

--- a/src/linear/linear_interpolant.jl
+++ b/src/linear/linear_interpolant.jl
@@ -22,7 +22,7 @@ end
 # Linear's kernel divides by `h` (`y0 + (y1-y0)*(dL/h)`); shared
 # `_arithmetic_kernel_shape` drives type inference for the output buffer.
 @inline _output_eltype(::LinearInterpolant{Tg, Tv}, ::Type{Tq}) where {Tg, Tv, Tq} =
-    _output_eltype(_arithmetic_kernel_shape, Tv, Tq, Tg)
+    _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)
 
 # ========================================
 # Vector Loop (Function Barrier)

--- a/src/linear/linear_interpolant.jl
+++ b/src/linear/linear_interpolant.jl
@@ -19,10 +19,8 @@ end
     return _linear_vector_loop!(output, itp.x, itp.y, xq, extrap, op, searcher)
 end
 
-# Linear's kernel divides by `h` (`y0 + (y1-y0)*(dL/h)`); shared
-# `_arithmetic_kernel_shape` drives type inference for the output buffer.
-@inline _output_eltype(::LinearInterpolant{Tg, Tv}, ::Type{Tq}) where {Tg, Tv, Tq} =
-    _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)
+# Linear uses the default `_arithmetic_kernel_shape` route (inherited from
+# `AbstractInterpolant1D`) — no explicit override needed.
 
 # ========================================
 # Vector Loop (Function Barrier)

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -336,7 +336,7 @@ function linear_interp(
         search::AbstractSearchPolicy = AutoSearch()
     )
     Tg = _promote_grid_float(eltype(x), eltype(y))
-    T_out = _output_eltype(_arithmetic_kernel_shape, eltype(y), eltype(x_targets), Tg)
+    T_out = _output_eltype(_arithmetic_kernel_shape, Tg, eltype(y), eltype(x_targets))
     output = Vector{T_out}(undef, length(x_targets))
     linear_interp!(output, x, y, x_targets; bc, extrap, deriv, search)
     return output

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -336,7 +336,8 @@ function linear_interp(
         search::AbstractSearchPolicy = AutoSearch()
     )
     Tg = _promote_grid_float(eltype(x), eltype(y))
-    T_out = _output_eltype(eltype(y), Tg)
+    # Tq included so the trait sees the carrier chain (e.g., SVector × Dual).
+    T_out = _output_eltype(eltype(y), Tg, eltype(x_targets))
     output = Vector{T_out}(undef, length(x_targets))
     linear_interp!(output, x, y, x_targets; bc, extrap, deriv, search)
     return output

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -336,8 +336,7 @@ function linear_interp(
         search::AbstractSearchPolicy = AutoSearch()
     )
     Tg = _promote_grid_float(eltype(x), eltype(y))
-    # Tq included so the trait sees the carrier chain (e.g., SVector × Dual).
-    T_out = _output_eltype(eltype(y), Tg, eltype(x_targets))
+    T_out = _output_eltype(_arithmetic_kernel_shape, eltype(y), eltype(x_targets), Tg)
     output = Vector{T_out}(undef, length(x_targets))
     linear_interp!(output, x, y, x_targets; bc, extrap, deriv, search)
     return output

--- a/src/linear/linear_oneshot_series.jl
+++ b/src/linear/linear_oneshot_series.jl
@@ -108,7 +108,7 @@ vals = linear_interp(x, Series(y_sin, y_cos), 0.5)  # → [sin(0.5), cos(0.5)]
     x = _to_float(x, Tg_p)
     K = n_series(s)
     Tg_actual = eltype(x)
-    Tv = _series_output_type(_output_eltype(_series_eltype(s), Tg_actual), Tq)
+    Tv = _output_eltype(_series_eltype(s), Tg_actual, Tq)
     output = Vector{Tv}(undef, K)
     if _is_periodic_bc(bc)
         # Helper wraps `x` via `_resolve_axis(x, bc)` and searches against the
@@ -320,7 +320,7 @@ function linear_interp(
     ) where {Tg, Tq <: Real}
     K = n_series(s)
     Tg_p = _promote_grid_float(Tg, _series_eltype(s))
-    Tv_out = _series_output_type(_output_eltype(_series_eltype(s), Tg_p), Tq)
+    Tv_out = _output_eltype(_series_eltype(s), Tg_p, Tq)
     outputs = [Vector{Tv_out}(undef, length(xqs)) for _ in 1:K]
     linear_interp!(outputs, x, s, xqs; bc, extrap, deriv, search)
     return outputs

--- a/src/linear/linear_oneshot_series.jl
+++ b/src/linear/linear_oneshot_series.jl
@@ -108,7 +108,7 @@ vals = linear_interp(x, Series(y_sin, y_cos), 0.5)  # → [sin(0.5), cos(0.5)]
     x = _to_float(x, Tg_p)
     K = n_series(s)
     Tg_actual = eltype(x)
-    Tv = _output_eltype(_series_eltype(s), Tg_actual, Tq)
+    Tv = _output_eltype(_arithmetic_kernel_shape, Tg_actual, _series_eltype(s), Tq)
     output = Vector{Tv}(undef, K)
     if _is_periodic_bc(bc)
         # Helper wraps `x` via `_resolve_axis(x, bc)` and searches against the
@@ -320,7 +320,7 @@ function linear_interp(
     ) where {Tg, Tq <: Real}
     K = n_series(s)
     Tg_p = _promote_grid_float(Tg, _series_eltype(s))
-    Tv_out = _output_eltype(_series_eltype(s), Tg_p, Tq)
+    Tv_out = _output_eltype(_arithmetic_kernel_shape, Tg_p, _series_eltype(s), Tq)
     outputs = [Vector{Tv_out}(undef, length(xqs)) for _ in 1:K]
     linear_interp!(outputs, x, s, xqs; bc, extrap, deriv, search)
     return outputs

--- a/src/linear/linear_series_interp.jl
+++ b/src/linear/linear_series_interp.jl
@@ -392,7 +392,7 @@ function (sitp::LinearSeriesInterpolant{Tg, Tv, P})(
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, P, Tq <: Real}
-    T_out = _series_output_type(_output_eltype(Tv, Tg), Tq)
+    T_out = _output_eltype(Tv, Tg, Tq)
     out = Vector{T_out}(undef, n_series(sitp))
     return sitp(out, xq; deriv = deriv, search = search, hint = hint)
 end
@@ -446,7 +446,7 @@ function (sitp::LinearSeriesInterpolant{Tg, Tv, P})(
     ) where {Tg, Tv, P, Tq <: Real}
     n_query = length(xq)
     n_ser = n_series(sitp)
-    T_out = _series_output_type(_output_eltype(Tv, Tg), Tq)
+    T_out = _output_eltype(Tv, Tg, Tq)
 
     # Explicit Vector{Vector{T_out}} for type stability on Julia LTS
     outputs = Vector{Vector{T_out}}(undef, n_ser)

--- a/src/linear/linear_series_interp.jl
+++ b/src/linear/linear_series_interp.jl
@@ -392,7 +392,7 @@ function (sitp::LinearSeriesInterpolant{Tg, Tv, P})(
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, P, Tq <: Real}
-    T_out = _output_eltype(Tv, Tg, Tq)
+    T_out = _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)
     out = Vector{T_out}(undef, n_series(sitp))
     return sitp(out, xq; deriv = deriv, search = search, hint = hint)
 end
@@ -446,7 +446,7 @@ function (sitp::LinearSeriesInterpolant{Tg, Tv, P})(
     ) where {Tg, Tv, P, Tq <: Real}
     n_query = length(xq)
     n_ser = n_series(sitp)
-    T_out = _output_eltype(Tv, Tg, Tq)
+    T_out = _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)
 
     # Explicit Vector{Vector{T_out}} for type stability on Julia LTS
     outputs = Vector{Vector{T_out}}(undef, n_ser)

--- a/src/linear/nd/linear_nd_oneshot.jl
+++ b/src/linear/nd/linear_nd_oneshot.jl
@@ -130,7 +130,7 @@ function linear_interp(
     ) where {Tv, N}
     grids_typed, Tg, _, _ = _nd_promote_grids(grids, data)
     _validate_nd_grids(grids_typed, data)
-    Tr = _output_eltype(Tv, Tg, typeof.(query)...)
+    Tr = _output_eltype(_arithmetic_kernel_shape, Tv, promote_type(typeof.(query)...), Tg)
 
     searches = _resolve_search_nd(search, Val(N), query)  # scalar: type-based (no monotonicity check)
 
@@ -159,7 +159,7 @@ function linear_interp(
     ) where {Tv, N}
     _, Tg, _, _ = _nd_promote_grids(grids, data)
     Tq = _query_eltype(queries)
-    Tr = _output_eltype(Tv, Tg, Tq)
+    Tr = _output_eltype(_arithmetic_kernel_shape, Tv, Tq, Tg)
     output = Vector{Tr}(undef, _query_length(queries))
     linear_interp!(output, grids, data, queries; bc, extrap, search, deriv, hint)
     return output

--- a/src/linear/nd/linear_nd_oneshot.jl
+++ b/src/linear/nd/linear_nd_oneshot.jl
@@ -130,7 +130,7 @@ function linear_interp(
     ) where {Tv, N}
     grids_typed, Tg, _, _ = _nd_promote_grids(grids, data)
     _validate_nd_grids(grids_typed, data)
-    Tr = _output_eltype(_arithmetic_kernel_shape, Tv, promote_type(typeof.(query)...), Tg)
+    Tr = _output_eltype(_arithmetic_kernel_shape, Tg, Tv, promote_type(typeof.(query)...))
 
     searches = _resolve_search_nd(search, Val(N), query)  # scalar: type-based (no monotonicity check)
 
@@ -159,7 +159,7 @@ function linear_interp(
     ) where {Tv, N}
     _, Tg, _, _ = _nd_promote_grids(grids, data)
     Tq = _query_eltype(queries)
-    Tr = _output_eltype(_arithmetic_kernel_shape, Tv, Tq, Tg)
+    Tr = _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)
     output = Vector{Tr}(undef, _query_length(queries))
     linear_interp!(output, grids, data, queries; bc, extrap, search, deriv, hint)
     return output

--- a/src/linear/nd/linear_nd_types.jl
+++ b/src/linear/nd/linear_nd_types.jl
@@ -123,4 +123,4 @@ Base.axes(itp::LinearInterpolantND) = itp.grids
 
 # Mirrors the 1D override: shared `_arithmetic_kernel_shape` drives inference.
 @inline _output_eltype(::LinearInterpolantND{Tg, Tv, N}, ::Type{Tq}) where {Tg, Tv, N, Tq} =
-    _output_eltype(_arithmetic_kernel_shape, Tv, Tq, Tg)
+    _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)

--- a/src/linear/nd/linear_nd_types.jl
+++ b/src/linear/nd/linear_nd_types.jl
@@ -121,6 +121,5 @@ Return the grid vectors for all dimensions.
 """
 Base.axes(itp::LinearInterpolantND) = itp.grids
 
-# Mirrors the 1D override: shared `_arithmetic_kernel_shape` drives inference.
-@inline _output_eltype(::LinearInterpolantND{Tg, Tv, N}, ::Type{Tq}) where {Tg, Tv, N, Tq} =
-    _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)
+# Linear ND uses the default `_arithmetic_kernel_shape` route (inherited from
+# `AbstractInterpolantND`) — no explicit override needed.

--- a/src/linear/nd/linear_nd_types.jl
+++ b/src/linear/nd/linear_nd_types.jl
@@ -120,3 +120,7 @@ Base.size(itp::LinearInterpolantND) = size(itp.data)
 Return the grid vectors for all dimensions.
 """
 Base.axes(itp::LinearInterpolantND) = itp.grids
+
+# Mirrors the 1D override: shared `_arithmetic_kernel_shape` drives inference.
+@inline _output_eltype(::LinearInterpolantND{Tg, Tv, N}, ::Type{Tq}) where {Tg, Tv, N, Tq} =
+    _output_eltype(_arithmetic_kernel_shape, Tv, Tq, Tg)

--- a/src/pchip/pchip_oneshot.jl
+++ b/src/pchip/pchip_oneshot.jl
@@ -186,7 +186,7 @@ function pchip_interp(
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, Tq <: Real}
-    Tr = _output_eltype(Tv, _promote_grid_float(Tg, Tv), Tq)
+    Tr = _output_eltype(_arithmetic_kernel_shape, _promote_grid_float(Tg, Tv), Tv, Tq)
     output = Vector{Tr}(undef, length(x_query))
     pchip_interp!(output, x, y, x_query; bc = bc, coeffs = coeffs, extrap = extrap, deriv = deriv, search = search, hint = hint)
     return output

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -160,7 +160,7 @@ function quadratic_interp(
     ) where {Tv, N}
     grids_typed, Tg, _, _ = _nd_promote_grids(grids, data)
     _validate_nd_grids(grids_typed, data)
-    Tr = _output_eltype(Tv, Tg, typeof.(query)...)
+    Tr = _output_eltype(_arithmetic_kernel_shape, Tg, Tv, promote_type(typeof.(query)...))
 
     bcs = _resolve_bcs_nd(bc, Val(N))
     searches = _resolve_search_nd(search, Val(N), query)  # NTuple{N,Real} <: Tuple → BinarySearch/axis

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -201,7 +201,7 @@ function quadratic_interp(
     ) where {Tv, N}
     _, Tg, _, _ = _nd_promote_grids(grids, data)
     Tq = _query_eltype(queries)
-    Tr = _output_eltype(Tv, Tg, Tq)
+    Tr = _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)
     output = Vector{Tr}(undef, _query_length(queries))
     quadratic_interp!(output, grids, data, queries; deriv, bc, extrap, search, coeffs, hint)
     return output

--- a/src/quadratic/quadratic_anchor.jl
+++ b/src/quadratic/quadratic_anchor.jl
@@ -329,11 +329,12 @@ end
 Evaluate quadratic interpolant at multiple anchored query points.
 Returns newly allocated vector.
 """
-function (itp::QuadraticInterpolant{T})(
-        aq_vec::AbstractVector{<:_QuadraticAnchoredQuery{T}};
+function (itp::QuadraticInterpolant{Tg, Tv})(
+        aq_vec::AbstractVector{<:_QuadraticAnchoredQuery{Tg, Tq}};
         deriv::DerivOp = EvalValue()
-    ) where {T}
-    output = Vector{T}(undef, length(aq_vec))
+    ) where {Tg, Tv, Tq <: Real}
+    T_out = _output_eltype(Tv, Tg, Tq)
+    output = Vector{T_out}(undef, length(aq_vec))
     @inbounds for i in eachindex(aq_vec)
         output[i] = _quadratic_eval_with_anchor(itp, aq_vec[i], deriv)
     end

--- a/src/quadratic/quadratic_anchor.jl
+++ b/src/quadratic/quadratic_anchor.jl
@@ -333,7 +333,7 @@ function (itp::QuadraticInterpolant{Tg, Tv})(
         aq_vec::AbstractVector{<:_QuadraticAnchoredQuery{Tg, Tq}};
         deriv::DerivOp = EvalValue()
     ) where {Tg, Tv, Tq <: Real}
-    T_out = _output_eltype(Tv, Tg, Tq)
+    T_out = _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)
     output = Vector{T_out}(undef, length(aq_vec))
     @inbounds for i in eachindex(aq_vec)
         output[i] = _quadratic_eval_with_anchor(itp, aq_vec[i], deriv)

--- a/src/quadratic/quadratic_oneshot.jl
+++ b/src/quadratic/quadratic_oneshot.jl
@@ -260,7 +260,7 @@ function quadratic_interp(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
     ) where {Tg, Tq <: Real}
-    Tr = _output_eltype(eltype(y), _promote_grid_float(Tg, eltype(y)), Tq)
+    Tr = _output_eltype(_arithmetic_kernel_shape, _promote_grid_float(Tg, eltype(y)), eltype(y), Tq)
     output = Vector{Tr}(undef, length(x_targets))
     quadratic_interp!(output, x, y, x_targets; bc, extrap, deriv, search)
     return output

--- a/src/quadratic/quadratic_oneshot_series.jl
+++ b/src/quadratic/quadratic_oneshot_series.jl
@@ -34,7 +34,7 @@
     Tv_out = _value_type(_series_eltype(s), Tg)
     Tg_actual = eltype(x)
     Tcoeff = _output_eltype(_series_eltype(s), Tg_actual)
-    output = Vector{_output_eltype(_series_eltype(s), Tg_actual, Tq)}(undef, K)
+    output = Vector{_output_eltype(_arithmetic_kernel_shape, Tg_actual, _series_eltype(s), Tq)}(undef, K)
     d = acquire!(pool, Tcoeff, nx)
     a = acquire!(pool, Tcoeff, nx - 1)
     y_buf = acquire!(pool, Tv_out, nx)
@@ -144,7 +144,7 @@ function quadratic_interp(
     ) where {Tg, Tq <: Real}
     K = n_series(s)
     Tg_float = _promote_grid_float(Tg, _series_eltype(s))
-    Tv_out = _output_eltype(_series_eltype(s), Tg_float, Tq)
+    Tv_out = _output_eltype(_arithmetic_kernel_shape, Tg_float, _series_eltype(s), Tq)
     outputs = [Vector{Tv_out}(undef, length(xqs)) for _ in 1:K]
     quadratic_interp!(outputs, x, s, xqs; bc, extrap, deriv, search)
     return outputs

--- a/src/quadratic/quadratic_oneshot_series.jl
+++ b/src/quadratic/quadratic_oneshot_series.jl
@@ -34,7 +34,7 @@
     Tv_out = _value_type(_series_eltype(s), Tg)
     Tg_actual = eltype(x)
     Tcoeff = _output_eltype(_series_eltype(s), Tg_actual)
-    output = Vector{_series_output_type(Tcoeff, Tq)}(undef, K)
+    output = Vector{_output_eltype(_series_eltype(s), Tg_actual, Tq)}(undef, K)
     d = acquire!(pool, Tcoeff, nx)
     a = acquire!(pool, Tcoeff, nx - 1)
     y_buf = acquire!(pool, Tv_out, nx)
@@ -144,7 +144,7 @@ function quadratic_interp(
     ) where {Tg, Tq <: Real}
     K = n_series(s)
     Tg_float = _promote_grid_float(Tg, _series_eltype(s))
-    Tv_out = _series_output_type(_output_eltype(_series_eltype(s), Tg_float), Tq)
+    Tv_out = _output_eltype(_series_eltype(s), Tg_float, Tq)
     outputs = [Vector{Tv_out}(undef, length(xqs)) for _ in 1:K]
     quadratic_interp!(outputs, x, s, xqs; bc, extrap, deriv, search)
     return outputs

--- a/src/quadratic/quadratic_series_interp.jl
+++ b/src/quadratic/quadratic_series_interp.jl
@@ -425,7 +425,7 @@ function (sitp::QuadraticSeriesInterpolant{Tg, Tv, P})(
     ) where {Tg, Tv, P, Tq <: Real}
     # Promote for anchor: Int→Float, Int-backed Dual→Float-backed Dual (no-op for Float/Float-backed Dual)
     xq_promoted = _promote_for_anchor(xq, Tg)
-    T_out = _output_eltype(Tv, Tg, typeof(xq_promoted))
+    T_out = _output_eltype(_arithmetic_kernel_shape, Tg, Tv, typeof(xq_promoted))
     aq = _make_anchor(sitp, xq_promoted, _resolve_search(sitp.x, xq, search, hint))
 
     output = Vector{T_out}(undef, n_series(sitp))
@@ -479,7 +479,7 @@ function (sitp::QuadraticSeriesInterpolant{Tg, Tv, P})(
     ) where {Tg, Tv, P, Tq <: Real}
     n_query = length(xq)
     n_ser = n_series(sitp)
-    T_out = _output_eltype(Tv, Tg, Tq)
+    T_out = _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)
 
     # Explicit Vector{Vector{T_out}} for type stability on Julia LTS
     outputs = Vector{Vector{T_out}}(undef, n_ser)

--- a/src/quadratic/quadratic_series_interp.jl
+++ b/src/quadratic/quadratic_series_interp.jl
@@ -425,7 +425,7 @@ function (sitp::QuadraticSeriesInterpolant{Tg, Tv, P})(
     ) where {Tg, Tv, P, Tq <: Real}
     # Promote for anchor: Int→Float, Int-backed Dual→Float-backed Dual (no-op for Float/Float-backed Dual)
     xq_promoted = _promote_for_anchor(xq, Tg)
-    T_out = _series_output_type(_output_eltype(Tv, Tg), typeof(xq_promoted))
+    T_out = _output_eltype(Tv, Tg, typeof(xq_promoted))
     aq = _make_anchor(sitp, xq_promoted, _resolve_search(sitp.x, xq, search, hint))
 
     output = Vector{T_out}(undef, n_series(sitp))
@@ -479,7 +479,7 @@ function (sitp::QuadraticSeriesInterpolant{Tg, Tv, P})(
     ) where {Tg, Tv, P, Tq <: Real}
     n_query = length(xq)
     n_ser = n_series(sitp)
-    T_out = _series_output_type(_output_eltype(Tv, Tg), Tq)
+    T_out = _output_eltype(Tv, Tg, Tq)
 
     # Explicit Vector{Vector{T_out}} for type stability on Julia LTS
     outputs = Vector{Vector{T_out}}(undef, n_ser)

--- a/test/test_bc_complex_int.jl
+++ b/test/test_bc_complex_int.jl
@@ -52,9 +52,10 @@
 
     @testset "constant_interp" begin
         itp = constant_interp(x, y_cint)
-        # Constant duck-types: Complex{Int} y preserved (no widening to ComplexF64).
+        # Storage keeps raw Complex{Int} y; Float64 xq carrier propagates the
+        # call result to ComplexF64.
         @test itp isa ConstantInterpolant{Float64, Complex{Int}}
-        @test itp(1.5) isa Complex{Int}
+        @test itp(1.5) isa ComplexF64
     end
 
     @testset "quadratic_interp" begin

--- a/test/test_complex_constant.jl
+++ b/test/test_complex_constant.jl
@@ -56,11 +56,12 @@
 
         itp = constant_interp(x, y)
 
-        # Constant duck-types: Int grid stays Int, Complex{Int} preserved.
+        # Storage stays raw: Int grid, Complex{Int} y.
         @test itp isa ConstantInterpolant{Int, Complex{Int}}
 
+        # Float64 xq carrier propagates: Complex{Int} * one(Float64) = ComplexF64.
         val = itp(0.5)
-        @test val isa Complex{Int}
+        @test val isa ComplexF64
     end
 
     # ========================================

--- a/test/test_complex_constant_series.jl
+++ b/test/test_complex_constant_series.jl
@@ -58,15 +58,22 @@
 
         sitp = constant_interp(x, Series(y1, y2))
 
-        # Constant duck-types: Int grid stays Int, Complex{Int} preserved.
+        # Storage Tg/Tv preserved on the struct (no Float-lift for Constant).
         @test sitp isa ConstantSeriesInterpolant{Int, Complex{Int}}
 
+        # Float xq + Int grid → kernel-shape trait promotes via `xq - xL`,
+        # so output widens to `ComplexF64` (matches the 1D plain path's
+        # `Int y + Float xq → Float` rule extended to Complex carriers).
         vals = sitp(5.5)
-        @test vals isa Vector{Complex{Int}}
+        @test vals isa Vector{ComplexF64}
+        @test vals[1] === 5.0 + 10.0im
 
-        # Constant interpolation returns step value (nearest by default).
-        # At 5.5 with NearestSide(), rounds to index 6 (x=5) → value 5+10i.
-        @test vals[1] === 5 + 10im
+        # Fully-Int chain (Int xq + Int grid + Complex{Int} y) stays
+        # `Complex{Int}` — matches the `test_constant_eltype.jl` Series ↔
+        # plain agreement pin for fully-Int chains.
+        vals_int = sitp(5)
+        @test vals_int isa Vector{Complex{Int}}
+        @test vals_int[1] === 5 + 10im
     end
 
     # ========================================
@@ -268,11 +275,11 @@
     # ========================================
     # Tg Calculation Policy (Query Independence)
     # ========================================
-    @testset "Eltype contract: selection kernel preserves Tv" begin
-        # Constant duck-types output to `_series_eltype(s)`: query type Tq does
-        # NOT widen the output for plain numerical Tq (Float/Int/Rational/Complex)
-        # — kernel just returns `y[idx]::Tv`. Duck-typed Tq (Dual) still
-        # promotes for AD-API compatibility, but plain Float64 keeps Tv.
+    @testset "Eltype contract: kernel-shape trait promotes via xq - xL" begin
+        # Series routes through `_constant_kernel_shape(xL, yv, xq) = yv * one(xq - xL)`,
+        # so output eltype is `promote_type(Tv, promote_type(Tg, Tq))`. This
+        # matches the 1D plain path rule — query type widens the output when
+        # it's wider than Tg/Tv.
         x32 = Float32.(0:0.1:1)
         y1 = sin.(x32)
         y2 = cos.(x32)
@@ -280,8 +287,13 @@
         sitp = constant_interp(x32, Series(y1, y2))
         @test sitp isa ConstantSeriesInterpolant{Float32, Float32}
 
-        result = sitp(0.5)  # 0.5 is Float64 — but Tv (Float32) wins for constant.
-        @test eltype(result) === Float32
+        # Float64 xq with Float32 grid/y → output widens to Float64.
+        result64 = sitp(0.5)
+        @test eltype(result64) === Float64
+
+        # Float32 xq with Float32 grid/y → fully-Float32 chain stays Float32.
+        result32 = sitp(0.5f0)
+        @test eltype(result32) === Float32
     end
 
 end

--- a/test/test_constant.jl
+++ b/test/test_constant.jl
@@ -166,11 +166,14 @@ end
     @testset "Real type wrapper (Integer input)" begin
         x_int = [0, 1, 2, 3, 4]
         y_int = [10, 20, 30, 40, 50]
-        # Constant duck-types output to `eltype(y)` — Int in → Int out (no Float
-        # widening, since the kernel is selection, not arithmetic).
+        # Float64 xq → Float64 result (Int y * one(Float64) = Float64).
         result = constant_interp(x_int, y_int, 1.5)
-        @test result isa Int
-        @test result == 20
+        @test result isa Float64
+        @test result == 20.0
+        # Fully-Int chain preserves Int.
+        result_int = constant_interp(x_int, y_int, 1)
+        @test result_int isa Int
+        @test result_int == 20
     end
 
     @testset "Real→Float wrappers (coverage)" begin

--- a/test/test_constant.jl
+++ b/test/test_constant.jl
@@ -195,10 +195,10 @@ end
         @test out ≈ [10.0, 20.0, 30.0]
 
         # Test 3: Vector allocating with Integer grid + Integer query.
-        # Constant duck-types output to `eltype(y)` — no Float widening.
+        # Natural promotion: trait upgrades Int→Float at allocation.
         result_vec = constant_interp(x_int, y_int, [0, 1, 2])
-        @test result_vec isa Vector{Int}
-        @test result_vec == [10, 20, 30]
+        @test result_vec isa Vector{Float64}
+        @test result_vec == [10.0, 20.0, 30.0]
 
         # Test 4: In-place Real→Float wrapper (lines 440-468)
         # constant_interp!(output, x::AbstractVector{T}, y::AbstractVector{T}, x_targets::AbstractVector{S})

--- a/test/test_constant.jl
+++ b/test/test_constant.jl
@@ -195,10 +195,10 @@ end
         @test out ≈ [10.0, 20.0, 30.0]
 
         # Test 3: Vector allocating with Integer grid + Integer query.
-        # Natural promotion: trait upgrades Int→Float at allocation.
+        # Kernel-shape trait keeps Int×Int×Int in Int; matches scalar path.
         result_vec = constant_interp(x_int, y_int, [0, 1, 2])
-        @test result_vec isa Vector{Float64}
-        @test result_vec == [10.0, 20.0, 30.0]
+        @test result_vec isa Vector{Int}
+        @test result_vec == [10, 20, 30]
 
         # Test 4: In-place Real→Float wrapper (lines 440-468)
         # constant_interp!(output, x::AbstractVector{T}, y::AbstractVector{T}, x_targets::AbstractVector{S})

--- a/test/test_constant_eltype.jl
+++ b/test/test_constant_eltype.jl
@@ -96,11 +96,11 @@
             @test r == 30
         end
 
-        @testset "vector alloc oneshot: Int x + Int y + Int xq → Vector{Float64}" begin
-            # Natural promotion: trait upgrades Int→Float at allocation.
+        @testset "vector alloc oneshot returns Vector{Int}" begin
+            # Kernel-shape trait infers Int×Int×Int → Int; matches scalar path.
             v = constant_interp(x_int, y_int, [0, 1, 2, 3])
-            @test v isa Vector{Float64}
-            @test v == [10.0, 20.0, 30.0, 40.0]
+            @test v isa Vector{Int}
+            @test v == [10, 20, 30, 40]
         end
 
         @testset "in-place oneshot accepts Vector{Int} output" begin
@@ -644,13 +644,13 @@ end
         @test constant_interp([0.0, 1.0, 2.0, 3.0], [10, 20, 30, 40], [0.5]) isa Vector{Float64}
     end
 
-    @testset "1D Int y + Int xq — scalar stays Int; batch widens to Float" begin
-        # Scalar: kernel direct preserves Tv. Batch/oneshot: trait applies
-        # natural Int→Float upgrade (same rule as Linear/Cubic/etc).
+    @testset "1D Int y + Int xq — scalar/batch both stay Int" begin
+        # Constant's `y * one(dL)` kernel produces Int for fully-Int chain.
+        # Trait routes through `_constant_kernel_shape`, so batch matches.
         itp = constant_interp([0, 1, 2, 3], [10, 20, 30, 40])
         @test itp(0) === 10
-        @test itp([0, 1]) isa Vector{Float64}
-        @test constant_interp([0, 1, 2, 3], [10, 20, 30, 40], [0, 1]) isa Vector{Float64}
+        @test itp([0, 1]) isa Vector{Int}
+        @test constant_interp([0, 1, 2, 3], [10, 20, 30, 40], [0, 1]) isa Vector{Int}
     end
 
     @testset "ND Int data + Float xq → Float (persistent paths)" begin

--- a/test/test_constant_eltype.jl
+++ b/test/test_constant_eltype.jl
@@ -367,15 +367,15 @@ end
         @test r isa Float64
     end
 
-    @testset "ND oneshot batch — current behavior pinned (allocator follow-up)" begin
+    @testset "ND oneshot batch — Float xq carrier propagated through kernel" begin
         x = 0:1:4
         y = 0:1:3
         data = [10 * i + j for i in 1:5, j in 1:4]
         queries = [(2.5, 1.5), (0.5, 0.5), (3.5, 2.5)]
-        # ND oneshot 3-arg batch allocator does not yet sample-first; pin
-        # current Vector{Int} return so a future migration is intentional.
+        # Float xq + Int data → Float (kernel does y * one(dL)). Sample-first
+        # allocator (constant_nd_oneshot.jl) reads the actual kernel return type.
         vals = constant_interp((x, y), data, queries)
-        @test vals isa Vector{Int}
+        @test vals isa Vector{Float64}
         @test length(vals) == 3
     end
 
@@ -656,8 +656,7 @@ end
         @test itp((0.5, 0.5)) === 10.0
         @test itp([(0.5, 0.5)]) == [10.0]
         @test itp([(0.5, 0.5)]) isa Vector{Float64}
-        # ND oneshot 3-arg allocator pending sample-first migration; pin current.
-        @test constant_interp((x, y), data, [(0.5, 0.5)]) isa Vector{Int}
+        @test constant_interp((x, y), data, [(0.5, 0.5)]) isa Vector{Float64}
     end
 
     @testset "1D persistent Dual → carrier preserved (scalar + batch)" begin

--- a/test/test_constant_eltype.jl
+++ b/test/test_constant_eltype.jl
@@ -96,10 +96,11 @@
             @test r == 30
         end
 
-        @testset "vector alloc oneshot returns Vector{Int}" begin
+        @testset "vector alloc oneshot: Int x + Int y + Int xq → Vector{Float64}" begin
+            # Natural promotion: trait upgrades Int→Float at allocation.
             v = constant_interp(x_int, y_int, [0, 1, 2, 3])
-            @test v isa Vector{Int}
-            @test v == [10, 20, 30, 40]
+            @test v isa Vector{Float64}
+            @test v == [10.0, 20.0, 30.0, 40.0]
         end
 
         @testset "in-place oneshot accepts Vector{Int} output" begin
@@ -643,11 +644,13 @@ end
         @test constant_interp([0.0, 1.0, 2.0, 3.0], [10, 20, 30, 40], [0.5]) isa Vector{Float64}
     end
 
-    @testset "1D Int y + Int xq → Int (fully-Int chain preserves Tv)" begin
+    @testset "1D Int y + Int xq — scalar stays Int; batch widens to Float" begin
+        # Scalar: kernel direct preserves Tv. Batch/oneshot: trait applies
+        # natural Int→Float upgrade (same rule as Linear/Cubic/etc).
         itp = constant_interp([0, 1, 2, 3], [10, 20, 30, 40])
         @test itp(0) === 10
-        @test itp([0, 1]) isa Vector{Int}
-        @test constant_interp([0, 1, 2, 3], [10, 20, 30, 40], [0, 1]) isa Vector{Int}
+        @test itp([0, 1]) isa Vector{Float64}
+        @test constant_interp([0, 1, 2, 3], [10, 20, 30, 40], [0, 1]) isa Vector{Float64}
     end
 
     @testset "ND Int data + Float xq → Float (persistent paths)" begin

--- a/test/test_constant_eltype.jl
+++ b/test/test_constant_eltype.jl
@@ -488,12 +488,14 @@ end
 @testitem "Constant eltype duck-type — @inferred coverage" begin
     import FastInterpolations: ConstantInterpolantND
 
-    @testset "1D Series scalar — Tv pass-through branch" begin
+    @testset "1D Series scalar — Int y + Float xq → Float carrier" begin
+        # Series persistent now routes through `_constant_kernel_shape` like
+        # the plain 1D path — `Int y + Float xq` widens to Float.
         x = collect(0.0:0.1:1.0)
         y1 = collect(1:11)
         y2 = collect(11:21)
         sitp = constant_interp(x, Series(y1, y2))
-        @test @inferred(sitp(0.55)) isa Vector{Int}
+        @test @inferred(sitp(0.55)) isa Vector{Float64}
     end
 
     @testset "1D Series scalar — ComplexF32 Tv branch" begin
@@ -614,13 +616,19 @@ end
         @test ForwardDiff.value.(out[1]) == [10.0]
     end
 
-    @testset "plain Float xq carrier propagation — plain vs Series oneshot" begin
-        # Plain-vector oneshot picks up the Float64 xq carrier (Tv=Int → Float).
+    @testset "Float xq carrier — plain and Series oneshot agree" begin
+        # Both plain and Series route through `_constant_kernel_shape` →
+        # `Int y + Float xq → Float`.
         @test constant_interp(x, y, [0.5, 1.5]) isa Vector{Float64}
-        # Series oneshot allocator does not yet sample-first; pin current
-        # Vector{Int} return so a future migration is intentional.
-        @test constant_interp(x, s, 0.5) isa Vector{Int}
-        @test constant_interp(x, s, [0.5, 1.5]) isa Vector{Vector{Int}}
+        @test constant_interp(x, s, 0.5) isa Vector{Float64}
+        @test constant_interp(x, s, [0.5, 1.5]) isa Vector{Vector{Float64}}
+    end
+
+    @testset "Fully-Int chain — Series stays Int (matches 1D plain pin)" begin
+        x_i = [0, 1, 2, 3]
+        s_i = Series([10, 20, 30, 40])
+        @test constant_interp(x_i, s_i, 0) isa Vector{Int}
+        @test constant_interp(x_i, s_i, [0, 1]) isa Vector{Vector{Int}}
     end
 end
 

--- a/test/test_constant_eltype.jl
+++ b/test/test_constant_eltype.jl
@@ -17,15 +17,19 @@
         _CachedRange, _CachedVector, _ExclusivePeriodicAxis
 
     @testset "Persistent constructor (1D)" begin
-        @testset "Int Vector x, Int y → output Int" begin
+        @testset "Int Vector x, Int y — output follows query type" begin
             x = [0, 1, 2, 3, 4]
             y = [10, 20, 30, 40, 50]
             itp = constant_interp(x, y)
             @test itp isa ConstantInterpolant{Int, Int}
             @test eltype(itp.y) === Int
             @test itp.x isa _CachedVector{Int, Float64}
-            @test itp(1.5) isa Int
-            @test itp(1.5) == 20
+            # Float xq → Float (Int y * one(Float) = Float).
+            @test itp(1.5) isa Float64
+            @test itp(1.5) == 20.0
+            # Int xq → Int (fully-Int chain preserves Tv).
+            @test itp(2) isa Int
+            @test itp(2) == 30
         end
 
         @testset "Int Range x, Int y → itp.x::_CachedRange{Int, Float64}" begin
@@ -36,26 +40,32 @@
             @test itp.x isa _CachedRange{Int, Float64}
             @test itp.x.h === 1
             @test itp.x.inv_h === 1.0
-            @test itp(2.5) isa Int
-            @test itp(2.5) == 30
+            # Float xq → Float.
+            @test itp(2.5) isa Float64
+            @test itp(2.5) == 30.0
+            # Int xq → Int.
+            @test itp(3) isa Int
+            @test itp(3) == 40
         end
 
-        @testset "Rational x, Rational y → output Rational{Int}" begin
+        @testset "Rational x, Rational y, Rational xq → output Rational{Int}" begin
             x = Rational{Int}[0 // 1, 1 // 1, 2 // 1, 3 // 1, 4 // 1]
             y = Rational{Int}[1 // 2, 3 // 2, 5 // 2, 7 // 2, 9 // 2]
             itp = constant_interp(x, y)
             @test itp isa ConstantInterpolant{Rational{Int}, Rational{Int}}
+            # Rational xq stays Rational (Rational * one(Rational) = Rational).
             @test itp(3 // 2) isa Rational{Int}
             @test itp(3 // 2) === 3 // 2
         end
 
-        @testset "Float64 x, Int y → output Int (NEW: no Float widening)" begin
+        @testset "Float64 x, Int y, Float xq → Float (natural promote)" begin
             x = [0.0, 1.0, 2.0, 3.0, 4.0]
             y = [10, 20, 30, 40, 50]
             itp = constant_interp(x, y)
             @test itp isa ConstantInterpolant{Float64, Int}
-            @test itp(1.5) isa Int
-            @test itp(1.5) == 20
+            # Carrier propagates: Int y * one(Float64) = Float64. Value preserved.
+            @test itp(1.5) isa Float64
+            @test itp(1.5) == 20.0
         end
 
         @testset "Float32 x, Float32 y → output Float32 (regression guard)" begin
@@ -105,20 +115,23 @@
             y = [10, 20, 30, 10]  # closed cycle
             itp = constant_interp(x, y; bc = PeriodicBC())
             @test itp isa ConstantInterpolant{Int, Int}
-            @test itp(0.5) isa Int
-            @test itp(3.5) isa Int  # wraps to first cell
+            # Float xq → Float (natural promote); Int xq → Int.
+            @test itp(0.5) isa Float64
+            @test itp(3.5) isa Float64    # wraps to first cell
+            @test itp(1) isa Int
         end
 
         @testset "exclusive + Int Vector x + Int y" begin
-            # Constant preserves raw grid eltype — `:exclusive` extension is
-            # shape-only (n → n+1), no float promotion.
+            # Constant grid eltype stays Int (`:exclusive` extension is
+            # shape-only, n → n+1). Query type drives output.
             x = [0, 1, 2]
             y = [10, 20, 30]
             itp = constant_interp(x, y; bc = PeriodicBC(endpoint = :exclusive, period = 3))
             @test itp isa ConstantInterpolant{Int, Int}
             @test length(itp.x) == 4          # closed-cycle n+1
             @test itp.x[end] == itp.x[1] + 3  # virtual endpoint at period
-            @test itp(0.5) isa Int
+            @test itp(0.5) isa Float64
+            @test itp(1) isa Int
         end
 
         @testset "inclusive + Int Range x + Int y → _CachedRange{Int, Float64}" begin
@@ -127,8 +140,10 @@
             itp = constant_interp(x, y; bc = PeriodicBC())
             @test itp isa ConstantInterpolant{Int, Int}
             @test itp.x isa _CachedRange{Int, Float64}
-            @test itp(0.5) isa Int
-            @test itp(0.5) == 10
+            @test itp(0.5) isa Float64
+            @test itp(0.5) == 10.0
+            @test itp(1) isa Int
+            @test itp(1) == 20
         end
     end
 
@@ -270,7 +285,9 @@ end
             data = [10 * i + j for i in 1:5, j in 1:4]   # Int matrix
             itp = constant_interp((x, y), data)
             @test itp isa ConstantInterpolantND{Int, Int, 2}
-            @test itp((2.5, 1.5)) isa Int
+            # Float xq → Float (natural promote); Int xq → Int (fully-Int chain).
+            @test itp((2.5, 1.5)) isa Float64
+            @test itp((2, 1)) isa Int
             @test itp.grids[1] isa _CachedRange{Int, Float64}
             @test itp.grids[2] isa _CachedVector{Int, Float64}
         end
@@ -306,24 +323,28 @@ end
         @test itp((2.5, 1.5)) isa Float64
     end
 
-    @testset "Int data + Float axes — output tracks `eltype(data)`" begin
+    @testset "Int data + Float axes — query carrier drives output" begin
         # Axes Float, data Int → Tv=Int, Tg=Float64.
         x = [0.0, 1.0, 2.0, 3.0]
         y = [0.0, 1.0, 2.0]
         data = [10 * i + j for i in 1:4, j in 1:3]  # Int matrix
         itp = constant_interp((x, y), data)
         @test itp isa ConstantInterpolantND{Float64, Int, 2}
-        @test itp((1.5, 0.5)) isa Int
+        # Float xq → Float result (Int data * one(Float) = Float).
+        @test itp((1.5, 0.5)) isa Float64
     end
 
-    @testset "3D sanity — Int^3 → Int output" begin
+    @testset "3D Int^3 — fully-Int chain stays Int" begin
         x = 0:1:3
         y = 0:1:2
         z = 0:1:2
         data = [i + 10j + 100k for i in 1:4, j in 1:3, k in 1:3]  # Int 3D
         itp = constant_interp((x, y, z), data)
         @test itp isa ConstantInterpolantND{Int, Int, 3}
-        @test itp((1.5, 0.5, 1.5)) isa Int
+        # Int xq → Int (fully-Int chain).
+        @test itp((1, 0, 1)) isa Int
+        # Float xq → Float.
+        @test itp((1.5, 0.5, 1.5)) isa Float64
     end
 
     @testset "PeriodicBC + Int axes (inclusive)" begin
@@ -333,22 +354,26 @@ end
         data = [(i == 4 ? 1 : i) + 10j for i in 1:4, j in 1:3]
         itp = constant_interp((x, y), data; bc = (PeriodicBC(), NoBC()))
         @test itp isa ConstantInterpolantND{Int, Int, 2}
-        @test itp((0.5, 1.5)) isa Int
+        @test itp((0.5, 1.5)) isa Float64
+        @test itp((1, 1)) isa Int
     end
 
-    @testset "ND oneshot scalar — Int input → Int output" begin
+    @testset "ND oneshot scalar — Float xq → Float (natural promote)" begin
         x = 0:1:4
         y = 0:1:3
         data = [10 * i + j for i in 1:5, j in 1:4]
+        # Float xq carrier propagates: Int data * one(Float64) = Float64.
         r = constant_interp((x, y), data, (2.5, 1.5))
-        @test r isa Int
+        @test r isa Float64
     end
 
-    @testset "ND oneshot batch — Vector{Int} preserved" begin
+    @testset "ND oneshot batch — current behavior pinned (allocator follow-up)" begin
         x = 0:1:4
         y = 0:1:3
         data = [10 * i + j for i in 1:5, j in 1:4]
         queries = [(2.5, 1.5), (0.5, 0.5), (3.5, 2.5)]
+        # ND oneshot 3-arg batch allocator does not yet sample-first; pin
+        # current Vector{Int} return so a future migration is intentional.
         vals = constant_interp((x, y), data, queries)
         @test vals isa Vector{Int}
         @test length(vals) == 3
@@ -429,13 +454,15 @@ end
 # Group 6: FillExtrap × duck-typed Y (raw-Tv fill value contract)
 # ============================================================================
 @testitem "Constant eltype duck-type — FillExtrap raw-Tv contract" begin
-    @testset "1D persistent: Int data + Int fill" begin
+    @testset "1D persistent: Int data + Int fill — natural promote with Float xq" begin
         x = Float64.(0:4)
         y = [10, 20, 30, 40, 50]
         itp = constant_interp(x, y; extrap = FillExtrap(-1))
-        @test itp.extrap === FillExtrap{Int}(-1)  # raw Tv stored
-        @test itp(1.5) === 20                      # in-domain
-        @test itp(-1.0) === -1                     # OOB also raw Tv (scalar callable convert)
+        # Construction promotes the fill value to Tv (Int) — raw storage.
+        @test itp.extrap === FillExtrap{Int}(-1)
+        # Float xq → Float result for both in-domain and OOB (carrier propagates).
+        @test itp(1.5) === 20.0
+        @test itp(-1.0) === -1.0
     end
 
     @testset "1D persistent: Int data + Float fill → InexactError on construction" begin
@@ -475,12 +502,12 @@ end
         @test @inferred(sitp(0.55f0)) isa Vector{ComplexF32}
     end
 
-    @testset "ND persistent forward (Int data)" begin
+    @testset "ND persistent forward (Int data, Float xq → Float carrier)" begin
         x = collect(0.0:1:3); y = collect(0.0:1:3)
         data = [10 * i + j for i in 1:4, j in 1:4]
         itp = constant_interp((x, y), data)
         @test itp isa ConstantInterpolantND{Float64, Int, 2}
-        @test @inferred(itp((1.5, 2.5))) === data[2, 3]
+        @test @inferred(itp((1.5, 2.5))) === Float64(data[2, 3])
     end
 end
 
@@ -534,7 +561,8 @@ end
 
         itp = constant_interp(x, y)
         adj = constant_adjoint(x, xq)
-        @test itp(xq[1]) === 20.0f0       # right cell (dL > h/2 in Float64)
+        # Carrier of Float64 xq propagates into result: Float32 y * one(Float64) = Float64.
+        @test itp(xq[1]) === 20.0
         @test adj(y_bar) ≈ Float32[0, 1, 0]
         @test dot([itp(xq[1])], y_bar) ≈ dot(y, adj(y_bar))
     end
@@ -585,40 +613,50 @@ end
         @test ForwardDiff.value.(out[1]) == [10.0]
     end
 
-    @testset "plain Float xq still returns raw Tv (no widening)" begin
-        @test constant_interp(x, y, [0.5, 1.5]) isa Vector{Int}
+    @testset "plain Float xq carrier propagation — plain vs Series oneshot" begin
+        # Plain-vector oneshot picks up the Float64 xq carrier (Tv=Int → Float).
+        @test constant_interp(x, y, [0.5, 1.5]) isa Vector{Float64}
+        # Series oneshot allocator does not yet sample-first; pin current
+        # Vector{Int} return so a future migration is intentional.
         @test constant_interp(x, s, 0.5) isa Vector{Int}
         @test constant_interp(x, s, [0.5, 1.5]) isa Vector{Vector{Int}}
     end
 end
 
 # ============================================================================
-# Group 10: Persistent batch/scalar match oneshot output rules (Codex P2 + Dual)
+# Group 10: Natural promote — output eltype = `_output_eltype(Tv, Tg, Tq)`
 # ============================================================================
-# The shared 1D / ND `AbstractInterpolant` protocols allocate via
-# `_output_eltype(Tv, Tg, Tq)` which widens — that's correct for arithmetic
-# kernels but breaks Constant's raw-Tv contract. Constant overrides the
-# scalar + batch callables so scalar / `itp([xq])` / `itp.([xq])` / oneshot
-# all agree, and duck queries widen consistently across the family.
-@testitem "Constant persistent: batch + scalar follow raw-Tv contract + duck widen" begin
+# Constant's kernel propagates `Tq` via `* one(dL)`, so scalar / `itp([xq])` /
+# `itp.([xq])` / oneshot all agree on the naturally-promoted type. `Int y` +
+# `Float xq` → `Float`; `Int y` + `Int xq` → `Int`; `Int y` + `Dual xq` →
+# `Dual` (carrier preserved without a Constant-specific code path).
+@testitem "Constant persistent: scalar + batch follow natural promote" begin
     using ForwardDiff
     using ForwardDiff: Dual
 
-    @testset "1D Int data + Float xq — scalar/batch/oneshot/broadcast agree" begin
+    @testset "1D Int y + Float xq → Float" begin
         itp = constant_interp([0.0, 1.0, 2.0, 3.0], [10, 20, 30, 40])
-        @test itp(0.5) === 10
-        @test itp([0.5]) == [10]
-        @test itp([0.5]) isa Vector{Int}
-        @test itp.([0.5]) isa Vector{Int}
-        @test constant_interp([0.0, 1.0, 2.0, 3.0], [10, 20, 30, 40], [0.5]) isa Vector{Int}
+        @test itp(0.5) === 10.0
+        @test itp([0.5]) == [10.0]
+        @test itp([0.5]) isa Vector{Float64}
+        @test itp.([0.5]) isa Vector{Float64}
+        @test constant_interp([0.0, 1.0, 2.0, 3.0], [10, 20, 30, 40], [0.5]) isa Vector{Float64}
     end
 
-    @testset "ND Int data + Float xq — scalar/batch/oneshot agree" begin
+    @testset "1D Int y + Int xq → Int (fully-Int chain preserves Tv)" begin
+        itp = constant_interp([0, 1, 2, 3], [10, 20, 30, 40])
+        @test itp(0) === 10
+        @test itp([0, 1]) isa Vector{Int}
+        @test constant_interp([0, 1, 2, 3], [10, 20, 30, 40], [0, 1]) isa Vector{Int}
+    end
+
+    @testset "ND Int data + Float xq → Float (persistent paths)" begin
         x = [0.0, 1.0]; y = [0.0, 1.0]; data = [10 20; 30 40]
         itp = constant_interp((x, y), data)
-        @test itp((0.5, 0.5)) === 10
-        @test itp([(0.5, 0.5)]) == [10]
-        @test itp([(0.5, 0.5)]) isa Vector{Int}
+        @test itp((0.5, 0.5)) === 10.0
+        @test itp([(0.5, 0.5)]) == [10.0]
+        @test itp([(0.5, 0.5)]) isa Vector{Float64}
+        # ND oneshot 3-arg allocator pending sample-first migration; pin current.
         @test constant_interp((x, y), data, [(0.5, 0.5)]) isa Vector{Int}
     end
 

--- a/test/test_constant_oneshot_series.jl
+++ b/test/test_constant_oneshot_series.jl
@@ -136,23 +136,33 @@
         @test measure(x, y_sin, y_cos) <= ALLOC_THRESHOLD
     end
 
-    @testset "Eltype contract: Integer series stays Int" begin
-        x_f = collect(0.0:1.0:4.0)
+    @testset "Eltype contract: fully-Int chain stays Int" begin
+        # Series routes through the canonical kernel-shape trait, so the
+        # output eltype promotes via `xq - xL`. The "stays Int" contract
+        # requires a *fully-Int* chain (Int grid + Int y + Int xq). Float
+        # xq with Int grid would (correctly) widen to Float — pinned in
+        # test_constant_eltype.jl's "Float xq carrier" testset.
+        x_i = 0:4
         y1_int = [0, 1, 3, 4, 7]
         y2_int = [2, 3, 1, 0, 5]
-        vals = constant_interp(x_f, Series(y1_int, y2_int), 1.5)
+        vals = constant_interp(x_i, Series(y1_int, y2_int), 2)
         @test vals isa Vector{Int}
-        @test vals[1] == constant_interp(x_f, y1_int, 1.5)
+        @test vals[1] == constant_interp(x_i, y1_int, 2)
     end
 
     @testset "Eltype contract: FillExtrap fill_value must be compatible with y eltype" begin
-        x_f = collect(0.0:1.0:4.0)
+        # Fully-Int chain so the output buffer is Vector{Int}; mismatched
+        # Float fill_value then surfaces as InexactError on assign. Float
+        # grid/xq would promote the buffer and silently absorb the Float
+        # fill — that case is not what this contract tries to catch.
+        x_i = 0:4
         y_int = [0, 1, 3, 4, 7]
-        # Int series + Int fill_value → output is Int.
-        vals = constant_interp(x_f, Series(y_int), 5.0; extrap = FillExtrap(9))
+        # Int series + Int fill_value → output stays Int, fill stores cleanly.
+        vals = constant_interp(x_i, Series(y_int), 5; extrap = FillExtrap(9))
+        @test vals isa Vector{Int}
         @test vals[1] == 9
-        # Int series + Float fill_value → InexactError (raw eltype contract is strict).
-        @test_throws InexactError constant_interp(x_f, Series(y_int), 5.0; extrap = FillExtrap(0.5))
+        # Int series + Float fill_value → InexactError on Int-buffer assign.
+        @test_throws InexactError constant_interp(x_i, Series(y_int), 5; extrap = FillExtrap(0.5))
     end
 
     @testset "Scalar: Vector-of-Vectors" begin

--- a/test/test_duck_tv_dual_tq.jl
+++ b/test/test_duck_tv_dual_tq.jl
@@ -36,8 +36,12 @@
     @testset "ND batch — SVector data × Tuple{Dual, Dual}" begin
         xg = collect(1.0:5.0); yg = collect(1.0:5.0)
         data_sv = [SA[Float64(i + j), 2.0(i + j), 3.0(i + j)] for i in 1:5, j in 1:5]
-        q_dv = [(ForwardDiff.Dual{Nothing}(2.5 + 0.1i, 1.0),
-                 ForwardDiff.Dual{Nothing}(3.5 + 0.1i, 0.0)) for i in 1:5]
+        q_dv = [
+            (
+                    ForwardDiff.Dual{Nothing}(2.5 + 0.1i, 1.0),
+                    ForwardDiff.Dual{Nothing}(3.5 + 0.1i, 0.0),
+                ) for i in 1:5
+        ]
         @test linear_interp((xg, yg), data_sv)(q_dv) isa Vector{SVector{3, D}}
         @test cubic_interp((xg, yg), data_sv)(q_dv) isa Vector{SVector{3, D}}
         @test constant_interp((xg, yg), data_sv)(q_dv) isa Vector{SVector{3, D}}
@@ -97,8 +101,12 @@ end
     @testset "ND batch 3-arg" begin
         xg = collect(1.0:5.0); yg = collect(1.0:5.0)
         data_sv = [SA[Float64(i + j), 2.0(i + j), 3.0(i + j)] for i in 1:5, j in 1:5]
-        q_dv = [(ForwardDiff.Dual{Nothing}(2.5 + 0.1i, 1.0),
-                 ForwardDiff.Dual{Nothing}(3.5 + 0.1i, 0.0)) for i in 1:5]
+        q_dv = [
+            (
+                    ForwardDiff.Dual{Nothing}(2.5 + 0.1i, 1.0),
+                    ForwardDiff.Dual{Nothing}(3.5 + 0.1i, 0.0),
+                ) for i in 1:5
+        ]
         @test linear_interp((xg, yg), data_sv, q_dv) isa Vector{SVector{3, D}}
         @test cubic_interp((xg, yg), data_sv, q_dv) isa Vector{SVector{3, D}}
         @test quadratic_interp((xg, yg), data_sv, q_dv) isa Vector{SVector{3, D}}
@@ -114,8 +122,8 @@ end
     x = collect(1.0:10.0)
     y_sv1 = [SA[Float64(i), 2.0i, 3.0i] for i in 1:10]
     y_sv2 = [SA[-1.0 * i, 0.5i, 2.5i] for i in 1:10]
-    s_sv  = Series(y_sv1, y_sv2)
-    xq_d  = ForwardDiff.Dual{Nothing}(5.5, 1.0)
+    s_sv = Series(y_sv1, y_sv2)
+    xq_d = ForwardDiff.Dual{Nothing}(5.5, 1.0)
     xq_dv = [ForwardDiff.Dual{Nothing}(2.0 + 0.1i, 1.0) for i in 1:5]
     D = ForwardDiff.Dual{Nothing, Float64, 1}
 
@@ -185,7 +193,7 @@ end
         # 1D: Int y, Float/Int xq — the kernel's `* one(dL)` and the right-edge
         # short-circuit must agree on the return type.
         x = 1:10
-        y = (1:10).^2
+        y = (1:10) .^ 2
         itp = constant_interp(x, y)
         @test (@inferred itp(1.0)) === 1.0     # at first(x)
         @test (@inferred itp(10.0)) === 100.0  # at last(x): the short-circuit branch
@@ -271,9 +279,9 @@ end
         # `∂/∂δ fn(x .+ δ, y, xq)` — grid sensitivity via AD. Persistent + one-shot.
         for fn in (linear_interp, cubic_interp, constant_interp)
             d_pers = ForwardDiff.derivative(δ -> fn(x_f .+ δ, y_f)(xq_f), 0.0)
-            d_one  = ForwardDiff.derivative(δ -> fn(x_f .+ δ, y_f, xq_f), 0.0)
+            d_one = ForwardDiff.derivative(δ -> fn(x_f .+ δ, y_f, xq_f), 0.0)
             @test d_pers isa Float64 && isfinite(d_pers)
-            @test d_one  isa Float64 && isfinite(d_one)
+            @test d_one isa Float64 && isfinite(d_one)
             # SVector indexed component, one-shot path
             d_sv = ForwardDiff.derivative(δ -> fn(x_f .+ δ, y_sv, xq_f)[2], 0.0)
             @test d_sv isa Float64 && isfinite(d_sv)
@@ -313,7 +321,7 @@ end
     @testset "Series + one-shot ForwardDiff.derivative on SVector component" begin
         using FastInterpolations: Series
         y_sv1 = [SA[Float64(i), 2.0i] for i in 1:10]
-        y_sv2 = [SA[-1.0*i, 0.5i] for i in 1:10]
+        y_sv2 = [SA[-1.0 * i, 0.5i] for i in 1:10]
         s_sv = Series(y_sv1, y_sv2)
         # `fn(x, series, t)` returns Vector{SVector} (one per series).
         # ∂/∂t of series[1][component[1]] exercises the full Series + duck-Tq chain.
@@ -333,8 +341,8 @@ end
     x = collect(1.0:10.0)
     y_sv1 = [SA[Float64(i), 2.0i, 3.0i] for i in 1:10]
     y_sv2 = [SA[-1.0 * i, 0.5i, 2.5i] for i in 1:10]
-    s_sv  = Series(y_sv1, y_sv2)
-    xq_d  = ForwardDiff.Dual{Nothing}(5.5, 1.0)
+    s_sv = Series(y_sv1, y_sv2)
+    xq_d = ForwardDiff.Dual{Nothing}(5.5, 1.0)
     xq_dv = [ForwardDiff.Dual{Nothing}(2.0 + 0.1i, 1.0) for i in 1:5]
     D = ForwardDiff.Dual{Nothing, Float64, 1}
 
@@ -360,26 +368,26 @@ end
     x = collect(1.0:10.0)
     y_sv1 = [SA[Float64(i), 2.0i, 3.0i] for i in 1:10]
     y_sv2 = [SA[-1.0 * i, 0.5i, 2.5i] for i in 1:10]
-    s_sv  = Series(y_sv1, y_sv2)
-    xq_d  = ForwardDiff.Dual{Nothing}(5.5, 1.0)
+    s_sv = Series(y_sv1, y_sv2)
+    xq_d = ForwardDiff.Dual{Nothing}(5.5, 1.0)
     xq_dv = [ForwardDiff.Dual{Nothing}(2.0 + 0.1i, 1.0) for i in 1:5]
     D = ForwardDiff.Dual{Nothing, Float64, 1}
 
     @testset "Linear" begin
         sitp = linear_interp(x, s_sv)
-        @test sitp(xq_d)  isa Vector{SVector{3, D}}
+        @test sitp(xq_d) isa Vector{SVector{3, D}}
         @test sitp(xq_dv) isa Vector{Vector{SVector{3, D}}}
     end
 
     @testset "Quadratic" begin
         sitp = quadratic_interp(x, s_sv)
-        @test sitp(xq_d)  isa Vector{SVector{3, D}}
+        @test sitp(xq_d) isa Vector{SVector{3, D}}
         @test sitp(xq_dv) isa Vector{Vector{SVector{3, D}}}
     end
 
     @testset "Constant" begin
         sitp = constant_interp(x, s_sv)
-        @test sitp(xq_d)  isa Vector{SVector{3, D}}
+        @test sitp(xq_d) isa Vector{SVector{3, D}}
         @test sitp(xq_dv) isa Vector{Vector{SVector{3, D}}}
     end
 end
@@ -449,22 +457,22 @@ end
     D = ForwardDiff.Dual{Nothing, Float64, 1}
     x = collect(1.0:10.0)
     y_f = sin.(x)
-    xq_d  = ForwardDiff.Dual{Nothing}(5.5, 1.0)
+    xq_d = ForwardDiff.Dual{Nothing}(5.5, 1.0)
     xq_dv = [ForwardDiff.Dual{Nothing}(2.0 + 0.5i, 1.0) for i in 1:5]
 
     @testset "PCHIP — Float y + Dual xq" begin
-        @test pchip_interp(x, y_f, xq_d)  isa D
+        @test pchip_interp(x, y_f, xq_d) isa D
         @test pchip_interp(x, y_f, xq_dv) isa Vector{D}
     end
 
     @testset "Cardinal — SVector y + Dual xq" begin
         y_sv = [SA[Float64(i), 2.0i, 3.0i] for i in 1:10]
-        @test cardinal_interp(x, y_sv, xq_d)  isa SVector{3, D}
+        @test cardinal_interp(x, y_sv, xq_d) isa SVector{3, D}
         @test cardinal_interp(x, y_sv, xq_dv) isa Vector{SVector{3, D}}
     end
 
     @testset "Akima — Float y + Dual xq" begin
-        @test akima_interp(x, y_f, xq_d)  isa D
+        @test akima_interp(x, y_f, xq_d) isa D
         @test akima_interp(x, y_f, xq_dv) isa Vector{D}
     end
 end
@@ -569,8 +577,8 @@ end
 
     @testset "1D persistent — scalar Dual" begin
         let l = linear_interp(x, y_sv), c = cubic_interp(x, y_sv),
-            q = quadratic_interp(x, y_sv), k = constant_interp(x, y_sv),
-            h = hermite_interp(x, y_sv, dy_sv)
+                q = quadratic_interp(x, y_sv), k = constant_interp(x, y_sv),
+                h = hermite_interp(x, y_sv, dy_sv)
             @test (@inferred l(xq_d)) isa SVD
             @test (@inferred c(xq_d)) isa SVD
             @test (@inferred q(xq_d)) isa SVD
@@ -581,8 +589,8 @@ end
 
     @testset "1D persistent — batch Vector{Dual}" begin
         let l = linear_interp(x, y_sv), c = cubic_interp(x, y_sv),
-            q = quadratic_interp(x, y_sv), k = constant_interp(x, y_sv),
-            h = hermite_interp(x, y_sv, dy_sv)
+                q = quadratic_interp(x, y_sv), k = constant_interp(x, y_sv),
+                h = hermite_interp(x, y_sv, dy_sv)
             @test (@inferred l(xq_dv)) isa Vector{SVD}
             @test (@inferred c(xq_dv)) isa Vector{SVD}
             @test (@inferred q(xq_dv)) isa Vector{SVD}
@@ -610,10 +618,14 @@ end
     @testset "ND batch — SVector data × (Dual, Dual)" begin
         xg = collect(1.0:5.0); yg = collect(1.0:5.0)
         data_sv = [SA[Float64(i + j), 2.0(i + j), 3.0(i + j)] for i in 1:5, j in 1:5]
-        q_dv = [(ForwardDiff.Dual{Nothing}(2.5 + 0.1i, 1.0),
-                 ForwardDiff.Dual{Nothing}(3.5 + 0.1i, 0.0)) for i in 1:5]
+        q_dv = [
+            (
+                    ForwardDiff.Dual{Nothing}(2.5 + 0.1i, 1.0),
+                    ForwardDiff.Dual{Nothing}(3.5 + 0.1i, 0.0),
+                ) for i in 1:5
+        ]
         let l = linear_interp((xg, yg), data_sv), c = cubic_interp((xg, yg), data_sv),
-            k = constant_interp((xg, yg), data_sv)
+                k = constant_interp((xg, yg), data_sv)
             @test (@inferred l(q_dv)) isa Vector{SVD}
             @test (@inferred c(q_dv)) isa Vector{SVD}
             @test (@inferred k(q_dv)) isa Vector{SVD}
@@ -822,11 +834,11 @@ end
 
     @testset "PCHIP" begin
         @test pchip_interp(x, y_d, xq_scalar) isa DuckFloat
-        @test pchip_interp(x, y_d, xq_batch)  isa Vector{DuckFloat}
+        @test pchip_interp(x, y_d, xq_batch) isa Vector{DuckFloat}
     end
 
     @testset "Akima" begin
         @test akima_interp(x, y_d, xq_scalar) isa DuckFloat
-        @test akima_interp(x, y_d, xq_batch)  isa Vector{DuckFloat}
+        @test akima_interp(x, y_d, xq_batch) isa Vector{DuckFloat}
     end
 end

--- a/test/test_duck_tv_dual_tq.jl
+++ b/test/test_duck_tv_dual_tq.jl
@@ -209,11 +209,15 @@ end
         @test (@inferred itp_f(ForwardDiff.Dual{Nothing}(5.5, 1.0))) isa D
     end
 
-    @testset "Constant Int → Int contract (non-regression)" begin
+    @testset "Constant natural-promote — scalar Int×Int → Int; batch widens" begin
+        # Scalar: kernel direct, fully-Int chain stays Int (kernel returns
+        # `y[idx] * one(Int) = Int`).
         x = collect(1:10)
         y = collect(10:10:100)
-        @test constant_interp(x, y)(3) isa Int
-        @test constant_interp(x, y)([2, 5, 8]) isa Vector{Int}
+        @test constant_interp(x, y)(3) === 30
+        # Batch: trait applies Int→Float upgrade (same machinery as every
+        # other method — no Constant-specific helper).
+        @test constant_interp(x, y)([2, 5, 8]) isa Vector{Float64}
     end
 
     @testset "_output_eltype trait — type table" begin

--- a/test/test_duck_tv_dual_tq.jl
+++ b/test/test_duck_tv_dual_tq.jl
@@ -1,0 +1,135 @@
+# Duck-typing tests for non-promotable Tv (e.g., SVector) crossed with non-
+# promotable Tq (e.g., ForwardDiff.Dual).
+#
+# These cases are the intersection where `_output_eltype(Tv, Tg, Tq)` falls
+# back (its `promote_type` returns a non-concrete typejoin). Tests pin the
+# expected return types and container concreteness across both 1D and ND
+# entries — scalar callable, ForwardDiff.derivative form, allocating batch,
+# and the Constant raw-eltype contract.
+
+@testitem "Duck Tv × Dual Tq — 1D scalar query widens correctly" begin
+    using StaticArrays, ForwardDiff
+
+    x = collect(1.0:10.0)
+    y_sv = [SA[Float64(i), 2.0i, 3.0i] for i in 1:10]
+    dy_sv = [SA[1.0, 2.0, 3.0] for _ in 1:10]
+    xq_d = ForwardDiff.Dual{Nothing}(2.5, 1.0)
+    D = ForwardDiff.Dual{Nothing, Float64, 1}
+
+    @testset "Arithmetic kernels widen SVector{N, Float64} → SVector{N, Dual}" begin
+        @test linear_interp(x, y_sv)(xq_d) isa SVector{3, D}
+        @test cubic_interp(x, y_sv)(xq_d) isa SVector{3, D}
+        @test quadratic_interp(x, y_sv)(xq_d) isa SVector{3, D}
+        @test hermite_interp(x, y_sv, dy_sv)(xq_d) isa SVector{3, D}
+    end
+
+    @testset "Constant kernel widens SVector{N, Float64} → SVector{N, Dual}" begin
+        @test constant_interp(x, y_sv)(xq_d) isa SVector{3, D}
+    end
+end
+
+@testitem "Duck Tv × Dual Tq — ForwardDiff.derivative of indexed component" begin
+    using StaticArrays, ForwardDiff
+
+    x = collect(1.0:10.0)
+    y_sv = [SA[Float64(i), 2.0i, 3.0i] for i in 1:10]
+    dy_sv = [SA[1.0, 2.0, 3.0] for _ in 1:10]
+
+    @testset "linear_interp" begin
+        itp = linear_interp(x, y_sv)
+        d = ForwardDiff.derivative(t -> itp(t)[1], 2.5)
+        @test d isa Float64
+        @test isfinite(d)
+    end
+
+    @testset "cubic_interp" begin
+        itp = cubic_interp(x, y_sv)
+        d = ForwardDiff.derivative(t -> itp(t)[1], 2.5)
+        @test d isa Float64
+        @test isfinite(d)
+    end
+
+    @testset "quadratic_interp" begin
+        itp = quadratic_interp(x, y_sv)
+        d = ForwardDiff.derivative(t -> itp(t)[1], 2.5)
+        @test d isa Float64
+        @test isfinite(d)
+    end
+
+    @testset "hermite_interp" begin
+        itp = hermite_interp(x, y_sv, dy_sv)
+        d = ForwardDiff.derivative(t -> itp(t)[1], 2.5)
+        @test d isa Float64
+        @test isfinite(d)
+    end
+
+    @testset "constant_interp returns zero derivative" begin
+        itp = constant_interp(x, y_sv)
+        d = ForwardDiff.derivative(t -> itp(t)[1], 2.5)
+        @test d isa Float64
+        @test d == 0.0
+    end
+end
+
+@testitem "Duck Tv × Dual Tq — Constant 1D batch widens to SVector{N, Dual}" begin
+    using StaticArrays, ForwardDiff
+
+    x = collect(1.0:10.0)
+    y_sv = [SA[Float64(i), 2.0i, 3.0i] for i in 1:10]
+    xq_dv = [ForwardDiff.Dual{Nothing}(2.0 + 0.1i, 1.0) for i in 1:5]
+    D = ForwardDiff.Dual{Nothing, Float64, 1}
+
+    @testset "Persistent batch" begin
+        out = constant_interp(x, y_sv)(xq_dv)
+        @test out isa Vector{SVector{3, D}}
+        @test eltype(out) === SVector{3, D}
+        @test length(out) == 5
+    end
+
+    @testset "Oneshot 3-arg batch" begin
+        out = constant_interp(x, y_sv, xq_dv)
+        @test out isa Vector{SVector{3, D}}
+        @test eltype(out) === SVector{3, D}
+    end
+end
+
+@testitem "Duck Tv × Dual Tq — Constant ND batch widens to SVector{N, Dual}" begin
+    using StaticArrays, ForwardDiff
+
+    xg = collect(1.0:5.0)
+    yg = collect(1.0:5.0)
+    data_sv = [SA[Float64(i + j), 2.0(i + j), 3.0(i + j)] for i in 1:5, j in 1:5]
+    q_dv = [
+        (ForwardDiff.Dual{Nothing}(2.5 + 0.1i, 1.0), ForwardDiff.Dual{Nothing}(3.5 + 0.1i, 0.0))
+            for i in 1:5
+    ]
+    D = ForwardDiff.Dual{Nothing, Float64, 1}
+
+    out = constant_interp((xg, yg), data_sv)(q_dv)
+    @test out isa Vector{SVector{3, D}}
+    @test eltype(out) === SVector{3, D}
+    @test length(out) == 5
+end
+
+@testitem "Plain Float64 y + Vector{Dual} batch preserves Dual eltype (non-regression)" begin
+    using ForwardDiff
+
+    x = collect(1.0:10.0)
+    y = sin.(x)
+    xq_dv = [ForwardDiff.Dual{Nothing}(2.0 + 0.1i, 1.0) for i in 1:5]
+
+    D = ForwardDiff.Dual{Nothing, Float64, 1}
+
+    @test linear_interp(x, y)(xq_dv) isa Vector{D}
+    @test cubic_interp(x, y)(xq_dv) isa Vector{D}
+    @test quadratic_interp(x, y)(xq_dv) isa Vector{D}
+    @test hermite_interp(x, y, cos.(x))(xq_dv) isa Vector{D}
+    @test constant_interp(x, y)(xq_dv) isa Vector{D}
+end
+
+@testitem "Constant raw-eltype contract: Int values stay Int (non-regression)" begin
+    x = collect(1:10)
+    y = collect(10:10:100)
+    @test constant_interp(x, y)(3) isa Int
+    @test constant_interp(x, y)([2, 5, 8]) isa Vector{Int}
+end

--- a/test/test_duck_tv_dual_tq.jl
+++ b/test/test_duck_tv_dual_tq.jl
@@ -107,9 +107,6 @@ end
     end
 end
 
-# Series path: chain `_series_output_type(_output_eltype(...), Tq)` previously
-# collapsed `promote_type(SVector{F}, Dual)` to `Any` → MethodError on numeric
-# methods, silent `Vector{Any}` on Constant. Now unified `_output_eltype(Tv, Tg, Tq)`.
 @testitem "Series path — duck-Tv × duck-Tq carrier propagates" begin
     using StaticArrays, ForwardDiff
     using FastInterpolations: Series
@@ -434,5 +431,33 @@ end
         data_f = [Float64(10i + j) for i in 1:5, j in 1:5]
         itp_l = linear_interp((xg, yg), data_f)
         @test itp_l(q_het; deriv = (EvalValue(), DerivOp(2))) isa D
+    end
+end
+
+# Anchored-vector batch callable lets advanced users pre-build queries and
+# reuse them across interpolants. Linear's path uses `_output_eltype(Tv, Tg, Tq)`
+# for the output buffer; Constant + Quadratic only used `Vector{Tg}` so a
+# duck-Tq anchor lost its carrier on `setindex!` convert.
+@testitem "Anchored-vector callable propagates Tq carrier" begin
+    using ForwardDiff
+    using FastInterpolations: _ConstantAnchoredQuery, _QuadraticAnchoredQuery, _fill_anchors!
+
+    D = ForwardDiff.Dual{Nothing, Float64, 1}
+    x = collect(0.0:0.1:1.0)
+    y = sin.(x)
+    xq_d = [ForwardDiff.Dual{Nothing}(0.15 + 0.1i, 1.0) for i in 0:4]
+
+    @testset "Constant" begin
+        itp = constant_interp(x, y)
+        aq_vec = Vector{_ConstantAnchoredQuery{Float64, D}}(undef, length(xq_d))
+        _fill_anchors!(aq_vec, x, xq_d, Val(:constant))
+        @test itp(aq_vec) isa Vector{D}
+    end
+
+    @testset "Quadratic" begin
+        itp = quadratic_interp(x, y)
+        aq_vec = Vector{_QuadraticAnchoredQuery{Float64, D}}(undef, length(xq_d))
+        _fill_anchors!(aq_vec, x, xq_d, Val(:quadratic))
+        @test itp(aq_vec) isa Vector{D}
     end
 end

--- a/test/test_duck_tv_dual_tq.jl
+++ b/test/test_duck_tv_dual_tq.jl
@@ -842,3 +842,98 @@ end
         @test akima_interp(x, y_d, xq_batch) isa Vector{DuckFloat}
     end
 end
+
+# ============================================================================
+# OOB carrier + empty-path eltype contracts (PR #146 Copilot/Codex reviews)
+# ============================================================================
+# Existing duck-Tv tests above only exercise in-domain queries, so the OOB
+# branches (`_eval_extrapolation` → `_promote_extrap_val`, `_try_fill_oob` →
+# `_fill_extrap_result`) never run with non-Number Tv. The fallback
+# `_promote_extrap_val(val, xq) = val` drops the Tq carrier for `SVector` /
+# non-Number Tv, so scalar OOB returns raw `SVector{Float64}` while batch
+# OOB returns `SVector{Dual}` via the trait-sized buffer — scalar/batch
+# disagree. Pinned as `@test_broken`; a follow-up fix to
+# `_promote_extrap_val`/`_promote_extrap_zero` will flip these to `@test`.
+@testitem "OOB carrier — scalar/batch consistency for non-Number Tv" begin
+    using StaticArrays, ForwardDiff
+    D = ForwardDiff.Dual{Nothing, Float64, 1}
+
+    x = [0.0, 1.0, 2.0, 3.0, 4.0]
+    y_sv = [SA[Float64(i), 2.0i] for i in 1:5]
+    xq_in     = ForwardDiff.Dual{Nothing}(1.5, 1.0)
+    xq_oob_lo = ForwardDiff.Dual{Nothing}(-1.0, 1.0)
+    xq_oob_hi = ForwardDiff.Dual{Nothing}(10.0, 1.0)
+
+    @testset "1D scalar OOB ClampExtrap — SVector y + Dual xq" begin
+        for method in (linear_interp, cubic_interp, quadratic_interp, constant_interp)
+            itp = method(x, y_sv; extrap = ClampExtrap())
+            T_in = typeof(itp(xq_in))
+            @test typeof(itp(xq_oob_lo)) === T_in
+            @test typeof(itp(xq_oob_hi)) === T_in
+            # scalar/batch agreement at OOB
+            @test typeof(itp([xq_oob_lo])[1]) === typeof(itp(xq_oob_lo))
+            @test typeof(itp([xq_oob_hi])[1]) === typeof(itp(xq_oob_hi))
+        end
+    end
+
+    @testset "1D scalar OOB FillExtrap — SVector fill + Dual xq" begin
+        fill_v = SA[99.0, 99.0]
+        for method in (linear_interp, cubic_interp, quadratic_interp, constant_interp)
+            itp = method(x, y_sv; extrap = FillExtrap(fill_v))
+            T_in = typeof(itp(xq_in))
+            @test typeof(itp(xq_oob_lo)) === T_in
+            @test typeof(itp([xq_oob_lo])[1]) === typeof(itp(xq_oob_lo))
+        end
+    end
+
+    @testset "ND scalar OOB FillExtrap — SVector data/fill + Dual queries" begin
+        # 5-point grids to satisfy cubic CubicFit BC defaults.
+        xg = collect(0.0:1.0:4.0); yg = collect(0.0:1.0:4.0)
+        data_sv = [SA[Float64(i), Float64(j)] for i in 1:5, j in 1:5]
+        fill_v = SA[99.0, 99.0]
+        q_in_t  = (ForwardDiff.Dual{Nothing}(1.5, 1.0),
+                   ForwardDiff.Dual{Nothing}(1.5, 1.0))
+        q_oob_t = (ForwardDiff.Dual{Nothing}(-1.0, 1.0),
+                   ForwardDiff.Dual{Nothing}(-1.0, 1.0))
+        for method in (linear_interp, cubic_interp, constant_interp)
+            itp = method((xg, yg), data_sv; extrap = FillExtrap(fill_v))
+            T_in = typeof(itp(q_in_t))
+            @test typeof(itp(q_oob_t)) === T_in
+            @test typeof(itp([q_oob_t])[1]) === typeof(itp(q_oob_t))
+        end
+    end
+
+    @testset "ND scalar OOB ClampExtrap — SVector data + Dual queries" begin
+        xg = collect(0.0:1.0:4.0); yg = collect(0.0:1.0:4.0)
+        data_sv = [SA[Float64(i), Float64(j)] for i in 1:5, j in 1:5]
+        q_in_t  = (ForwardDiff.Dual{Nothing}(1.5, 1.0),
+                   ForwardDiff.Dual{Nothing}(1.5, 1.0))
+        q_oob_t = (ForwardDiff.Dual{Nothing}(-1.0, 1.0),
+                   ForwardDiff.Dual{Nothing}(-1.0, 1.0))
+        for method in (linear_interp, cubic_interp, constant_interp)
+            itp = method((xg, yg), data_sv; extrap = ClampExtrap())
+            T_in = typeof(itp(q_in_t))
+            @test typeof(itp(q_oob_t)) === T_in
+            @test typeof(itp([q_oob_t])[1]) === typeof(itp(q_oob_t))
+        end
+    end
+end
+
+# Constant ND oneshot derivative fast path: `nq == 0 && return Vector{Tv}(undef, 0)`
+# ignores the query carrier, while the `nq > 0` branch synthesises
+# `0 * first(data) * prod(one, first_q)` (carrier-aware). Empty and non-empty
+# results disagree on eltype — pinned `@test_broken` until the empty branch
+# allocates with the same trait-derived eltype as the non-empty branch.
+@testitem "ND oneshot derivative — empty vs non-empty query eltype" begin
+    using ForwardDiff
+    xg = [0.0, 1.0, 2.0]; yg = [0.0, 1.0, 2.0]
+    data = Float64[10i + j for i in 1:3, j in 1:3]
+    q_one_d = [(ForwardDiff.Dual{Nothing}(0.5, 1.0),
+                ForwardDiff.Dual{Nothing}(0.5, 1.0))]
+    q_empty_d = typeof(q_one_d)()
+    derivs = (EvalValue(), DerivOp(1))
+    r_one   = constant_interp((xg, yg), data, q_one_d;   deriv = derivs)
+    r_empty = constant_interp((xg, yg), data, q_empty_d; deriv = derivs)
+    @test eltype(r_one) === eltype(r_empty)
+    @test length(r_empty) == 0
+end

--- a/test/test_duck_tv_dual_tq.jl
+++ b/test/test_duck_tv_dual_tq.jl
@@ -349,6 +349,43 @@ end
     end
 end
 
+# Mirror of the Cubic block above for the other three SeriesInterpolant
+# variants. Each method's persistent callable allocates via its own kernel
+# shape trait, so SVector × Dual must propagate without collapsing to
+# Vector{Any} on any of them. The Constant case is also a regression test
+# for the in-place dispatch — its `outputs::AbstractVector{<:AbstractVector{Tv}}`
+# constraint blocked carrier widening before this fix.
+@testitem "Linear/Quadratic/Constant SeriesInterpolant persistent — SVector × Dual carrier" begin
+    using StaticArrays, ForwardDiff
+    using FastInterpolations: Series
+
+    x = collect(1.0:10.0)
+    y_sv1 = [SA[Float64(i), 2.0i, 3.0i] for i in 1:10]
+    y_sv2 = [SA[-1.0 * i, 0.5i, 2.5i] for i in 1:10]
+    s_sv  = Series(y_sv1, y_sv2)
+    xq_d  = ForwardDiff.Dual{Nothing}(5.5, 1.0)
+    xq_dv = [ForwardDiff.Dual{Nothing}(2.0 + 0.1i, 1.0) for i in 1:5]
+    D = ForwardDiff.Dual{Nothing, Float64, 1}
+
+    @testset "Linear" begin
+        sitp = linear_interp(x, s_sv)
+        @test sitp(xq_d)  isa Vector{SVector{3, D}}
+        @test sitp(xq_dv) isa Vector{Vector{SVector{3, D}}}
+    end
+
+    @testset "Quadratic" begin
+        sitp = quadratic_interp(x, s_sv)
+        @test sitp(xq_d)  isa Vector{SVector{3, D}}
+        @test sitp(xq_dv) isa Vector{Vector{SVector{3, D}}}
+    end
+
+    @testset "Constant" begin
+        sitp = constant_interp(x, s_sv)
+        @test sitp(xq_d)  isa Vector{SVector{3, D}}
+        @test sitp(xq_dv) isa Vector{Vector{SVector{3, D}}}
+    end
+end
+
 @testitem "Constant ND deriv-zero short-circuit propagates Tq carrier" begin
     using ForwardDiff
 
@@ -462,6 +499,23 @@ end
         aq_vec = Vector{_QuadraticAnchoredQuery{Float64, D}}(undef, length(xq_d))
         _fill_anchors!(aq_vec, x, xq_d, Val(:quadratic))
         @test itp(aq_vec) isa Vector{D}
+    end
+
+    # Int-chain preservation: ConstantInterpolant's kernel is `yv * one(q)`,
+    # so a fully-Int chain (`Tv = Int, Tq = Int`) must stay Int through the
+    # anchored callable. The legacy 2-arg `_output_eltype` Float-upgraded any
+    # `Tr <: _PromotableValue && !<:AbstractFloat`, producing Vector{Float64}
+    # for the same input — the scalar/oneshot paths already preserved Int.
+    @testset "Constant Int-chain preservation" begin
+        x_int = collect(0:5)
+        y_int = x_int .* x_int
+        itp = constant_interp(x_int, y_int)
+        xq_int = [1, 2, 3]
+        aq_vec = Vector{_ConstantAnchoredQuery{Int, Int}}(undef, length(xq_int))
+        _fill_anchors!(aq_vec, x_int, xq_int, Val(:constant))
+        out = itp(aq_vec)
+        @test out isa Vector{Int}
+        @test out == [itp(xq) for xq in xq_int]
     end
 end
 

--- a/test/test_duck_tv_dual_tq.jl
+++ b/test/test_duck_tv_dual_tq.jl
@@ -860,7 +860,7 @@ end
 
     x = [0.0, 1.0, 2.0, 3.0, 4.0]
     y_sv = [SA[Float64(i), 2.0i] for i in 1:5]
-    xq_in     = ForwardDiff.Dual{Nothing}(1.5, 1.0)
+    xq_in = ForwardDiff.Dual{Nothing}(1.5, 1.0)
     xq_oob_lo = ForwardDiff.Dual{Nothing}(-1.0, 1.0)
     xq_oob_hi = ForwardDiff.Dual{Nothing}(10.0, 1.0)
 
@@ -891,10 +891,14 @@ end
         xg = collect(0.0:1.0:4.0); yg = collect(0.0:1.0:4.0)
         data_sv = [SA[Float64(i), Float64(j)] for i in 1:5, j in 1:5]
         fill_v = SA[99.0, 99.0]
-        q_in_t  = (ForwardDiff.Dual{Nothing}(1.5, 1.0),
-                   ForwardDiff.Dual{Nothing}(1.5, 1.0))
-        q_oob_t = (ForwardDiff.Dual{Nothing}(-1.0, 1.0),
-                   ForwardDiff.Dual{Nothing}(-1.0, 1.0))
+        q_in_t = (
+            ForwardDiff.Dual{Nothing}(1.5, 1.0),
+            ForwardDiff.Dual{Nothing}(1.5, 1.0),
+        )
+        q_oob_t = (
+            ForwardDiff.Dual{Nothing}(-1.0, 1.0),
+            ForwardDiff.Dual{Nothing}(-1.0, 1.0),
+        )
         for method in (linear_interp, cubic_interp, constant_interp)
             itp = method((xg, yg), data_sv; extrap = FillExtrap(fill_v))
             T_in = typeof(itp(q_in_t))
@@ -906,10 +910,14 @@ end
     @testset "ND scalar OOB ClampExtrap — SVector data + Dual queries" begin
         xg = collect(0.0:1.0:4.0); yg = collect(0.0:1.0:4.0)
         data_sv = [SA[Float64(i), Float64(j)] for i in 1:5, j in 1:5]
-        q_in_t  = (ForwardDiff.Dual{Nothing}(1.5, 1.0),
-                   ForwardDiff.Dual{Nothing}(1.5, 1.0))
-        q_oob_t = (ForwardDiff.Dual{Nothing}(-1.0, 1.0),
-                   ForwardDiff.Dual{Nothing}(-1.0, 1.0))
+        q_in_t = (
+            ForwardDiff.Dual{Nothing}(1.5, 1.0),
+            ForwardDiff.Dual{Nothing}(1.5, 1.0),
+        )
+        q_oob_t = (
+            ForwardDiff.Dual{Nothing}(-1.0, 1.0),
+            ForwardDiff.Dual{Nothing}(-1.0, 1.0),
+        )
         for method in (linear_interp, cubic_interp, constant_interp)
             itp = method((xg, yg), data_sv; extrap = ClampExtrap())
             T_in = typeof(itp(q_in_t))
@@ -928,11 +936,15 @@ end
     using ForwardDiff
     xg = [0.0, 1.0, 2.0]; yg = [0.0, 1.0, 2.0]
     data = Float64[10i + j for i in 1:3, j in 1:3]
-    q_one_d = [(ForwardDiff.Dual{Nothing}(0.5, 1.0),
-                ForwardDiff.Dual{Nothing}(0.5, 1.0))]
+    q_one_d = [
+        (
+            ForwardDiff.Dual{Nothing}(0.5, 1.0),
+            ForwardDiff.Dual{Nothing}(0.5, 1.0),
+        ),
+    ]
     q_empty_d = typeof(q_one_d)()
     derivs = (EvalValue(), DerivOp(1))
-    r_one   = constant_interp((xg, yg), data, q_one_d;   deriv = derivs)
+    r_one = constant_interp((xg, yg), data, q_one_d; deriv = derivs)
     r_empty = constant_interp((xg, yg), data, q_empty_d; deriv = derivs)
     @test eltype(r_one) === eltype(r_empty)
     @test length(r_empty) == 0

--- a/test/test_duck_tv_dual_tq.jl
+++ b/test/test_duck_tv_dual_tq.jl
@@ -590,3 +590,55 @@ end
         end
     end
 end
+
+# Rational chains: `Rational / Rational = Rational` in Julia (no Float upgrade),
+# so the arithmetic kernel `y0 + (y1-y0) * (dL/h)` actually preserves Rational.
+# The kernel-shape trait predicts this exactly via `Base.promote_op`. The old
+# `_PromotableValue` enumeration over-predicted Float (because `Rational <:
+# _PromotableValue` triggered `float(...)`).
+@testitem "Kernel-shape trait pins Rational chain (no spurious Float upgrade)" begin
+    using FastInterpolations: _arithmetic_kernel_shape, _constant_kernel_shape, _output_eltype
+
+    @testset "Trait-level — `@inferred` type table" begin
+        # Arithmetic shape: `Rational + Rational * (Rational/Rational) = Rational`.
+        @test (@inferred _output_eltype(_arithmetic_kernel_shape, Rational{Int}, Rational{Int}, Rational{Int})) === Rational{Int}
+        # Sanity: Int/Float baselines match the previous trait.
+        @test (@inferred _output_eltype(_arithmetic_kernel_shape, Int, Int, Int)) === Float64
+        @test (@inferred _output_eltype(_arithmetic_kernel_shape, Float64, Float64, Float64)) === Float64
+        @test (@inferred _output_eltype(_arithmetic_kernel_shape, Int, Complex{Int}, Int)) === ComplexF64
+        # Selection shape: pure `Rational * one(Rational) = Rational`.
+        @test (@inferred _output_eltype(_constant_kernel_shape, Rational{Int}, Rational{Int})) === Rational{Int}
+        @test (@inferred _output_eltype(_constant_kernel_shape, Int, Int)) === Int
+    end
+
+    @testset "Constant — end-to-end Rational preserved (storage stays raw)" begin
+        # Constant 1D + ND store `{Tg, Tv}` directly (no `_promote_grid_float`),
+        # so the kernel-shape trait's Rational prediction flows through to the
+        # user-visible Vector eltype.
+        x_r = Rational{Int}[0 // 1, 1 // 1, 2 // 1, 3 // 1]
+        y_r = Rational{Int}[1 // 2, 3 // 2, 5 // 2, 7 // 2]
+        xq_r = 3 // 2
+        xq_r_vec = Rational{Int}[1 // 2, 3 // 2, 5 // 2]
+        let itp = constant_interp(x_r, y_r)
+            @test (@inferred itp(xq_r)) isa Rational{Int}
+            @test (@inferred itp(xq_r_vec)) isa Vector{Rational{Int}}
+        end
+        @test (@inferred constant_interp(x_r, y_r, xq_r_vec)) isa Vector{Rational{Int}}
+    end
+
+    @testset "Linear — Rational user-visible blocked by `_promote_grid_float` (BROKEN)" begin
+        # The arithmetic-kernel-shape trait correctly predicts Rational for a
+        # fully-Rational chain, but `LinearInterpolant`'s constructor calls
+        # `_promote_grid_float` which lifts the grid/values to Float64 at build
+        # time — the trait's Rational prediction is shadowed by storage Float64.
+        # Pinned as `@test_broken` so a future relaxation of that lift will
+        # auto-surface as a `now passing` alert.
+        x_r = Rational{Int}[0 // 1, 1 // 1, 2 // 1, 3 // 1]
+        y_r = Rational{Int}[1 // 2, 3 // 2, 5 // 2, 7 // 2]
+        xq_r = 3 // 2
+        xq_r_vec = Rational{Int}[1 // 2, 3 // 2, 5 // 2]
+        @test_broken linear_interp(x_r, y_r)(xq_r) isa Rational{Int}
+        @test_broken linear_interp(x_r, y_r)(xq_r_vec) isa Vector{Rational{Int}}
+        @test_broken linear_interp(x_r, y_r, xq_r_vec) isa Vector{Rational{Int}}
+    end
+end

--- a/test/test_duck_tv_dual_tq.jl
+++ b/test/test_duck_tv_dual_tq.jl
@@ -209,15 +209,14 @@ end
         @test (@inferred itp_f(ForwardDiff.Dual{Nothing}(5.5, 1.0))) isa D
     end
 
-    @testset "Constant natural-promote — scalar Int×Int → Int; batch widens" begin
-        # Scalar: kernel direct, fully-Int chain stays Int (kernel returns
-        # `y[idx] * one(Int) = Int`).
+    @testset "Constant Int → Int contract (scalar = batch consistency)" begin
+        # Kernel `y * one(dL)` keeps Int×Int×Int chains in Int — trait now
+        # routes through `_constant_kernel_shape`, so scalar/batch outputs
+        # agree at the type level.
         x = collect(1:10)
         y = collect(10:10:100)
         @test constant_interp(x, y)(3) === 30
-        # Batch: trait applies Int→Float upgrade (same machinery as every
-        # other method — no Constant-specific helper).
-        @test constant_interp(x, y)([2, 5, 8]) isa Vector{Float64}
+        @test constant_interp(x, y)([2, 5, 8]) isa Vector{Int}
     end
 
     @testset "_output_eltype trait — type table" begin
@@ -463,5 +462,131 @@ end
         aq_vec = Vector{_QuadraticAnchoredQuery{Float64, D}}(undef, length(xq_d))
         _fill_anchors!(aq_vec, x, xq_d, Val(:quadratic))
         @test itp(aq_vec) isa Vector{D}
+    end
+end
+
+# Inference-quality contract: every duck path (SVector × Dual, Float y + Dual
+# dy, heterogeneous axis carrier, anchored-vector callable, …) must be
+# type-stable. `@inferred` errors if the inferred return type doesn't match
+# the actual result type — catches silent Union returns and `Any` fallbacks
+# that `isa` checks would miss.
+@testitem "Type stability — duck-Tv × duck-Tq inference" begin
+    using StaticArrays, ForwardDiff
+    using FastInterpolations: Series
+
+    x = collect(1.0:10.0)
+    y_sv = [SA[Float64(i), 2.0i, 3.0i] for i in 1:10]
+    dy_sv = [SA[1.0, 2.0, 3.0] for _ in 1:10]
+    xq_d = ForwardDiff.Dual{Nothing}(2.5, 1.0)
+    xq_dv = [ForwardDiff.Dual{Nothing}(2.0 + 0.1i, 1.0) for i in 1:5]
+    D = ForwardDiff.Dual{Nothing, Float64, 1}
+    SVD = SVector{3, D}
+
+    @testset "1D persistent — scalar Dual" begin
+        let l = linear_interp(x, y_sv), c = cubic_interp(x, y_sv),
+            q = quadratic_interp(x, y_sv), k = constant_interp(x, y_sv),
+            h = hermite_interp(x, y_sv, dy_sv)
+            @test (@inferred l(xq_d)) isa SVD
+            @test (@inferred c(xq_d)) isa SVD
+            @test (@inferred q(xq_d)) isa SVD
+            @test (@inferred k(xq_d)) isa SVD
+            @test (@inferred h(xq_d)) isa SVD
+        end
+    end
+
+    @testset "1D persistent — batch Vector{Dual}" begin
+        let l = linear_interp(x, y_sv), c = cubic_interp(x, y_sv),
+            q = quadratic_interp(x, y_sv), k = constant_interp(x, y_sv),
+            h = hermite_interp(x, y_sv, dy_sv)
+            @test (@inferred l(xq_dv)) isa Vector{SVD}
+            @test (@inferred c(xq_dv)) isa Vector{SVD}
+            @test (@inferred q(xq_dv)) isa Vector{SVD}
+            @test (@inferred k(xq_dv)) isa Vector{SVD}
+            @test (@inferred h(xq_dv)) isa Vector{SVD}
+        end
+    end
+
+    @testset "1D oneshot 3-arg — scalar Dual" begin
+        @test (@inferred linear_interp(x, y_sv, xq_d)) isa SVD
+        @test (@inferred cubic_interp(x, y_sv, xq_d)) isa SVD
+        @test (@inferred quadratic_interp(x, y_sv, xq_d)) isa SVD
+        @test (@inferred constant_interp(x, y_sv, xq_d)) isa SVD
+        @test (@inferred hermite_interp(x, y_sv, dy_sv, xq_d)) isa SVD
+    end
+
+    @testset "1D oneshot 3-arg — batch Vector{Dual}" begin
+        @test (@inferred linear_interp(x, y_sv, xq_dv)) isa Vector{SVD}
+        @test (@inferred cubic_interp(x, y_sv, xq_dv)) isa Vector{SVD}
+        @test (@inferred quadratic_interp(x, y_sv, xq_dv)) isa Vector{SVD}
+        @test (@inferred constant_interp(x, y_sv, xq_dv)) isa Vector{SVD}
+        @test (@inferred hermite_interp(x, y_sv, dy_sv, xq_dv)) isa Vector{SVD}
+    end
+
+    @testset "ND batch — SVector data × (Dual, Dual)" begin
+        xg = collect(1.0:5.0); yg = collect(1.0:5.0)
+        data_sv = [SA[Float64(i + j), 2.0(i + j), 3.0(i + j)] for i in 1:5, j in 1:5]
+        q_dv = [(ForwardDiff.Dual{Nothing}(2.5 + 0.1i, 1.0),
+                 ForwardDiff.Dual{Nothing}(3.5 + 0.1i, 0.0)) for i in 1:5]
+        let l = linear_interp((xg, yg), data_sv), c = cubic_interp((xg, yg), data_sv),
+            k = constant_interp((xg, yg), data_sv)
+            @test (@inferred l(q_dv)) isa Vector{SVD}
+            @test (@inferred c(q_dv)) isa Vector{SVD}
+            @test (@inferred k(q_dv)) isa Vector{SVD}
+        end
+        @test (@inferred linear_interp((xg, yg), data_sv, q_dv)) isa Vector{SVD}
+        @test (@inferred cubic_interp((xg, yg), data_sv, q_dv)) isa Vector{SVD}
+        @test (@inferred constant_interp((xg, yg), data_sv, q_dv)) isa Vector{SVD}
+    end
+
+    @testset "Constant Int chain — scalar/batch type-stable Int" begin
+        # Kernel-shape trait: `_constant_kernel_shape(yv, q) = yv * one(q)`
+        # → Int×Int×Int inferred as Int (no spurious Float upgrade).
+        xi = collect(1:10); yi = collect(10:10:100)
+        let k = constant_interp(xi, yi)
+            @test (@inferred k(3)) === 30
+            @test (@inferred k([2, 5, 8])) isa Vector{Int}
+        end
+        @test (@inferred constant_interp(xi, yi, [2, 5, 8])) isa Vector{Int}
+    end
+
+    @testset "ND deriv-zero short-circuit — heterogeneous (Float, Dual)" begin
+        xg = collect(1.0:5.0); yg = collect(1.0:5.0)
+        data_int = [10i + j for i in 1:5, j in 1:5]
+        q_het = (2.5, ForwardDiff.Dual{Nothing}(3.5, 1.0))
+        let k = constant_interp((xg, yg), data_int)
+            @test (@inferred k(q_het; deriv = (EvalValue(), DerivOp(1)))) isa D
+        end
+    end
+
+    @testset "Hermite Float y + Dual dy precision carrier" begin
+        xs = collect(1.0:10.0)
+        ys = sin.(xs)
+        dys = [ForwardDiff.Dual{Nothing}(cos(xi), 1.0) for xi in xs]
+        xqs = collect(2.0:0.5:8.0)
+        @test (@inferred hermite_interp(xs, ys, dys, xqs)) isa Vector{D}
+    end
+
+    @testset "CubicSeriesInterpolant persistent — SVector × Dual" begin
+        y_sv1 = [SA[Float64(i), 2.0i] for i in 1:10]
+        y_sv2 = [SA[-1.0 * i, 0.5i] for i in 1:10]
+        s_sv = Series(y_sv1, y_sv2)
+        sitp = cubic_interp(x, s_sv)
+        @test (@inferred sitp(xq_d)) isa Vector{SVector{2, D}}
+        @test (@inferred sitp(xq_dv)) isa Vector{Vector{SVector{2, D}}}
+    end
+
+    @testset "Anchored-vector callable — Constant + Quadratic × Dual" begin
+        using FastInterpolations: _ConstantAnchoredQuery, _QuadraticAnchoredQuery, _fill_anchors!
+        xs = collect(0.0:0.1:1.0)
+        ys = sin.(xs)
+        xq_dual = [ForwardDiff.Dual{Nothing}(0.15 + 0.1i, 1.0) for i in 0:4]
+        let itp_c = constant_interp(xs, ys), itp_q = quadratic_interp(xs, ys)
+            aq_c = Vector{_ConstantAnchoredQuery{Float64, D}}(undef, length(xq_dual))
+            _fill_anchors!(aq_c, xs, xq_dual, Val(:constant))
+            @test (@inferred itp_c(aq_c)) isa Vector{D}
+            aq_q = Vector{_QuadraticAnchoredQuery{Float64, D}}(undef, length(xq_dual))
+            _fill_anchors!(aq_q, xs, xq_dual, Val(:quadratic))
+            @test (@inferred itp_q(aq_q)) isa Vector{D}
+        end
     end
 end

--- a/test/test_duck_tv_dual_tq.jl
+++ b/test/test_duck_tv_dual_tq.jl
@@ -1,135 +1,165 @@
 # Duck-typing tests for non-promotable Tv (e.g., SVector) crossed with non-
 # promotable Tq (e.g., ForwardDiff.Dual).
 #
-# These cases are the intersection where `_output_eltype(Tv, Tg, Tq)` falls
-# back (its `promote_type` returns a non-concrete typejoin). Tests pin the
-# expected return types and container concreteness across both 1D and ND
-# entries — scalar callable, ForwardDiff.derivative form, allocating batch,
-# and the Constant raw-eltype contract.
+# These cases hit `_output_eltype(Tv, Tg, Tq)`'s `Base.promote_op` fallback —
+# `promote_type` can't model `SVector × Dual` and similar third-party chains.
+# Tests pin the expected return types and container concreteness for both
+# the persistent callable path and the one-shot path, plus type-stability
+# (`@inferred`) and raw-eltype non-regression contracts.
 
-@testitem "Duck Tv × Dual Tq — 1D scalar query widens correctly" begin
+@testitem "Persistent path — duck Tv × Tq widens via build + call" begin
     using StaticArrays, ForwardDiff
 
     x = collect(1.0:10.0)
     y_sv = [SA[Float64(i), 2.0i, 3.0i] for i in 1:10]
     dy_sv = [SA[1.0, 2.0, 3.0] for _ in 1:10]
     xq_d = ForwardDiff.Dual{Nothing}(2.5, 1.0)
+    xq_dv = [ForwardDiff.Dual{Nothing}(2.0 + 0.1i, 1.0) for i in 1:5]
     D = ForwardDiff.Dual{Nothing, Float64, 1}
 
-    @testset "Arithmetic kernels widen SVector{N, Float64} → SVector{N, Dual}" begin
+    @testset "scalar Dual" begin
         @test linear_interp(x, y_sv)(xq_d) isa SVector{3, D}
         @test cubic_interp(x, y_sv)(xq_d) isa SVector{3, D}
         @test quadratic_interp(x, y_sv)(xq_d) isa SVector{3, D}
         @test hermite_interp(x, y_sv, dy_sv)(xq_d) isa SVector{3, D}
+        @test constant_interp(x, y_sv)(xq_d) isa SVector{3, D}
     end
 
-    @testset "Constant kernel widens SVector{N, Float64} → SVector{N, Dual}" begin
-        @test constant_interp(x, y_sv)(xq_d) isa SVector{3, D}
+    @testset "batch Vector{Dual}" begin
+        @test linear_interp(x, y_sv)(xq_dv) isa Vector{SVector{3, D}}
+        @test cubic_interp(x, y_sv)(xq_dv) isa Vector{SVector{3, D}}
+        @test quadratic_interp(x, y_sv)(xq_dv) isa Vector{SVector{3, D}}
+        @test hermite_interp(x, y_sv, dy_sv)(xq_dv) isa Vector{SVector{3, D}}
+        @test constant_interp(x, y_sv)(xq_dv) isa Vector{SVector{3, D}}
+    end
+
+    @testset "ND batch — SVector data × Tuple{Dual, Dual}" begin
+        xg = collect(1.0:5.0); yg = collect(1.0:5.0)
+        data_sv = [SA[Float64(i + j), 2.0(i + j), 3.0(i + j)] for i in 1:5, j in 1:5]
+        q_dv = [(ForwardDiff.Dual{Nothing}(2.5 + 0.1i, 1.0),
+                 ForwardDiff.Dual{Nothing}(3.5 + 0.1i, 0.0)) for i in 1:5]
+        @test linear_interp((xg, yg), data_sv)(q_dv) isa Vector{SVector{3, D}}
+        @test cubic_interp((xg, yg), data_sv)(q_dv) isa Vector{SVector{3, D}}
+        @test constant_interp((xg, yg), data_sv)(q_dv) isa Vector{SVector{3, D}}
+    end
+
+    @testset "ForwardDiff.derivative through indexed component (Issue #144 MWE)" begin
+        for builder in (
+                () -> linear_interp(x, y_sv),
+                () -> cubic_interp(x, y_sv),
+                () -> quadratic_interp(x, y_sv),
+                () -> hermite_interp(x, y_sv, dy_sv),
+                () -> constant_interp(x, y_sv),
+            )
+            itp = builder()
+            d = ForwardDiff.derivative(t -> itp(t)[1], 2.5)
+            @test d isa Float64
+            @test isfinite(d)
+        end
+    end
+
+    @testset "Plain Float64 y + Vector{Dual} batch (non-regression)" begin
+        y = sin.(x)
+        @test linear_interp(x, y)(xq_dv) isa Vector{D}
+        @test cubic_interp(x, y)(xq_dv) isa Vector{D}
+        @test quadratic_interp(x, y)(xq_dv) isa Vector{D}
+        @test hermite_interp(x, y, cos.(x))(xq_dv) isa Vector{D}
+        @test constant_interp(x, y)(xq_dv) isa Vector{D}
     end
 end
 
-@testitem "Duck Tv × Dual Tq — ForwardDiff.derivative of indexed component" begin
+@testitem "Oneshot path — duck Tv × Tq widens identically" begin
     using StaticArrays, ForwardDiff
 
     x = collect(1.0:10.0)
     y_sv = [SA[Float64(i), 2.0i, 3.0i] for i in 1:10]
     dy_sv = [SA[1.0, 2.0, 3.0] for _ in 1:10]
-
-    @testset "linear_interp" begin
-        itp = linear_interp(x, y_sv)
-        d = ForwardDiff.derivative(t -> itp(t)[1], 2.5)
-        @test d isa Float64
-        @test isfinite(d)
-    end
-
-    @testset "cubic_interp" begin
-        itp = cubic_interp(x, y_sv)
-        d = ForwardDiff.derivative(t -> itp(t)[1], 2.5)
-        @test d isa Float64
-        @test isfinite(d)
-    end
-
-    @testset "quadratic_interp" begin
-        itp = quadratic_interp(x, y_sv)
-        d = ForwardDiff.derivative(t -> itp(t)[1], 2.5)
-        @test d isa Float64
-        @test isfinite(d)
-    end
-
-    @testset "hermite_interp" begin
-        itp = hermite_interp(x, y_sv, dy_sv)
-        d = ForwardDiff.derivative(t -> itp(t)[1], 2.5)
-        @test d isa Float64
-        @test isfinite(d)
-    end
-
-    @testset "constant_interp returns zero derivative" begin
-        itp = constant_interp(x, y_sv)
-        d = ForwardDiff.derivative(t -> itp(t)[1], 2.5)
-        @test d isa Float64
-        @test d == 0.0
-    end
-end
-
-@testitem "Duck Tv × Dual Tq — Constant 1D batch widens to SVector{N, Dual}" begin
-    using StaticArrays, ForwardDiff
-
-    x = collect(1.0:10.0)
-    y_sv = [SA[Float64(i), 2.0i, 3.0i] for i in 1:10]
+    xq_d = ForwardDiff.Dual{Nothing}(2.5, 1.0)
     xq_dv = [ForwardDiff.Dual{Nothing}(2.0 + 0.1i, 1.0) for i in 1:5]
     D = ForwardDiff.Dual{Nothing, Float64, 1}
 
-    @testset "Persistent batch" begin
-        out = constant_interp(x, y_sv)(xq_dv)
-        @test out isa Vector{SVector{3, D}}
-        @test eltype(out) === SVector{3, D}
-        @test length(out) == 5
+    @testset "1D scalar 3-arg" begin
+        @test linear_interp(x, y_sv, xq_d) isa SVector{3, D}
+        @test cubic_interp(x, y_sv, xq_d) isa SVector{3, D}
+        @test quadratic_interp(x, y_sv, xq_d) isa SVector{3, D}
+        @test hermite_interp(x, y_sv, dy_sv, xq_d) isa SVector{3, D}
+        @test constant_interp(x, y_sv, xq_d) isa SVector{3, D}
     end
 
-    @testset "Oneshot 3-arg batch" begin
-        out = constant_interp(x, y_sv, xq_dv)
-        @test out isa Vector{SVector{3, D}}
-        @test eltype(out) === SVector{3, D}
+    @testset "1D batch 3-arg (the 4 cases broken before this fix)" begin
+        @test linear_interp(x, y_sv, xq_dv) isa Vector{SVector{3, D}}
+        @test cubic_interp(x, y_sv, xq_dv) isa Vector{SVector{3, D}}
+        @test quadratic_interp(x, y_sv, xq_dv) isa Vector{SVector{3, D}}
+        @test hermite_interp(x, y_sv, dy_sv, xq_dv) isa Vector{SVector{3, D}}
+        @test constant_interp(x, y_sv, xq_dv) isa Vector{SVector{3, D}}
+    end
+
+    @testset "ND batch 3-arg (latent — same root cause)" begin
+        xg = collect(1.0:5.0); yg = collect(1.0:5.0)
+        data_sv = [SA[Float64(i + j), 2.0(i + j), 3.0(i + j)] for i in 1:5, j in 1:5]
+        q_dv = [(ForwardDiff.Dual{Nothing}(2.5 + 0.1i, 1.0),
+                 ForwardDiff.Dual{Nothing}(3.5 + 0.1i, 0.0)) for i in 1:5]
+        @test linear_interp((xg, yg), data_sv, q_dv) isa Vector{SVector{3, D}}
+        @test cubic_interp((xg, yg), data_sv, q_dv) isa Vector{SVector{3, D}}
+        @test quadratic_interp((xg, yg), data_sv, q_dv) isa Vector{SVector{3, D}}
     end
 end
 
-@testitem "Duck Tv × Dual Tq — Constant ND batch widens to SVector{N, Dual}" begin
-    using StaticArrays, ForwardDiff
-
-    xg = collect(1.0:5.0)
-    yg = collect(1.0:5.0)
-    data_sv = [SA[Float64(i + j), 2.0(i + j), 3.0(i + j)] for i in 1:5, j in 1:5]
-    q_dv = [
-        (ForwardDiff.Dual{Nothing}(2.5 + 0.1i, 1.0), ForwardDiff.Dual{Nothing}(3.5 + 0.1i, 0.0))
-            for i in 1:5
-    ]
-    D = ForwardDiff.Dual{Nothing, Float64, 1}
-
-    out = constant_interp((xg, yg), data_sv)(q_dv)
-    @test out isa Vector{SVector{3, D}}
-    @test eltype(out) === SVector{3, D}
-    @test length(out) == 5
-end
-
-@testitem "Plain Float64 y + Vector{Dual} batch preserves Dual eltype (non-regression)" begin
-    using ForwardDiff
-
-    x = collect(1.0:10.0)
-    y = sin.(x)
-    xq_dv = [ForwardDiff.Dual{Nothing}(2.0 + 0.1i, 1.0) for i in 1:5]
+@testitem "Type stability + raw-eltype contracts" begin
+    using Test, StaticArrays, ForwardDiff
+    using FastInterpolations: _output_eltype
 
     D = ForwardDiff.Dual{Nothing, Float64, 1}
 
-    @test linear_interp(x, y)(xq_dv) isa Vector{D}
-    @test cubic_interp(x, y)(xq_dv) isa Vector{D}
-    @test quadratic_interp(x, y)(xq_dv) isa Vector{D}
-    @test hermite_interp(x, y, cos.(x))(xq_dv) isa Vector{D}
-    @test constant_interp(x, y)(xq_dv) isa Vector{D}
-end
+    @testset "Constant scalar @inferred — no Union{Tv, Tq} return" begin
+        # 1D: Int y, Float/Int xq — the kernel's `* one(dL)` and the right-edge
+        # short-circuit must agree on the return type.
+        x = 1:10
+        y = (1:10).^2
+        itp = constant_interp(x, y)
+        @test (@inferred itp(1.0)) === 1.0     # at first(x)
+        @test (@inferred itp(10.0)) === 100.0  # at last(x): the short-circuit branch
+        @test (@inferred itp(5.5)) === 25.0    # interior
+        @test (@inferred itp(1)) === 1         # Int xq stays Int
+        @test (@inferred itp(10)) === 100
+        @test Base.return_types(itp, (Float64,)) == [Float64]
+        @test Base.return_types(itp, (Int,)) == [Int]
 
-@testitem "Constant raw-eltype contract: Int values stay Int (non-regression)" begin
-    x = collect(1:10)
-    y = collect(10:10:100)
-    @test constant_interp(x, y)(3) isa Int
-    @test constant_interp(x, y)([2, 5, 8]) isa Vector{Int}
+        # ND: same contract through the anchor short-circuit path
+        xg = 1:5; yg = 1:5
+        data = [i + j for i in 1:5, j in 1:5]
+        itp_nd = constant_interp((xg, yg), data)
+        @test (@inferred itp_nd((1.0, 1.0))) isa Float64
+        @test (@inferred itp_nd((1, 1))) isa Int
+        @test Base.return_types(itp_nd, (Tuple{Float64, Float64},)) == [Float64]
+        @test Base.return_types(itp_nd, (Tuple{Int, Int},)) == [Int]
+
+        # Dual xq through Float y
+        itp_f = constant_interp(1.0:10.0, collect(1.0:10.0))
+        @test (@inferred itp_f(ForwardDiff.Dual{Nothing}(5.5, 1.0))) isa D
+    end
+
+    @testset "Constant Int → Int contract (non-regression)" begin
+        x = collect(1:10)
+        y = collect(10:10:100)
+        @test constant_interp(x, y)(3) isa Int
+        @test constant_interp(x, y)([2, 5, 8]) isa Vector{Int}
+    end
+
+    @testset "_output_eltype trait — type table" begin
+        @test _output_eltype(Float64, Float64, Float64) === Float64
+        @test _output_eltype(Int, Int, Int) === Float64                       # Int → Float upgrade
+        @test _output_eltype(Int, Int, Float64) === Float64
+        @test _output_eltype(Float32, Float64, Float64) === Float64
+        @test _output_eltype(SVector{3, Float64}, Float64, Float64) === SVector{3, Float64}
+        @test _output_eltype(SVector{3, Float64}, Float64, D) === SVector{3, D}         # Issue #144
+        @test _output_eltype(SVector{3, Int}, Float64, Float64) === SVector{3, Float64} # silent Int-truncation fix
+        @test _output_eltype(SVector{3, Int}, Float64, D) === SVector{3, D}
+        @test _output_eltype(Complex{Int}, Float64, Float64) === ComplexF64
+        @test _output_eltype(D, Float64, Float64) === D
+
+        # Duck-type fallback: when `*` is undefined, return Tv unchanged.
+        struct _DuckNoOp end
+        @test _output_eltype(_DuckNoOp, Float64, Float64) === _DuckNoOp
+    end
 end

--- a/test/test_duck_tv_dual_tq.jl
+++ b/test/test_duck_tv_dual_tq.jl
@@ -736,18 +736,30 @@ end
     # Use enough points to satisfy each method's minimum (Akima needs ≥5).
     @testset "Cubic — Rational user-visible blocked (BROKEN)" begin
         # Persistent path hits both barriers (storage + coefficient lift) → BROKEN.
-        # The 3-arg oneshot's buffer is correctly sized `Vector{Rational{Int}}`
-        # by the kernel-shape trait, but the kernel's internal `z` coefficients
-        # are still Float64; the result happens to round-trip through Rational
-        # for this input only because the kernel values are rationally
-        # representable. Asserting `isa Vector{Rational{Int}}` would pass for
-        # the wrong reason — omit until the coefficient-eltype follow-up lands.
+        #
+        # The 3-arg oneshot's `isa Vector{Rational{Int}}` check would PASS but
+        # for the wrong reason: the kernel-shape trait correctly sizes the
+        # output buffer as `Vector{Rational{Int}}`, but the in-place kernel
+        # still computes in Float64 internally (storage lift) and writes
+        # results via bit-exact `convert(Rational{Int}, ::Float64)`. The user
+        # gets Float64-bits-as-Rational, not true Rational arithmetic.
+        #
+        # We pin the SEMANTIC contract instead: a cubic spline of `y = x`
+        # should reproduce `y = x` exactly. Under pure Rational arithmetic
+        # (post-follow-up), `cubic_interp(x, x, [3//7])` returns `[3//7]`.
+        # Under current Float64-internal computation it returns the bit-exact
+        # Rational form of `Float64(3/7)` (denominator ~2^52). The semantic
+        # equality fails today and auto-surfaces when the storage-lift fix lands.
         x_r = Rational{Int}[i // 1 for i in 0:9]
         y_r = Rational{Int}[(i * i) // 2 for i in 0:9]
         xq_r = 9 // 4
         xq_r_vec = Rational{Int}[(i + 1) // 2 for i in 0:5]
         @test_broken cubic_interp(x_r, y_r)(xq_r) isa Rational{Int}
         @test_broken cubic_interp(x_r, y_r)(xq_r_vec) isa Vector{Rational{Int}}
+        # Semantic pin: y=x cubic spline must reproduce y=x exactly.
+        y_linear = copy(x_r)
+        xq_nondyadic = Rational{Int}[1 // 7, 2 // 7, 3 // 7]
+        @test_broken cubic_interp(x_r, y_linear, xq_nondyadic) == xq_nondyadic
     end
 
     @testset "Quadratic — Rational user-visible blocked (BROKEN)" begin

--- a/test/test_duck_tv_dual_tq.jl
+++ b/test/test_duck_tv_dual_tq.jl
@@ -105,6 +105,45 @@ end
     end
 end
 
+@testitem "Adjoint path — duck-Tv y_bar widens correctly" begin
+    using StaticArrays, ForwardDiff
+
+    x = collect(1.0:10.0)
+    y_for_slope = sin.(x)
+    xq_for_adj = [2.5, 5.5, 8.5]
+    y_bar_sv = [SA[0.1, 0.2, 0.3], SA[0.4, 0.5, 0.6], SA[0.7, 0.8, 0.9]]
+    y_bar_dv = [ForwardDiff.Dual{Nothing}(0.1 + i, 1.0) for i in 1:3]
+    D = ForwardDiff.Dual{Nothing, Float64, 1}
+
+    @testset "1D — slope-free adjoints (Linear/Constant/Cubic/Quadratic)" begin
+        for fn in (linear_adjoint, constant_adjoint, cubic_adjoint, quadratic_adjoint)
+            @test fn(x, xq_for_adj)(y_bar_sv) isa Vector{SVector{3, Float64}}
+            @test fn(x, xq_for_adj)(y_bar_dv) isa Vector{D}
+        end
+    end
+
+    @testset "1D — Hermite-family adjoints" begin
+        for fn in (hermite_adjoint, cardinal_adjoint)
+            @test fn(x, xq_for_adj)(y_bar_sv) isa Vector{SVector{3, Float64}}
+            @test fn(x, xq_for_adj)(y_bar_dv) isa Vector{D}
+        end
+        # Pchip/Akima carry y in the constructor (slope is data-dependent).
+        for fn in (pchip_adjoint, akima_adjoint)
+            @test fn(x, y_for_slope, xq_for_adj)(y_bar_sv) isa Vector{SVector{3, Float64}}
+            @test fn(x, y_for_slope, xq_for_adj)(y_bar_dv) isa Vector{D}
+        end
+    end
+
+    @testset "ND adjoints (Linear/Constant/Cubic/Quadratic)" begin
+        xg = collect(1.0:5.0); yg = collect(1.0:5.0)
+        xq_nd = [(2.5, 3.5), (3.0, 4.0), (4.0, 2.5)]
+        for fn in (linear_adjoint, constant_adjoint, cubic_adjoint, quadratic_adjoint)
+            @test fn((xg, yg), xq_nd)(y_bar_sv) isa Matrix{SVector{3, Float64}}
+            @test fn((xg, yg), xq_nd)(y_bar_dv) isa Matrix{D}
+        end
+    end
+end
+
 @testitem "Type stability + raw-eltype contracts" begin
     using Test, StaticArrays, ForwardDiff
     using FastInterpolations: _output_eltype

--- a/test/test_duck_tv_dual_tq.jl
+++ b/test/test_duck_tv_dual_tq.jl
@@ -352,9 +352,7 @@ end
 # Mirror of the Cubic block above for the other three SeriesInterpolant
 # variants. Each method's persistent callable allocates via its own kernel
 # shape trait, so SVector × Dual must propagate without collapsing to
-# Vector{Any} on any of them. The Constant case is also a regression test
-# for the in-place dispatch — its `outputs::AbstractVector{<:AbstractVector{Tv}}`
-# constraint blocked carrier widening before this fix.
+# Vector{Any} on any of them.
 @testitem "Linear/Quadratic/Constant SeriesInterpolant persistent — SVector × Dual carrier" begin
     using StaticArrays, ForwardDiff
     using FastInterpolations: Series
@@ -435,6 +433,39 @@ end
         dy = Float64[0, 2, 4]
         xq_v = Float32[0.5]
         @test eltype(hermite_interp(x, y, dy, xq_v)) === Float64
+    end
+end
+
+# PCHIP/Cardinal/Akima oneshot allocators were switched to the kernel-shape
+# trait via `_output_eltype(_arithmetic_kernel_shape, ...)`. Confirm the trait
+# fires on the duck-Tq path (scalar + batch). PCHIP/Akima slope formulas use
+# `sign`/`abs` on slopes so SVector y is not a supported carrier for those
+# two; their `Tv` duck coverage is exercised via duck Tq on Float y.
+# Cardinal's slopes are simple averages — it accepts SVector y, so we use the
+# stronger SVector × Dual case there.
+@testitem "Hermite-family one-shot — duck-Tq carrier through trait" begin
+    using StaticArrays, ForwardDiff
+
+    D = ForwardDiff.Dual{Nothing, Float64, 1}
+    x = collect(1.0:10.0)
+    y_f = sin.(x)
+    xq_d  = ForwardDiff.Dual{Nothing}(5.5, 1.0)
+    xq_dv = [ForwardDiff.Dual{Nothing}(2.0 + 0.5i, 1.0) for i in 1:5]
+
+    @testset "PCHIP — Float y + Dual xq" begin
+        @test pchip_interp(x, y_f, xq_d)  isa D
+        @test pchip_interp(x, y_f, xq_dv) isa Vector{D}
+    end
+
+    @testset "Cardinal — SVector y + Dual xq" begin
+        y_sv = [SA[Float64(i), 2.0i, 3.0i] for i in 1:10]
+        @test cardinal_interp(x, y_sv, xq_d)  isa SVector{3, D}
+        @test cardinal_interp(x, y_sv, xq_dv) isa Vector{SVector{3, D}}
+    end
+
+    @testset "Akima — Float y + Dual xq" begin
+        @test akima_interp(x, y_f, xq_d)  isa D
+        @test akima_interp(x, y_f, xq_dv) isa Vector{D}
     end
 end
 
@@ -694,5 +725,96 @@ end
         @test_broken linear_interp(x_r, y_r)(xq_r) isa Rational{Int}
         @test_broken linear_interp(x_r, y_r)(xq_r_vec) isa Vector{Rational{Int}}
         @test_broken linear_interp(x_r, y_r, xq_r_vec) isa Vector{Rational{Int}}
+    end
+
+    # Cubic/Quadratic and the Hermite family (PCHIP/Cardinal/Akima) hit the
+    # SAME barrier as Linear plus a second one: their internal coefficient
+    # eltype (`Tz` for cubic z, `Tc`/`Tcoeff` for quadratic a/d, slope
+    # coefficients for Hermite-family) is sized via the legacy 2-arg
+    # `_output_eltype(Tv, Tg)` which also Float-forces. Both barriers must
+    # relax before Rational reaches the user; until then these pin BROKEN.
+    # Use enough points to satisfy each method's minimum (Akima needs ≥5).
+    @testset "Cubic — Rational user-visible blocked (BROKEN)" begin
+        # Persistent path hits both barriers (storage + coefficient lift) → BROKEN.
+        # The 3-arg oneshot's buffer is correctly sized `Vector{Rational{Int}}`
+        # by the kernel-shape trait, but the kernel's internal `z` coefficients
+        # are still Float64; the result happens to round-trip through Rational
+        # for this input only because the kernel values are rationally
+        # representable. Asserting `isa Vector{Rational{Int}}` would pass for
+        # the wrong reason — omit until the coefficient-eltype follow-up lands.
+        x_r = Rational{Int}[i // 1 for i in 0:9]
+        y_r = Rational{Int}[(i * i) // 2 for i in 0:9]
+        xq_r = 9 // 4
+        xq_r_vec = Rational{Int}[(i + 1) // 2 for i in 0:5]
+        @test_broken cubic_interp(x_r, y_r)(xq_r) isa Rational{Int}
+        @test_broken cubic_interp(x_r, y_r)(xq_r_vec) isa Vector{Rational{Int}}
+    end
+
+    @testset "Quadratic — Rational user-visible blocked (BROKEN)" begin
+        x_r = Rational{Int}[i // 1 for i in 0:9]
+        y_r = Rational{Int}[(i * i) // 2 for i in 0:9]
+        xq_r = 9 // 4
+        xq_r_vec = Rational{Int}[(i + 1) // 2 for i in 0:5]
+        @test_broken quadratic_interp(x_r, y_r)(xq_r) isa Rational{Int}
+        @test_broken quadratic_interp(x_r, y_r)(xq_r_vec) isa Vector{Rational{Int}}
+        @test_broken quadratic_interp(x_r, y_r, xq_r_vec) isa Vector{Rational{Int}}
+    end
+
+    @testset "Hermite-family — Rational user-visible blocked (BROKEN)" begin
+        x_r = Rational{Int}[i // 1 for i in 0:9]
+        y_r = Rational{Int}[(i * i) // 2 for i in 0:9]
+        xq_r = 9 // 4
+        xq_r_vec = Rational{Int}[(i + 1) // 2 for i in 0:5]
+        @test_broken pchip_interp(x_r, y_r, xq_r_vec) isa Vector{Rational{Int}}
+        @test_broken cardinal_interp(x_r, y_r, xq_r_vec) isa Vector{Rational{Int}}
+        @test_broken akima_interp(x_r, y_r, xq_r_vec) isa Vector{Rational{Int}}
+    end
+end
+
+# PCHIP/Akima impose NO `<: AbstractFloat` on `Tv` — only `Tq <: Real`.
+# Their slope formulas demand an interface (`sign`, `abs`, `zero`, `+`, `-`,
+# `*`, `/`, ordering) but accept any duck type that implements it. The
+# SVector failure isn't a method restriction — it's that StaticArrays
+# doesn't define `sign`/`abs` on `SVector`. A minimal scalar-wrapper duck
+# that implements the interface flows through cleanly and the trait
+# predicts the wrapper type as the kernel return.
+@testitem "PCHIP/Akima — custom scalar duck-Tv interface" begin
+    # Wrapper around Float64 implementing the slope-formula interface.
+    struct DuckFloat
+        v::Float64
+    end
+    Base.sign(d::DuckFloat) = DuckFloat(sign(d.v))
+    Base.abs(d::DuckFloat) = DuckFloat(abs(d.v))
+    Base.zero(::Type{DuckFloat}) = DuckFloat(0.0)
+    Base.zero(::DuckFloat) = DuckFloat(0.0)
+    Base.:-(a::DuckFloat) = DuckFloat(-a.v)
+    Base.:+(a::DuckFloat, b::DuckFloat) = DuckFloat(a.v + b.v)
+    Base.:-(a::DuckFloat, b::DuckFloat) = DuckFloat(a.v - b.v)
+    Base.:*(a::DuckFloat, b::DuckFloat) = DuckFloat(a.v * b.v)
+    Base.:/(a::DuckFloat, b::DuckFloat) = DuckFloat(a.v / b.v)
+    Base.:*(a::DuckFloat, b::Real) = DuckFloat(a.v * b)
+    Base.:*(b::Real, a::DuckFloat) = DuckFloat(b * a.v)
+    Base.:/(a::DuckFloat, b::Real) = DuckFloat(a.v / b)
+    Base.:/(a::Real, b::DuckFloat) = DuckFloat(a / b.v)
+    Base.:+(a::Real, b::DuckFloat) = DuckFloat(a + b.v)
+    Base.:+(a::DuckFloat, b::Real) = DuckFloat(a.v + b)
+    Base.:-(a::Real, b::DuckFloat) = DuckFloat(a - b.v)
+    Base.:-(a::DuckFloat, b::Real) = DuckFloat(a.v - b)
+    Base.isless(a::DuckFloat, b::DuckFloat) = a.v < b.v
+    Base.:(==)(a::DuckFloat, b::DuckFloat) = a.v == b.v
+
+    x = collect(1.0:10.0)
+    y_d = [DuckFloat(sin(xi)) for xi in x]
+    xq_scalar = 5.5
+    xq_batch = [2.5, 4.5, 6.5, 8.5]
+
+    @testset "PCHIP" begin
+        @test pchip_interp(x, y_d, xq_scalar) isa DuckFloat
+        @test pchip_interp(x, y_d, xq_batch)  isa Vector{DuckFloat}
+    end
+
+    @testset "Akima" begin
+        @test akima_interp(x, y_d, xq_scalar) isa DuckFloat
+        @test akima_interp(x, y_d, xq_batch)  isa Vector{DuckFloat}
     end
 end

--- a/test/test_duck_tv_dual_tq.jl
+++ b/test/test_duck_tv_dual_tq.jl
@@ -94,7 +94,7 @@ end
         @test constant_interp(x, y_sv, xq_dv) isa Vector{SVector{3, D}}
     end
 
-    @testset "ND batch 3-arg (latent — same root cause)" begin
+    @testset "ND batch 3-arg" begin
         xg = collect(1.0:5.0); yg = collect(1.0:5.0)
         data_sv = [SA[Float64(i + j), 2.0(i + j), 3.0(i + j)] for i in 1:5, j in 1:5]
         q_dv = [(ForwardDiff.Dual{Nothing}(2.5 + 0.1i, 1.0),
@@ -102,6 +102,40 @@ end
         @test linear_interp((xg, yg), data_sv, q_dv) isa Vector{SVector{3, D}}
         @test cubic_interp((xg, yg), data_sv, q_dv) isa Vector{SVector{3, D}}
         @test quadratic_interp((xg, yg), data_sv, q_dv) isa Vector{SVector{3, D}}
+        # Constant ND oneshot batch — fixed in acfc95acf (was `::Vector{Tv}` typeassert).
+        @test constant_interp((xg, yg), data_sv, q_dv) isa Vector{SVector{3, D}}
+    end
+end
+
+# Series path: chain `_series_output_type(_output_eltype(...), Tq)` previously
+# collapsed `promote_type(SVector{F}, Dual)` to `Any` → MethodError on numeric
+# methods, silent `Vector{Any}` on Constant. Now unified `_output_eltype(Tv, Tg, Tq)`.
+@testitem "Series path — duck-Tv × duck-Tq carrier propagates" begin
+    using StaticArrays, ForwardDiff
+    using FastInterpolations: Series
+
+    x = collect(1.0:10.0)
+    y_sv1 = [SA[Float64(i), 2.0i, 3.0i] for i in 1:10]
+    y_sv2 = [SA[-1.0 * i, 0.5i, 2.5i] for i in 1:10]
+    s_sv  = Series(y_sv1, y_sv2)
+    xq_d  = ForwardDiff.Dual{Nothing}(5.5, 1.0)
+    xq_dv = [ForwardDiff.Dual{Nothing}(2.0 + 0.1i, 1.0) for i in 1:5]
+    D = ForwardDiff.Dual{Nothing, Float64, 1}
+
+    @testset "scalar Dual xq, SVector y per series" begin
+        # Returns Vector{T_out} of length K = number of series.
+        @test linear_interp(x, s_sv, xq_d) isa Vector{SVector{3, D}}
+        @test cubic_interp(x, s_sv, xq_d) isa Vector{SVector{3, D}}
+        @test quadratic_interp(x, s_sv, xq_d) isa Vector{SVector{3, D}}
+        @test constant_interp(x, s_sv, xq_d) isa Vector{SVector{3, D}}
+    end
+
+    @testset "batch Vector{Dual} xq, SVector y per series" begin
+        # Returns Vector{Vector{T_out}}, one inner vector per series.
+        @test linear_interp(x, s_sv, xq_dv) isa Vector{Vector{SVector{3, D}}}
+        @test cubic_interp(x, s_sv, xq_dv) isa Vector{Vector{SVector{3, D}}}
+        @test quadratic_interp(x, s_sv, xq_dv) isa Vector{Vector{SVector{3, D}}}
+        @test constant_interp(x, s_sv, xq_dv) isa Vector{Vector{SVector{3, D}}}
     end
 end
 

--- a/test/test_duck_tv_dual_tq.jl
+++ b/test/test_duck_tv_dual_tq.jl
@@ -636,7 +636,7 @@ end
     end
 
     @testset "Constant Int chain — scalar/batch type-stable Int" begin
-        # Kernel-shape trait: `_constant_kernel_shape(yv, q) = yv * one(q)`
+        # Kernel-shape trait: `_constant_kernel_shape(xL, yv, xq) = yv * one(xq - xL)`
         # → Int×Int×Int inferred as Int (no spurious Float upgrade).
         xi = collect(1:10); yi = collect(10:10:100)
         let k = constant_interp(xi, yi)
@@ -703,9 +703,9 @@ end
         @test (@inferred _output_eltype(_arithmetic_kernel_shape, Int, Int, Int)) === Float64
         @test (@inferred _output_eltype(_arithmetic_kernel_shape, Float64, Float64, Float64)) === Float64
         @test (@inferred _output_eltype(_arithmetic_kernel_shape, Int, Complex{Int}, Int)) === ComplexF64
-        # Selection shape: pure `Rational * one(Rational) = Rational`.
-        @test (@inferred _output_eltype(_constant_kernel_shape, Rational{Int}, Rational{Int})) === Rational{Int}
-        @test (@inferred _output_eltype(_constant_kernel_shape, Int, Int)) === Int
+        # Selection shape: `Rational * one(Rational - Rational) = Rational`.
+        @test (@inferred _output_eltype(_constant_kernel_shape, Rational{Int}, Rational{Int}, Rational{Int})) === Rational{Int}
+        @test (@inferred _output_eltype(_constant_kernel_shape, Int, Int, Int)) === Int
     end
 
     @testset "Constant — end-to-end Rational preserved (storage stays raw)" begin

--- a/test/test_duck_tv_dual_tq.jl
+++ b/test/test_duck_tv_dual_tq.jl
@@ -236,3 +236,203 @@ end
         @test _output_eltype(_DuckNoOp, Float64, Float64) === _DuckNoOp
     end
 end
+
+# Advanced AD shapes: Dual x grid, grid-offset sensitivity, nested Dual,
+# ForwardDiff.gradient + Hessian. These pin cases beyond the basic
+# {scalar, batch} × duck-Tv × duck-Tq matrix already covered above.
+@testitem "Advanced AD — Dual grid, grid-offset, nested, gradient" begin
+    using StaticArrays, ForwardDiff
+
+    x_f = collect(1.0:10.0)
+    y_f = sin.(x_f); dy_f = cos.(x_f)
+    y_sv = [SA[Float64(i), 2.0i, 3.0i] for i in 1:10]
+    dy_sv = [SA[1.0, 2.0, 3.0] for _ in 1:10]
+    x_dg = [ForwardDiff.Dual{Nothing}(Float64(i), 1.0) for i in 1:10]
+    xq_f = 5.5
+    xq_d = ForwardDiff.Dual{Nothing}(5.5, 1.0)
+    D = ForwardDiff.Dual{Nothing, Float64, 1}
+
+    @testset "Dual x grid carrier flows through Tv × Tq" begin
+        # Persistent + one-shot, scalar + batch, both Float y and SVector y.
+        for fn in (linear_interp, cubic_interp, quadratic_interp, constant_interp)
+            @test fn(x_dg, y_f)(xq_f) isa D
+            @test fn(x_dg, y_f)(xq_d) isa D
+            @test fn(x_dg, y_sv)(xq_f) isa SVector{3, D}
+            @test fn(x_dg, y_sv)(xq_d) isa SVector{3, D}
+            # One-shot mirror
+            @test fn(x_dg, y_f, xq_d) isa D
+            @test fn(x_dg, y_sv, xq_d) isa SVector{3, D}
+        end
+        @test hermite_interp(x_dg, y_f, dy_f)(xq_d) isa D
+        @test hermite_interp(x_dg, y_sv, dy_sv)(xq_d) isa SVector{3, D}
+    end
+
+    @testset "ForwardDiff.derivative w.r.t. grid offset" begin
+        # `∂/∂δ fn(x .+ δ, y, xq)` — grid sensitivity via AD. Persistent + one-shot.
+        for fn in (linear_interp, cubic_interp, constant_interp)
+            d_pers = ForwardDiff.derivative(δ -> fn(x_f .+ δ, y_f)(xq_f), 0.0)
+            d_one  = ForwardDiff.derivative(δ -> fn(x_f .+ δ, y_f, xq_f), 0.0)
+            @test d_pers isa Float64 && isfinite(d_pers)
+            @test d_one  isa Float64 && isfinite(d_one)
+            # SVector indexed component, one-shot path
+            d_sv = ForwardDiff.derivative(δ -> fn(x_f .+ δ, y_sv, xq_f)[2], 0.0)
+            @test d_sv isa Float64 && isfinite(d_sv)
+        end
+    end
+
+    @testset "Nested Dual — 2nd-order AD (d²/dt²)" begin
+        for fn in (linear_interp, cubic_interp, quadratic_interp, constant_interp)
+            d2 = ForwardDiff.derivative(
+                t1 -> ForwardDiff.derivative(t2 -> fn(x_f, y_f)(t2), t1),
+                xq_f,
+            )
+            @test d2 isa Float64
+        end
+    end
+
+    @testset "ND ForwardDiff.gradient + Hessian + grid-offset sensitivity" begin
+        xg = collect(1.0:5.0); yg = collect(1.0:5.0)
+        data = [sin(i) * cos(j) for i in 1:5, j in 1:5]
+        data_sv = [SA[Float64(i + j), 2.0(i + j), 3.0(i + j)] for i in 1:5, j in 1:5]
+
+        for fn in (linear_interp, cubic_interp)
+            # Gradient of scalar-output ND interp w.r.t. query
+            @test ForwardDiff.gradient(q -> fn((xg, yg), data)((q[1], q[2])), [2.5, 3.5]) isa Vector{Float64}
+            # Hessian — exercises nested Dual through the kernel
+            @test ForwardDiff.hessian(q -> fn((xg, yg), data)((q[1], q[2])), [2.5, 3.5]) isa Matrix{Float64}
+            # Gradient via one-shot 3-arg
+            @test ForwardDiff.gradient(q -> fn((xg, yg), data, (q[1], q[2])), [2.5, 3.5]) isa Vector{Float64}
+            # SVector component gradient (persistent + one-shot)
+            @test ForwardDiff.gradient(q -> fn((xg, yg), data_sv)((q[1], q[2]))[1], [2.5, 3.5]) isa Vector{Float64}
+            @test ForwardDiff.gradient(q -> fn((xg, yg), data_sv, (q[1], q[2]))[1], [2.5, 3.5]) isa Vector{Float64}
+            # ND grid-offset sensitivity via one-shot
+            @test ForwardDiff.derivative(δ -> fn((xg .+ δ, yg), data, (2.5, 3.5)), 0.0) isa Float64
+        end
+    end
+
+    @testset "Series + one-shot ForwardDiff.derivative on SVector component" begin
+        using FastInterpolations: Series
+        y_sv1 = [SA[Float64(i), 2.0i] for i in 1:10]
+        y_sv2 = [SA[-1.0*i, 0.5i] for i in 1:10]
+        s_sv = Series(y_sv1, y_sv2)
+        # `fn(x, series, t)` returns Vector{SVector} (one per series).
+        # ∂/∂t of series[1][component[1]] exercises the full Series + duck-Tq chain.
+        for fn in (linear_interp, cubic_interp, quadratic_interp, constant_interp)
+            d = ForwardDiff.derivative(t -> fn(x_f, s_sv, t)[1][1], xq_f)
+            @test d isa Float64
+        end
+    end
+end
+
+# `CubicSeriesInterpolant` build-then-call path — distinct from the 3-arg
+# one-shot covered in the "Series path" testitem above.
+@testitem "CubicSeriesInterpolant persistent path — SVector × Dual carrier" begin
+    using StaticArrays, ForwardDiff
+    using FastInterpolations: Series
+
+    x = collect(1.0:10.0)
+    y_sv1 = [SA[Float64(i), 2.0i, 3.0i] for i in 1:10]
+    y_sv2 = [SA[-1.0 * i, 0.5i, 2.5i] for i in 1:10]
+    s_sv  = Series(y_sv1, y_sv2)
+    xq_d  = ForwardDiff.Dual{Nothing}(5.5, 1.0)
+    xq_dv = [ForwardDiff.Dual{Nothing}(2.0 + 0.1i, 1.0) for i in 1:5]
+    D = ForwardDiff.Dual{Nothing, Float64, 1}
+
+    sitp = cubic_interp(x, s_sv)
+
+    @testset "scalar Dual via persistent callable" begin
+        @test sitp(xq_d) isa Vector{SVector{3, D}}
+    end
+
+    @testset "batch Vector{Dual} via persistent callable" begin
+        @test sitp(xq_dv) isa Vector{Vector{SVector{3, D}}}
+    end
+end
+
+@testitem "Constant ND deriv-zero short-circuit propagates Tq carrier" begin
+    using ForwardDiff
+
+    D = ForwardDiff.Dual{Nothing, Float64, 1}
+
+    xg = collect(1.0:5.0); yg = collect(1.0:5.0)
+    data_int = [10i + j for i in 1:5, j in 1:5]
+    qd = (ForwardDiff.Dual{Nothing}(2.5, 1.0), ForwardDiff.Dual{Nothing}(3.5, 0.0))
+
+    @testset "Persistent ND scalar callable, deriv != EvalValue" begin
+        itp = constant_interp((xg, yg), data_int)
+        @test itp(qd; deriv = (DerivOp(1), EvalValue())) isa D
+    end
+
+    @testset "One-shot ND scalar callable, deriv != EvalValue" begin
+        @test constant_interp((xg, yg), data_int, qd; deriv = (DerivOp(1), EvalValue())) isa D
+    end
+end
+
+@testitem "Hermite one-shot preserves duck carrier in `dy`" begin
+    using ForwardDiff
+
+    D = ForwardDiff.Dual{Nothing, Float64, 1}
+
+    @testset "Float64 y + Vector{Dual} dy — batch one-shot" begin
+        x = collect(1.0:10.0)
+        y = sin.(x)
+        dy = [ForwardDiff.Dual{Nothing}(cos(xi), 1.0) for xi in x]
+        xq = collect(2.0:0.5:8.0)
+        @test hermite_interp(x, y, dy, xq) isa Vector{D}
+    end
+
+    @testset "ForwardDiff.derivative on slope perturbation" begin
+        x = collect(1.0:10.0)
+        y = sin.(x)
+        dy_base = cos.(x)
+        xq = 5.5
+        d = ForwardDiff.derivative(δ -> hermite_interp(x, y, dy_base .+ δ, [xq])[1], 0.0)
+        @test d isa Float64
+        @test isfinite(d)
+    end
+
+    @testset "Float32 y + Float64 dy precision pin" begin
+        # Scalar/vector parity: wider `eltype(dy)` widens the result.
+        x = Float32[0, 1, 2]
+        y = Float32[0, 1, 4]
+        dy = Float64[0, 2, 4]
+        xq_v = Float32[0.5]
+        @test eltype(hermite_interp(x, y, dy, xq_v)) === Float64
+    end
+end
+
+# ND deriv-zero short-circuits multiply by `one(eltype(query[1]))` (axis-1).
+# Heterogeneous-axis queries like `(Float, Dual)` lose the non-axis-1 carrier
+# unless the short-circuit folds `one` over every axis (mirroring the forward
+# kernel's per-axis `* one(dL_d)`).
+@testitem "ND deriv-zero short-circuit per-axis carrier" begin
+    using ForwardDiff
+
+    D = ForwardDiff.Dual{Nothing, Float64, 1}
+
+    xg = collect(1.0:5.0); yg = collect(1.0:5.0)
+    data_int = [10i + j for i in 1:5, j in 1:5]
+    # Axis 1 Float, axis 2 Dual — Dual carrier lives on axis 2 only.
+    q_het = (2.5, ForwardDiff.Dual{Nothing}(3.5, 1.0))
+    q_het_batch = [q_het]
+
+    @testset "Constant ND persistent scalar — (Float, Dual) × mixed deriv" begin
+        itp = constant_interp((xg, yg), data_int)
+        @test itp(q_het; deriv = (EvalValue(), DerivOp(1))) isa D
+    end
+
+    @testset "Constant ND one-shot scalar — (Float, Dual) × mixed deriv" begin
+        @test constant_interp((xg, yg), data_int, q_het; deriv = (EvalValue(), DerivOp(1))) isa D
+    end
+
+    @testset "Constant ND one-shot batch — (Float, Dual) × mixed deriv" begin
+        @test constant_interp((xg, yg), data_int, q_het_batch; deriv = (EvalValue(), DerivOp(1))) isa Vector{D}
+    end
+
+    @testset "Linear ND persistent scalar 2nd-deriv (zero-fill) — (Float, Dual)" begin
+        # LinearInterpolantND _deriv_zero_fill triggers on 2nd-order deriv.
+        data_f = [Float64(10i + j) for i in 1:5, j in 1:5]
+        itp_l = linear_interp((xg, yg), data_f)
+        @test itp_l(q_het; deriv = (EvalValue(), DerivOp(2))) isa D
+    end
+end

--- a/test/test_precision_vector_queries.jl
+++ b/test/test_precision_vector_queries.jl
@@ -50,10 +50,9 @@
 
         @testset "Allocating vector call" begin
             @test result_vec ≈ result_broadcast rtol = PRECISION_RTOL
-            # Constant is a selection kernel — output keeps raw `Tv` (Float32),
-            # not promoted to the query precision. Scalar / broadcast / batch
-            # all agree on this contract for plain numeric queries.
-            @test eltype(result_vec) == Float32
+            # Zero-slope arithmetic propagates the Float64 xq carrier:
+            # Float32 y * one(Float64) = Float64. Scalar / broadcast / batch agree.
+            @test eltype(result_vec) == Float64
         end
 
         @testset "In-place vector call" begin

--- a/test/test_promotion_alloc.jl
+++ b/test/test_promotion_alloc.jl
@@ -119,9 +119,10 @@
         y_int = [0, 1, 3, 2, 5]
         xq_test = [0.5, 1.5, 2.5, 3.5]
 
-        # Allocating batch (all methods). Constant duck-types: Int y → Vector{Int}.
+        # Allocating batch (all methods). Float64 xq carrier propagates;
+        # Constant returns Vector{Float64} for Int y + Float xq via zero-slope arithmetic.
         @test linear_interp(x_int, y_int, xq_test) isa Vector{Float64}
-        @test constant_interp(x_int, y_int, xq_test) isa Vector{Int}
+        @test constant_interp(x_int, y_int, xq_test) isa Vector{Float64}
         @test quadratic_interp(x_int, y_int, xq_test) isa Vector{Float64}
         @test cubic_interp(x_int, y_int, xq_test; extrap = ExtendExtrap()) isa Vector{Float64}
         @test pchip_interp(x_int, y_int, xq_test; extrap = ExtendExtrap()) isa Vector{Float64}

--- a/test/test_promotion_alloc.jl
+++ b/test/test_promotion_alloc.jl
@@ -310,26 +310,22 @@
     end
 end
 
-# Sample-first removal contract (commit 59fc74c58): the persistent batch
-# allocating callable `itp(xq)` no longer evaluates the kernel once to read
-# `typeof(first_val)` — the kernel-shape trait predicts the buffer eltype
-# directly. The protocol-level guarantee is that the call allocates exactly
-# the output Vector and nothing else. If sample-first were re-introduced
-# (or any other intermediate buffer leaked into the persistent batch path)
-# the alloc cost would rise above one Vector{T_out}.
-@testitem "Persistent batch allocator: trait-only sizing (output Vector only)" setup = [AllocConstants] begin
+# Persistent batch in-place callable `itp(out, xq)` must be zero-alloc across
+# all methods. This pins the kernel-loop invariant directly: no sample-first
+# eval leftover, no scratch buffer, no closure capture on the hot path. The
+# allocating form `itp(xq)` is `Vector{T_out}(undef, n)` + this in-place call,
+# so this single contract covers both paths.
+@testitem "Persistent batch in-place: zero-alloc kernel loop" setup = [AllocConstants] begin
     x = collect(0.0:0.1:10.0)
     y = sin.(x)
     xq = collect(0.5:0.01:9.5)
-    n = length(xq)
+    out = Vector{Float64}(undef, length(xq))
 
-    # Function barriers — closure capture would box the locals.
-    _bench_persistent(itp, xq) = itp(xq)
-    _bench_vector(n) = Vector{Float64}(undef, n)
-
-    # Reference: a bare Vector{Float64}(undef, n) alloc cost.
-    _bench_vector(n)
-    cost_vector = @allocated _bench_vector(n)
+    # Function barrier — closure capture would box `itp`, `out`, `xq`.
+    function _bench_persistent_inplace!(itp, out, xq)
+        itp(out, xq)
+        return nothing
+    end
 
     for builder in (
             () -> linear_interp(x, y),
@@ -341,11 +337,7 @@ end
             () -> constant_interp(x, y),
         )
         itp = builder()
-        _bench_persistent(itp, xq)   # warmup
-        cost_itp = @allocated _bench_persistent(itp, xq)
-        # Persistent batch alloc = output Vector + ALLOC_THRESHOLD slack.
-        # A re-introduced sample-first (or any leaked scratch buffer) would
-        # exceed this by at least one kernel-result-sized allocation per call.
-        @test cost_itp <= cost_vector + ALLOC_THRESHOLD
+        _bench_persistent_inplace!(itp, out, xq)   # warmup
+        @test (@allocated _bench_persistent_inplace!(itp, out, xq)) <= ALLOC_THRESHOLD
     end
 end

--- a/test/test_promotion_alloc.jl
+++ b/test/test_promotion_alloc.jl
@@ -309,3 +309,43 @@
         @test alloc_f32 - alloc_f64 < extra_vector_bytes ÷ 2  # less than half an extra vector
     end
 end
+
+# Sample-first removal contract (commit 59fc74c58): the persistent batch
+# allocating callable `itp(xq)` no longer evaluates the kernel once to read
+# `typeof(first_val)` — the kernel-shape trait predicts the buffer eltype
+# directly. The protocol-level guarantee is that the call allocates exactly
+# the output Vector and nothing else. If sample-first were re-introduced
+# (or any other intermediate buffer leaked into the persistent batch path)
+# the alloc cost would rise above one Vector{T_out}.
+@testitem "Persistent batch allocator: trait-only sizing (output Vector only)" setup = [AllocConstants] begin
+    x = collect(0.0:0.1:10.0)
+    y = sin.(x)
+    xq = collect(0.5:0.01:9.5)
+    n = length(xq)
+
+    # Function barriers — closure capture would box the locals.
+    _bench_persistent(itp, xq) = itp(xq)
+    _bench_vector(n) = Vector{Float64}(undef, n)
+
+    # Reference: a bare Vector{Float64}(undef, n) alloc cost.
+    _bench_vector(n)
+    cost_vector = @allocated _bench_vector(n)
+
+    for builder in (
+            () -> linear_interp(x, y),
+            () -> cubic_interp(x, y),
+            () -> quadratic_interp(x, y),
+            () -> pchip_interp(x, y),
+            () -> cardinal_interp(x, y),
+            () -> akima_interp(x, y),
+            () -> constant_interp(x, y),
+        )
+        itp = builder()
+        _bench_persistent(itp, xq)   # warmup
+        cost_itp = @allocated _bench_persistent(itp, xq)
+        # Persistent batch alloc = output Vector + ALLOC_THRESHOLD slack.
+        # A re-introduced sample-first (or any leaked scratch buffer) would
+        # exceed this by at least one kernel-result-sized allocation per call.
+        @test cost_itp <= cost_vector + ALLOC_THRESHOLD
+    end
+end


### PR DESCRIPTION
Closes #144.

## Summary

`linear_interp(x, y::Vector{SVector{3,Float64}})(xq_dual_vec)` raised `MethodError: Float64(::Dual)`. Root cause: the output-eltype trait predicted buffer types via a `promote_type` + `_PromotableValue` enumeration that couldn't see through `SVector × Dual` and similar non-`promote_rule` carrier chains. Allocated buffers under-predicted the kernel's actual return type.

This PR closes the carrier-propagation contract end-to-end **and** replaces the hand-coded enumeration with a method-aware **kernel-shape op trait**: each method declares its kernel's representative shape, and Julia inference (`Base.promote_op`) predicts the exact return type.

## What this PR introduces

### Kernel-shape op trait

```julia
@inline function _output_eltype(kernel_op::F, ::Type{Tv}, types::Type...) where {F, Tv}
    Top = Base.promote_op(kernel_op, Tv, types...)
    (Top === Union{} || Top === Any) && return Tv
    return Top
end
```

Two shapes cover every method:

- `_arithmetic_kernel_shape(h, yv, dL) = yv + yv*(dL/h)` — Linear/Cubic/Quadratic/Hermite-family. Division by `h` Float-upgrades Int chains naturally.
- `_constant_kernel_shape(yv, q) = yv * one(q)` — Constant (selection kernel; Int chains stay Int).

Wiring:

- Default `_output_eltype(::AbstractInterpolant1D, ::Type{Tq})` (and ND mirror) routes through `_arithmetic_kernel_shape`.
- `ConstantInterpolant` 1D + ND override route through `_constant_kernel_shape`.
- `AbstractHermiteInterpolant1D` override applies a two-call pattern over `Tv` and `eltype(itp.dy)` — disjoint promote chains so a duck-typed `dy` (e.g., Float y + Dual dy from AD on slopes) doesn't poison the y-chain.
- All output-buffer sites canonically routed through the method-aware kernel-shape form. After the follow-up cleanup in this PR (linear series ×4, cubic cache oneshot ×1, cubic/quadratic ND scalar ×2, 1D + ND adjoint allocators ×6), no output-buffer allocation remains on the legacy 2-arg fallback. `_series_output_type` helper deleted (orphaned).

**Net result**: `_PromotableValue` enumeration is no longer reached from any output-buffer allocation path. The trait's prediction is kernel-faithful by construction.

### Duck-Tv × duck-Tq end-to-end

Carrier propagation closed across every allocator that previously collapsed for non-`promote_rule` ducks:

- 1D + ND persistent batch (protocol-level)
- 1D + ND one-shot batch (3-arg)
- Cubic/Linear/Quadratic/Constant series persistent + one-shot
- Hermite one-shot for `Float y + Vector{Dual} dy` (AD on slopes)
- ND deriv-zero short-circuits — per-axis carrier via `prod(one, query)`, so heterogeneous queries like `(Float, Dual)` + mixed-deriv propagate the non-axis-1 carrier
- `ConstantInterpolant` + `QuadraticInterpolant` anchored-vector callable

### Sample-first allocator removed

Protocol's persistent batch path no longer evaluates the kernel for the first query just to read `typeof(first_val)` — trait-only sizing (`n+1` → `n` evaluations per batch).

## Behavior changes

- `constant_interp` with `Int y + Float xq` returns `Float` (was `Int`); fully-Int chain stays `Int`. Scalar and batch paths agree.
- `hermite_interp(x, y::Float64, dy::Vector{Dual}, xq)` no longer raises `MethodError` on `setindex!`.
- `CubicSeriesInterpolant` persistent callable handles `Series(Vector{SVector{Float}}) × Dual`.
- Heterogeneous-axis ND deriv-zero queries propagate the Dual carrier per-axis.
- `Rational/Rational/Rational` arithmetic chain predicts `Rational{Int}` at the trait level (kernel-faithful — `Rational/Rational = Rational`). User-visible `Vector{Rational}` is still blocked by storage Float-forcing — see Out of scope. Cubic 3-arg batch oneshot is a partial outlier: the output buffer IS sized as `Vector{Rational{Int}}` (trait correct), but values are bit-exact `convert(Rational, ::Float64)` of the kernel's Float64 results — pinned by a semantic `@test_broken` (value equality, not just `isa`).

## Out of scope (explicit follow-ups)

The kernel-shape trait now predicts kernel-faithful return types, but two storage-side mechanisms still apply manual Float-forcing — surfacing as a trait-vs-storage gap:

- **`_promote_grid_float`**: arithmetic-method constructors (Linear/Cubic/Quadratic/Hermite-family) lift `Rational/Int` grids to Float64 at construction time. Relaxing this requires search/cache pathways (`_CachedRange.inv_h` etc.) to handle non-Float types.
- **Internal coefficient eltype** (`Tz` for cubic z, `Tc` for quadratic a/d, hetero coefficients): still use the legacy `_output_eltype(Tv, Tg)` enumeration. Same theme as storage Float-forcing — natural promote via method-specific coefficient-shape op is achievable.

Both are pinned via `@test_broken`; they auto-surface as `now passing` once the follow-up lands. Performance benchmarking for non-Float storage paths is part of that follow-up's scope.