### PR TITLE
(feat): ND cubic Hermite with user-supplied mixed partials

### DIFF
--- a/docs/src/api/types.md
+++ b/docs/src/api/types.md
@@ -26,6 +26,13 @@ AutoCoeffs
 CubicInterpolantND
 ```
 
+### ND Cubic Hermite (User-Supplied Partials)
+
+```@docs
+HermitePartials
+CubicHermiteInterpolantND
+```
+
 ### Unified API Types
 
 ```@docs

--- a/src/FastInterpolations.jl
+++ b/src/FastInterpolations.jl
@@ -51,7 +51,7 @@ export constant_interp, constant_interp!, ConstantInterpolant, ConstantSeriesInt
 export quadratic_interp, quadratic_interp!, QuadraticInterpolant, QuadraticSeriesInterpolant, QuadraticInterpolantND
 export cubic_interp, cubic_interp!, CubicSplineCache, CubicInterpolant, CubicSeriesInterpolant
 export hermite_interp, hermite_interp!, CubicHermiteInterpolant1D  # Cubic Hermite with user-supplied slopes
-export CubicHermiteInterpolantND, HermitePartials, HermiteFullPartials  # ND cubic Hermite (user-supplied full mixed partials, Phase 1a)
+export CubicHermiteInterpolantND, HermitePartials  # ND cubic Hermite (user-supplied full mixed partials, Phase 1a)
 export pchip_interp, pchip_interp!, PchipInterpolant1D  # PCHIP monotone interpolation
 export cardinal_interp, cardinal_interp!, CardinalInterpolant1D  # Cardinal spline (CatmullRom default)
 export akima_interp, akima_interp!, AkimaInterpolant1D  # Akima outlier-robust interpolation

--- a/src/FastInterpolations.jl
+++ b/src/FastInterpolations.jl
@@ -51,6 +51,7 @@ export constant_interp, constant_interp!, ConstantInterpolant, ConstantSeriesInt
 export quadratic_interp, quadratic_interp!, QuadraticInterpolant, QuadraticSeriesInterpolant, QuadraticInterpolantND
 export cubic_interp, cubic_interp!, CubicSplineCache, CubicInterpolant, CubicSeriesInterpolant
 export hermite_interp, hermite_interp!, CubicHermiteInterpolant1D  # Cubic Hermite with user-supplied slopes
+export CubicHermiteInterpolantND, HermitePartials, HermiteFullPartials  # ND cubic Hermite (user-supplied full mixed partials, Phase 1a)
 export pchip_interp, pchip_interp!, PchipInterpolant1D  # PCHIP monotone interpolation
 export cardinal_interp, cardinal_interp!, CardinalInterpolant1D  # Cardinal spline (CatmullRom default)
 export akima_interp, akima_interp!, AkimaInterpolant1D  # Akima outlier-robust interpolation

--- a/src/core/show.jl
+++ b/src/core/show.jl
@@ -135,6 +135,7 @@ _format_bc(bc::PeriodicBC{:inclusive}) = bc.period === nothing ? "Periodic" : "P
 _format_bc(bc::PeriodicBC{:exclusive}) = bc.period === nothing ? "Periodic (exclusive)" : "Periodic (exclusive, period≈$(Printf.@sprintf("%.4g", bc.period)))"
 _format_bc(bc::PeriodicBC{:extended}) = bc.period === nothing ? "Periodic (extended from :exclusive)" : "Periodic (extended from :exclusive, period≈$(Printf.@sprintf("%.4g", bc.period)))"
 _format_bc(::PeriodicBC) = "Periodic"
+_format_bc(::NoBC) = "NoBC"
 _format_bc(bc::Deriv1) = "Deriv1($(bc.val))"
 _format_bc(bc::Deriv2) = "Deriv2($(bc.val))"
 _format_bc(bc::Deriv3) = "Deriv3($(bc.val))"
@@ -520,6 +521,7 @@ function Base.show(io::IO, ::MIME"text/plain", adj::AbstractAdjoint1D{Tg}) where
 end
 
 # Short BC name for compact display
+_short_bc_name(::NoBC) = "NoBC"
 _short_bc_name(::PeriodicBC{:inclusive}) = "Periodic"
 _short_bc_name(::PeriodicBC{:exclusive}) = "Periodic(excl)"
 _short_bc_name(::PeriodicBC{:extended}) = "Periodic(ext)"
@@ -1052,6 +1054,36 @@ function Base.show(io::IO, ::MIME"text/plain", itp::QuadraticInterpolantND{Tg, T
     end
 
     # Boundary conditions
+    return _show_nd_bc_summary(io, true, itp.bcs)
+end
+
+# ========================================
+# CubicHermiteInterpolantND Show Methods
+# ========================================
+
+function Base.show(io::IO, itp::CubicHermiteInterpolantND{Tg, Tv, N}) where {Tg, Tv, N}
+    sizes = join([string(length(g)) for g in itp.grids], "×")
+    bc_name = _short_bc_name_nd(itp.bcs)
+    _show_type_header_nd(io, "CubicHermiteInterpolantND", Tg, Tv, N)
+    return print(io, "($sizes, $bc_name)")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", itp::CubicHermiteInterpolantND{Tg, Tv, N}) where {Tg, Tv, N}
+    _show_type_header_nd(io, "CubicHermiteInterpolantND", Tg, Tv, N)
+    println(io)
+
+    _show_nd_grids_summary(io, false, itp.grids)
+    println(io)
+
+    _show_nd_config_row(io, false, "Extrap:", itp.extraps, _format_extrap)
+    println(io)
+
+    has_vector_grid = any(g -> !(g isa AbstractRange), itp.grids)
+    if has_vector_grid
+        _show_nd_config_row(io, false, "Search:", itp.searches, _format_search)
+        println(io)
+    end
+
     return _show_nd_bc_summary(io, true, itp.bcs)
 end
 

--- a/src/hermite/hermite.jl
+++ b/src/hermite/hermite.jl
@@ -10,3 +10,4 @@ include("hermite_oneshot.jl")          # 6. hermite_interp / hermite_interp!
 include("hermite_interpolant.jl")      # 7. 2-arg hermite_interp + protocol traits
 include("hermite_adjoint.jl")          # 8. HermiteAdjoint1D + shared scatter core
 include("hermite_integrate.jl")        # 9. integrate(itp::AbstractHermiteInterpolant1D)
+include("nd/nd.jl")                    # 10. ND cubic Hermite with user-supplied partials (Phase 1a)

--- a/src/hermite/nd/hermite_nd_build.jl
+++ b/src/hermite/nd/hermite_nd_build.jl
@@ -1,0 +1,239 @@
+# ========================================
+# CubicHermiteInterpolantND Build Path
+# ========================================
+#
+# Pack data + user-supplied partials into `_NodalDerivativesND`, extending
+# grid + every stored array along each `PeriodicBC{:exclusive}` axis. Mirrors
+# the BC-promotion pattern used by `_prepare_periodic_nd` (`:exclusive →
+# :extended`).
+#
+# Phase 1a BC policy: only `NoBC`, `PeriodicBC{:inclusive}`,
+# `PeriodicBC{:exclusive}` are accepted. Other BCs (BCPair, NaturalBC, etc.)
+# affect partial *derivation* — irrelevant here because the user supplies
+# every partial directly.
+
+# ========================================
+# BC validation (Phase 1a)
+# ========================================
+
+@noinline function _throw_unsupported_hermite_nd_bc(d::Int, bc)
+    throw(ArgumentError(
+        "CubicHermiteInterpolantND (Phase 1a): bc[$d] = $(bc) is unsupported. " *
+        "Only `NoBC()`, `PeriodicBC(...; endpoint=:inclusive)`, and " *
+        "`PeriodicBC(...; endpoint=:exclusive)` are accepted because user " *
+        "partials supersede BC-derived ones. Use the auto-slope methods " *
+        "(`pchip_interp`, `cardinal_interp`, `akima_interp`) for richer BC families.",
+    ))
+end
+
+@inline _is_hermite_nd_bc_allowed(::NoBC) = true
+@inline _is_hermite_nd_bc_allowed(::PeriodicBC) = true
+@inline _is_hermite_nd_bc_allowed(::AbstractBC) = false
+
+function _validate_hermite_nd_bcs_phase1a(bcs::Tuple{Vararg{AbstractBC, N}}) where {N}
+    @inbounds for d in 1:N
+        _is_hermite_nd_bc_allowed(bcs[d]) || _throw_unsupported_hermite_nd_bc(d, bcs[d])
+    end
+    return nothing
+end
+
+# ========================================
+# Size consistency between data and every stored partial
+# ========================================
+
+@noinline function _throw_data_partial_size_mismatch(sz_data, mask::Int, sz_part)
+    throw(DimensionMismatch(
+        "CubicHermiteInterpolantND: data size $(sz_data) ≠ partial size $(sz_part) " *
+        "for mask=$mask. data and every partial array must share `size`.",
+    ))
+end
+
+function _validate_partial_sizes(
+        data::AbstractArray{Tv, N},
+        partials::HermitePartials{N, Tv, K},
+    ) where {Tv, N, K}
+    sz = size(data)
+    @inbounds for m in 1:K
+        size(partials.partials[m]) == sz || _throw_data_partial_size_mismatch(sz, m, size(partials.partials[m]))
+    end
+    return nothing
+end
+
+# ========================================
+# Inclusive periodic seam validation
+# ========================================
+#
+# For axes with `PeriodicBC{:inclusive}`, user-supplied data + every partial
+# array must already be closed-cycle along that axis. Validate once at
+# build time so downstream search/eval can assume the invariant.
+
+@noinline function _throw_inclusive_seam_mismatch(slot_name::String, d::Int)
+    throw(ArgumentError(
+        "CubicHermiteInterpolantND: $slot_name has unequal endpoints along axis $d " *
+        "but `bcs[$d]` is PeriodicBC{:inclusive}. Either fix the data or use " *
+        "`endpoint=:exclusive`.",
+    ))
+end
+
+# Compare slabs along axis `d`: array[..., 1, ...] vs array[..., end, ...].
+# Uses `selectdim` so the check works for any N without explicit dispatch.
+# Tolerance matches `_check_periodic_endpoints` for AbstractFloat in
+# `src/core/periodic.jl` (`atol = 8 * eps(T), rtol = sqrt(eps(T))`).
+function _check_inclusive_seam_one_axis(arr::AbstractArray{T}, d::Int) where {T}
+    n = size(arr, d)
+    n >= 2 || return true   # length-1 axis trivially "matches"
+    slab_first = selectdim(arr, d, 1)
+    slab_last  = selectdim(arr, d, n)
+    return _seam_isapprox(slab_first, slab_last, T)
+end
+
+# Tolerance-aware comparison matching `_check_periodic_endpoints` per-eltype.
+@inline function _seam_isapprox(a, b, ::Type{T}) where {T <: AbstractFloat}
+    return isapprox(a, b; atol = 8 * eps(T), rtol = sqrt(eps(T)))
+end
+@inline function _seam_isapprox(a, b, ::Type{Complex{T}}) where {T <: AbstractFloat}
+    return isapprox(a, b; atol = 8 * eps(T), rtol = sqrt(eps(T)))
+end
+@inline _seam_isapprox(a, b, ::Type) = a == b   # integer / duck-type fallback
+
+function _validate_inclusive_seams(
+        data::AbstractArray{Tv, N},
+        partials::HermitePartials{N, Tv, K},
+        bcs::Tuple{Vararg{AbstractBC, N}},
+    ) where {Tv, N, K}
+    @inbounds for d in 1:N
+        bcs[d] isa PeriodicBC{:inclusive} || continue
+        _check_inclusive_seam_one_axis(data, d) ||
+            _throw_inclusive_seam_mismatch("data", d)
+        for m in 1:K
+            _check_inclusive_seam_one_axis(partials.partials[m], d) ||
+                _throw_inclusive_seam_mismatch("partials[mask=$m]", d)
+        end
+    end
+    return nothing
+end
+
+# ========================================
+# Pack and extend
+# ========================================
+
+"""
+    _pack_and_extend_nodal_derivs(grids, data, partials, bcs)
+        -> (grids_ext, nodal_derivs, bcs_post_extend)
+
+In one pass:
+
+1. Compute post-extension axis lengths: `n_ext[d] = n[d] + 1` if
+   `bcs[d] isa PeriodicBC{:exclusive}`, else `n[d]`.
+2. Allocate `buf::Array{Tv, N+1}` of shape `(2^N, n_ext_1, …, n_ext_N)`.
+3. Fill `buf[1, …]` from `data` (mask=0 slot) and `buf[m+1, …]` from
+   `partials.partials[m]` for `m ∈ 1:2^N-1`. For each `:exclusive` axis,
+   append a wrap row equal to the first slice along that axis.
+4. Extend grids: Range → `range(first(g); step=step(g), length=n+1)`;
+   Vector → `vcat(g, x_end)`.
+5. Promote each `:exclusive` BC to `:extended` via `_bc_after_extend`.
+
+Returns the extended grids, the packed `_NodalDerivativesND{Tv, N, N+1}`,
+and the per-axis BC tuple post-extension.
+"""
+function _pack_and_extend_nodal_derivs(
+        grids::Tuple{Vararg{AbstractVector{Tg}, N}},
+        data::AbstractArray{Tv, N},
+        partials::HermitePartials{N, Tv, K},
+        bcs::Tuple{Vararg{AbstractBC, N}},
+    ) where {Tg, Tv, N, K}
+    # 1. Per-axis extension flag + final size
+    extended = ntuple(d -> bcs[d] isa PeriodicBC{:exclusive}, Val(N))
+    n_orig = size(data)
+    n_ext = ntuple(d -> extended[d] ? n_orig[d] + 1 : n_orig[d], Val(N))
+
+    # 2. Allocate packed buffer
+    K_total = 1 << N  # 2^N (data + all mixed partials)
+    NP1 = N + 1
+    buf = Array{Tv, NP1}(undef, K_total, n_ext...)
+
+    # 3. Fill slots — mask=0 from data, mask=m from partials.partials[m]
+    _fill_mask_slot_with_wrap!(buf, 1, data, extended)
+    @inbounds for m in 1:K
+        _fill_mask_slot_with_wrap!(buf, m + 1, partials.partials[m], extended)
+    end
+
+    nodal_derivs = _NodalDerivativesND{Tv, N, NP1}(buf)
+
+    # 4. Extend grids (Range type preserved when possible)
+    grids_ext = ntuple(Val(N)) do d
+        bc_d = bcs[d]
+        if bc_d isa PeriodicBC{:exclusive}
+            _extend_grid_one_axis(grids[d], bc_d, Tg)
+        else
+            grids[d]
+        end
+    end
+
+    # 5. Promote `:exclusive` BCs to `:extended`, with period materialized
+    #    from the extended grid span. Inclusive / NoBC pass through (with
+    #    period materialized for inclusive too, mirroring CubicInterpolantND).
+    bcs_post = ntuple(Val(N)) do d
+        bc_d = bcs[d]
+        bc_eff = _bc_after_extend(bc_d)
+        if bc_eff isa PeriodicBC
+            _with_resolved_period(bc_eff, last(grids_ext[d]) - first(grids_ext[d]))
+        else
+            bc_eff
+        end
+    end
+
+    return grids_ext, nodal_derivs, bcs_post
+end
+
+# Wrap-aware fill into one mask slot. After this call:
+# - `buf[slot, 1:n_src[1], …, 1:n_src[N]] == src`
+# - For every axis d with `extended[d]==true`, `buf[slot, …, n_ext_d, …]`
+#   along that axis duplicates `buf[slot, …, 1, …]` (wrap row).
+#
+# Sequential wrap is safe: after axis 1 wrap, the corner cell at index
+# `(n_ext_1, n_ext_2, …)` is reached by axis 2 wrap pulling from index
+# `(n_ext_1, 1, …)` which was already set from `src[1, …]`.
+function _fill_mask_slot_with_wrap!(
+        buf::AbstractArray{Tv, NP1},
+        slot::Int,
+        src::AbstractArray{Tv, N},
+        extended::NTuple{N, Bool},
+    ) where {Tv, NP1, N}
+    n_src = size(src)
+    # Copy `src` into `buf[slot, 1:n_src[1], …, 1:n_src[N]]`.
+    src_view = view(buf, slot, ntuple(d -> Base.OneTo(n_src[d]), Val(N))...)
+    src_view .= src
+
+    # For every extended axis, write wrap row.
+    mask_view = view(buf, slot, ntuple(_ -> Colon(), Val(N))...)
+    @inbounds for d in 1:N
+        if extended[d]
+            n_ext_d = size(mask_view, d)
+            last_slab  = selectdim(mask_view, d, n_ext_d)
+            first_slab = selectdim(mask_view, d, 1)
+            last_slab .= first_slab
+        end
+    end
+    return buf
+end
+
+# Per-axis grid extension for an `:exclusive` axis. Range-preserving for
+# AbstractRange inputs; vcat-based for Vector inputs.
+@inline function _extend_grid_one_axis(
+        grid::AbstractVector{Tg}, bc::PeriodicBC{:exclusive}, ::Type{Tg},
+    ) where {Tg}
+    period = _resolve_exclusive_period(grid, bc)
+    _validate_exclusive_period(grid, period)
+    x_end = first(grid) + Tg(period)
+    last(grid) < x_end ||
+        throw(ArgumentError(
+            "CubicHermiteInterpolantND: exclusive-axis grid last point $(last(grid)) " *
+            "≥ extended endpoint $(x_end); check the period.",
+        ))
+    if grid isa AbstractRange
+        return range(first(grid); step = step(grid), length = length(grid) + 1)
+    else
+        return vcat(grid, x_end)
+    end
+end

--- a/src/hermite/nd/hermite_nd_build.jl
+++ b/src/hermite/nd/hermite_nd_build.jl
@@ -75,42 +75,72 @@ end
     ))
 end
 
-# Compare slabs along axis `d`: array[..., 1, ...] vs array[..., end, ...].
-# Uses `selectdim` so the check works for any N without explicit dispatch.
-# Tolerance matches `_check_periodic_endpoints` for AbstractFloat in
-# `src/core/periodic.jl` (`atol = 8 * eps(T), rtol = sqrt(eps(T))`).
-function _check_inclusive_seam_one_axis(arr::AbstractArray{T}, d::Int) where {T}
-    n = size(arr, d)
-    n >= 2 || return true   # length-1 axis trivially "matches"
-    slab_first = selectdim(arr, d, 1)
-    slab_last  = selectdim(arr, d, n)
-    return _seam_isapprox(slab_first, slab_last, T)
+# Per-eltype tolerance matching `_check_periodic_endpoints` in
+# `src/core/periodic.jl` (`atol = 8 * eps(T), rtol = sqrt(eps(T))` for floats).
+@inline _seam_atol(::Type{T}) where {T <: AbstractFloat} = 8 * eps(T)
+@inline _seam_atol(::Type{Complex{T}}) where {T <: AbstractFloat} = 8 * eps(T)
+@inline _seam_atol(::Type) = false   # integer / duck-type fallback → exact ==
+@inline _seam_rtol(::Type{T}) where {T <: AbstractFloat} = sqrt(eps(T))
+@inline _seam_rtol(::Type{Complex{T}}) where {T <: AbstractFloat} = sqrt(eps(T))
+@inline _seam_rtol(::Type) = false
+
+# Element-wise inclusive-seam check along compile-time axis `d`. Iterates
+# the other N-1 axes with a `CartesianIndices` loop; the `d`-th index is
+# fixed at `1` (first) vs. `n_d` (last). Comparing scalars one-by-one
+# avoids the view/broadcast allocation that `selectdim(arr, ::Int, ...)`
+# would incur from the Union-return `ntuple` over a runtime `d`.
+@inline function _check_inclusive_seam_along!(
+        arr::AbstractArray{Tv, N}, ::Val{d},
+    ) where {Tv, N, d}
+    n_d = size(arr, d)
+    n_d >= 2 || return true
+    atol = _seam_atol(Tv)
+    rtol = _seam_rtol(Tv)
+    other_sizes = ntuple(Val(N)) do i
+        i == d ? 1 : size(arr, i)
+    end
+    @inbounds for I in CartesianIndices(other_sizes)
+        idx_first = ntuple(Val(N)) do i
+            i == d ? 1   : I[i]
+        end
+        idx_last = ntuple(Val(N)) do i
+            i == d ? n_d : I[i]
+        end
+        a = arr[idx_first...]
+        b = arr[idx_last...]
+        if Tv <: AbstractFloat || Tv <: Complex{<:AbstractFloat}
+            isapprox(a, b; atol = atol, rtol = rtol) || return false
+        else
+            a == b || return false
+        end
+    end
+    return true
 end
 
-# Tolerance-aware comparison matching `_check_periodic_endpoints` per-eltype.
-@inline function _seam_isapprox(a, b, ::Type{T}) where {T <: AbstractFloat}
-    return isapprox(a, b; atol = 8 * eps(T), rtol = sqrt(eps(T)))
-end
-@inline function _seam_isapprox(a, b, ::Type{Complex{T}}) where {T <: AbstractFloat}
-    return isapprox(a, b; atol = 8 * eps(T), rtol = sqrt(eps(T)))
-end
-@inline _seam_isapprox(a, b, ::Type) = a == b   # integer / duck-type fallback
-
-function _validate_inclusive_seams(
+@generated function _validate_inclusive_seams(
         data::AbstractArray{Tv, N},
         partials::HermitePartials{N, Tv, K},
         bcs::Tuple{Vararg{AbstractBC, N}},
     ) where {Tv, N, K}
-    @inbounds for d in 1:N
-        bcs[d] isa PeriodicBC{:inclusive} || continue
-        _check_inclusive_seam_one_axis(data, d) ||
-            _throw_inclusive_seam_mismatch("data", d)
-        for m in 1:K
-            _check_inclusive_seam_one_axis(partials.partials[m], d) ||
-                _throw_inclusive_seam_mismatch("partials[mask=$m]", d)
-        end
+    # Compile-time unroll over data axes. For each axis `d`, if the BC is
+    # `PeriodicBC{:inclusive}` we run `_check_inclusive_seam_along!` on the
+    # data array and every stored partial. Runtime branch on the bc type is
+    # type-stable (single tuple element type per slot), so the body
+    # specializes per-axis and the per-element index tuples stay inferable.
+    blocks = Expr[]
+    for d in 1:N
+        push!(blocks, quote
+            if bcs[$d] isa PeriodicBC{:inclusive}
+                _check_inclusive_seam_along!(data, Val($d)) ||
+                    _throw_inclusive_seam_mismatch("data", $d)
+                @inbounds for m in 1:K
+                    _check_inclusive_seam_along!(partials.partials[m], Val($d)) ||
+                        _throw_inclusive_seam_mismatch("partials[mask=$m]", $d)
+                end
+            end
+        end)
     end
-    return nothing
+    return Expr(:block, blocks..., :(return nothing))
 end
 
 # ========================================
@@ -205,17 +235,47 @@ function _fill_mask_slot_with_wrap!(
     src_view = view(buf, slot, ntuple(d -> Base.OneTo(n_src[d]), Val(N))...)
     src_view .= src
 
-    # For every extended axis, write wrap row.
-    mask_view = view(buf, slot, ntuple(_ -> Colon(), Val(N))...)
-    @inbounds for d in 1:N
-        if extended[d]
-            n_ext_d = size(mask_view, d)
-            last_slab  = selectdim(mask_view, d, n_ext_d)
-            first_slab = selectdim(mask_view, d, 1)
-            last_slab .= first_slab
-        end
-    end
+    # Wrap rows for every `:exclusive` axis (no-op if none). Routed through
+    # a `@generated` unroll so each per-axis `d` is a compile-time Val, the
+    # SubArray index tuples are inferable, and the views are stack-elidable.
+    # Mirrors `_extend_all_slices!` in core/periodic.jl.
+    _wrap_all_axes_in_buf_slot!(buf, slot, extended, Val(N))
     return buf
+end
+
+# Apply ONE wrap row along data-axis `d` (= buf-dim `d+1`). Compile-time `d`
+# via Val keeps the index-tuple `ntuple` closures inferable, so the SubArray
+# headers produced by `view(buf, slot, ...)` are stack-allocated.
+@inline function _wrap_one_axis_in_buf_slot!(
+        buf::AbstractArray{Tv, NP1}, slot::Int,
+        extended::NTuple{N, Bool},
+        ::Val{d}, ::Val{N},
+    ) where {Tv, NP1, N, d}
+    extended[d] || return nothing
+    n_buf_d = size(buf, d + 1)
+    src_inds = ntuple(Val(N)) do i
+        i == d ? (1:1) : (1:size(buf, i + 1))
+    end
+    dst_inds = ntuple(Val(N)) do i
+        i == d ? (n_buf_d:n_buf_d) : (1:size(buf, i + 1))
+    end
+    copyto!(view(buf, slot, dst_inds...), view(buf, slot, src_inds...))
+    return nothing
+end
+
+# Compile-time unroll of per-axis wrap calls. Emits N straight-line dispatches
+# to `_wrap_one_axis_in_buf_slot!` with literal `Val($d)`. The runtime
+# `extended[d] || return nothing` short-circuit then compiles to a constant
+# branch when the caller's `extended` tuple is constant-folded.
+@generated function _wrap_all_axes_in_buf_slot!(
+        buf::AbstractArray{Tv, NP1}, slot::Int,
+        extended::NTuple{N, Bool}, ::Val{N},
+    ) where {Tv, NP1, N}
+    calls = [
+        :(_wrap_one_axis_in_buf_slot!(buf, slot, extended, Val($d), Val(N)))
+            for d in 1:N
+    ]
+    return Expr(:block, calls..., :(return nothing))
 end
 
 # Per-axis grid extension for an `:exclusive` axis. Range-preserving for
@@ -235,5 +295,85 @@ end
         return range(first(grid); step = step(grid), length = length(grid) + 1)
     else
         return vcat(grid, x_end)
+    end
+end
+
+# ========================================
+# Pool-based pack + extend (one-shot zero-alloc backend)
+# ========================================
+#
+# Mirrors `_pack_and_extend_nodal_derivs` but uses `acquire!(pool, ...)` for
+# the packed buffer and any Vector-grid extension. Returns the same triple
+# (grids_ext, packed_buf, bcs_post) where `packed_buf` is a *pool-owned*
+# `Array{Tv, N+1}` of shape `(2^N, n_ext_1, …, n_ext_N)`.
+#
+# Safety: the returned `packed_buf` must NOT escape the enclosing
+# `@with_pool` scope — it is reclaimed on pool rewind. Caller is the
+# `@with_pool`-decorated oneshot entry, which only uses the buffer in-line
+# through `_eval_nd_cell` before returning a scalar value.
+@inline function _pack_and_extend_nodal_derivs_pooled(
+        pool::AbstractArrayPool,
+        grids::Tuple{Vararg{AbstractVector{Tg}, N}},
+        data::AbstractArray{Tv, N},
+        partials::HermitePartials{N, Tv, K},
+        bcs::Tuple{Vararg{AbstractBC, N}},
+    ) where {Tg, Tv, N, K}
+    extended = ntuple(d -> bcs[d] isa PeriodicBC{:exclusive}, Val(N))
+    n_orig = size(data)
+    n_ext = ntuple(d -> extended[d] ? n_orig[d] + 1 : n_orig[d], Val(N))
+
+    K_total = 1 << N
+    buf = acquire!(pool, Tv, (K_total, n_ext...))
+
+    _fill_mask_slot_with_wrap!(buf, 1, data, extended)
+    @inbounds for m in 1:K
+        _fill_mask_slot_with_wrap!(buf, m + 1, partials.partials[m], extended)
+    end
+
+    # `map` over tuples dispatches per-element with concrete (grid_d, bc_d)
+    # types, so the `isa PeriodicBC{:exclusive}` branch specializes
+    # per-axis and the return type is inferred without Union boxing. The
+    # `ntuple(d -> ...)` form with `bcs[d]` runtime indexing into a
+    # heterogeneous tuple would otherwise box the Union (~5 KB/call).
+    # See MEMORY.md "ND Constructor Inferrability Pattern".
+    grids_ext = map(grids, bcs) do grid_d, bc_d
+        bc_d isa PeriodicBC{:exclusive} ?
+            _extend_grid_one_axis_pooled(pool, grid_d, bc_d, Tg) :
+            grid_d
+    end
+
+    bcs_post = map(bcs, grids_ext) do bc_d, grid_ext_d
+        bc_eff = _bc_after_extend(bc_d)
+        bc_eff isa PeriodicBC ?
+            _with_resolved_period(bc_eff, last(grid_ext_d) - first(grid_ext_d)) :
+            bc_eff
+    end
+
+    return grids_ext, buf, bcs_post
+end
+
+# Pool-based per-axis grid extension. Range case preserves Range type
+# (alloc-free); Vector case acquires a pool buffer and copies + writes the
+# wrap endpoint (mirrors `_PoolGridExtender` from core/periodic.jl).
+@inline function _extend_grid_one_axis_pooled(
+        pool::AbstractArrayPool,
+        grid::AbstractVector{Tg}, bc::PeriodicBC{:exclusive}, ::Type{Tg},
+    ) where {Tg}
+    period = _resolve_exclusive_period(grid, bc)
+    _validate_exclusive_period(grid, period)
+    x_end = first(grid) + Tg(period)
+    last(grid) < x_end ||
+        throw(ArgumentError(
+            "CubicHermiteInterpolantND: exclusive-axis grid last point $(last(grid)) " *
+            "≥ extended endpoint $(x_end); check the period.",
+        ))
+    if grid isa AbstractRange
+        return range(first(grid); step = step(grid), length = length(grid) + 1)
+    else
+        n = length(grid)
+        g_ext = acquire!(pool, Tg, n + 1)
+        @inbounds copyto!(g_ext, 1, grid, 1, n)
+        @inbounds g_ext[n + 1] = x_end
+        return g_ext
     end
 end

--- a/src/hermite/nd/hermite_nd_build.jl
+++ b/src/hermite/nd/hermite_nd_build.jl
@@ -238,16 +238,14 @@ end
 # A naïve slot-major fill `buf[slot, :, :, ...] .= src` is a stride-`2^N`
 # write pattern, repeated `2^N` times — every cache line of `buf` is touched
 # `2^N` times (once per slot) with only one of `2^N` writes landing on it
-# per pass. For grids that spill the L1 (≥40 KB packed buffer at 100×100
-# Float64 N=2), the line is re-fetched on each subsequent pass, costing
-# multiple memory round-trips per cache line.
+# per pass. For grids large enough to spill the L1 cache, the line is
+# re-fetched on each subsequent pass, costing multiple memory round-trips
+# per cache line.
 #
 # Node-major with the slot loop unrolled at compile time fixes this: each
 # iteration writes all `2^N` partials at one grid node — those writes are
 # *contiguous* (mask is the fastest-iterating axis), so one cache line is
-# fully populated in a single burst. Empirically ~2.7× faster than
-# slot-major at 100×100 + larger, and saturates single-channel DDR4
-# bandwidth (~5.4 GW/s Float64).
+# fully populated in a single burst before moving on.
 #
 # Reads come from `K_total = 2^N` separate source arrays (data + every
 # user partial) streamed linearly — the hardware prefetcher handles the

--- a/src/hermite/nd/hermite_nd_build.jl
+++ b/src/hermite/nd/hermite_nd_build.jl
@@ -3,17 +3,15 @@
 # ========================================
 #
 # Pack data + user-supplied partials into `_NodalDerivativesND`, extending
-# grid + every stored array along each `PeriodicBC{:exclusive}` axis. Mirrors
-# the BC-promotion pattern used by `_prepare_periodic_nd` (`:exclusive →
-# :extended`).
+# grid + every stored array along each `PeriodicBC{:exclusive}` axis
+# (`:exclusive → :extended`).
 #
-# Phase 1a BC policy: only `NoBC`, `PeriodicBC{:inclusive}`,
-# `PeriodicBC{:exclusive}` are accepted. Other BCs (BCPair, NaturalBC, etc.)
-# affect partial *derivation* — irrelevant here because the user supplies
+# Only `NoBC` / `PeriodicBC{:inclusive,:exclusive}` are accepted: other BC
+# families shape partial *derivation*, which is moot when the user supplies
 # every partial directly.
 
 # ========================================
-# BC validation (Phase 1a)
+# BC validation
 # ========================================
 
 @noinline function _throw_unsupported_hermite_nd_bc(d::Int, bc)
@@ -81,8 +79,8 @@ end
     )
 end
 
-# Per-eltype tolerance matching `_check_periodic_endpoints` in
-# `src/core/periodic.jl` (`atol = 8 * eps(T), rtol = sqrt(eps(T))` for floats).
+# Per-eltype seam tolerance: 8·eps atol, sqrt(eps) rtol for floats; exact
+# `==` (atol/rtol = false) for integer / duck types.
 @inline _seam_atol(::Type{T}) where {T <: AbstractFloat} = 8 * eps(T)
 @inline _seam_atol(::Type{Complex{T}}) where {T <: AbstractFloat} = 8 * eps(T)
 @inline _seam_atol(::Type) = false   # integer / duck-type fallback → exact ==
@@ -90,11 +88,8 @@ end
 @inline _seam_rtol(::Type{Complex{T}}) where {T <: AbstractFloat} = sqrt(eps(T))
 @inline _seam_rtol(::Type) = false
 
-# Element-wise inclusive-seam check along compile-time axis `d`. Iterates
-# the other N-1 axes with a `CartesianIndices` loop; the `d`-th index is
-# fixed at `1` (first) vs. `n_d` (last). Comparing scalars one-by-one
-# avoids the view/broadcast allocation that `selectdim(arr, ::Int, ...)`
-# would incur from the Union-return `ntuple` over a runtime `d`.
+# Element-wise inclusive-seam check along compile-time axis `d`: compare the
+# first vs. last slice (scalar-by-scalar, alloc-free) over the other N-1 axes.
 @inline function _check_inclusive_seam_along!(
         arr::AbstractArray{Tv, N}, ::Val{d},
     ) where {Tv, N, d}
@@ -128,11 +123,8 @@ end
         partials::HermitePartials{N, Tv, K},
         bcs::Tuple{Vararg{AbstractBC, N}},
     ) where {Tv, N, K}
-    # Compile-time unroll over data axes. For each axis `d`, if the BC is
-    # `PeriodicBC{:inclusive}` we run `_check_inclusive_seam_along!` on the
-    # data array and every stored partial. Runtime branch on the bc type is
-    # type-stable (single tuple element type per slot), so the body
-    # specializes per-axis and the per-element index tuples stay inferable.
+    # Unroll over axes; for each `:inclusive` axis check the data array and
+    # every stored partial.
     blocks = Expr[]
     for d in 1:N
         push!(
@@ -157,22 +149,12 @@ end
 
 """
     _pack_and_extend_nodal_derivs(grids, data, partials, bcs)
-        -> (grids_ext, nodal_derivs, bcs_post_extend)
+        -> (grids_ext, nodal_derivs, bcs_post)
 
-In one pass:
-
-1. Compute post-extension axis lengths: `n_ext[d] = n[d] + 1` if
-   `bcs[d] isa PeriodicBC{:exclusive}`, else `n[d]`.
-2. Allocate `buf::Array{Tv, N+1}` of shape `(2^N, n_ext_1, …, n_ext_N)`.
-3. Fill `buf[1, …]` from `data` (mask=0 slot) and `buf[m+1, …]` from
-   `partials.partials[m]` for `m ∈ 1:2^N-1`. For each `:exclusive` axis,
-   append a wrap row equal to the first slice along that axis.
-4. Extend grids: Range → `range(first(g); step=step(g), length=n+1)`;
-   Vector → `vcat(g, x_end)`.
-5. Promote each `:exclusive` BC to `:extended` via `_bc_after_extend`.
-
-Returns the extended grids, the packed `_NodalDerivativesND{Tv, N, N+1}`,
-and the per-axis BC tuple post-extension.
+Pack `data` + the `2^N-1` partials into a `(2^N, n_ext...)` buffer, append a
+wrap row along each `:exclusive` axis, extend those grids, and promote their
+BCs `:exclusive → :extended`. Heap-allocating; see the pooled twin for the
+zero-alloc one-shot path.
 """
 function _pack_and_extend_nodal_derivs(
         grids::Tuple{Vararg{AbstractVector{Tg}, N}},
@@ -197,66 +179,36 @@ function _pack_and_extend_nodal_derivs(
 
     nodal_derivs = _NodalDerivativesND{Tv, N, NP1}(buf)
 
-    # 4. Extend grids (Range type preserved when possible)
-    grids_ext = ntuple(Val(N)) do d
-        bc_d = bcs[d]
-        if bc_d isa PeriodicBC{:exclusive}
-            _extend_grid_one_axis(grids[d], bc_d, Tg)
-        else
-            grids[d]
-        end
+    # 4. Extend grids (Range type preserved). `map` is used over
+    #    `ntuple(d -> ...bcs[d]...)` so each axis dispatches with a concrete
+    #    `bc_d` type — runtime-indexing the heterogeneous `bcs` tuple would
+    #    box the Union into the result.
+    grids_ext = map(grids, bcs) do grid_d, bc_d
+        bc_d isa PeriodicBC{:exclusive} ? _extend_grid_one_axis(grid_d, bc_d, Tg) : grid_d
     end
 
-    # 5. Promote `:exclusive` BCs to `:extended`, with period materialized
-    #    from the extended grid span. Inclusive / NoBC pass through (with
-    #    period materialized for inclusive too, mirroring CubicInterpolantND).
-    bcs_post = ntuple(Val(N)) do d
-        bc_d = bcs[d]
+    # 5. Promote `:exclusive` BCs to `:extended` and materialize the period
+    #    from the extended grid span (inclusive period materialized too).
+    bcs_post = map(bcs, grids_ext) do bc_d, grid_ext_d
         bc_eff = _bc_after_extend(bc_d)
-        if bc_eff isa PeriodicBC
-            _with_resolved_period(bc_eff, last(grids_ext[d]) - first(grids_ext[d]))
-        else
+        bc_eff isa PeriodicBC ?
+            _with_resolved_period(bc_eff, last(grid_ext_d) - first(grid_ext_d)) :
             bc_eff
-        end
     end
 
     return grids_ext, nodal_derivs, bcs_post
 end
 
-# Wrap-aware fill into one mask slot. After this call:
-# - `buf[slot, 1:n_src[1], …, 1:n_src[N]] == src`
-# - For every axis d with `extended[d]==true`, `buf[slot, …, n_ext_d, …]`
-#   along that axis duplicates `buf[slot, …, 1, …]` (wrap row).
-#
-# Sequential wrap is safe: after axis 1 wrap, the corner cell at index
-# `(n_ext_1, n_ext_2, …)` is reached by axis 2 wrap pulling from index
-# `(n_ext_1, 1, …)` which was already set from `src[1, …]`.
 # ========================================
 # Packed-buffer fill (node-major @generated unroll)
 # ========================================
 #
-# A naïve slot-major fill `buf[slot, :, :, ...] .= src` is a stride-`2^N`
-# write pattern, repeated `2^N` times — every cache line of `buf` is touched
-# `2^N` times (once per slot) with only one of `2^N` writes landing on it
-# per pass. For grids large enough to spill the L1 cache, the line is
-# re-fetched on each subsequent pass, costing multiple memory round-trips
-# per cache line.
-#
-# Node-major with the slot loop unrolled at compile time fixes this: each
-# iteration writes all `2^N` partials at one grid node — those writes are
-# *contiguous* (mask is the fastest-iterating axis), so one cache line is
-# fully populated in a single burst before moving on.
-#
-# Reads come from `K_total = 2^N` separate source arrays (data + every
-# user partial) streamed linearly — the hardware prefetcher handles the
-# few-stream pattern easily.
-
-# Write the user-source region into `buf[:, 1:n_1, ..., 1:n_N]`. The
-# `@generated` body emits the `K_total` per-slot writes as straight-line
-# code inside the column-major (innermost = first data axis) loop nest,
-# avoiding the runtime tuple-indexing that would otherwise box the
-# heterogeneous-source dispatch. Wrap rows for `:exclusive` axes are
-# added separately via `_wrap_all_axes_all_slots!`.
+# Slot-major (`buf[slot, :, …] .= src`, 2^N passes) re-touches every cache
+# line once per slot; for L1-spilling grids each line is re-fetched 2^N
+# times. Node-major writes all 2^N partials at one node contiguously (mask
+# is dim 1, the fast axis), filling each cache line in one burst. The slot
+# loop is unrolled at compile time so each source array indexes with a
+# concrete element type. Wrap rows for `:exclusive` axes are added after.
 @inline function _fill_packed_src_region!(
         buf::AbstractArray{Tv, NP1},
         sources::Tuple{Vararg{AbstractArray{Tv, N}}},
@@ -269,16 +221,14 @@ end
         sources::Tuple{Vararg{AbstractArray{Tv, N}, K}},
         ::Val{N},
     ) where {Tv, NP1, N, K}
-    # Per-slot scalar writes at one node. `sources[$k]` is a literal tuple
-    # access in the AST, so each call dispatches with a concrete element
-    # type at codegen — no boxing.
+    # Per-slot scalar writes at one node; literal `sources[$k]` access keeps
+    # each write concretely typed.
     loop_vars = [Symbol(:i_, d) for d in 1:N]
     inner = Expr(:block)
     for k in 1:K
         push!(inner.args, :(@inbounds buf[$k, $(loop_vars...)] = sources[$k][$(loop_vars...)]))
     end
-    # Wrap in nested for loops; innermost = i_1 (column-major fast axis on
-    # both src and buf since mask is dim 1 of buf).
+    # Nest loops with i_1 innermost (column-major fast axis of buf).
     body = inner
     for d in 1:N
         body = quote
@@ -298,11 +248,8 @@ end
 # Wrap rows for `:exclusive` axes — all-slots at once
 # ========================================
 #
-# For each axis `d` with `extended[d] == true`, the wrap row at index
-# `n_buf_d` is filled from index `1` across **every** mask slot
-# simultaneously — `buf[:, ..., n_d, ...] = buf[:, ..., 1, ...]`. One
-# `copyto!` covers all `K_total = 2^N` slots at once, which is correct
-# (each slot wraps the same way) and faster than per-slot iteration.
+# For each `extended[d]` axis, copy slice 1 → the wrap row across all 2^N
+# mask slots in one `copyto!` (every slot wraps identically).
 @inline function _wrap_one_axis_all_slots!(
         buf::AbstractArray{Tv, NP1},
         extended::NTuple{N, Bool},
@@ -320,8 +267,7 @@ end
     return nothing
 end
 
-# Compile-time unroll over data axes. Same `@inline + @generated` pattern as
-# `_extend_all_slices!` in core/periodic.jl.
+# Compile-time unroll over data axes.
 @generated function _wrap_all_axes_all_slots!(
         buf::AbstractArray{Tv, NP1},
         extended::NTuple{N, Bool}, ::Val{N},
@@ -359,15 +305,12 @@ end
 # Pool-based pack + extend (one-shot zero-alloc backend)
 # ========================================
 #
-# Mirrors `_pack_and_extend_nodal_derivs` but uses `acquire!(pool, ...)` for
-# the packed buffer and any Vector-grid extension. Returns the same triple
-# (grids_ext, packed_buf, bcs_post) where `packed_buf` is a *pool-owned*
-# `Array{Tv, N+1}` of shape `(2^N, n_ext_1, …, n_ext_N)`.
+# `_pack_and_extend_nodal_derivs` with `acquire!(pool, ...)` for the packed
+# buffer and any Vector-grid extension.
 #
-# Safety: the returned `packed_buf` must NOT escape the enclosing
-# `@with_pool` scope — it is reclaimed on pool rewind. Caller is the
-# `@with_pool`-decorated oneshot entry, which only uses the buffer in-line
-# through `_eval_nd_cell` before returning a scalar value.
+# SAFETY: the returned `packed_buf` is pool-owned and reclaimed on `@with_pool`
+# rewind — it must NOT escape that scope. The caller consumes it in-line
+# through `_eval_nd_cell` and returns a scalar.
 @inline function _pack_and_extend_nodal_derivs_pooled(
         pool::AbstractArrayPool,
         grids::Tuple{Vararg{AbstractVector{Tg}, N}},
@@ -385,12 +328,8 @@ end
     _fill_packed_src_region!(buf, (data, partials.partials...))
     _wrap_all_axes_all_slots!(buf, extended, Val(N))
 
-    # `map` over tuples dispatches per-element with concrete (grid_d, bc_d)
-    # types, so the `isa PeriodicBC{:exclusive}` branch specializes
-    # per-axis and the return type is inferred without Union boxing. The
-    # `ntuple(d -> ...)` form with `bcs[d]` runtime indexing into a
-    # heterogeneous tuple would otherwise box the Union (~5 KB/call).
-    # See MEMORY.md "ND Constructor Inferrability Pattern".
+    # `map` (not `ntuple` over `bcs[d]`) so each axis dispatches concretely
+    # without boxing the Union — see the heap twin.
     grids_ext = map(grids, bcs) do grid_d, bc_d
         bc_d isa PeriodicBC{:exclusive} ?
             _extend_grid_one_axis_pooled(pool, grid_d, bc_d, Tg) :
@@ -408,8 +347,7 @@ end
 end
 
 # Pool-based per-axis grid extension. Range case preserves Range type
-# (alloc-free); Vector case acquires a pool buffer and copies + writes the
-# wrap endpoint (mirrors `_PoolGridExtender` from core/periodic.jl).
+# (alloc-free); Vector case acquires a pool buffer + writes the wrap endpoint.
 @inline function _extend_grid_one_axis_pooled(
         pool::AbstractArrayPool,
         grid::AbstractVector{Tg}, bc::PeriodicBC{:exclusive}, ::Type{Tg},

--- a/src/hermite/nd/hermite_nd_build.jl
+++ b/src/hermite/nd/hermite_nd_build.jl
@@ -17,13 +17,15 @@
 # ========================================
 
 @noinline function _throw_unsupported_hermite_nd_bc(d::Int, bc)
-    throw(ArgumentError(
-        "CubicHermiteInterpolantND (Phase 1a): bc[$d] = $(bc) is unsupported. " *
-        "Only `NoBC()`, `PeriodicBC(...; endpoint=:inclusive)`, and " *
-        "`PeriodicBC(...; endpoint=:exclusive)` are accepted because user " *
-        "partials supersede BC-derived ones. Use the auto-slope methods " *
-        "(`pchip_interp`, `cardinal_interp`, `akima_interp`) for richer BC families.",
-    ))
+    throw(
+        ArgumentError(
+            "CubicHermiteInterpolantND (Phase 1a): bc[$d] = $(bc) is unsupported. " *
+                "Only `NoBC()`, `PeriodicBC(...; endpoint=:inclusive)`, and " *
+                "`PeriodicBC(...; endpoint=:exclusive)` are accepted because user " *
+                "partials supersede BC-derived ones. Use the auto-slope methods " *
+                "(`pchip_interp`, `cardinal_interp`, `akima_interp`) for richer BC families.",
+        )
+    )
 end
 
 @inline _is_hermite_nd_bc_allowed(::NoBC) = true
@@ -42,10 +44,12 @@ end
 # ========================================
 
 @noinline function _throw_data_partial_size_mismatch(sz_data, mask::Int, sz_part)
-    throw(DimensionMismatch(
-        "CubicHermiteInterpolantND: data size $(sz_data) ≠ partial size $(sz_part) " *
-        "for mask=$mask. data and every partial array must share `size`.",
-    ))
+    throw(
+        DimensionMismatch(
+            "CubicHermiteInterpolantND: data size $(sz_data) ≠ partial size $(sz_part) " *
+                "for mask=$mask. data and every partial array must share `size`.",
+        )
+    )
 end
 
 function _validate_partial_sizes(
@@ -68,11 +72,13 @@ end
 # build time so downstream search/eval can assume the invariant.
 
 @noinline function _throw_inclusive_seam_mismatch(slot_name::String, d::Int)
-    throw(ArgumentError(
-        "CubicHermiteInterpolantND: $slot_name has unequal endpoints along axis $d " *
-        "but `bcs[$d]` is PeriodicBC{:inclusive}. Either fix the data or use " *
-        "`endpoint=:exclusive`.",
-    ))
+    throw(
+        ArgumentError(
+            "CubicHermiteInterpolantND: $slot_name has unequal endpoints along axis $d " *
+                "but `bcs[$d]` is PeriodicBC{:inclusive}. Either fix the data or use " *
+                "`endpoint=:exclusive`.",
+        )
+    )
 end
 
 # Per-eltype tolerance matching `_check_periodic_endpoints` in
@@ -101,7 +107,7 @@ end
     end
     @inbounds for I in CartesianIndices(other_sizes)
         idx_first = ntuple(Val(N)) do i
-            i == d ? 1   : I[i]
+            i == d ? 1 : I[i]
         end
         idx_last = ntuple(Val(N)) do i
             i == d ? n_d : I[i]
@@ -129,16 +135,18 @@ end
     # specializes per-axis and the per-element index tuples stay inferable.
     blocks = Expr[]
     for d in 1:N
-        push!(blocks, quote
-            if bcs[$d] isa PeriodicBC{:inclusive}
-                _check_inclusive_seam_along!(data, Val($d)) ||
-                    _throw_inclusive_seam_mismatch("data", $d)
-                @inbounds for m in 1:K
-                    _check_inclusive_seam_along!(partials.partials[m], Val($d)) ||
-                        _throw_inclusive_seam_mismatch("partials[mask=$m]", $d)
+        push!(
+            blocks, quote
+                if bcs[$d] isa PeriodicBC{:inclusive}
+                    _check_inclusive_seam_along!(data, Val($d)) ||
+                        _throw_inclusive_seam_mismatch("data", $d)
+                    @inbounds for m in 1:K
+                        _check_inclusive_seam_along!(partials.partials[m], Val($d)) ||
+                            _throw_inclusive_seam_mismatch("partials[mask=$m]", $d)
+                    end
                 end
             end
-        end)
+        )
     end
     return Expr(:block, blocks..., :(return nothing))
 end
@@ -336,10 +344,12 @@ end
     _validate_exclusive_period(grid, period)
     x_end = first(grid) + Tg(period)
     last(grid) < x_end ||
-        throw(ArgumentError(
+        throw(
+        ArgumentError(
             "CubicHermiteInterpolantND: exclusive-axis grid last point $(last(grid)) " *
-            "≥ extended endpoint $(x_end); check the period.",
-        ))
+                "≥ extended endpoint $(x_end); check the period.",
+        )
+    )
     if grid isa AbstractRange
         return range(first(grid); step = step(grid), length = length(grid) + 1)
     else
@@ -410,10 +420,12 @@ end
     _validate_exclusive_period(grid, period)
     x_end = first(grid) + Tg(period)
     last(grid) < x_end ||
-        throw(ArgumentError(
+        throw(
+        ArgumentError(
             "CubicHermiteInterpolantND: exclusive-axis grid last point $(last(grid)) " *
-            "≥ extended endpoint $(x_end); check the period.",
-        ))
+                "≥ extended endpoint $(x_end); check the period.",
+        )
+    )
     if grid isa AbstractRange
         return range(first(grid); step = step(grid), length = length(grid) + 1)
     else

--- a/src/hermite/nd/hermite_nd_build.jl
+++ b/src/hermite/nd/hermite_nd_build.jl
@@ -17,7 +17,7 @@
 @noinline function _throw_unsupported_hermite_nd_bc(d::Int, bc)
     throw(
         ArgumentError(
-            "CubicHermiteInterpolantND (Phase 1a): bc[$d] = $(bc) is unsupported. " *
+            "CubicHermiteInterpolantND: bc[$d] = $(bc) is unsupported. " *
                 "Only `NoBC()`, `PeriodicBC(...; endpoint=:inclusive)`, and " *
                 "`PeriodicBC(...; endpoint=:exclusive)` are accepted because user " *
                 "partials supersede BC-derived ones. Use the auto-slope methods " *
@@ -30,7 +30,7 @@ end
 @inline _is_hermite_nd_bc_allowed(::PeriodicBC) = true
 @inline _is_hermite_nd_bc_allowed(::AbstractBC) = false
 
-function _validate_hermite_nd_bcs_phase1a(bcs::Tuple{Vararg{AbstractBC, N}}) where {N}
+function _validate_hermite_nd_bcs(bcs::Tuple{Vararg{AbstractBC, N}}) where {N}
     @inbounds for d in 1:N
         _is_hermite_nd_bc_allowed(bcs[d]) || _throw_unsupported_hermite_nd_bc(d, bcs[d])
     end

--- a/src/hermite/nd/hermite_nd_build.jl
+++ b/src/hermite/nd/hermite_nd_build.jl
@@ -182,11 +182,10 @@ function _pack_and_extend_nodal_derivs(
     NP1 = N + 1
     buf = Array{Tv, NP1}(undef, K_total, n_ext...)
 
-    # 3. Fill slots — mask=0 from data, mask=m from partials.partials[m]
-    _fill_mask_slot_with_wrap!(buf, 1, data, extended)
-    @inbounds for m in 1:K
-        _fill_mask_slot_with_wrap!(buf, m + 1, partials.partials[m], extended)
-    end
+    # 3. Node-major fill — all 2^N slots at each node written in one burst.
+    #    Wrap rows for `:exclusive` axes are filled separately afterwards.
+    _fill_packed_src_region!(buf, (data, partials.partials...))
+    _wrap_all_axes_all_slots!(buf, extended, Val(N))
 
     nodal_derivs = _NodalDerivativesND{Tv, N, NP1}(buf)
 
@@ -224,30 +223,82 @@ end
 # Sequential wrap is safe: after axis 1 wrap, the corner cell at index
 # `(n_ext_1, n_ext_2, …)` is reached by axis 2 wrap pulling from index
 # `(n_ext_1, 1, …)` which was already set from `src[1, …]`.
-function _fill_mask_slot_with_wrap!(
-        buf::AbstractArray{Tv, NP1},
-        slot::Int,
-        src::AbstractArray{Tv, N},
-        extended::NTuple{N, Bool},
-    ) where {Tv, NP1, N}
-    n_src = size(src)
-    # Copy `src` into `buf[slot, 1:n_src[1], …, 1:n_src[N]]`.
-    src_view = view(buf, slot, ntuple(d -> Base.OneTo(n_src[d]), Val(N))...)
-    src_view .= src
+# ========================================
+# Packed-buffer fill (node-major @generated unroll)
+# ========================================
+#
+# A naïve slot-major fill `buf[slot, :, :, ...] .= src` is a stride-`2^N`
+# write pattern, repeated `2^N` times — every cache line of `buf` is touched
+# `2^N` times (once per slot) with only one of `2^N` writes landing on it
+# per pass. For grids that spill the L1 (≥40 KB packed buffer at 100×100
+# Float64 N=2), the line is re-fetched on each subsequent pass, costing
+# multiple memory round-trips per cache line.
+#
+# Node-major with the slot loop unrolled at compile time fixes this: each
+# iteration writes all `2^N` partials at one grid node — those writes are
+# *contiguous* (mask is the fastest-iterating axis), so one cache line is
+# fully populated in a single burst. Empirically ~2.7× faster than
+# slot-major at 100×100 + larger, and saturates single-channel DDR4
+# bandwidth (~5.4 GW/s Float64).
+#
+# Reads come from `K_total = 2^N` separate source arrays (data + every
+# user partial) streamed linearly — the hardware prefetcher handles the
+# few-stream pattern easily.
 
-    # Wrap rows for every `:exclusive` axis (no-op if none). Routed through
-    # a `@generated` unroll so each per-axis `d` is a compile-time Val, the
-    # SubArray index tuples are inferable, and the views are stack-elidable.
-    # Mirrors `_extend_all_slices!` in core/periodic.jl.
-    _wrap_all_axes_in_buf_slot!(buf, slot, extended, Val(N))
-    return buf
+# Write the user-source region into `buf[:, 1:n_1, ..., 1:n_N]`. The
+# `@generated` body emits the `K_total` per-slot writes as straight-line
+# code inside the column-major (innermost = first data axis) loop nest,
+# avoiding the runtime tuple-indexing that would otherwise box the
+# heterogeneous-source dispatch. Wrap rows for `:exclusive` axes are
+# added separately via `_wrap_all_axes_all_slots!`.
+@inline function _fill_packed_src_region!(
+        buf::AbstractArray{Tv, NP1},
+        sources::Tuple{Vararg{AbstractArray{Tv, N}}},
+    ) where {Tv, NP1, N}
+    return _fill_packed_src_region_unrolled!(buf, sources, Val(N))
 end
 
-# Apply ONE wrap row along data-axis `d` (= buf-dim `d+1`). Compile-time `d`
-# via Val keeps the index-tuple `ntuple` closures inferable, so the SubArray
-# headers produced by `view(buf, slot, ...)` are stack-allocated.
-@inline function _wrap_one_axis_in_buf_slot!(
-        buf::AbstractArray{Tv, NP1}, slot::Int,
+@generated function _fill_packed_src_region_unrolled!(
+        buf::AbstractArray{Tv, NP1},
+        sources::Tuple{Vararg{AbstractArray{Tv, N}, K}},
+        ::Val{N},
+    ) where {Tv, NP1, N, K}
+    # Per-slot scalar writes at one node. `sources[$k]` is a literal tuple
+    # access in the AST, so each call dispatches with a concrete element
+    # type at codegen — no boxing.
+    loop_vars = [Symbol(:i_, d) for d in 1:N]
+    inner = Expr(:block)
+    for k in 1:K
+        push!(inner.args, :(@inbounds buf[$k, $(loop_vars...)] = sources[$k][$(loop_vars...)]))
+    end
+    # Wrap in nested for loops; innermost = i_1 (column-major fast axis on
+    # both src and buf since mask is dim 1 of buf).
+    body = inner
+    for d in 1:N
+        body = quote
+            @inbounds for $(loop_vars[d]) in 1:size(sources[1], $d)
+                $body
+            end
+        end
+    end
+    return quote
+        Base.@_inline_meta
+        $body
+        return buf
+    end
+end
+
+# ========================================
+# Wrap rows for `:exclusive` axes — all-slots at once
+# ========================================
+#
+# For each axis `d` with `extended[d] == true`, the wrap row at index
+# `n_buf_d` is filled from index `1` across **every** mask slot
+# simultaneously — `buf[:, ..., n_d, ...] = buf[:, ..., 1, ...]`. One
+# `copyto!` covers all `K_total = 2^N` slots at once, which is correct
+# (each slot wraps the same way) and faster than per-slot iteration.
+@inline function _wrap_one_axis_all_slots!(
+        buf::AbstractArray{Tv, NP1},
         extended::NTuple{N, Bool},
         ::Val{d}, ::Val{N},
     ) where {Tv, NP1, N, d}
@@ -259,20 +310,18 @@ end
     dst_inds = ntuple(Val(N)) do i
         i == d ? (n_buf_d:n_buf_d) : (1:size(buf, i + 1))
     end
-    copyto!(view(buf, slot, dst_inds...), view(buf, slot, src_inds...))
+    copyto!(view(buf, :, dst_inds...), view(buf, :, src_inds...))
     return nothing
 end
 
-# Compile-time unroll of per-axis wrap calls. Emits N straight-line dispatches
-# to `_wrap_one_axis_in_buf_slot!` with literal `Val($d)`. The runtime
-# `extended[d] || return nothing` short-circuit then compiles to a constant
-# branch when the caller's `extended` tuple is constant-folded.
-@generated function _wrap_all_axes_in_buf_slot!(
-        buf::AbstractArray{Tv, NP1}, slot::Int,
+# Compile-time unroll over data axes. Same `@inline + @generated` pattern as
+# `_extend_all_slices!` in core/periodic.jl.
+@generated function _wrap_all_axes_all_slots!(
+        buf::AbstractArray{Tv, NP1},
         extended::NTuple{N, Bool}, ::Val{N},
     ) where {Tv, NP1, N}
     calls = [
-        :(_wrap_one_axis_in_buf_slot!(buf, slot, extended, Val($d), Val(N)))
+        :(_wrap_one_axis_all_slots!(buf, extended, Val($d), Val(N)))
             for d in 1:N
     ]
     return Expr(:block, calls..., :(return nothing))
@@ -325,10 +374,8 @@ end
     K_total = 1 << N
     buf = acquire!(pool, Tv, (K_total, n_ext...))
 
-    _fill_mask_slot_with_wrap!(buf, 1, data, extended)
-    @inbounds for m in 1:K
-        _fill_mask_slot_with_wrap!(buf, m + 1, partials.partials[m], extended)
-    end
+    _fill_packed_src_region!(buf, (data, partials.partials...))
+    _wrap_all_axes_all_slots!(buf, extended, Val(N))
 
     # `map` over tuples dispatches per-element with concrete (grid_d, bc_d)
     # types, so the `isa PeriodicBC{:exclusive}` branch specializes

--- a/src/hermite/nd/hermite_nd_interpolant.jl
+++ b/src/hermite/nd/hermite_nd_interpolant.jl
@@ -46,12 +46,12 @@ function CubicHermiteInterpolantND(
     grids_typed, _, Tv_promoted, _ = _nd_promote_grids(grids, data)
     Tv = promote_type(Tv_promoted, Tv_part)
 
-    data_typed     = _coerce_data_eltype(data, Tv, Val(N))
+    data_typed = _coerce_data_eltype(data, Tv, Val(N))
     partials_typed = _coerce_partials_eltype(partials, Tv, Val(N))
 
     _validate_nd_grids(grids_typed, data_typed)
 
-    bcs      = _resolve_bcs_nd(bc, Val(N))
+    bcs = _resolve_bcs_nd(bc, Val(N))
     searches = _resolve_search_nd(search, Val(N))
 
     _validate_hermite_nd_bcs_phase1a(bcs)
@@ -68,11 +68,13 @@ end
 
 @noinline function _throw_partials_not_full_mixed(N::Int, K::Int)
     expected = (1 << N) - 1
-    throw(ArgumentError(
-        "CubicHermiteInterpolantND (Phase 1a): partials must contain every " *
-        "non-zero multiindex in {0,1}^N (K = 2^N - 1 = $expected for N=$N), got K=$K. " *
-        "Construct via `HermitePartials(...)`.",
-    ))
+    throw(
+        ArgumentError(
+            "CubicHermiteInterpolantND (Phase 1a): partials must contain every " *
+                "non-zero multiindex in {0,1}^N (K = 2^N - 1 = $expected for N=$N), got K=$K. " *
+                "Construct via `HermitePartials(...)`.",
+        )
+    )
 end
 
 # Zero-copy when eltype already matches; broadcast-convert otherwise.

--- a/src/hermite/nd/hermite_nd_interpolant.jl
+++ b/src/hermite/nd/hermite_nd_interpolant.jl
@@ -2,15 +2,11 @@
 # CubicHermiteInterpolantND — outer ctor, callable, protocol traits
 # ========================================
 #
-# Wires `hermite_interp(grids, data, partials; …)` into the build path,
-# implements `_locate_cell` / `_eval_at_cell` (the `AbstractInterpolantND`
-# protocol traits — they let the shared callable in `interpolant_protocol.jl`
-# do scalar evaluation, batch evaluation, gradient/hessian/laplacian, etc.
-# with no further work), and provides the direct scalar callable.
-#
-# The eval kernel `_eval_nd_cell` lives in `src/cubic/nd/cubic_nd_eval.jl` —
-# it operates on the packed `_NodalDerivativesND.partials` we share with
-# `CubicInterpolantND`, so no kernel duplication is required.
+# Wires `hermite_interp(grids, data, partials; …)` into the build path and
+# implements the `AbstractInterpolantND` protocol traits `_locate_cell` /
+# `_eval_at_cell`, which give scalar/batch eval and gradient/hessian/laplacian
+# for free via the shared callable. The `_eval_nd_cell` kernel is reused from
+# `CubicInterpolantND` (same packed `_NodalDerivativesND` layout).
 
 # ========================================
 # OUTER CONSTRUCTOR — public build entry
@@ -154,11 +150,8 @@ end
 # PROTOCOL TRAITS — _locate_cell + _eval_at_cell
 # ========================================
 #
-# These mirror the CubicInterpolantND implementations verbatim because the
-# storage layout (packed `_NodalDerivativesND.partials`) and the eval kernel
-# (`_eval_nd_cell` from `cubic_nd_eval.jl`) are identical. The only
-# difference between the two interpolants is *how* `nodal_derivs` was filled
-# — auto-solved (Cubic) vs. user-supplied (CubicHermite).
+# Identical to CubicInterpolantND — shared storage layout + `_eval_nd_cell`
+# kernel; only the fill of `nodal_derivs` differs (user-supplied here).
 
 @inline function _locate_cell(
         itp::CubicHermiteInterpolantND{Tg, Tv, N},

--- a/src/hermite/nd/hermite_nd_interpolant.jl
+++ b/src/hermite/nd/hermite_nd_interpolant.jl
@@ -19,7 +19,7 @@ Build a cubic Hermite ND interpolant from grid vectors, function values, and
 user-supplied mixed partials. Mirrors the option shape of `cubic_interp` /
 `quadratic_interp` (per-axis `bc` / `extrap` / `search`).
 
-# Phase 1a BC restrictions
+# BC restrictions
 Only `NoBC()`, `PeriodicBC(...; endpoint=:inclusive)`, and
 `PeriodicBC(...; endpoint=:exclusive)` are accepted. User partials supersede
 any BC-derived ones, so richer BC families (BCPair, CubicFit, ...) have no
@@ -33,9 +33,8 @@ function CubicHermiteInterpolantND(
         extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
         search::Union{AbstractSearchPolicy, NTuple{N, AbstractSearchPolicy}} = AutoSearch(),
     ) where {N, Tv_part, K}
-    # Phase 1a only accepts full mixed partials (K = 2^N - 1). Future
-    # FirstOnly support would dispatch on K (or reintroduce a Completeness
-    # marker) — for now we hard-reject any other K so the contract is loud.
+    # Only the full mixed set (K = 2^N - 1) is accepted. `HermitePartials`
+    # already enforces this, so this guards direct struct construction.
     K == (1 << N) - 1 || _throw_partials_not_full_mixed(N, K)
 
     # Promote across (grid, data, partials) to a single Tv.
@@ -50,7 +49,7 @@ function CubicHermiteInterpolantND(
     bcs = _resolve_bcs_nd(bc, Val(N))
     searches = _resolve_search_nd(search, Val(N))
 
-    _validate_hermite_nd_bcs_phase1a(bcs)
+    _validate_hermite_nd_bcs(bcs)
     _validate_partial_sizes(data_typed, partials_typed)
     _validate_inclusive_seams(data_typed, partials_typed, bcs)
 
@@ -66,7 +65,7 @@ end
     expected = (1 << N) - 1
     throw(
         ArgumentError(
-            "CubicHermiteInterpolantND (Phase 1a): partials must contain every " *
+            "CubicHermiteInterpolantND: partials must contain every " *
                 "non-zero multiindex in {0,1}^N (K = 2^N - 1 = $expected for N=$N), got K=$K. " *
                 "Construct via `HermitePartials(...)`.",
         )
@@ -96,8 +95,7 @@ end
     hermite_interp(grids::Tuple, data, partials::HermitePartials; bc, extrap, search) -> CubicHermiteInterpolantND
 
 ND cubic Hermite interpolant from user-supplied data + mixed partials. See
-[`CubicHermiteInterpolantND`](@ref) for option semantics and Phase 1a BC
-restrictions.
+[`CubicHermiteInterpolantND`](@ref) for option semantics and BC restrictions.
 
 # Example (N=2)
 ```julia

--- a/src/hermite/nd/hermite_nd_interpolant.jl
+++ b/src/hermite/nd/hermite_nd_interpolant.jl
@@ -1,0 +1,185 @@
+# ========================================
+# CubicHermiteInterpolantND — outer ctor, callable, protocol traits
+# ========================================
+#
+# Wires `hermite_interp(grids, data, partials; …)` into the build path,
+# implements `_locate_cell` / `_eval_at_cell` (the `AbstractInterpolantND`
+# protocol traits — they let the shared callable in `interpolant_protocol.jl`
+# do scalar evaluation, batch evaluation, gradient/hessian/laplacian, etc.
+# with no further work), and provides the direct scalar callable.
+#
+# The eval kernel `_eval_nd_cell` lives in `src/cubic/nd/cubic_nd_eval.jl` —
+# it operates on the packed `_NodalDerivativesND.partials` we share with
+# `CubicInterpolantND`, so no kernel duplication is required.
+
+# ========================================
+# OUTER CONSTRUCTOR — public build entry
+# ========================================
+
+"""
+    CubicHermiteInterpolantND(grids, data, partials::HermitePartials; bc, extrap, search)
+
+Build a cubic Hermite ND interpolant from grid vectors, function values, and
+user-supplied mixed partials. Mirrors the option shape of `cubic_interp` /
+`quadratic_interp` (per-axis `bc` / `extrap` / `search`).
+
+# Phase 1a BC restrictions
+Only `NoBC()`, `PeriodicBC(...; endpoint=:inclusive)`, and
+`PeriodicBC(...; endpoint=:exclusive)` are accepted. User partials supersede
+any BC-derived ones, so richer BC families (BCPair, CubicFit, ...) have no
+role here — use `cubic_interp` or the auto-slope methods if you need them.
+"""
+function CubicHermiteInterpolantND(
+        grids::Tuple{Vararg{AbstractVector, N}},
+        data::AbstractArray{<:Any, N},
+        partials::HermitePartials{N, Tv_part, K};
+        bc::Union{AbstractBC, NTuple{N, AbstractBC}} = NoBC(),
+        extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
+        search::Union{AbstractSearchPolicy, NTuple{N, AbstractSearchPolicy}} = AutoSearch(),
+    ) where {N, Tv_part, K}
+    # Phase 1a only accepts full mixed partials (K = 2^N - 1). Future
+    # FirstOnly support would dispatch on K (or reintroduce a Completeness
+    # marker) — for now we hard-reject any other K so the contract is loud.
+    K == (1 << N) - 1 || _throw_partials_not_full_mixed(N, K)
+
+    # Promote across (grid, data, partials) to a single Tv.
+    grids_typed, _, Tv_promoted, _ = _nd_promote_grids(grids, data)
+    Tv = promote_type(Tv_promoted, Tv_part)
+
+    data_typed     = _coerce_data_eltype(data, Tv, Val(N))
+    partials_typed = _coerce_partials_eltype(partials, Tv, Val(N))
+
+    _validate_nd_grids(grids_typed, data_typed)
+
+    bcs      = _resolve_bcs_nd(bc, Val(N))
+    searches = _resolve_search_nd(search, Val(N))
+
+    _validate_hermite_nd_bcs_phase1a(bcs)
+    _validate_partial_sizes(data_typed, partials_typed)
+    _validate_inclusive_seams(data_typed, partials_typed, bcs)
+
+    grids_ext, nodal_derivs, bcs_post =
+        _pack_and_extend_nodal_derivs(grids_typed, data_typed, partials_typed, bcs)
+
+    extraps_val = _resolve_extrap(extrap, bcs_post, Val(N), Tv)
+
+    return CubicHermiteInterpolantND(grids_ext, nodal_derivs, bcs_post, extraps_val, searches)
+end
+
+@noinline function _throw_partials_not_full_mixed(N::Int, K::Int)
+    expected = (1 << N) - 1
+    throw(ArgumentError(
+        "CubicHermiteInterpolantND (Phase 1a): partials must contain every " *
+        "non-zero multiindex in {0,1}^N (K = 2^N - 1 = $expected for N=$N), got K=$K. " *
+        "Construct via `HermiteFullPartials(...)`.",
+    ))
+end
+
+# Zero-copy when eltype already matches; broadcast-convert otherwise.
+@inline _coerce_data_eltype(data::AbstractArray{Tv, N}, ::Type{Tv}, ::Val{N}) where {Tv, N} = data
+@inline _coerce_data_eltype(data::AbstractArray{<:Any, N}, ::Type{Tv}, ::Val{N}) where {Tv, N} = Tv.(data)
+
+# Zero-copy when eltype already matches; rebuild HermitePartials with
+# converted arrays otherwise. The constructor itself already enforces a
+# single common Tv across all stored arrays, so a single type check suffices.
+@inline _coerce_partials_eltype(p::HermitePartials{N, Tv, K}, ::Type{Tv}, ::Val{N}) where {N, Tv, K} = p
+@inline function _coerce_partials_eltype(
+        p::HermitePartials{N, Tv_in, K}, ::Type{Tv}, ::Val{N},
+    ) where {N, Tv_in, K, Tv}
+    converted = ntuple(k -> convert(Array{Tv, N}, p.partials[k]), Val(K))
+    return HermitePartials{N, Tv, K, typeof(first(converted))}(converted)
+end
+
+# ========================================
+# PUBLIC API — hermite_interp(grids, data, partials; …)
+# ========================================
+
+"""
+    hermite_interp(grids::Tuple, data, partials::HermitePartials; bc, extrap, search) -> CubicHermiteInterpolantND
+
+ND cubic Hermite interpolant from user-supplied data + mixed partials. See
+[`CubicHermiteInterpolantND`](@ref) for option semantics and Phase 1a BC
+restrictions.
+
+# Example (N=2)
+```julia
+x = range(0.0, 1.0, 11)
+y = range(0.0, 2π, 21)
+data = [sin(xi) * cos(yj) for xi in x, yj in y]
+partials = HermiteFullPartials(
+    (1, 0) => [ cos(xi) * cos(yj) for xi in x, yj in y],
+    (0, 1) => [-sin(xi) * sin(yj) for xi in x, yj in y],
+    (1, 1) => [-cos(xi) * sin(yj) for xi in x, yj in y],
+)
+itp = hermite_interp((x, y), data, partials)
+itp((0.3, 1.7))
+```
+"""
+@inline function hermite_interp(
+        grids::Tuple{Vararg{AbstractVector, N}},
+        data::AbstractArray{<:Any, N},
+        partials::HermitePartials{N};
+        kwargs...,
+    ) where {N}
+    return CubicHermiteInterpolantND(grids, data, partials; kwargs...)
+end
+
+# ========================================
+# CALLABLE INTERFACE
+# ========================================
+
+"""
+    (itp::CubicHermiteInterpolantND)(query; deriv=EvalValue(), search=itp.searches)
+
+Evaluate ND cubic Hermite at `query::NTuple{N, Real}`. Supports `deriv` as
+`DerivOp` (same order all axes) or `NTuple{N, DerivOp}` (per-axis).
+"""
+@inline function (itp::CubicHermiteInterpolantND{Tg, Tv, N})(
+        query::Tuple{Vararg{Real, N}};
+        deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
+        search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing,
+    ) where {Tg, Tv, N}
+    resolved = map(_resolve_grididx, query, itp.grids)
+    ops = _resolve_deriv_nd(deriv, Val(N))
+    policies = _resolve_search_nd(search, Val(N))
+    hints = _ensure_hint_nd(hint, Val(N))
+    mono = _scalar_mono(hint, Val(N))
+    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono)
+end
+
+# ========================================
+# PROTOCOL TRAITS — _locate_cell + _eval_at_cell
+# ========================================
+#
+# These mirror the CubicInterpolantND implementations verbatim because the
+# storage layout (packed `_NodalDerivativesND.partials`) and the eval kernel
+# (`_eval_nd_cell` from `cubic_nd_eval.jl`) are identical. The only
+# difference between the two interpolants is *how* `nodal_derivs` was filled
+# — auto-solved (Cubic) vs. user-supplied (CubicHermite).
+
+@inline function _locate_cell(
+        itp::CubicHermiteInterpolantND{Tg, Tv, N},
+        query::Tuple{Vararg{Real, N}},
+        extraps::Tuple{Vararg{AbstractExtrap, N}},
+        policies::NTuple{N, AbstractSearchPolicy},
+        hints::Tuple{Vararg{Base.RefValue{Int}, N}},
+        mono::NTuple{N, Bool},
+    ) where {Tg, Tv, N}
+    q_evals = _handle_all_extraps(query, itp.grids, extraps)
+    indices, Ls, _ = _search_all_intervals(q_evals, itp.grids, policies, hints, mono)
+    hs, inv_hs, dLs = _compute_all_local_params(q_evals, itp.grids, indices, Ls)
+    return (itp.nodal_derivs.partials, indices, hs, inv_hs, dLs)
+end
+
+@inline function _eval_at_cell(
+        ::CubicHermiteInterpolantND,
+        cell::Tuple,
+        ops::NTuple{N, AbstractEvalOp},
+    ) where {N}
+    partials, indices, hs, inv_hs, dLs = cell
+    return _eval_nd_cell(partials, indices, hs, inv_hs, dLs, ops)
+end
+
+# Per-method sample-of-Tv used by fill-extrap paths.
+@inline _sample_data(itp::CubicHermiteInterpolantND) = @inbounds first(itp.nodal_derivs.partials)

--- a/src/hermite/nd/hermite_nd_interpolant.jl
+++ b/src/hermite/nd/hermite_nd_interpolant.jl
@@ -71,7 +71,7 @@ end
     throw(ArgumentError(
         "CubicHermiteInterpolantND (Phase 1a): partials must contain every " *
         "non-zero multiindex in {0,1}^N (K = 2^N - 1 = $expected for N=$N), got K=$K. " *
-        "Construct via `HermiteFullPartials(...)`.",
+        "Construct via `HermitePartials(...)`.",
     ))
 end
 
@@ -106,7 +106,7 @@ restrictions.
 x = range(0.0, 1.0, 11)
 y = range(0.0, 2π, 21)
 data = [sin(xi) * cos(yj) for xi in x, yj in y]
-partials = HermiteFullPartials(
+partials = HermitePartials(
     (1, 0) => [ cos(xi) * cos(yj) for xi in x, yj in y],
     (0, 1) => [-sin(xi) * sin(yj) for xi in x, yj in y],
     (1, 1) => [-cos(xi) * sin(yj) for xi in x, yj in y],

--- a/src/hermite/nd/hermite_nd_oneshot.jl
+++ b/src/hermite/nd/hermite_nd_oneshot.jl
@@ -1,25 +1,34 @@
 # ========================================
-# CubicHermiteInterpolantND — One-shot Evaluation (Phase 1a)
+# CubicHermiteInterpolantND — One-shot Evaluation (Pool-based)
 # ========================================
 #
-# Phase 1a strategy: build the interpolant, evaluate, return. Allocates a
-# `_NodalDerivativesND` buffer per call (1 × Array{Tv, N+1}), so it's not
-# pool-grade zero-alloc. Cleaner code and correctness come first; an
-# allocation-tight pool-based path is a Phase 2 follow-up (mirroring
-# `_cubic_interp_nd_oneshot`).
+# Zero-allocation one-shot API. The packed `_NodalDerivativesND`-shaped buffer
+# and any Vector-grid extension are acquired from a thread-local
+# `AbstractArrayPool` via `@with_pool` (mirrors `_cubic_interp_nd_oneshot`).
+# After the first warmup call, every subsequent one-shot — scalar or batch —
+# re-uses the same pool buffers, so user loops over many queries with
+# changing data / partials see zero per-call allocation.
+#
+# Internal contract: the pool buffer returned from
+# `_pack_and_extend_nodal_derivs_pooled` MUST NOT escape the enclosing
+# `@with_pool` block. We satisfy this by consuming it in-line through
+# `_eval_nd_cell` and returning a scalar value (or writing into a
+# pre-allocated caller-owned `output` for batch).
 
 # ========================================
-# Scalar one-shot
+# Public API entries (scalar + batch + in-place)
 # ========================================
 
 """
     hermite_interp(grids, data, partials, query::Tuple) -> value
 
-ND cubic Hermite one-shot at a single query point. Equivalent to
-`hermite_interp(grids, data, partials)(query)` but accepted as a single call.
+ND cubic Hermite one-shot at a single query point.
 
-Keywords: same as the persistent-build form (`bc`, `extrap`, `search`,
-`deriv`).
+Zero-allocation after warmup: the packed partials buffer is acquired from a
+thread-local pool and reused across calls. Equivalent in result to
+`hermite_interp(grids, data, partials)(query)`.
+
+Keywords: same as the persistent-build form (`bc`, `extrap`, `search`, `deriv`).
 """
 function hermite_interp(
         grids::Tuple{Vararg{AbstractVector, N}},
@@ -32,20 +41,20 @@ function hermite_interp(
         search::Union{AbstractSearchPolicy, NTuple{N, AbstractSearchPolicy}} = AutoSearch(),
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing,
     ) where {N}
-    itp = CubicHermiteInterpolantND(grids, data, partials; bc, extrap, search)
-    return itp(query; deriv, hint)
+    grids_typed, data_typed, partials_typed, bcs, extraps_val, searches, ops =
+        _hermite_oneshot_prepare(grids, data, partials, bc, extrap, search, deriv)
+    return _hermite_interp_nd_oneshot(
+        grids_typed, data_typed, partials_typed, query,
+        bcs, extraps_val, searches, ops, hint,
+    )
 end
-
-# ========================================
-# Batch one-shot (allocating)
-# ========================================
 
 """
     hermite_interp(grids, data, partials, queries) -> Vector
 
-ND cubic Hermite one-shot at multiple query points. `queries` follows the
-project's query protocol (`_query_length` / `_query_extract` / etc.). The
-return type follows the standard ND output-eltype computation.
+ND cubic Hermite one-shot at multiple query points. Allocates `output`
+internally; the packed partials buffer is pool-based so per-query alloc
+is zero after warmup.
 """
 function hermite_interp(
         grids::Tuple{Vararg{AbstractVector, N}},
@@ -67,16 +76,10 @@ function hermite_interp(
     return output
 end
 
-# ========================================
-# Batch one-shot (in-place)
-# ========================================
-
 """
     hermite_interp!(output, grids, data, partials, queries) -> output
 
-In-place batch ND cubic Hermite one-shot. `output` must have length
-`_query_length(queries)`. Builds the interpolant once and dispatches to the
-shared batch-evaluation pipeline.
+In-place batch ND cubic Hermite one-shot. Zero-alloc workspace after warmup.
 """
 function hermite_interp!(
         output::AbstractVector,
@@ -90,8 +93,125 @@ function hermite_interp!(
         search::Union{AbstractSearchPolicy, NTuple{N, AbstractSearchPolicy}} = AutoSearch(),
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing,
     ) where {N}
-    itp = CubicHermiteInterpolantND(grids, data, partials; bc, extrap, search)
-    # Delegate to the shared callable's in-place batch path
-    # (`AbstractInterpolantND` callable handles all batch shapes).
-    return itp(output, queries; deriv, hint)
+    grids_typed, data_typed, partials_typed, bcs, extraps_val, searches, ops =
+        _hermite_oneshot_prepare(grids, data, partials, bc, extrap, search, deriv)
+    return _hermite_interp_nd_oneshot_batch!(
+        output, grids_typed, data_typed, partials_typed, queries,
+        bcs, extraps_val, ops, searches, hint,
+    )
+end
+
+# ========================================
+# Shared prepare path (kwarg normalization + validation)
+# ========================================
+#
+# Pulled out so scalar/batch APIs share the same validation order and any
+# type promotion happens exactly once per call. The actual pool-acquiring
+# work happens later inside `_hermite_interp_nd_oneshot[_batch!]`.
+@inline function _hermite_oneshot_prepare(
+        grids::Tuple{Vararg{AbstractVector, N}},
+        data::AbstractArray{<:Any, N},
+        partials::HermitePartials{N, Tv_part, K},
+        bc, extrap, search, deriv,
+    ) where {N, Tv_part, K}
+    K == (1 << N) - 1 || _throw_partials_not_full_mixed(N, K)
+
+    grids_typed, _, Tv_promoted, _ = _nd_promote_grids(grids, data)
+    Tv = promote_type(Tv_promoted, Tv_part)
+    data_typed     = _coerce_data_eltype(data, Tv, Val(N))
+    partials_typed = _coerce_partials_eltype(partials, Tv, Val(N))
+
+    _validate_nd_grids(grids_typed, data_typed)
+
+    bcs      = _resolve_bcs_nd(bc, Val(N))
+    searches = _resolve_search_nd(search, Val(N))
+
+    _validate_hermite_nd_bcs_phase1a(bcs)
+    _validate_partial_sizes(data_typed, partials_typed)
+    _validate_inclusive_seams(data_typed, partials_typed, bcs)
+
+    extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)
+    ops         = _resolve_deriv_nd(deriv, Val(N))
+
+    return grids_typed, data_typed, partials_typed, bcs, extraps_val, searches, ops
+end
+
+# ========================================
+# Pool-based oneshot — scalar
+# ========================================
+#
+# Mirrors `_cubic_interp_nd_oneshot`: validate domain → fill-OOB short
+# circuit → pool-acquire packed buffer + extend grids/data wrap rows → run
+# the shared search + eval pipeline → return scalar. Pool buffers are
+# reclaimed on `@with_pool` rewind.
+@with_pool pool function _hermite_interp_nd_oneshot(
+        grids::Tuple{Vararg{AbstractVector{Tg}, N}},
+        data::AbstractArray{Tv, N},
+        partials::HermitePartials{N, Tv, K},
+        query::Tuple{Vararg{Real, N}},
+        bcs::Tuple{Vararg{AbstractBC, N}},
+        extraps_val::Tuple{Vararg{AbstractExtrap, N}},
+        searches::NTuple{N, AbstractSearchPolicy},
+        ops::NTuple{N, AbstractEvalOp},
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}},
+    ) where {Tg, Tv, N, K}
+    _validate_nd_domain(grids, query, extraps_val)
+    oob_result = _try_fill_oob(query, grids, extraps_val, ops, @inbounds first(data))
+    oob_result !== nothing && return oob_result
+
+    grids_p, buf, bcs_p = _pack_and_extend_nodal_derivs_pooled(pool, grids, data, partials, bcs)
+    extraps_eff = map(_resolve_extrap, extraps_val, grids_p)
+
+    # Use the shared hint helper so the per-axis Ref allocation stays local
+    # (stack-elidable). `mono` is `(true,…,true)` for a single point — no
+    # monotone-hint optimization needed for one query.
+    hints = _ensure_hint_nd(hint, Val(N))
+    mono  = _scalar_mono(hint, Val(N))
+
+    q_evals = _handle_all_extraps(query, grids_p, extraps_eff)
+    indices, Ls, _ = _search_all_intervals(q_evals, grids_p, searches, hints, mono)
+    hs, inv_hs, dLs = _compute_all_local_params(q_evals, grids_p, indices, Ls)
+    return _eval_nd_cell(buf, indices, hs, inv_hs, dLs, ops)
+end
+
+# ========================================
+# Pool-based oneshot — batch in-place
+# ========================================
+#
+# Build pass (pack + extend + per-axis extrap resolution + InBounds promotion)
+# happens ONCE; then a tight per-query eval loop writes into `output`.
+@with_pool pool function _hermite_interp_nd_oneshot_batch!(
+        output::AbstractVector,
+        grids::Tuple{Vararg{AbstractVector{Tg}, N}},
+        data::AbstractArray{Tv, N},
+        partials::HermitePartials{N, Tv, K},
+        queries,
+        bcs::Tuple{Vararg{AbstractBC, N}},
+        extraps_val::Tuple{Vararg{AbstractExtrap, N}},
+        ops::NTuple{N, AbstractEvalOp},
+        search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}},
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}},
+    ) where {Tg, Tv, N, K}
+    policies, hints = _resolve_oneshot_search_nd(search, queries, hint, Val(N))
+    nq = _query_length(queries)
+    length(output) == nq || _throw_query_output_mismatch(nq, length(output))
+    _query_validate(queries)
+
+    grids_p, buf, bcs_p = _pack_and_extend_nodal_derivs_pooled(pool, grids, data, partials, bcs)
+    extraps_eff = map(_resolve_extrap, extraps_val, grids_p)
+    extraps_eff = _check_domain_nd(grids_p, queries, extraps_eff)
+
+    @inbounds for k in 1:nq
+        query_k = _extract_query_point(queries, k, Val(N))
+        oob_val = _try_fill_oob(query_k, grids_p, extraps_eff, ops, first(data))
+        if oob_val !== nothing
+            output[k] = oob_val
+            continue
+        end
+        q_evals = _handle_all_extraps(query_k, grids_p, extraps_eff)
+        indices, Ls, _ = _search_all_intervals(q_evals, grids_p, policies, hints)
+        hs, inv_hs, dLs = _compute_all_local_params(q_evals, grids_p, indices, Ls)
+        output[k] = _eval_nd_cell(buf, indices, hs, inv_hs, dLs, ops)
+    end
+    return output
 end

--- a/src/hermite/nd/hermite_nd_oneshot.jl
+++ b/src/hermite/nd/hermite_nd_oneshot.jl
@@ -121,7 +121,7 @@ end
     bcs = _resolve_bcs_nd(bc, Val(N))
     searches = _resolve_search_nd(search, Val(N))
 
-    _validate_hermite_nd_bcs_phase1a(bcs)
+    _validate_hermite_nd_bcs(bcs)
     _validate_partial_sizes(data_typed, partials_typed)
     _validate_inclusive_seams(data_typed, partials_typed, bcs)
 

--- a/src/hermite/nd/hermite_nd_oneshot.jl
+++ b/src/hermite/nd/hermite_nd_oneshot.jl
@@ -59,20 +59,22 @@ is zero after warmup.
 function hermite_interp(
         grids::Tuple{Vararg{AbstractVector, N}},
         data::AbstractArray{Tv, N},
-        partials::HermitePartials{N},
+        partials::HermitePartials{N, Tv_part},
         queries;
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
         bc::Union{AbstractBC, NTuple{N, AbstractBC}} = NoBC(),
         extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
         search::Union{AbstractSearchPolicy, NTuple{N, AbstractSearchPolicy}} = AutoSearch(),
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing,
-    ) where {Tv, N}
+    ) where {Tv, N, Tv_part}
     _, Tg, _, _ = _nd_promote_grids(grids, data)
     Tq = _query_eltype(queries)
-    Tr = _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)
+    Tr = _output_eltype(_arithmetic_kernel_shape, Tg, promote_type(Tv, Tv_part), Tq)
     output = Vector{Tr}(undef, _query_length(queries))
-    hermite_interp!(output, grids, data, partials, queries;
-                    deriv, bc, extrap, search, hint)
+    hermite_interp!(
+        output, grids, data, partials, queries;
+        deriv, bc, extrap, search, hint
+    )
     return output
 end
 
@@ -118,12 +120,12 @@ end
 
     grids_typed, _, Tv_promoted, _ = _nd_promote_grids(grids, data)
     Tv = promote_type(Tv_promoted, Tv_part)
-    data_typed     = _coerce_data_eltype(data, Tv, Val(N))
+    data_typed = _coerce_data_eltype(data, Tv, Val(N))
     partials_typed = _coerce_partials_eltype(partials, Tv, Val(N))
 
     _validate_nd_grids(grids_typed, data_typed)
 
-    bcs      = _resolve_bcs_nd(bc, Val(N))
+    bcs = _resolve_bcs_nd(bc, Val(N))
     searches = _resolve_search_nd(search, Val(N))
 
     _validate_hermite_nd_bcs_phase1a(bcs)
@@ -131,7 +133,7 @@ end
     _validate_inclusive_seams(data_typed, partials_typed, bcs)
 
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)
-    ops         = _resolve_deriv_nd(deriv, Val(N))
+    ops = _resolve_deriv_nd(deriv, Val(N))
 
     return grids_typed, data_typed, partials_typed, bcs, extraps_val, searches, ops
 end
@@ -166,7 +168,7 @@ end
     # (stack-elidable). `mono` is `(true,…,true)` for a single point — no
     # monotone-hint optimization needed for one query.
     hints = _ensure_hint_nd(hint, Val(N))
-    mono  = _scalar_mono(hint, Val(N))
+    mono = _scalar_mono(hint, Val(N))
 
     q_evals = _handle_all_extraps(query, grids_p, extraps_eff)
     indices, Ls, _ = _search_all_intervals(q_evals, grids_p, searches, hints, mono)

--- a/src/hermite/nd/hermite_nd_oneshot.jl
+++ b/src/hermite/nd/hermite_nd_oneshot.jl
@@ -2,18 +2,12 @@
 # CubicHermiteInterpolantND — One-shot Evaluation (Pool-based)
 # ========================================
 #
-# Zero-allocation one-shot API. The packed `_NodalDerivativesND`-shaped buffer
-# and any Vector-grid extension are acquired from a thread-local
-# `AbstractArrayPool` via `@with_pool` (mirrors `_cubic_interp_nd_oneshot`).
-# After the first warmup call, every subsequent one-shot — scalar or batch —
-# re-uses the same pool buffers, so user loops over many queries with
-# changing data / partials see zero per-call allocation.
-#
-# Internal contract: the pool buffer returned from
-# `_pack_and_extend_nodal_derivs_pooled` MUST NOT escape the enclosing
-# `@with_pool` block. We satisfy this by consuming it in-line through
-# `_eval_nd_cell` and returning a scalar value (or writing into a
-# pre-allocated caller-owned `output` for batch).
+# Zero-allocation one-shot API. The packed buffer and any Vector-grid
+# extension are acquired from a thread-local pool via `@with_pool`, so loops
+# over many queries (even with changing data / partials) see zero per-call
+# alloc after warmup. The pool buffer must not escape the `@with_pool` block:
+# it is consumed in-line through `_eval_nd_cell`, returning a scalar (or
+# writing into the caller-owned `output` for batch).
 
 # ========================================
 # Public API entries (scalar + batch + in-place)
@@ -107,9 +101,8 @@ end
 # Shared prepare path (kwarg normalization + validation)
 # ========================================
 #
-# Pulled out so scalar/batch APIs share the same validation order and any
-# type promotion happens exactly once per call. The actual pool-acquiring
-# work happens later inside `_hermite_interp_nd_oneshot[_batch!]`.
+# Shared by scalar/batch so validation + promotion run once, identically.
+# Pool acquisition happens later in `_hermite_interp_nd_oneshot[_batch!]`.
 @inline function _hermite_oneshot_prepare(
         grids::Tuple{Vararg{AbstractVector, N}},
         data::AbstractArray{<:Any, N},
@@ -142,10 +135,8 @@ end
 # Pool-based oneshot — scalar
 # ========================================
 #
-# Mirrors `_cubic_interp_nd_oneshot`: validate domain → fill-OOB short
-# circuit → pool-acquire packed buffer + extend grids/data wrap rows → run
-# the shared search + eval pipeline → return scalar. Pool buffers are
-# reclaimed on `@with_pool` rewind.
+# validate domain → fill-OOB short circuit → pool-pack + extend → shared
+# search + eval → scalar.
 @with_pool pool function _hermite_interp_nd_oneshot(
         grids::Tuple{Vararg{AbstractVector{Tg}, N}},
         data::AbstractArray{Tv, N},
@@ -161,12 +152,12 @@ end
     oob_result = _try_fill_oob(query, grids, extraps_val, ops, @inbounds first(data))
     oob_result !== nothing && return oob_result
 
-    grids_p, buf, bcs_p = _pack_and_extend_nodal_derivs_pooled(pool, grids, data, partials, bcs)
+    # `bcs_post` (3rd return) is unused: no partial-solve step here, and
+    # extrap is materialized from `extraps_val` + `grids_p`.
+    grids_p, buf, _ = _pack_and_extend_nodal_derivs_pooled(pool, grids, data, partials, bcs)
     extraps_eff = map(_resolve_extrap, extraps_val, grids_p)
 
-    # Use the shared hint helper so the per-axis Ref allocation stays local
-    # (stack-elidable). `mono` is `(true,…,true)` for a single point — no
-    # monotone-hint optimization needed for one query.
+    # `mono` is all-true for a single point (no monotone-hint optimization).
     hints = _ensure_hint_nd(hint, Val(N))
     mono = _scalar_mono(hint, Val(N))
 
@@ -199,7 +190,8 @@ end
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
 
-    grids_p, buf, bcs_p = _pack_and_extend_nodal_derivs_pooled(pool, grids, data, partials, bcs)
+    # `bcs_post` (3rd return) is unused here — see the scalar path note.
+    grids_p, buf, _ = _pack_and_extend_nodal_derivs_pooled(pool, grids, data, partials, bcs)
     extraps_eff = map(_resolve_extrap, extraps_val, grids_p)
     extraps_eff = _check_domain_nd(grids_p, queries, extraps_eff)
 

--- a/src/hermite/nd/hermite_nd_oneshot.jl
+++ b/src/hermite/nd/hermite_nd_oneshot.jl
@@ -1,0 +1,97 @@
+# ========================================
+# CubicHermiteInterpolantND — One-shot Evaluation (Phase 1a)
+# ========================================
+#
+# Phase 1a strategy: build the interpolant, evaluate, return. Allocates a
+# `_NodalDerivativesND` buffer per call (1 × Array{Tv, N+1}), so it's not
+# pool-grade zero-alloc. Cleaner code and correctness come first; an
+# allocation-tight pool-based path is a Phase 2 follow-up (mirroring
+# `_cubic_interp_nd_oneshot`).
+
+# ========================================
+# Scalar one-shot
+# ========================================
+
+"""
+    hermite_interp(grids, data, partials, query::Tuple) -> value
+
+ND cubic Hermite one-shot at a single query point. Equivalent to
+`hermite_interp(grids, data, partials)(query)` but accepted as a single call.
+
+Keywords: same as the persistent-build form (`bc`, `extrap`, `search`,
+`deriv`).
+"""
+function hermite_interp(
+        grids::Tuple{Vararg{AbstractVector, N}},
+        data::AbstractArray{<:Any, N},
+        partials::HermitePartials{N},
+        query::Tuple{Vararg{Real, N}};
+        deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
+        bc::Union{AbstractBC, NTuple{N, AbstractBC}} = NoBC(),
+        extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
+        search::Union{AbstractSearchPolicy, NTuple{N, AbstractSearchPolicy}} = AutoSearch(),
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing,
+    ) where {N}
+    itp = CubicHermiteInterpolantND(grids, data, partials; bc, extrap, search)
+    return itp(query; deriv, hint)
+end
+
+# ========================================
+# Batch one-shot (allocating)
+# ========================================
+
+"""
+    hermite_interp(grids, data, partials, queries) -> Vector
+
+ND cubic Hermite one-shot at multiple query points. `queries` follows the
+project's query protocol (`_query_length` / `_query_extract` / etc.). The
+return type follows the standard ND output-eltype computation.
+"""
+function hermite_interp(
+        grids::Tuple{Vararg{AbstractVector, N}},
+        data::AbstractArray{Tv, N},
+        partials::HermitePartials{N},
+        queries;
+        deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
+        bc::Union{AbstractBC, NTuple{N, AbstractBC}} = NoBC(),
+        extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
+        search::Union{AbstractSearchPolicy, NTuple{N, AbstractSearchPolicy}} = AutoSearch(),
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing,
+    ) where {Tv, N}
+    _, Tg, _, _ = _nd_promote_grids(grids, data)
+    Tq = _query_eltype(queries)
+    Tr = _output_eltype(_arithmetic_kernel_shape, Tg, Tv, Tq)
+    output = Vector{Tr}(undef, _query_length(queries))
+    hermite_interp!(output, grids, data, partials, queries;
+                    deriv, bc, extrap, search, hint)
+    return output
+end
+
+# ========================================
+# Batch one-shot (in-place)
+# ========================================
+
+"""
+    hermite_interp!(output, grids, data, partials, queries) -> output
+
+In-place batch ND cubic Hermite one-shot. `output` must have length
+`_query_length(queries)`. Builds the interpolant once and dispatches to the
+shared batch-evaluation pipeline.
+"""
+function hermite_interp!(
+        output::AbstractVector,
+        grids::Tuple{Vararg{AbstractVector, N}},
+        data::AbstractArray{<:Any, N},
+        partials::HermitePartials{N},
+        queries;
+        deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
+        bc::Union{AbstractBC, NTuple{N, AbstractBC}} = NoBC(),
+        extrap::Union{AbstractExtrap, NTuple{N, AbstractExtrap}} = NoExtrap(),
+        search::Union{AbstractSearchPolicy, NTuple{N, AbstractSearchPolicy}} = AutoSearch(),
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing,
+    ) where {N}
+    itp = CubicHermiteInterpolantND(grids, data, partials; bc, extrap, search)
+    # Delegate to the shared callable's in-place batch path
+    # (`AbstractInterpolantND` callable handles all batch shapes).
+    return itp(output, queries; deriv, hint)
+end

--- a/src/hermite/nd/hermite_nd_partials.jl
+++ b/src/hermite/nd/hermite_nd_partials.jl
@@ -112,7 +112,7 @@ function _validate_hermite_full_pairs(
             "HermitePartials{N=$N}: expected $((1 << N) - 1) pairs, got $K",
         )
     )
-    seen = fill(false, 1 << N)   # index 1 ↔ mask 0 (sentinel; never set for FullPartials)
+    seen = fill(false, 1 << N)   # index 1 ↔ mask 0 (function-value sentinel; never set here)
     sz_ref = size(last(pairs[1]))
     mask_ref = _multiindex_to_mask(first(pairs[1]))
     @inbounds for (k, p) in enumerate(pairs)

--- a/src/hermite/nd/hermite_nd_partials.jl
+++ b/src/hermite/nd/hermite_nd_partials.jl
@@ -1,5 +1,5 @@
 # ========================================
-# HermiteFullPartials — multiindex-keyed user-input constructor
+# HermitePartials — multiindex-keyed user-input constructor
 # ========================================
 #
 # Public entry for assembling a `HermitePartials{N, Tv, K, A}` from user
@@ -8,7 +8,7 @@
 # with a single common `Tv`.
 
 """
-    HermiteFullPartials(pairs::Pair{<:NTuple{N, Int}, <:AbstractArray}...) -> HermitePartials
+    HermitePartials(pairs::Pair{<:NTuple{N, Int}, <:AbstractArray}...) -> HermitePartials
 
 Construct user-supplied full mixed partial derivatives for ND cubic Hermite
 interpolation.
@@ -31,18 +31,18 @@ across (grid, data, partials) yields the storage `Tv`.
 
 # Example (N=2)
 ```julia
-partials = HermiteFullPartials(
+partials = HermitePartials(
     (1, 0) => dfdx,
     (0, 1) => dfdy,
     (1, 1) => d2fdxdy,
 )
 ```
 """
-function HermiteFullPartials(pairs::Pair{<:NTuple{N, Int}, <:AbstractArray}...) where {N}
-    N >= 1 || throw(ArgumentError("HermiteFullPartials requires N >= 1"))
+function HermitePartials(pairs::Pair{<:NTuple{N, Int}, <:AbstractArray}...) where {N}
+    N >= 1 || throw(ArgumentError("HermitePartials requires N >= 1"))
     K = (1 << N) - 1
     length(pairs) == K || throw(ArgumentError(
-        "HermiteFullPartials{N=$N} requires exactly $K (mask=1..$K) partials, got $(length(pairs))",
+        "HermitePartials{N=$N} requires exactly $K (mask=1..$K) partials, got $(length(pairs))",
     ))
 
     _validate_hermite_full_pairs(Val(N), pairs)
@@ -63,32 +63,32 @@ end
 
 @noinline function _throw_bad_multiindex_entry(mi::NTuple{N, Int}, slot::Int, val::Int) where {N}
     throw(ArgumentError(
-        "HermiteFullPartials: multiindex $(mi) has entry $val at axis $slot; " *
+        "HermitePartials: multiindex $(mi) has entry $val at axis $slot; " *
         "Phase 1a requires every entry ∈ {0, 1}",
     ))
 end
 
 @noinline function _throw_zero_multiindex(N::Int)
     throw(ArgumentError(
-        "HermiteFullPartials: multiindex $(ntuple(_ -> 0, N)) (function value) " *
+        "HermitePartials: multiindex $(ntuple(_ -> 0, N)) (function value) " *
         "is not allowed — pass data as the `data` argument to `hermite_interp` instead",
     ))
 end
 
 @noinline function _throw_duplicate_multiindex(mi)
-    throw(ArgumentError("HermiteFullPartials: duplicate multiindex $(mi)"))
+    throw(ArgumentError("HermitePartials: duplicate multiindex $(mi)"))
 end
 
 @noinline function _throw_missing_multiindex(mi, mask::Int)
     throw(ArgumentError(
-        "HermiteFullPartials: missing multiindex $(mi) (mask=$mask); " *
+        "HermitePartials: missing multiindex $(mi) (mask=$mask); " *
         "supply every non-zero entry of {0,1}^N",
     ))
 end
 
 @noinline function _throw_size_mismatch_partials(mask_ref, sz_ref, mask_cur, sz_cur)
     throw(DimensionMismatch(
-        "HermiteFullPartials: array for mask=$mask_cur has size $sz_cur, " *
+        "HermitePartials: array for mask=$mask_cur has size $sz_cur, " *
         "but mask=$mask_ref has size $sz_ref — all partials must match",
     ))
 end
@@ -98,7 +98,7 @@ function _validate_hermite_full_pairs(
         pairs::NTuple{K, Pair{<:NTuple{N, Int}, <:AbstractArray}},
     ) where {N, K}
     K == (1 << N) - 1 || throw(ArgumentError(
-        "HermiteFullPartials{N=$N}: expected $((1<<N)-1) pairs, got $K",
+        "HermitePartials{N=$N}: expected $((1<<N)-1) pairs, got $K",
     ))
     seen = fill(false, 1 << N)   # index 1 ↔ mask 0 (sentinel; never set for FullPartials)
     sz_ref = size(last(pairs[1]))
@@ -115,7 +115,7 @@ function _validate_hermite_full_pairs(
         seen[m + 1] && _throw_duplicate_multiindex(mi)
         seen[m + 1] = true
         ndims(arr) == N || throw(DimensionMismatch(
-            "HermiteFullPartials: array for multiindex $(mi) is $(ndims(arr))-D, expected $N-D",
+            "HermitePartials: array for multiindex $(mi) is $(ndims(arr))-D, expected $N-D",
         ))
         if k > 1
             sz_cur = size(arr)

--- a/src/hermite/nd/hermite_nd_partials.jl
+++ b/src/hermite/nd/hermite_nd_partials.jl
@@ -1,0 +1,151 @@
+# ========================================
+# HermiteFullPartials — multiindex-keyed user-input constructor
+# ========================================
+#
+# Public entry for assembling a `HermitePartials{N, Tv, K, A}` from user
+# `multiindex => array` pairs. All validation + element-type promotion lives
+# here, so downstream code (build, eval) can assume a well-formed container
+# with a single common `Tv`.
+
+"""
+    HermiteFullPartials(pairs::Pair{<:NTuple{N, Int}, <:AbstractArray}...) -> HermitePartials
+
+Construct user-supplied full mixed partial derivatives for ND cubic Hermite
+interpolation.
+
+Each `pair` is `multiindex => array`, where `multiindex::NTuple{N, Int}` encodes
+the derivative order per axis. For Phase 1a, each entry must be `0` or `1`.
+
+# Required pairs (count `2^N - 1`)
+Exactly the non-zero multiindices in `{0, 1}^N`. Order is irrelevant — the
+constructor reorders to canonical mask order internally. The zero multiindex
+`(0, …, 0)` (function value) is **not** allowed here; it is supplied via the
+`data` argument of `hermite_interp`.
+
+# Element-type handling
+Arrays may have different element types. A common `Tv` is derived via
+`promote_type` across all pairs, and each array is converted to
+`Array{Tv, N}` (zero-copy when already matching). The data argument of
+`hermite_interp` is promoted separately, then a final round of promotion
+across (grid, data, partials) yields the storage `Tv`.
+
+# Example (N=2)
+```julia
+partials = HermiteFullPartials(
+    (1, 0) => dfdx,
+    (0, 1) => dfdy,
+    (1, 1) => d2fdxdy,
+)
+```
+"""
+function HermiteFullPartials(pairs::Pair{<:NTuple{N, Int}, <:AbstractArray}...) where {N}
+    N >= 1 || throw(ArgumentError("HermiteFullPartials requires N >= 1"))
+    K = (1 << N) - 1
+    length(pairs) == K || throw(ArgumentError(
+        "HermiteFullPartials{N=$N} requires exactly $K (mask=1..$K) partials, got $(length(pairs))",
+    ))
+
+    _validate_hermite_full_pairs(Val(N), pairs)
+
+    # Common element type across all arrays.
+    Tv = promote_type(map(p -> eltype(last(p)), pairs)...)
+
+    # Reorder by mask + coerce to a single concrete eltype/Array container.
+    ordered = _reorder_pairs_by_mask(Val(N), pairs, Tv)
+
+    A = typeof(first(ordered))
+    return HermitePartials{N, Tv, K, A}(ordered)
+end
+
+# ========================================
+# Validation helpers
+# ========================================
+
+@noinline function _throw_bad_multiindex_entry(mi::NTuple{N, Int}, slot::Int, val::Int) where {N}
+    throw(ArgumentError(
+        "HermiteFullPartials: multiindex $(mi) has entry $val at axis $slot; " *
+        "Phase 1a requires every entry ∈ {0, 1}",
+    ))
+end
+
+@noinline function _throw_zero_multiindex(N::Int)
+    throw(ArgumentError(
+        "HermiteFullPartials: multiindex $(ntuple(_ -> 0, N)) (function value) " *
+        "is not allowed — pass data as the `data` argument to `hermite_interp` instead",
+    ))
+end
+
+@noinline function _throw_duplicate_multiindex(mi)
+    throw(ArgumentError("HermiteFullPartials: duplicate multiindex $(mi)"))
+end
+
+@noinline function _throw_missing_multiindex(mi, mask::Int)
+    throw(ArgumentError(
+        "HermiteFullPartials: missing multiindex $(mi) (mask=$mask); " *
+        "supply every non-zero entry of {0,1}^N",
+    ))
+end
+
+@noinline function _throw_size_mismatch_partials(mask_ref, sz_ref, mask_cur, sz_cur)
+    throw(DimensionMismatch(
+        "HermiteFullPartials: array for mask=$mask_cur has size $sz_cur, " *
+        "but mask=$mask_ref has size $sz_ref — all partials must match",
+    ))
+end
+
+function _validate_hermite_full_pairs(
+        ::Val{N},
+        pairs::NTuple{K, Pair{<:NTuple{N, Int}, <:AbstractArray}},
+    ) where {N, K}
+    K == (1 << N) - 1 || throw(ArgumentError(
+        "HermiteFullPartials{N=$N}: expected $((1<<N)-1) pairs, got $K",
+    ))
+    seen = fill(false, 1 << N)   # index 1 ↔ mask 0 (sentinel; never set for FullPartials)
+    sz_ref = size(last(pairs[1]))
+    mask_ref = _multiindex_to_mask(first(pairs[1]))
+    @inbounds for (k, p) in enumerate(pairs)
+        mi = first(p)
+        arr = last(p)
+        for d in 1:N
+            entry = mi[d]
+            (entry == 0 || entry == 1) || _throw_bad_multiindex_entry(mi, d, entry)
+        end
+        m = _multiindex_to_mask(mi)
+        m == 0 && _throw_zero_multiindex(N)
+        seen[m + 1] && _throw_duplicate_multiindex(mi)
+        seen[m + 1] = true
+        ndims(arr) == N || throw(DimensionMismatch(
+            "HermiteFullPartials: array for multiindex $(mi) is $(ndims(arr))-D, expected $N-D",
+        ))
+        if k > 1
+            sz_cur = size(arr)
+            sz_cur == sz_ref || _throw_size_mismatch_partials(mask_ref, sz_ref, m, sz_cur)
+        end
+    end
+    @inbounds for m in 1:((1 << N) - 1)
+        if !seen[m + 1]
+            mi = ntuple(d -> (m >> (d - 1)) & 1, Val(N))
+            _throw_missing_multiindex(mi, m)
+        end
+    end
+    return nothing
+end
+
+# Reorder pairs into canonical mask order (1, 2, ..., 2^N-1) and coerce each
+# array to `Array{Tv, N}`. `convert` is a no-op when the input already
+# satisfies the target type (zero-copy alias); otherwise allocates one new
+# dense Array per mismatching entry. Wrapper types (OffsetArray, SubArray,
+# ReshapedArray, ...) are materialized to plain `Array` because the
+# downstream packed buffer uses 1-based indexing.
+function _reorder_pairs_by_mask(
+        ::Val{N},
+        pairs::NTuple{K, Pair{<:NTuple{N, Int}, <:AbstractArray}},
+        ::Type{Tv},
+    ) where {N, K, Tv}
+    slots = Vector{Array{Tv, N}}(undef, K)
+    @inbounds for p in pairs
+        m = _multiindex_to_mask(first(p))
+        slots[m] = convert(Array{Tv, N}, last(p))
+    end
+    return ntuple(i -> slots[i], Val(K))
+end

--- a/src/hermite/nd/hermite_nd_partials.jl
+++ b/src/hermite/nd/hermite_nd_partials.jl
@@ -145,12 +145,9 @@ function _validate_hermite_full_pairs(
     return nothing
 end
 
-# Reorder pairs into canonical mask order (1, 2, ..., 2^N-1) and coerce each
-# array to `Array{Tv, N}`. `convert` is a no-op when the input already
-# satisfies the target type (zero-copy alias); otherwise allocates one new
-# dense Array per mismatching entry. Wrapper types (OffsetArray, SubArray,
-# ReshapedArray, ...) are materialized to plain `Array` because the
-# downstream packed buffer uses 1-based indexing.
+# Reorder pairs into canonical mask order and coerce each array to
+# `Array{Tv, N}` (zero-copy when already matching; wrappers like OffsetArray
+# are materialized since the packed buffer is 1-based).
 function _reorder_pairs_by_mask(
         ::Val{N},
         pairs::NTuple{K, Pair{<:NTuple{N, Int}, <:AbstractArray}},

--- a/src/hermite/nd/hermite_nd_partials.jl
+++ b/src/hermite/nd/hermite_nd_partials.jl
@@ -14,7 +14,7 @@ Construct user-supplied full mixed partial derivatives for ND cubic Hermite
 interpolation.
 
 Each `pair` is `multiindex => array`, where `multiindex::NTuple{N, Int}` encodes
-the derivative order per axis. For Phase 1a, each entry must be `0` or `1`.
+the derivative order per axis. Each entry must be `0` or `1`.
 
 # Required pairs (count `2^N - 1`)
 Exactly the non-zero multiindices in `{0, 1}^N`. Order is irrelevant — the
@@ -67,7 +67,7 @@ end
     throw(
         ArgumentError(
             "HermitePartials: multiindex $(mi) has entry $val at axis $slot; " *
-                "Phase 1a requires every entry ∈ {0, 1}",
+                "every entry must be ∈ {0, 1}",
         )
     )
 end

--- a/src/hermite/nd/hermite_nd_partials.jl
+++ b/src/hermite/nd/hermite_nd_partials.jl
@@ -41,9 +41,11 @@ partials = HermitePartials(
 function HermitePartials(pairs::Pair{<:NTuple{N, Int}, <:AbstractArray}...) where {N}
     N >= 1 || throw(ArgumentError("HermitePartials requires N >= 1"))
     K = (1 << N) - 1
-    length(pairs) == K || throw(ArgumentError(
-        "HermitePartials{N=$N} requires exactly $K (mask=1..$K) partials, got $(length(pairs))",
-    ))
+    length(pairs) == K || throw(
+        ArgumentError(
+            "HermitePartials{N=$N} requires exactly $K (mask=1..$K) partials, got $(length(pairs))",
+        )
+    )
 
     _validate_hermite_full_pairs(Val(N), pairs)
 
@@ -62,17 +64,21 @@ end
 # ========================================
 
 @noinline function _throw_bad_multiindex_entry(mi::NTuple{N, Int}, slot::Int, val::Int) where {N}
-    throw(ArgumentError(
-        "HermitePartials: multiindex $(mi) has entry $val at axis $slot; " *
-        "Phase 1a requires every entry ∈ {0, 1}",
-    ))
+    throw(
+        ArgumentError(
+            "HermitePartials: multiindex $(mi) has entry $val at axis $slot; " *
+                "Phase 1a requires every entry ∈ {0, 1}",
+        )
+    )
 end
 
 @noinline function _throw_zero_multiindex(N::Int)
-    throw(ArgumentError(
-        "HermitePartials: multiindex $(ntuple(_ -> 0, N)) (function value) " *
-        "is not allowed — pass data as the `data` argument to `hermite_interp` instead",
-    ))
+    throw(
+        ArgumentError(
+            "HermitePartials: multiindex $(ntuple(_ -> 0, N)) (function value) " *
+                "is not allowed — pass data as the `data` argument to `hermite_interp` instead",
+        )
+    )
 end
 
 @noinline function _throw_duplicate_multiindex(mi)
@@ -80,26 +86,32 @@ end
 end
 
 @noinline function _throw_missing_multiindex(mi, mask::Int)
-    throw(ArgumentError(
-        "HermitePartials: missing multiindex $(mi) (mask=$mask); " *
-        "supply every non-zero entry of {0,1}^N",
-    ))
+    throw(
+        ArgumentError(
+            "HermitePartials: missing multiindex $(mi) (mask=$mask); " *
+                "supply every non-zero entry of {0,1}^N",
+        )
+    )
 end
 
 @noinline function _throw_size_mismatch_partials(mask_ref, sz_ref, mask_cur, sz_cur)
-    throw(DimensionMismatch(
-        "HermitePartials: array for mask=$mask_cur has size $sz_cur, " *
-        "but mask=$mask_ref has size $sz_ref — all partials must match",
-    ))
+    throw(
+        DimensionMismatch(
+            "HermitePartials: array for mask=$mask_cur has size $sz_cur, " *
+                "but mask=$mask_ref has size $sz_ref — all partials must match",
+        )
+    )
 end
 
 function _validate_hermite_full_pairs(
         ::Val{N},
         pairs::NTuple{K, Pair{<:NTuple{N, Int}, <:AbstractArray}},
     ) where {N, K}
-    K == (1 << N) - 1 || throw(ArgumentError(
-        "HermitePartials{N=$N}: expected $((1<<N)-1) pairs, got $K",
-    ))
+    K == (1 << N) - 1 || throw(
+        ArgumentError(
+            "HermitePartials{N=$N}: expected $((1 << N) - 1) pairs, got $K",
+        )
+    )
     seen = fill(false, 1 << N)   # index 1 ↔ mask 0 (sentinel; never set for FullPartials)
     sz_ref = size(last(pairs[1]))
     mask_ref = _multiindex_to_mask(first(pairs[1]))
@@ -114,9 +126,11 @@ function _validate_hermite_full_pairs(
         m == 0 && _throw_zero_multiindex(N)
         seen[m + 1] && _throw_duplicate_multiindex(mi)
         seen[m + 1] = true
-        ndims(arr) == N || throw(DimensionMismatch(
-            "HermitePartials: array for multiindex $(mi) is $(ndims(arr))-D, expected $N-D",
-        ))
+        ndims(arr) == N || throw(
+            DimensionMismatch(
+                "HermitePartials: array for multiindex $(mi) is $(ndims(arr))-D, expected $N-D",
+            )
+        )
         if k > 1
             sz_cur = size(arr)
             sz_cur == sz_ref || _throw_size_mismatch_partials(mask_ref, sz_ref, m, sz_cur)

--- a/src/hermite/nd/hermite_nd_types.jl
+++ b/src/hermite/nd/hermite_nd_types.jl
@@ -32,7 +32,7 @@ derivative for mask `m ∈ 1:K`, where bit `d-1` set in `m` means
 (mask `0`) is **not** stored here — it is supplied as the separate `data`
 argument to `hermite_interp`.
 
-Phase 1a: the only public constructor is `HermiteFullPartials(...)`, which
+Phase 1a: the only public constructor is `HermitePartials(...)`, which
 populates every non-zero multiindex in `{0, 1}^N` (so `K == 2^N - 1`).
 
 # Type parameters

--- a/src/hermite/nd/hermite_nd_types.jl
+++ b/src/hermite/nd/hermite_nd_types.jl
@@ -2,20 +2,10 @@
 # ND Cubic Hermite Interpolation Types (User-Supplied Partials)
 # ========================================
 #
-# Type definitions for ND cubic Hermite interpolation with user-supplied
-# partial derivatives at grid nodes. Phase 1a: user provides every non-zero
-# element of `{0, 1}^N` ("full mixed partials").
-#
-# Mirrors the storage conventions of `QuadraticInterpolantND` and
-# `CubicInterpolantND`: data + all 2^N - 1 mixed partials are packed into a
-# single `_NodalDerivativesND{Tv, N, N+1}` of shape `(2^N, n_ext_1, ..., n_ext_N)`,
-# enabling reuse of the existing tensor-product `_eval_nd_cell` kernel.
-#
-# Future-extension note: alternative input modes (e.g. user supplies only
-# first-order ∂f/∂xᵢ and the build estimates mixed terms internally) would
-# reintroduce a "Completeness" type parameter on `HermitePartials` and a new
-# public constructor — neither affects the current storage layout or
-# evaluation kernel.
+# User supplies every non-zero partial in `{0,1}^N` ("full mixed partials").
+# Data + all 2^N-1 mixed partials pack into one `_NodalDerivativesND{Tv, N, N+1}`
+# of shape `(2^N, n_ext...)`, reusing the tensor-product `_eval_nd_cell` kernel
+# shared with `CubicInterpolantND` / `QuadraticInterpolantND`.
 
 # ========================================
 # HermitePartials — user-input container

--- a/src/hermite/nd/hermite_nd_types.jl
+++ b/src/hermite/nd/hermite_nd_types.jl
@@ -1,0 +1,140 @@
+# ========================================
+# ND Cubic Hermite Interpolation Types (User-Supplied Partials)
+# ========================================
+#
+# Type definitions for ND cubic Hermite interpolation with user-supplied
+# partial derivatives at grid nodes. Phase 1a: user provides every non-zero
+# element of `{0, 1}^N` ("full mixed partials").
+#
+# Mirrors the storage conventions of `QuadraticInterpolantND` and
+# `CubicInterpolantND`: data + all 2^N - 1 mixed partials are packed into a
+# single `_NodalDerivativesND{Tv, N, N+1}` of shape `(2^N, n_ext_1, ..., n_ext_N)`,
+# enabling reuse of the existing tensor-product `_eval_nd_cell` kernel.
+#
+# Future-extension note: alternative input modes (e.g. user supplies only
+# first-order ∂f/∂xᵢ and the build estimates mixed terms internally) would
+# reintroduce a "Completeness" type parameter on `HermitePartials` and a new
+# public constructor — neither affects the current storage layout or
+# evaluation kernel.
+
+# ========================================
+# HermitePartials — user-input container
+# ========================================
+
+"""
+    HermitePartials{N, Tv, K, A}
+
+User-supplied partial derivatives for ND cubic Hermite interpolation.
+
+Holds `K` arrays in canonical mask order: `partials[m]` is the partial
+derivative for mask `m ∈ 1:K`, where bit `d-1` set in `m` means
+"differentiate once with respect to axis `d`". The function value itself
+(mask `0`) is **not** stored here — it is supplied as the separate `data`
+argument to `hermite_interp`.
+
+Phase 1a: the only public constructor is `HermiteFullPartials(...)`, which
+populates every non-zero multiindex in `{0, 1}^N` (so `K == 2^N - 1`).
+
+# Type parameters
+- `N` : spatial dimension
+- `Tv`: value element type (common eltype across all stored arrays)
+- `K` : number of stored arrays
+- `A` : concrete element-array type (`<: AbstractArray{Tv, N}`)
+"""
+struct HermitePartials{N, Tv, K, A <: AbstractArray{Tv, N}}
+    partials::NTuple{K, A}
+end
+
+# ========================================
+# Multiindex → mask conversion (internal)
+# ========================================
+
+# Convert a derivative-order multiindex (each entry ∈ {0, 1} for Phase 1a)
+# to the canonical bitmask: bit `d-1` ← `mi[d] & 1`. Compile-time foldable.
+#
+# Examples (N=2):
+#   (0, 0) → 0  (data slot — not stored on HermitePartials)
+#   (1, 0) → 1  (∂f/∂x)
+#   (0, 1) → 2  (∂f/∂y)
+#   (1, 1) → 3  (∂²f/∂x∂y)
+@inline _multiindex_to_mask(mi::NTuple{N, Int}) where {N} =
+    sum(ntuple(d -> (mi[d] & 1) << (d - 1), Val(N)))
+
+# ========================================
+# CubicHermiteInterpolantND — the persistent interpolant
+# ========================================
+
+"""
+    CubicHermiteInterpolantND{Tg, Tv, N, NP1, G, B, E, P}
+
+N-dimensional cubic Hermite interpolant with user-supplied partial
+derivatives. Stores function values and all `2^N - 1` mixed partials packed
+in a single `_NodalDerivativesND{Tv, N, NP1}`, enabling O(4^N) tensor-product
+cubic Hermite evaluation via the shared `_eval_nd_cell` kernel.
+
+# Type parameters
+- `Tg` : grid coordinate type
+- `Tv` : value type
+- `N`  : spatial dimensions
+- `NP1`: `N + 1` (partials-array dimensionality)
+- `G`  : tuple of wrapped axes (post-extension, post-`_cache_axis`)
+- `B`  : tuple of per-axis BCs (`:exclusive → :extended` after build extension)
+- `E`  : tuple of per-axis extrapolation modes
+- `P`  : tuple of per-axis search policies
+
+# Fields
+- `grids`        : per-axis wrapped vectors (`_CachedRange` / `_CachedVector`)
+- `nodal_derivs` : packed `(2^N, n_ext_1, ..., n_ext_N)` partials
+- `bcs`          : per-axis BC tuple — `:exclusive` is promoted to `:extended`
+                   after build-time extension; `:inclusive` and `NoBC` pass through
+- `extraps`      : per-axis extrap policies
+- `searches`     : per-axis search policies
+"""
+struct CubicHermiteInterpolantND{
+        Tg,
+        Tv,
+        N,
+        NP1,
+        G <: Tuple{Vararg{AbstractVector, N}},
+        B <: Tuple{Vararg{AbstractBC, N}},
+        E <: Tuple{Vararg{AbstractExtrap, N}},
+        P <: Tuple{Vararg{AbstractSearchPolicy, N}},
+    } <: AbstractInterpolantND{Tg, Tv, N}
+    grids::G
+    nodal_derivs::_NodalDerivativesND{Tv, N, NP1}
+    bcs::B
+    extraps::E
+    searches::P
+
+    # Inner constructor: caller provides post-extension grids, packed
+    # nodal_derivs, post-extension bcs, resolved extraps, and searches.
+    # Wrapping `grids` via `_cache_axis(grid, bc, Tg)` ensures `_get_h` /
+    # `_get_inv_h` are O(1) cached lookups during eval.
+    function CubicHermiteInterpolantND(
+            grids::Tuple{Vararg{AbstractVector{Tg}, N}},
+            nodal_derivs::_NodalDerivativesND{Tv, N, NP1},
+            bcs::Tuple{Vararg{AbstractBC, N}},
+            extraps::Tuple{Vararg{AbstractExtrap, N}},
+            searches::Tuple{Vararg{AbstractSearchPolicy, N}},
+        ) where {Tg, Tv, N, NP1}
+        NP1 == N + 1 || throw(ArgumentError("NP1 must equal N+1"))
+        grids_c = map((g, bc) -> _convert_copy(_cache_axis(g, bc, Tg), Tg), grids, bcs)
+        return new{Tg, Tv, N, NP1, typeof(grids_c), typeof(bcs), typeof(extraps), typeof(searches)}(
+            grids_c, nodal_derivs, bcs, extraps, searches,
+        )
+    end
+end
+
+# ========================================
+# Type introspection
+# ========================================
+
+Base.ndims(::CubicHermiteInterpolantND{Tg, Tv, N}) where {Tg, Tv, N} = N
+Base.size(itp::CubicHermiteInterpolantND{Tg, Tv, N}) where {Tg, Tv, N} =
+    ntuple(d -> length(itp.grids[d]), Val(N))
+Base.axes(itp::CubicHermiteInterpolantND) = itp.grids
+
+# Convenience: number of stored partial slots per grid point (data + all
+# mixed partials = 2^N).
+num_partials(::CubicHermiteInterpolantND{Tg, Tv, N}) where {Tg, Tv, N} = 1 << N
+num_partials(::Type{<:CubicHermiteInterpolantND{Tg, Tv, N}}) where {Tg, Tv, N} = 1 << N

--- a/src/hermite/nd/hermite_nd_types.jl
+++ b/src/hermite/nd/hermite_nd_types.jl
@@ -22,8 +22,8 @@ derivative for mask `m ∈ 1:K`, where bit `d-1` set in `m` means
 (mask `0`) is **not** stored here — it is supplied as the separate `data`
 argument to `hermite_interp`.
 
-Phase 1a: the only public constructor is `HermitePartials(...)`, which
-populates every non-zero multiindex in `{0, 1}^N` (so `K == 2^N - 1`).
+The only public constructor is `HermitePartials(...)`; it populates every
+non-zero multiindex in `{0, 1}^N` (so `K == 2^N - 1`).
 
 # Type parameters
 - `N` : spatial dimension
@@ -39,8 +39,8 @@ end
 # Multiindex → mask conversion (internal)
 # ========================================
 
-# Convert a derivative-order multiindex (each entry ∈ {0, 1} for Phase 1a)
-# to the canonical bitmask: bit `d-1` ← `mi[d] & 1`. Compile-time foldable.
+# Convert a derivative-order multiindex (each entry ∈ {0, 1}) to the
+# canonical bitmask: bit `d-1` ← `mi[d] & 1`. Compile-time foldable.
 #
 # Examples (N=2):
 #   (0, 0) → 0  (data slot — not stored on HermitePartials)

--- a/src/hermite/nd/nd.jl
+++ b/src/hermite/nd/nd.jl
@@ -1,0 +1,9 @@
+# ND Cubic Hermite (user-supplied partials) module aggregator.
+# Phase 1a: full mixed partials only. See
+# docs/superpowers/specs/2026-05-28-hermite-nd-full-partials-design.md
+
+include("hermite_nd_types.jl")        # 1. HermitePartials, FullMixed, CubicHermiteInterpolantND
+include("hermite_nd_partials.jl")     # 2. HermiteFullPartials constructor + validation
+include("hermite_nd_build.jl")        # 3. _pack_and_extend_nodal_derivs + BC/size validation
+include("hermite_nd_interpolant.jl")  # 4. outer ctor + callable + _locate_cell / _eval_at_cell + hermite_interp(grids, data, partials)
+include("hermite_nd_oneshot.jl")      # 5. hermite_interp / hermite_interp! one-shot variants

--- a/src/hermite/nd/nd.jl
+++ b/src/hermite/nd/nd.jl
@@ -2,7 +2,7 @@
 # Phase 1a: full mixed partials only. See
 # docs/superpowers/specs/2026-05-28-hermite-nd-full-partials-design.md
 
-include("hermite_nd_types.jl")        # 1. HermitePartials, FullMixed, CubicHermiteInterpolantND
+include("hermite_nd_types.jl")        # 1. HermitePartials, CubicHermiteInterpolantND
 include("hermite_nd_partials.jl")     # 2. HermitePartials constructor + validation
 include("hermite_nd_build.jl")        # 3. _pack_and_extend_nodal_derivs + BC/size validation
 include("hermite_nd_interpolant.jl")  # 4. outer ctor + callable + _locate_cell / _eval_at_cell + hermite_interp(grids, data, partials)

--- a/src/hermite/nd/nd.jl
+++ b/src/hermite/nd/nd.jl
@@ -3,7 +3,7 @@
 # docs/superpowers/specs/2026-05-28-hermite-nd-full-partials-design.md
 
 include("hermite_nd_types.jl")        # 1. HermitePartials, FullMixed, CubicHermiteInterpolantND
-include("hermite_nd_partials.jl")     # 2. HermiteFullPartials constructor + validation
+include("hermite_nd_partials.jl")     # 2. HermitePartials constructor + validation
 include("hermite_nd_build.jl")        # 3. _pack_and_extend_nodal_derivs + BC/size validation
 include("hermite_nd_interpolant.jl")  # 4. outer ctor + callable + _locate_cell / _eval_at_cell + hermite_interp(grids, data, partials)
 include("hermite_nd_oneshot.jl")      # 5. hermite_interp / hermite_interp! one-shot variants

--- a/src/hermite/nd/nd.jl
+++ b/src/hermite/nd/nd.jl
@@ -1,6 +1,4 @@
 # ND Cubic Hermite (user-supplied partials) module aggregator.
-# Phase 1a: full mixed partials only. See
-# docs/superpowers/specs/2026-05-28-hermite-nd-full-partials-design.md
 
 include("hermite_nd_types.jl")        # 1. HermitePartials, CubicHermiteInterpolantND
 include("hermite_nd_partials.jl")     # 2. HermitePartials constructor + validation

--- a/src/method_traits.jl
+++ b/src/method_traits.jl
@@ -36,3 +36,18 @@ _adjoint_kwargs_from_itp(itp::QuadraticInterpolantND) = (bc = itp.bcs, extrap = 
 _adjoint_kwargs_from_itp(itp::LinearInterpolantND) = (extrap = itp.extraps,)
 _adjoint_kwargs_from_itp(itp::ConstantInterpolantND) = (side = itp.sides, extrap = itp.extraps)
 _adjoint_kwargs_from_itp(itp::HeteroInterpolantND) = (methods = itp.methods, extrap = itp.extraps)
+
+# CubicHermiteInterpolantND has no adjoint yet (user supplies data + 2^N-1
+# separate partial arrays, so the single-`data`-tangent protocol does not
+# apply). It subtypes `AbstractInterpolantND`, so the generic reverse-mode
+# rrules reach these traits — guard with a clear error instead of a MethodError.
+# Forward eval and `gradient`/`hessian`/`laplacian` are unaffected.
+@noinline _throw_hermite_nd_adjoint_unsupported() = throw(
+    ArgumentError(
+        "CubicHermiteInterpolantND does not support reverse-mode AD (adjoint) yet. " *
+            "Forward `gradient`/`hessian`/`laplacian` work; for ∂/∂data use an auto-slope " *
+            "ND method (`cubic_interp`, `pchip_interp`, …) until the Hermite ND adjoint lands.",
+    )
+)
+_adjoint_func_from_itp(::CubicHermiteInterpolantND) = _throw_hermite_nd_adjoint_unsupported()
+_adjoint_kwargs_from_itp(::CubicHermiteInterpolantND) = _throw_hermite_nd_adjoint_unsupported()

--- a/src/method_traits.jl
+++ b/src/method_traits.jl
@@ -45,8 +45,9 @@ _adjoint_kwargs_from_itp(itp::HeteroInterpolantND) = (methods = itp.methods, ext
 @noinline _throw_hermite_nd_adjoint_unsupported() = throw(
     ArgumentError(
         "CubicHermiteInterpolantND does not support reverse-mode AD (adjoint) yet. " *
-            "Forward `gradient`/`hessian`/`laplacian` work; for ∂/∂data use an auto-slope " *
-            "ND method (`cubic_interp`, `pchip_interp`, …) until the Hermite ND adjoint lands.",
+            "Forward `gradient`/`hessian`/`laplacian` work; for reverse-mode ∂/∂data use an " *
+            "ND method that supports it (`cubic_interp`, `pchip_interp`, `cardinal_interp`, " *
+            "`akima_interp`) until the Hermite ND adjoint lands.",
     )
 )
 _adjoint_func_from_itp(::CubicHermiteInterpolantND) = _throw_hermite_nd_adjoint_unsupported()

--- a/src/nodal_partials.jl
+++ b/src/nodal_partials.jl
@@ -38,6 +38,8 @@ end
 
 @inline _partials_array(itp::CubicInterpolantND) = itp.nodal_derivs.partials
 @inline _partials_array(itp::QuadraticInterpolantND) = itp.nodal_derivs.partials
+# User-supplied: the packed buffer already holds data + every mixed partial.
+@inline _partials_array(itp::CubicHermiteInterpolantND) = itp.nodal_derivs.partials
 
 @inline function _partials_array(itp::HeteroInterpolantND)
     if itp.data isa _HeteroPartials
@@ -88,7 +90,7 @@ end
 # --- Validate + compute index ---
 
 @inline function _validate_and_index(
-        ::Union{CubicInterpolantND, QuadraticInterpolantND},
+        ::Union{CubicInterpolantND, QuadraticInterpolantND, CubicHermiteInterpolantND},
         order::NTuple{N, Integer},
     ) where {N}
     _validate_binary_order(order)
@@ -170,6 +172,7 @@ For heterogeneous interpolants, only axes using `CubicInterp` or
 # Supported types
 - `CubicInterpolantND` — all `2^N` derivative combinations
 - `QuadraticInterpolantND` — all `2^N` combinations (mixed partials are zero)
+- `CubicHermiteInterpolantND` — all `2^N` combinations (user-supplied partials)
 - `HeteroInterpolantND` with `PreCompute()` — per-axis validation
 """
 function nodal_partials end

--- a/test/test_hermite_nd_full_partials.jl
+++ b/test/test_hermite_nd_full_partials.jl
@@ -319,5 +319,118 @@ end
     @test itp((0.3, 0.5)) ≈ itp((0.3, 0.5))
 end
 
+@testset "Hermite ND — Pool-based oneshot zero-alloc" begin
+    # All measurements live inside one function so locals are type-stable and
+    # `@allocated` reports the steady-state, post-warmup cost (no @testset
+    # try/catch artifacts). Bulk-loop divisor confirms per-call alloc.
+
+    function _measure_nobc(n_iters)
+        x = range(0.0, 1.0, length=20)
+        y = range(0.0, 1.0, length=20)
+        data = [xi*yj for xi in x, yj in y]
+        p = HermiteFullPartials(
+            (1, 0) => [yj for xi in x, yj in y],
+            (0, 1) => [xi for xi in x, yj in y],
+            (1, 1) => ones(20, 20),
+        )
+        # warmup
+        hermite_interp((x, y), data, p, (0.5, 0.5))
+        function loop!(out, x, y, data, p, queries, n)
+            @inbounds for k in 1:n
+                out[k] = hermite_interp((x, y), data, p, queries[k])
+            end
+            return nothing
+        end
+        queries = [(0.1 + 0.0001*k, 0.5) for k in 1:n_iters]
+        out = Vector{Float64}(undef, n_iters)
+        loop!(out, x, y, data, p, queries, n_iters)
+        return @allocated loop!(out, x, y, data, p, queries, n_iters)
+    end
+
+    function _measure_excl(n_iters)
+        xp = range(0.0, 2π * 19/20, length=20)
+        yp = range(0.0, 2π * 19/20, length=20)
+        dp = [sin(xi)*cos(yj) for xi in xp, yj in yp]
+        pp = HermiteFullPartials(
+            (1, 0) => [ cos(xi)*cos(yj) for xi in xp, yj in yp],
+            (0, 1) => [-sin(xi)*sin(yj) for xi in xp, yj in yp],
+            (1, 1) => [-cos(xi)*sin(yj) for xi in xp, yj in yp],
+        )
+        bc = (PeriodicBC(endpoint = :exclusive), PeriodicBC(endpoint = :exclusive))
+        hermite_interp((xp, yp), dp, pp, (0.5, 0.5); bc)
+        function loop!(out, xp, yp, dp, pp, queries, n, bc)
+            @inbounds for k in 1:n
+                out[k] = hermite_interp((xp, yp), dp, pp, queries[k]; bc)
+            end
+            return nothing
+        end
+        queries = [(0.1 + 0.0001*k, 0.5) for k in 1:n_iters]
+        out = Vector{Float64}(undef, n_iters)
+        loop!(out, xp, yp, dp, pp, queries, n_iters, bc)
+        return @allocated loop!(out, xp, yp, dp, pp, queries, n_iters, bc)
+    end
+
+    function _measure_inc(n_iters)
+        xi2 = range(0.0, 2π, length=20)
+        yi2 = range(0.0, 2π, length=20)
+        di = [cos(xi)*cos(yj) for xi in xi2, yj in yi2]
+        pi2 = HermiteFullPartials(
+            (1, 0) => [-sin(xi)*cos(yj) for xi in xi2, yj in yi2],
+            (0, 1) => [-cos(xi)*sin(yj) for xi in xi2, yj in yi2],
+            (1, 1) => [ sin(xi)*sin(yj) for xi in xi2, yj in yi2],
+        )
+        bc = (PeriodicBC(endpoint = :inclusive), PeriodicBC(endpoint = :inclusive))
+        hermite_interp((xi2, yi2), di, pi2, (0.5, 0.5); bc)
+        function loop!(out, xi2, yi2, di, pi2, queries, n, bc)
+            @inbounds for k in 1:n
+                out[k] = hermite_interp((xi2, yi2), di, pi2, queries[k]; bc)
+            end
+            return nothing
+        end
+        queries = [(0.1 + 0.0001*k, 0.5) for k in 1:n_iters]
+        out = Vector{Float64}(undef, n_iters)
+        loop!(out, xi2, yi2, di, pi2, queries, n_iters, bc)
+        return @allocated loop!(out, xi2, yi2, di, pi2, queries, n_iters, bc)
+    end
+
+    function _measure_batch_inplace()
+        x = range(0.0, 1.0, length=20)
+        y = range(0.0, 1.0, length=20)
+        data = [xi*yj for xi in x, yj in y]
+        p = HermiteFullPartials(
+            (1, 0) => [yj for xi in x, yj in y],
+            (0, 1) => [xi for xi in x, yj in y],
+            (1, 1) => ones(20, 20),
+        )
+        queries = [(0.13, 0.42), (0.77, 0.51), (0.23, 0.83)]
+        out = Vector{Float64}(undef, 3)
+        hermite_interp!(out, (x, y), data, p, queries)
+        return @allocated hermite_interp!(out, (x, y), data, p, queries)
+    end
+
+    function _measure_persistent_eval()
+        x = range(0.0, 1.0, length=20)
+        y = range(0.0, 1.0, length=20)
+        data = [xi*yj for xi in x, yj in y]
+        p = HermiteFullPartials(
+            (1, 0) => [yj for xi in x, yj in y],
+            (0, 1) => [xi for xi in x, yj in y],
+            (1, 1) => ones(20, 20),
+        )
+        itp = hermite_interp((x, y), data, p)
+        itp((0.5, 0.5))
+        return @allocated itp((0.7, 0.3))
+    end
+
+    # Bulk-loop measurements amortize single-call setup noise.
+    # 1000-iter bulk / 1000 must be exactly 0.
+    @test _measure_nobc(1000) == 0
+    @test _measure_excl(1000) == 0
+    @test _measure_inc(1000)  == 0
+    # Single-call batch & persistent eval (already inside function barrier).
+    @test _measure_batch_inplace() <= ALLOC_THRESHOLD
+    @test _measure_persistent_eval() <= ALLOC_THRESHOLD
+end
+
 end  # @testitem
 

--- a/test/test_hermite_nd_full_partials.jl
+++ b/test/test_hermite_nd_full_partials.jl
@@ -319,6 +319,85 @@ end
     @test itp((0.3, 0.5)) ≈ itp((0.3, 0.5))
 end
 
+@testset "Hermite ND — Input isolation (persistent copies, oneshot snapshots)" begin
+    # ── Persistent: build snapshots inputs; user mutations after build are
+    #    not visible to the interpolant.
+    @testset "Persistent: itp isolated from post-build user mutation" begin
+        x = range(0.0, 1.0, length=5)
+        y = range(0.0, 1.0, length=5)
+        data = [xi*yj for xi in x, yj in y]
+        dfdx = [yj for xi in x, yj in y]
+        dfdy = [xi for xi in x, yj in y]
+        d2   = ones(5, 5)
+        p = HermiteFullPartials((1, 0) => dfdx, (0, 1) => dfdy, (1, 1) => d2)
+
+        itp = hermite_interp((x, y), data, p)
+        val_before = itp((0.5, 0.5))
+
+        # Trash every user-owned input array
+        fill!(data, NaN)
+        fill!(dfdx, NaN)
+        fill!(dfdy, NaN)
+        fill!(d2,   NaN)
+        # `p.partials[k]` is the *same array* as the dfdx/dfdy/d2 we just
+        # nuked — these are aliases established by `HermiteFullPartials`
+        # (zero-copy when eltypes match). Confirm:
+        @test all(isnan, p.partials[1])
+        @test all(isnan, p.partials[2])
+        @test all(isnan, p.partials[3])
+
+        # Despite user-side trashing, itp still reproduces the original value:
+        # the build-time copy into `nodal_derivs.partials` decoupled it.
+        val_after = itp((0.5, 0.5))
+        @test val_after == val_before
+        @test !isnan(val_after)
+    end
+
+    # ── Persistent: the stored packed buffer is also independent (a third
+    #    snapshot — mutate itp.nodal_derivs internally, user data untouched).
+    @testset "Persistent: user data unaffected by itp internal mutation" begin
+        x = range(0.0, 1.0, length=4)
+        y = range(0.0, 1.0, length=4)
+        data = [xi*yj for xi in x, yj in y]
+        original_data = copy(data)
+        p = HermiteFullPartials(
+            (1, 0) => [yj for xi in x, yj in y],
+            (0, 1) => [xi for xi in x, yj in y],
+            (1, 1) => ones(4, 4),
+        )
+        itp = hermite_interp((x, y), data, p)
+        # Stomp the internal packed buffer
+        fill!(itp.nodal_derivs.partials, 99.0)
+        # User's `data` is unchanged
+        @test data == original_data
+    end
+
+    # ── One-shot: each call snapshots the *current* user data. Mutating
+    #    between calls is safe and reflected in the next return.
+    @testset "One-shot: snapshots current data per call" begin
+        x = range(0.0, 1.0, length=5)
+        y = range(0.0, 1.0, length=5)
+        data = [xi*yj for xi in x, yj in y]
+        p = HermiteFullPartials(
+            (1, 0) => [yj for xi in x, yj in y],
+            (0, 1) => [xi for xi in x, yj in y],
+            (1, 1) => ones(5, 5),
+        )
+        v1 = hermite_interp((x, y), data, p, (0.5, 0.5))
+        # Replace data in-place with a constant; result must follow.
+        # Partials still describe the OLD data, but for cubic Hermite the
+        # value at a node is the corresponding data entry exactly — so at
+        # interior the eval is a polynomial mix of {data, partials}. Easier
+        # invariant: at a *grid node* the eval reduces to `data[i, j]`.
+        data .= 7.5
+        v2 = hermite_interp((x, y), data, p, (x[3], y[3]))   # grid node
+        @test v2 == 7.5
+        # And the original call shouldn't have been retroactively affected
+        # (no aliasing back into user's array via the pool).
+        @test v1 == 0.25   # x[3]*y[3] when data was xi*yj; sanity
+    end
+end
+
 @testset "Hermite ND — Pool-based oneshot zero-alloc" begin
     # All measurements live inside one function so locals are type-stable and
     # `@allocated` reports the steady-state, post-warmup cost (no @testset

--- a/test/test_hermite_nd_full_partials.jl
+++ b/test/test_hermite_nd_full_partials.jl
@@ -1,0 +1,323 @@
+# ========================================
+# ND Cubic Hermite (User-Supplied Full Mixed Partials) — Phase 1a Tests
+# ========================================
+#
+# Coverage:
+# - Construction validation (bad keys, missing, duplicates, size mismatches, BC rejection)
+# - Analytic exactness (polynomials up to cubic in each axis, separable trig)
+# - Cross-validation against `cardinal_interp` ND with manually-computed central FDM
+# - Periodic BC modes (NoBC / :inclusive / :exclusive)
+# - Derivative output (`deriv` kwarg)
+# - One-shot scalar + batch + in-place
+
+@testitem "Hermite ND Full Partials (Phase 1a)" setup = [AllocConstants] begin
+
+# Helper: central FDM along axis `d` of N-D array, using grid `g` (length n_d).
+# Interior: (arr[..., j+1, ...] - arr[..., j-1, ...]) / (g[j+1] - g[j-1])
+# Boundary j=1 :          forward difference  (arr[..., 2, ...] - arr[..., 1, ...]) / (g[2] - g[1])
+# Boundary j=n :          backward difference (arr[..., n, ...] - arr[..., n-1, ...]) / (g[n] - g[n-1])
+function _central_fdm_along_axis(arr::AbstractArray{T, N}, grid::AbstractVector, d::Int) where {T, N}
+    n = size(arr, d)
+    n >= 2 || throw(ArgumentError("FDM requires axis length >= 2"))
+    out = similar(arr, float(T))
+    for j in 1:n
+        if j == 1
+            slab_lo = selectdim(arr, d, 1)
+            slab_hi = selectdim(arr, d, 2)
+            denom = grid[2] - grid[1]
+        elseif j == n
+            slab_lo = selectdim(arr, d, n - 1)
+            slab_hi = selectdim(arr, d, n)
+            denom = grid[n] - grid[n - 1]
+        else
+            slab_lo = selectdim(arr, d, j - 1)
+            slab_hi = selectdim(arr, d, j + 1)
+            denom = grid[j + 1] - grid[j - 1]
+        end
+        selectdim(out, d, j) .= (slab_hi .- slab_lo) ./ denom
+    end
+    return out
+end
+
+@testset "Hermite ND — Construction validation (N=2)" begin
+    n = 5
+    A = zeros(n, n)
+
+    @testset "Happy path" begin
+        p = HermiteFullPartials(
+            (1, 0) => copy(A),
+            (0, 1) => copy(A),
+            (1, 1) => copy(A),
+        )
+        @test p isa HermitePartials{2, Float64, 3, Matrix{Float64}}
+    end
+
+    @testset "Mixed eltypes promote to common Tv" begin
+        A32 = zeros(Float32, n, n)
+        A64 = zeros(Float64, n, n)
+        p = HermiteFullPartials(
+            (1, 0) => A32,         # Float32
+            (0, 1) => A64,         # Float64
+            (1, 1) => A32,         # Float32
+        )
+        @test p isa HermitePartials{2, Float64, 3, Matrix{Float64}}
+    end
+
+    @testset "Wrong pair count" begin
+        @test_throws ArgumentError HermiteFullPartials(
+            (1, 0) => copy(A),
+            (0, 1) => copy(A),
+            # missing (1, 1)
+        )
+        @test_throws ArgumentError HermiteFullPartials(
+            (1, 0) => copy(A),
+            (0, 1) => copy(A),
+            (1, 1) => copy(A),
+            (1, 1) => copy(A),  # too many
+        )
+    end
+
+    @testset "Duplicate multiindex" begin
+        @test_throws ArgumentError HermiteFullPartials(
+            (1, 0) => copy(A),
+            (0, 1) => copy(A),
+            (0, 1) => copy(A),  # duplicate
+        )
+    end
+
+    @testset "Zero multiindex disallowed" begin
+        @test_throws ArgumentError HermiteFullPartials(
+            (0, 0) => copy(A),
+            (1, 0) => copy(A),
+            (0, 1) => copy(A),
+        )
+    end
+
+    @testset "Out-of-range multiindex entry" begin
+        @test_throws ArgumentError HermiteFullPartials(
+            (1, 0) => copy(A),
+            (0, 1) => copy(A),
+            (2, 0) => copy(A),  # entry == 2, not 0 or 1
+        )
+    end
+
+    @testset "Mismatched array sizes" begin
+        B = zeros(n + 1, n)
+        @test_throws DimensionMismatch HermiteFullPartials(
+            (1, 0) => copy(A),
+            (0, 1) => copy(B),
+            (1, 1) => copy(A),
+        )
+    end
+
+    @testset "Wrong array ndims" begin
+        v = zeros(n)
+        @test_throws DimensionMismatch HermiteFullPartials(
+            (1, 0) => copy(A),
+            (0, 1) => v,        # 1-D, not 2-D
+            (1, 1) => copy(A),
+        )
+    end
+end
+
+@testset "Hermite ND — Build-time BC rejection (Phase 1a)" begin
+    x = range(0.0, 1.0, length=5)
+    y = range(0.0, 1.0, length=5)
+    data = [xi*yj for xi in x, yj in y]
+    dfdx = [yj for xi in x, yj in y]
+    dfdy = [xi for xi in x, yj in y]
+    d2   = ones(5, 5)
+    p = HermiteFullPartials((1, 0) => dfdx, (0, 1) => dfdy, (1, 1) => d2)
+
+    # NoBC, PeriodicBC ok
+    @test hermite_interp((x, y), data, p) isa CubicHermiteInterpolantND
+    # CubicFit, NaturalBC, etc. rejected — user partials supersede.
+    @test_throws ArgumentError hermite_interp((x, y), data, p; bc = CubicFit())
+    @test_throws ArgumentError hermite_interp((x, y), data, p; bc = ZeroSlopeBC())
+end
+
+@testset "Hermite ND — Analytic exactness (polynomial)" begin
+    # f(x, y) = a + b x + c y + d x y + e x² + f y² + g x²y + h x y² + i x³ + j y³
+    # Cubic Hermite is exact on any bicubic polynomial when supplied with the
+    # corresponding analytic partials.
+
+    a, b, c, dd = 0.7, 1.3, -0.4, 2.1
+    e, ff, gg, hh = -0.6, 0.5, 0.3, -0.2
+    ii, jj = 0.15, -0.25
+
+    F(x, y)    = a + b*x + c*y + dd*x*y + e*x^2 + ff*y^2 + gg*x^2*y + hh*x*y^2 + ii*x^3 + jj*y^3
+    Fx(x, y)   = b + dd*y + 2e*x + 2gg*x*y + hh*y^2 + 3ii*x^2
+    Fy(x, y)   = c + dd*x + 2ff*y + gg*x^2 + 2hh*x*y + 3jj*y^2
+    Fxy(x, y)  = dd + 2gg*x + 2hh*y
+
+    x = collect(range(-1.0, 1.5, length=8))
+    y = collect(range(-0.8, 1.2, length=7))
+
+    data = [F(xi, yj) for xi in x, yj in y]
+    dfdx = [Fx(xi, yj) for xi in x, yj in y]
+    dfdy = [Fy(xi, yj) for xi in x, yj in y]
+    d2   = [Fxy(xi, yj) for xi in x, yj in y]
+    p    = HermiteFullPartials((1,0) => dfdx, (0,1) => dfdy, (1,1) => d2)
+
+    itp = hermite_interp((x, y), data, p)
+
+    # 1. Grid nodes — exact
+    for i in 1:length(x), j in 1:length(y)
+        @test itp((x[i], y[j])) ≈ data[i, j] atol = 1e-12
+    end
+
+    # 2. Random interior points — exact for bicubic polynomial
+    for (qx, qy) in [(0.13, 0.42), (-0.51, 1.1), (1.32, -0.7), (0.0, 0.0), (1.0, 1.0)]
+        @test itp((qx, qy)) ≈ F(qx, qy) atol = 1e-10
+    end
+
+    # 3. Derivative queries
+    for (qx, qy) in [(0.13, 0.42), (-0.51, 1.1)]
+        @test itp((qx, qy); deriv=(DerivOp(1), DerivOp(0))) ≈ Fx(qx, qy) atol = 1e-10
+        @test itp((qx, qy); deriv=(DerivOp(0), DerivOp(1))) ≈ Fy(qx, qy) atol = 1e-10
+        @test itp((qx, qy); deriv=(DerivOp(1), DerivOp(1))) ≈ Fxy(qx, qy) atol = 1e-10
+    end
+end
+
+@testset "Hermite ND — Cardinal cross-validation (central FDM partials)" begin
+    # The key test the user explicitly requested:
+    # Feed Hermite ND with manually-computed central-FDM partials, compare
+    # to `cardinal_interp` ND on the same data. They should agree at
+    # interior query points (boundary handling may differ; sticking to
+    # interior cells for strict equivalence).
+
+    F(x, y) = sin(0.7x) * cos(0.5y) + 0.3x*y
+
+    x = collect(range(0.0, 4.0, length=12))
+    y = collect(range(0.0, 3.0, length=10))
+    data = [F(xi, yj) for xi in x, yj in y]
+
+    # Central FDM partials
+    dfdx_fdm = _central_fdm_along_axis(data, x, 1)
+    dfdy_fdm = _central_fdm_along_axis(data, y, 2)
+    d2_fdm   = _central_fdm_along_axis(dfdx_fdm, y, 2)
+
+    p = HermiteFullPartials((1,0) => dfdx_fdm, (0,1) => dfdy_fdm, (1,1) => d2_fdm)
+    itp_h = hermite_interp((x, y), data, p)
+    itp_c = cardinal_interp((x, y), data)
+
+    # Interior query points (away from boundary by at least 2 cells).
+    # Cardinal's boundary FDM treatment may differ from our forward/backward
+    # at edges — interior queries are where the two surfaces should agree.
+    interior_queries = [
+        (x[4],         y[4]),         # exact node, both must return data exactly
+        (x[6] + 0.13,  y[5] + 0.07),  # interior point
+        (x[7] + 0.31,  y[6] - 0.09),
+        (x[8] - 0.04,  y[7] + 0.02),
+    ]
+    for (qx, qy) in interior_queries
+        vh = itp_h((qx, qy))
+        vc = itp_c((qx, qy))
+        @test vh ≈ vc atol = 1e-10
+    end
+end
+
+@testset "Hermite ND — One-shot variants" begin
+    F(x, y)   = 0.4 + 0.7x - 0.3y + 0.5x*y + 0.2x^2*y - 0.1y^3
+    Fx(x, y)  = 0.7 + 0.5y + 0.4x*y
+    Fy(x, y)  = -0.3 + 0.5x + 0.2x^2 - 0.3y^2
+    Fxy(x, y) = 0.5 + 0.4x
+
+    x = collect(range(0.0, 2.0, length=6))
+    y = collect(range(-1.0, 1.0, length=5))
+
+    data = [F(xi, yj) for xi in x, yj in y]
+    p = HermiteFullPartials(
+        (1, 0) => [Fx(xi, yj)  for xi in x, yj in y],
+        (0, 1) => [Fy(xi, yj)  for xi in x, yj in y],
+        (1, 1) => [Fxy(xi, yj) for xi in x, yj in y],
+    )
+
+    # Scalar one-shot
+    v = hermite_interp((x, y), data, p, (0.33, 0.42))
+    @test v ≈ F(0.33, 0.42) atol = 1e-10
+
+    # Batch one-shot (allocating)
+    queries = [(0.13, -0.42), (0.77, 0.51), (1.23, 0.83)]
+    out_batch = hermite_interp((x, y), data, p, queries)
+    @test out_batch ≈ [F(qx, qy) for (qx, qy) in queries] atol = 1e-10
+
+    # Batch one-shot (in-place)
+    out_inplace = Vector{Float64}(undef, length(queries))
+    hermite_interp!(out_inplace, (x, y), data, p, queries)
+    @test out_inplace ≈ out_batch atol = 1e-12
+end
+
+@testset "Hermite ND — Periodic :inclusive" begin
+    # f(x, y) = cos(x) * cos(y); both axes periodic of period 2π
+    F(x, y)   = cos(x) * cos(y)
+    Fx(x, y)  = -sin(x) * cos(y)
+    Fy(x, y)  = -cos(x) * sin(y)
+    Fxy(x, y) =  sin(x) * sin(y)
+
+    # Inclusive: grid includes both endpoints; data periodic in both axes.
+    n = 17
+    x = collect(range(0.0, 2π, length=n))   # inclusive endpoints
+    y = collect(range(0.0, 2π, length=n))
+
+    data = [F(xi, yj) for xi in x, yj in y]
+    p = HermiteFullPartials(
+        (1,0) => [Fx(xi, yj)  for xi in x, yj in y],
+        (0,1) => [Fy(xi, yj)  for xi in x, yj in y],
+        (1,1) => [Fxy(xi, yj) for xi in x, yj in y],
+    )
+
+    bc = (PeriodicBC(endpoint = :inclusive), PeriodicBC(endpoint = :inclusive))
+    itp = hermite_interp((x, y), data, p; bc)
+
+    # Endpoints must match exactly (data was constructed periodic)
+    for qx in [0.13, 0.71, 1.5, 3.0, 5.4, 6.2]
+        for qy in [0.21, 0.55, 1.1, 2.7, 4.4, 5.9]
+            v = itp((qx, qy))
+            @test v ≈ F(qx, qy) atol = 5e-3   # cubic Hermite + analytic partials → small surface error
+        end
+    end
+end
+
+@testset "Hermite ND — Periodic :exclusive (extension)" begin
+    F(x, y)   = sin(x) * cos(y)
+    Fx(x, y)  =  cos(x) * cos(y)
+    Fy(x, y)  = -sin(x) * sin(y)
+    Fxy(x, y) = -cos(x) * sin(y)
+
+    # Exclusive: grid does NOT include the last (wrap) point.
+    # length(x) == n, x[end] + step(x) == x[1] + 2π.
+    # Keep as `range` so `period` is inferable from `step(x)*length(x)`
+    # (Vector grids require an explicit `period` kwarg).
+    n = 16
+    x = range(0.0, 2π * (n - 1) / n, length=n)
+    y = range(0.0, 2π * (n - 1) / n, length=n)
+
+    data = [F(xi, yj) for xi in x, yj in y]
+    p = HermiteFullPartials(
+        (1,0) => [Fx(xi, yj)  for xi in x, yj in y],
+        (0,1) => [Fy(xi, yj)  for xi in x, yj in y],
+        (1,1) => [Fxy(xi, yj) for xi in x, yj in y],
+    )
+
+    bc = (PeriodicBC(endpoint = :exclusive), PeriodicBC(endpoint = :exclusive))
+    itp = hermite_interp((x, y), data, p; bc)
+
+    # After build, size(itp) reflects extension (n+1 per axis).
+    @test size(itp) == (n + 1, n + 1)
+
+    # Evaluate at points across (including past the user's last grid point — must wrap)
+    for qx in [0.13, 1.5, 3.0, 5.4]
+        for qy in [0.21, 1.1, 2.7, 5.9]
+            v = itp((qx, qy))
+            @test v ≈ F(qx, qy) atol = 5e-3
+        end
+    end
+
+    # Round-trip: value at xq must equal value at xq + 2π (within wrap-aware extrap, but
+    # PeriodicBC at build time bakes in the wrap so domain query inside [0, 2π) is exact)
+    @test itp((0.3, 0.5)) ≈ itp((0.3, 0.5))
+end
+
+end  # @testitem
+

--- a/test/test_hermite_nd_partials.jl
+++ b/test/test_hermite_nd_partials.jl
@@ -120,7 +120,7 @@
         end
     end
 
-    @testset "Hermite ND — Build-time BC rejection (Phase 1a)" begin
+    @testset "Hermite ND — Build-time BC rejection" begin
         x = range(0.0, 1.0, length = 5)
         y = range(0.0, 1.0, length = 5)
         data = [xi * yj for xi in x, yj in y]

--- a/test/test_hermite_nd_partials.jl
+++ b/test/test_hermite_nd_partials.jl
@@ -328,9 +328,10 @@
             end
         end
 
-        # Round-trip: value at xq must equal value at xq + 2π (within wrap-aware extrap, but
-        # PeriodicBC at build time bakes in the wrap so domain query inside [0, 2π) is exact)
-        @test itp((0.3, 0.5)) ≈ itp((0.3, 0.5))
+        # Period wrap: a query shifted by one full period (2π on each axis)
+        # must return the same value. Periodic axes resolve to WrapExtrap, so
+        # the out-of-domain shifted query folds back into the base cell.
+        @test itp((0.3 + 2π, 0.5 + 2π)) ≈ itp((0.3, 0.5))
     end
 
     @testset "Hermite ND — Input isolation (persistent copies, oneshot snapshots)" begin

--- a/test/test_hermite_nd_partials.jl
+++ b/test/test_hermite_nd_partials.jl
@@ -777,4 +777,27 @@
         @test_throws ArgumentError hermite_interp((x, y), data, bad, (0.5, 0.5))  # one-shot path
     end
 
+    @testset "Hermite ND — nodal_partials access + adjoint guard" begin
+        x = range(0.0, 1.0, length = 5)
+        y = range(0.0, 1.0, length = 5)
+        data = [0.3 + xi * yj for xi in x, yj in y]
+        dfdx = [yj for xi in x, yj in y]
+        dfdy = [xi for xi in x, yj in y]
+        d2 = ones(5, 5)
+        p = HermitePartials((1, 0) => dfdx, (0, 1) => dfdy, (1, 1) => d2)
+        itp = hermite_interp((x, y), data, p)
+
+        # The packed buffer exposes the user inputs via `nodal_partials`:
+        # order (0,0) = value, (1,0)/(0,1) = first partials, (1,1) = mixed.
+        @test nodal_partials(itp, (0, 0)) == data
+        @test nodal_partials(itp, (1, 0)) == dfdx
+        @test nodal_partials(itp, (0, 1)) == dfdy
+        @test nodal_partials(itp, (1, 1)) == d2
+
+        # Reverse-mode AD is unimplemented: the generic ND rrule reaches these
+        # traits, which must raise a clear error rather than a MethodError.
+        @test_throws ArgumentError FastInterpolations._adjoint_func_from_itp(itp)
+        @test_throws ArgumentError FastInterpolations._adjoint_kwargs_from_itp(itp)
+    end
+
 end  # @testitem

--- a/test/test_hermite_nd_partials.jl
+++ b/test/test_hermite_nd_partials.jl
@@ -10,7 +10,7 @@
 # - Derivative output (`deriv` kwarg)
 # - One-shot scalar + batch + in-place
 
-@testitem "Hermite ND Full Partials (Phase 1a)" setup = [AllocConstants] begin
+@testitem "Hermite ND Partials (Phase 1a)" setup = [AllocConstants] begin
 
 # Helper: central FDM along axis `d` of N-D array, using grid `g` (length n_d).
 # Interior: (arr[..., j+1, ...] - arr[..., j-1, ...]) / (g[j+1] - g[j-1])
@@ -44,7 +44,7 @@ end
     A = zeros(n, n)
 
     @testset "Happy path" begin
-        p = HermiteFullPartials(
+        p = HermitePartials(
             (1, 0) => copy(A),
             (0, 1) => copy(A),
             (1, 1) => copy(A),
@@ -55,7 +55,7 @@ end
     @testset "Mixed eltypes promote to common Tv" begin
         A32 = zeros(Float32, n, n)
         A64 = zeros(Float64, n, n)
-        p = HermiteFullPartials(
+        p = HermitePartials(
             (1, 0) => A32,         # Float32
             (0, 1) => A64,         # Float64
             (1, 1) => A32,         # Float32
@@ -64,12 +64,12 @@ end
     end
 
     @testset "Wrong pair count" begin
-        @test_throws ArgumentError HermiteFullPartials(
+        @test_throws ArgumentError HermitePartials(
             (1, 0) => copy(A),
             (0, 1) => copy(A),
             # missing (1, 1)
         )
-        @test_throws ArgumentError HermiteFullPartials(
+        @test_throws ArgumentError HermitePartials(
             (1, 0) => copy(A),
             (0, 1) => copy(A),
             (1, 1) => copy(A),
@@ -78,7 +78,7 @@ end
     end
 
     @testset "Duplicate multiindex" begin
-        @test_throws ArgumentError HermiteFullPartials(
+        @test_throws ArgumentError HermitePartials(
             (1, 0) => copy(A),
             (0, 1) => copy(A),
             (0, 1) => copy(A),  # duplicate
@@ -86,7 +86,7 @@ end
     end
 
     @testset "Zero multiindex disallowed" begin
-        @test_throws ArgumentError HermiteFullPartials(
+        @test_throws ArgumentError HermitePartials(
             (0, 0) => copy(A),
             (1, 0) => copy(A),
             (0, 1) => copy(A),
@@ -94,7 +94,7 @@ end
     end
 
     @testset "Out-of-range multiindex entry" begin
-        @test_throws ArgumentError HermiteFullPartials(
+        @test_throws ArgumentError HermitePartials(
             (1, 0) => copy(A),
             (0, 1) => copy(A),
             (2, 0) => copy(A),  # entry == 2, not 0 or 1
@@ -103,7 +103,7 @@ end
 
     @testset "Mismatched array sizes" begin
         B = zeros(n + 1, n)
-        @test_throws DimensionMismatch HermiteFullPartials(
+        @test_throws DimensionMismatch HermitePartials(
             (1, 0) => copy(A),
             (0, 1) => copy(B),
             (1, 1) => copy(A),
@@ -112,7 +112,7 @@ end
 
     @testset "Wrong array ndims" begin
         v = zeros(n)
-        @test_throws DimensionMismatch HermiteFullPartials(
+        @test_throws DimensionMismatch HermitePartials(
             (1, 0) => copy(A),
             (0, 1) => v,        # 1-D, not 2-D
             (1, 1) => copy(A),
@@ -127,7 +127,7 @@ end
     dfdx = [yj for xi in x, yj in y]
     dfdy = [xi for xi in x, yj in y]
     d2   = ones(5, 5)
-    p = HermiteFullPartials((1, 0) => dfdx, (0, 1) => dfdy, (1, 1) => d2)
+    p = HermitePartials((1, 0) => dfdx, (0, 1) => dfdy, (1, 1) => d2)
 
     # NoBC, PeriodicBC ok
     @test hermite_interp((x, y), data, p) isa CubicHermiteInterpolantND
@@ -157,7 +157,7 @@ end
     dfdx = [Fx(xi, yj) for xi in x, yj in y]
     dfdy = [Fy(xi, yj) for xi in x, yj in y]
     d2   = [Fxy(xi, yj) for xi in x, yj in y]
-    p    = HermiteFullPartials((1,0) => dfdx, (0,1) => dfdy, (1,1) => d2)
+    p    = HermitePartials((1,0) => dfdx, (0,1) => dfdy, (1,1) => d2)
 
     itp = hermite_interp((x, y), data, p)
 
@@ -197,7 +197,7 @@ end
     dfdy_fdm = _central_fdm_along_axis(data, y, 2)
     d2_fdm   = _central_fdm_along_axis(dfdx_fdm, y, 2)
 
-    p = HermiteFullPartials((1,0) => dfdx_fdm, (0,1) => dfdy_fdm, (1,1) => d2_fdm)
+    p = HermitePartials((1,0) => dfdx_fdm, (0,1) => dfdy_fdm, (1,1) => d2_fdm)
     itp_h = hermite_interp((x, y), data, p)
     itp_c = cardinal_interp((x, y), data)
 
@@ -227,7 +227,7 @@ end
     y = collect(range(-1.0, 1.0, length=5))
 
     data = [F(xi, yj) for xi in x, yj in y]
-    p = HermiteFullPartials(
+    p = HermitePartials(
         (1, 0) => [Fx(xi, yj)  for xi in x, yj in y],
         (0, 1) => [Fy(xi, yj)  for xi in x, yj in y],
         (1, 1) => [Fxy(xi, yj) for xi in x, yj in y],
@@ -261,7 +261,7 @@ end
     y = collect(range(0.0, 2π, length=n))
 
     data = [F(xi, yj) for xi in x, yj in y]
-    p = HermiteFullPartials(
+    p = HermitePartials(
         (1,0) => [Fx(xi, yj)  for xi in x, yj in y],
         (0,1) => [Fy(xi, yj)  for xi in x, yj in y],
         (1,1) => [Fxy(xi, yj) for xi in x, yj in y],
@@ -294,7 +294,7 @@ end
     y = range(0.0, 2π * (n - 1) / n, length=n)
 
     data = [F(xi, yj) for xi in x, yj in y]
-    p = HermiteFullPartials(
+    p = HermitePartials(
         (1,0) => [Fx(xi, yj)  for xi in x, yj in y],
         (0,1) => [Fy(xi, yj)  for xi in x, yj in y],
         (1,1) => [Fxy(xi, yj) for xi in x, yj in y],
@@ -329,7 +329,7 @@ end
         dfdx = [yj for xi in x, yj in y]
         dfdy = [xi for xi in x, yj in y]
         d2   = ones(5, 5)
-        p = HermiteFullPartials((1, 0) => dfdx, (0, 1) => dfdy, (1, 1) => d2)
+        p = HermitePartials((1, 0) => dfdx, (0, 1) => dfdy, (1, 1) => d2)
 
         itp = hermite_interp((x, y), data, p)
         val_before = itp((0.5, 0.5))
@@ -340,7 +340,7 @@ end
         fill!(dfdy, NaN)
         fill!(d2,   NaN)
         # `p.partials[k]` is the *same array* as the dfdx/dfdy/d2 we just
-        # nuked — these are aliases established by `HermiteFullPartials`
+        # nuked — these are aliases established by `HermitePartials`
         # (zero-copy when eltypes match). Confirm:
         @test all(isnan, p.partials[1])
         @test all(isnan, p.partials[2])
@@ -360,7 +360,7 @@ end
         y = range(0.0, 1.0, length=4)
         data = [xi*yj for xi in x, yj in y]
         original_data = copy(data)
-        p = HermiteFullPartials(
+        p = HermitePartials(
             (1, 0) => [yj for xi in x, yj in y],
             (0, 1) => [xi for xi in x, yj in y],
             (1, 1) => ones(4, 4),
@@ -378,7 +378,7 @@ end
         x = range(0.0, 1.0, length=5)
         y = range(0.0, 1.0, length=5)
         data = [xi*yj for xi in x, yj in y]
-        p = HermiteFullPartials(
+        p = HermitePartials(
             (1, 0) => [yj for xi in x, yj in y],
             (0, 1) => [xi for xi in x, yj in y],
             (1, 1) => ones(5, 5),
@@ -407,7 +407,7 @@ end
         x = range(0.0, 1.0, length=20)
         y = range(0.0, 1.0, length=20)
         data = [xi*yj for xi in x, yj in y]
-        p = HermiteFullPartials(
+        p = HermitePartials(
             (1, 0) => [yj for xi in x, yj in y],
             (0, 1) => [xi for xi in x, yj in y],
             (1, 1) => ones(20, 20),
@@ -430,7 +430,7 @@ end
         xp = range(0.0, 2π * 19/20, length=20)
         yp = range(0.0, 2π * 19/20, length=20)
         dp = [sin(xi)*cos(yj) for xi in xp, yj in yp]
-        pp = HermiteFullPartials(
+        pp = HermitePartials(
             (1, 0) => [ cos(xi)*cos(yj) for xi in xp, yj in yp],
             (0, 1) => [-sin(xi)*sin(yj) for xi in xp, yj in yp],
             (1, 1) => [-cos(xi)*sin(yj) for xi in xp, yj in yp],
@@ -453,7 +453,7 @@ end
         xi2 = range(0.0, 2π, length=20)
         yi2 = range(0.0, 2π, length=20)
         di = [cos(xi)*cos(yj) for xi in xi2, yj in yi2]
-        pi2 = HermiteFullPartials(
+        pi2 = HermitePartials(
             (1, 0) => [-sin(xi)*cos(yj) for xi in xi2, yj in yi2],
             (0, 1) => [-cos(xi)*sin(yj) for xi in xi2, yj in yi2],
             (1, 1) => [ sin(xi)*sin(yj) for xi in xi2, yj in yi2],
@@ -476,7 +476,7 @@ end
         x = range(0.0, 1.0, length=20)
         y = range(0.0, 1.0, length=20)
         data = [xi*yj for xi in x, yj in y]
-        p = HermiteFullPartials(
+        p = HermitePartials(
             (1, 0) => [yj for xi in x, yj in y],
             (0, 1) => [xi for xi in x, yj in y],
             (1, 1) => ones(20, 20),
@@ -491,7 +491,7 @@ end
         x = range(0.0, 1.0, length=20)
         y = range(0.0, 1.0, length=20)
         data = [xi*yj for xi in x, yj in y]
-        p = HermiteFullPartials(
+        p = HermitePartials(
             (1, 0) => [yj for xi in x, yj in y],
             (0, 1) => [xi for xi in x, yj in y],
             (1, 1) => ones(20, 20),

--- a/test/test_hermite_nd_partials.jl
+++ b/test/test_hermite_nd_partials.jl
@@ -12,504 +12,517 @@
 
 @testitem "Hermite ND Partials (Phase 1a)" setup = [AllocConstants] begin
 
-# Helper: central FDM along axis `d` of N-D array, using grid `g` (length n_d).
-# Interior: (arr[..., j+1, ...] - arr[..., j-1, ...]) / (g[j+1] - g[j-1])
-# Boundary j=1 :          forward difference  (arr[..., 2, ...] - arr[..., 1, ...]) / (g[2] - g[1])
-# Boundary j=n :          backward difference (arr[..., n, ...] - arr[..., n-1, ...]) / (g[n] - g[n-1])
-function _central_fdm_along_axis(arr::AbstractArray{T, N}, grid::AbstractVector, d::Int) where {T, N}
-    n = size(arr, d)
-    n >= 2 || throw(ArgumentError("FDM requires axis length >= 2"))
-    out = similar(arr, float(T))
-    for j in 1:n
-        if j == 1
-            slab_lo = selectdim(arr, d, 1)
-            slab_hi = selectdim(arr, d, 2)
-            denom = grid[2] - grid[1]
-        elseif j == n
-            slab_lo = selectdim(arr, d, n - 1)
-            slab_hi = selectdim(arr, d, n)
-            denom = grid[n] - grid[n - 1]
-        else
-            slab_lo = selectdim(arr, d, j - 1)
-            slab_hi = selectdim(arr, d, j + 1)
-            denom = grid[j + 1] - grid[j - 1]
+    # Helper: central FDM along axis `d` of N-D array, using grid `g` (length n_d).
+    # Interior: (arr[..., j+1, ...] - arr[..., j-1, ...]) / (g[j+1] - g[j-1])
+    # Boundary j=1 :          forward difference  (arr[..., 2, ...] - arr[..., 1, ...]) / (g[2] - g[1])
+    # Boundary j=n :          backward difference (arr[..., n, ...] - arr[..., n-1, ...]) / (g[n] - g[n-1])
+    function _central_fdm_along_axis(arr::AbstractArray{T, N}, grid::AbstractVector, d::Int) where {T, N}
+        n = size(arr, d)
+        n >= 2 || throw(ArgumentError("FDM requires axis length >= 2"))
+        out = similar(arr, float(T))
+        for j in 1:n
+            if j == 1
+                slab_lo = selectdim(arr, d, 1)
+                slab_hi = selectdim(arr, d, 2)
+                denom = grid[2] - grid[1]
+            elseif j == n
+                slab_lo = selectdim(arr, d, n - 1)
+                slab_hi = selectdim(arr, d, n)
+                denom = grid[n] - grid[n - 1]
+            else
+                slab_lo = selectdim(arr, d, j - 1)
+                slab_hi = selectdim(arr, d, j + 1)
+                denom = grid[j + 1] - grid[j - 1]
+            end
+            selectdim(out, d, j) .= (slab_hi .- slab_lo) ./ denom
         end
-        selectdim(out, d, j) .= (slab_hi .- slab_lo) ./ denom
-    end
-    return out
-end
-
-@testset "Hermite ND — Construction validation (N=2)" begin
-    n = 5
-    A = zeros(n, n)
-
-    @testset "Happy path" begin
-        p = HermitePartials(
-            (1, 0) => copy(A),
-            (0, 1) => copy(A),
-            (1, 1) => copy(A),
-        )
-        @test p isa HermitePartials{2, Float64, 3, Matrix{Float64}}
+        return out
     end
 
-    @testset "Mixed eltypes promote to common Tv" begin
-        A32 = zeros(Float32, n, n)
-        A64 = zeros(Float64, n, n)
-        p = HermitePartials(
-            (1, 0) => A32,         # Float32
-            (0, 1) => A64,         # Float64
-            (1, 1) => A32,         # Float32
-        )
-        @test p isa HermitePartials{2, Float64, 3, Matrix{Float64}}
-    end
+    @testset "Hermite ND — Construction validation (N=2)" begin
+        n = 5
+        A = zeros(n, n)
 
-    @testset "Wrong pair count" begin
-        @test_throws ArgumentError HermitePartials(
-            (1, 0) => copy(A),
-            (0, 1) => copy(A),
-            # missing (1, 1)
-        )
-        @test_throws ArgumentError HermitePartials(
-            (1, 0) => copy(A),
-            (0, 1) => copy(A),
-            (1, 1) => copy(A),
-            (1, 1) => copy(A),  # too many
-        )
-    end
-
-    @testset "Duplicate multiindex" begin
-        @test_throws ArgumentError HermitePartials(
-            (1, 0) => copy(A),
-            (0, 1) => copy(A),
-            (0, 1) => copy(A),  # duplicate
-        )
-    end
-
-    @testset "Zero multiindex disallowed" begin
-        @test_throws ArgumentError HermitePartials(
-            (0, 0) => copy(A),
-            (1, 0) => copy(A),
-            (0, 1) => copy(A),
-        )
-    end
-
-    @testset "Out-of-range multiindex entry" begin
-        @test_throws ArgumentError HermitePartials(
-            (1, 0) => copy(A),
-            (0, 1) => copy(A),
-            (2, 0) => copy(A),  # entry == 2, not 0 or 1
-        )
-    end
-
-    @testset "Mismatched array sizes" begin
-        B = zeros(n + 1, n)
-        @test_throws DimensionMismatch HermitePartials(
-            (1, 0) => copy(A),
-            (0, 1) => copy(B),
-            (1, 1) => copy(A),
-        )
-    end
-
-    @testset "Wrong array ndims" begin
-        v = zeros(n)
-        @test_throws DimensionMismatch HermitePartials(
-            (1, 0) => copy(A),
-            (0, 1) => v,        # 1-D, not 2-D
-            (1, 1) => copy(A),
-        )
-    end
-end
-
-@testset "Hermite ND — Build-time BC rejection (Phase 1a)" begin
-    x = range(0.0, 1.0, length=5)
-    y = range(0.0, 1.0, length=5)
-    data = [xi*yj for xi in x, yj in y]
-    dfdx = [yj for xi in x, yj in y]
-    dfdy = [xi for xi in x, yj in y]
-    d2   = ones(5, 5)
-    p = HermitePartials((1, 0) => dfdx, (0, 1) => dfdy, (1, 1) => d2)
-
-    # NoBC, PeriodicBC ok
-    @test hermite_interp((x, y), data, p) isa CubicHermiteInterpolantND
-    # CubicFit, NaturalBC, etc. rejected — user partials supersede.
-    @test_throws ArgumentError hermite_interp((x, y), data, p; bc = CubicFit())
-    @test_throws ArgumentError hermite_interp((x, y), data, p; bc = ZeroSlopeBC())
-end
-
-@testset "Hermite ND — Analytic exactness (polynomial)" begin
-    # f(x, y) = a + b x + c y + d x y + e x² + f y² + g x²y + h x y² + i x³ + j y³
-    # Cubic Hermite is exact on any bicubic polynomial when supplied with the
-    # corresponding analytic partials.
-
-    a, b, c, dd = 0.7, 1.3, -0.4, 2.1
-    e, ff, gg, hh = -0.6, 0.5, 0.3, -0.2
-    ii, jj = 0.15, -0.25
-
-    F(x, y)    = a + b*x + c*y + dd*x*y + e*x^2 + ff*y^2 + gg*x^2*y + hh*x*y^2 + ii*x^3 + jj*y^3
-    Fx(x, y)   = b + dd*y + 2e*x + 2gg*x*y + hh*y^2 + 3ii*x^2
-    Fy(x, y)   = c + dd*x + 2ff*y + gg*x^2 + 2hh*x*y + 3jj*y^2
-    Fxy(x, y)  = dd + 2gg*x + 2hh*y
-
-    x = collect(range(-1.0, 1.5, length=8))
-    y = collect(range(-0.8, 1.2, length=7))
-
-    data = [F(xi, yj) for xi in x, yj in y]
-    dfdx = [Fx(xi, yj) for xi in x, yj in y]
-    dfdy = [Fy(xi, yj) for xi in x, yj in y]
-    d2   = [Fxy(xi, yj) for xi in x, yj in y]
-    p    = HermitePartials((1,0) => dfdx, (0,1) => dfdy, (1,1) => d2)
-
-    itp = hermite_interp((x, y), data, p)
-
-    # 1. Grid nodes — exact
-    for i in 1:length(x), j in 1:length(y)
-        @test itp((x[i], y[j])) ≈ data[i, j] atol = 1e-12
-    end
-
-    # 2. Random interior points — exact for bicubic polynomial
-    for (qx, qy) in [(0.13, 0.42), (-0.51, 1.1), (1.32, -0.7), (0.0, 0.0), (1.0, 1.0)]
-        @test itp((qx, qy)) ≈ F(qx, qy) atol = 1e-10
-    end
-
-    # 3. Derivative queries
-    for (qx, qy) in [(0.13, 0.42), (-0.51, 1.1)]
-        @test itp((qx, qy); deriv=(DerivOp(1), DerivOp(0))) ≈ Fx(qx, qy) atol = 1e-10
-        @test itp((qx, qy); deriv=(DerivOp(0), DerivOp(1))) ≈ Fy(qx, qy) atol = 1e-10
-        @test itp((qx, qy); deriv=(DerivOp(1), DerivOp(1))) ≈ Fxy(qx, qy) atol = 1e-10
-    end
-end
-
-@testset "Hermite ND — Cardinal cross-validation (central FDM partials)" begin
-    # The key test the user explicitly requested:
-    # Feed Hermite ND with manually-computed central-FDM partials, compare
-    # to `cardinal_interp` ND on the same data. They should agree at
-    # interior query points (boundary handling may differ; sticking to
-    # interior cells for strict equivalence).
-
-    F(x, y) = sin(0.7x) * cos(0.5y) + 0.3x*y
-
-    x = collect(range(0.0, 4.0, length=12))
-    y = collect(range(0.0, 3.0, length=10))
-    data = [F(xi, yj) for xi in x, yj in y]
-
-    # Central FDM partials
-    dfdx_fdm = _central_fdm_along_axis(data, x, 1)
-    dfdy_fdm = _central_fdm_along_axis(data, y, 2)
-    d2_fdm   = _central_fdm_along_axis(dfdx_fdm, y, 2)
-
-    p = HermitePartials((1,0) => dfdx_fdm, (0,1) => dfdy_fdm, (1,1) => d2_fdm)
-    itp_h = hermite_interp((x, y), data, p)
-    itp_c = cardinal_interp((x, y), data)
-
-    # Interior query points (away from boundary by at least 2 cells).
-    # Cardinal's boundary FDM treatment may differ from our forward/backward
-    # at edges — interior queries are where the two surfaces should agree.
-    interior_queries = [
-        (x[4],         y[4]),         # exact node, both must return data exactly
-        (x[6] + 0.13,  y[5] + 0.07),  # interior point
-        (x[7] + 0.31,  y[6] - 0.09),
-        (x[8] - 0.04,  y[7] + 0.02),
-    ]
-    for (qx, qy) in interior_queries
-        vh = itp_h((qx, qy))
-        vc = itp_c((qx, qy))
-        @test vh ≈ vc atol = 1e-10
-    end
-end
-
-@testset "Hermite ND — One-shot variants" begin
-    F(x, y)   = 0.4 + 0.7x - 0.3y + 0.5x*y + 0.2x^2*y - 0.1y^3
-    Fx(x, y)  = 0.7 + 0.5y + 0.4x*y
-    Fy(x, y)  = -0.3 + 0.5x + 0.2x^2 - 0.3y^2
-    Fxy(x, y) = 0.5 + 0.4x
-
-    x = collect(range(0.0, 2.0, length=6))
-    y = collect(range(-1.0, 1.0, length=5))
-
-    data = [F(xi, yj) for xi in x, yj in y]
-    p = HermitePartials(
-        (1, 0) => [Fx(xi, yj)  for xi in x, yj in y],
-        (0, 1) => [Fy(xi, yj)  for xi in x, yj in y],
-        (1, 1) => [Fxy(xi, yj) for xi in x, yj in y],
-    )
-
-    # Scalar one-shot
-    v = hermite_interp((x, y), data, p, (0.33, 0.42))
-    @test v ≈ F(0.33, 0.42) atol = 1e-10
-
-    # Batch one-shot (allocating)
-    queries = [(0.13, -0.42), (0.77, 0.51), (1.23, 0.83)]
-    out_batch = hermite_interp((x, y), data, p, queries)
-    @test out_batch ≈ [F(qx, qy) for (qx, qy) in queries] atol = 1e-10
-
-    # Batch one-shot (in-place)
-    out_inplace = Vector{Float64}(undef, length(queries))
-    hermite_interp!(out_inplace, (x, y), data, p, queries)
-    @test out_inplace ≈ out_batch atol = 1e-12
-end
-
-@testset "Hermite ND — Periodic :inclusive" begin
-    # f(x, y) = cos(x) * cos(y); both axes periodic of period 2π
-    F(x, y)   = cos(x) * cos(y)
-    Fx(x, y)  = -sin(x) * cos(y)
-    Fy(x, y)  = -cos(x) * sin(y)
-    Fxy(x, y) =  sin(x) * sin(y)
-
-    # Inclusive: grid includes both endpoints; data periodic in both axes.
-    n = 17
-    x = collect(range(0.0, 2π, length=n))   # inclusive endpoints
-    y = collect(range(0.0, 2π, length=n))
-
-    data = [F(xi, yj) for xi in x, yj in y]
-    p = HermitePartials(
-        (1,0) => [Fx(xi, yj)  for xi in x, yj in y],
-        (0,1) => [Fy(xi, yj)  for xi in x, yj in y],
-        (1,1) => [Fxy(xi, yj) for xi in x, yj in y],
-    )
-
-    bc = (PeriodicBC(endpoint = :inclusive), PeriodicBC(endpoint = :inclusive))
-    itp = hermite_interp((x, y), data, p; bc)
-
-    # Endpoints must match exactly (data was constructed periodic)
-    for qx in [0.13, 0.71, 1.5, 3.0, 5.4, 6.2]
-        for qy in [0.21, 0.55, 1.1, 2.7, 4.4, 5.9]
-            v = itp((qx, qy))
-            @test v ≈ F(qx, qy) atol = 5e-3   # cubic Hermite + analytic partials → small surface error
+        @testset "Happy path" begin
+            p = HermitePartials(
+                (1, 0) => copy(A),
+                (0, 1) => copy(A),
+                (1, 1) => copy(A),
+            )
+            @test p isa HermitePartials{2, Float64, 3, Matrix{Float64}}
         end
-    end
-end
 
-@testset "Hermite ND — Periodic :exclusive (extension)" begin
-    F(x, y)   = sin(x) * cos(y)
-    Fx(x, y)  =  cos(x) * cos(y)
-    Fy(x, y)  = -sin(x) * sin(y)
-    Fxy(x, y) = -cos(x) * sin(y)
+        @testset "Mixed eltypes promote to common Tv" begin
+            A32 = zeros(Float32, n, n)
+            A64 = zeros(Float64, n, n)
+            p = HermitePartials(
+                (1, 0) => A32,         # Float32
+                (0, 1) => A64,         # Float64
+                (1, 1) => A32,         # Float32
+            )
+            @test p isa HermitePartials{2, Float64, 3, Matrix{Float64}}
+        end
 
-    # Exclusive: grid does NOT include the last (wrap) point.
-    # length(x) == n, x[end] + step(x) == x[1] + 2π.
-    # Keep as `range` so `period` is inferable from `step(x)*length(x)`
-    # (Vector grids require an explicit `period` kwarg).
-    n = 16
-    x = range(0.0, 2π * (n - 1) / n, length=n)
-    y = range(0.0, 2π * (n - 1) / n, length=n)
+        @testset "Wrong pair count" begin
+            @test_throws ArgumentError HermitePartials(
+                (1, 0) => copy(A),
+                (0, 1) => copy(A),
+                # missing (1, 1)
+            )
+            @test_throws ArgumentError HermitePartials(
+                (1, 0) => copy(A),
+                (0, 1) => copy(A),
+                (1, 1) => copy(A),
+                (1, 1) => copy(A),  # too many
+            )
+        end
 
-    data = [F(xi, yj) for xi in x, yj in y]
-    p = HermitePartials(
-        (1,0) => [Fx(xi, yj)  for xi in x, yj in y],
-        (0,1) => [Fy(xi, yj)  for xi in x, yj in y],
-        (1,1) => [Fxy(xi, yj) for xi in x, yj in y],
-    )
+        @testset "Duplicate multiindex" begin
+            @test_throws ArgumentError HermitePartials(
+                (1, 0) => copy(A),
+                (0, 1) => copy(A),
+                (0, 1) => copy(A),  # duplicate
+            )
+        end
 
-    bc = (PeriodicBC(endpoint = :exclusive), PeriodicBC(endpoint = :exclusive))
-    itp = hermite_interp((x, y), data, p; bc)
+        @testset "Zero multiindex disallowed" begin
+            @test_throws ArgumentError HermitePartials(
+                (0, 0) => copy(A),
+                (1, 0) => copy(A),
+                (0, 1) => copy(A),
+            )
+        end
 
-    # After build, size(itp) reflects extension (n+1 per axis).
-    @test size(itp) == (n + 1, n + 1)
+        @testset "Out-of-range multiindex entry" begin
+            @test_throws ArgumentError HermitePartials(
+                (1, 0) => copy(A),
+                (0, 1) => copy(A),
+                (2, 0) => copy(A),  # entry == 2, not 0 or 1
+            )
+        end
 
-    # Evaluate at points across (including past the user's last grid point — must wrap)
-    for qx in [0.13, 1.5, 3.0, 5.4]
-        for qy in [0.21, 1.1, 2.7, 5.9]
-            v = itp((qx, qy))
-            @test v ≈ F(qx, qy) atol = 5e-3
+        @testset "Mismatched array sizes" begin
+            B = zeros(n + 1, n)
+            @test_throws DimensionMismatch HermitePartials(
+                (1, 0) => copy(A),
+                (0, 1) => copy(B),
+                (1, 1) => copy(A),
+            )
+        end
+
+        @testset "Wrong array ndims" begin
+            v = zeros(n)
+            @test_throws DimensionMismatch HermitePartials(
+                (1, 0) => copy(A),
+                (0, 1) => v,        # 1-D, not 2-D
+                (1, 1) => copy(A),
+            )
         end
     end
 
-    # Round-trip: value at xq must equal value at xq + 2π (within wrap-aware extrap, but
-    # PeriodicBC at build time bakes in the wrap so domain query inside [0, 2π) is exact)
-    @test itp((0.3, 0.5)) ≈ itp((0.3, 0.5))
-end
-
-@testset "Hermite ND — Input isolation (persistent copies, oneshot snapshots)" begin
-    # ── Persistent: build snapshots inputs; user mutations after build are
-    #    not visible to the interpolant.
-    @testset "Persistent: itp isolated from post-build user mutation" begin
-        x = range(0.0, 1.0, length=5)
-        y = range(0.0, 1.0, length=5)
-        data = [xi*yj for xi in x, yj in y]
+    @testset "Hermite ND — Build-time BC rejection (Phase 1a)" begin
+        x = range(0.0, 1.0, length = 5)
+        y = range(0.0, 1.0, length = 5)
+        data = [xi * yj for xi in x, yj in y]
         dfdx = [yj for xi in x, yj in y]
         dfdy = [xi for xi in x, yj in y]
-        d2   = ones(5, 5)
+        d2 = ones(5, 5)
+        p = HermitePartials((1, 0) => dfdx, (0, 1) => dfdy, (1, 1) => d2)
+
+        # NoBC, PeriodicBC ok
+        @test hermite_interp((x, y), data, p) isa CubicHermiteInterpolantND
+        # CubicFit, NaturalBC, etc. rejected — user partials supersede.
+        @test_throws ArgumentError hermite_interp((x, y), data, p; bc = CubicFit())
+        @test_throws ArgumentError hermite_interp((x, y), data, p; bc = ZeroSlopeBC())
+    end
+
+    @testset "Hermite ND — Analytic exactness (polynomial)" begin
+        # f(x, y) = a + b x + c y + d x y + e x² + f y² + g x²y + h x y² + i x³ + j y³
+        # Cubic Hermite is exact on any bicubic polynomial when supplied with the
+        # corresponding analytic partials.
+
+        a, b, c, dd = 0.7, 1.3, -0.4, 2.1
+        e, ff, gg, hh = -0.6, 0.5, 0.3, -0.2
+        ii, jj = 0.15, -0.25
+
+        F(x, y) = a + b * x + c * y + dd * x * y + e * x^2 + ff * y^2 + gg * x^2 * y + hh * x * y^2 + ii * x^3 + jj * y^3
+        Fx(x, y) = b + dd * y + 2e * x + 2gg * x * y + hh * y^2 + 3ii * x^2
+        Fy(x, y) = c + dd * x + 2ff * y + gg * x^2 + 2hh * x * y + 3jj * y^2
+        Fxy(x, y) = dd + 2gg * x + 2hh * y
+
+        x = collect(range(-1.0, 1.5, length = 8))
+        y = collect(range(-0.8, 1.2, length = 7))
+
+        data = [F(xi, yj) for xi in x, yj in y]
+        dfdx = [Fx(xi, yj) for xi in x, yj in y]
+        dfdy = [Fy(xi, yj) for xi in x, yj in y]
+        d2 = [Fxy(xi, yj) for xi in x, yj in y]
         p = HermitePartials((1, 0) => dfdx, (0, 1) => dfdy, (1, 1) => d2)
 
         itp = hermite_interp((x, y), data, p)
-        val_before = itp((0.5, 0.5))
 
-        # Trash every user-owned input array
-        fill!(data, NaN)
-        fill!(dfdx, NaN)
-        fill!(dfdy, NaN)
-        fill!(d2,   NaN)
-        # `p.partials[k]` is the *same array* as the dfdx/dfdy/d2 we just
-        # nuked — these are aliases established by `HermitePartials`
-        # (zero-copy when eltypes match). Confirm:
-        @test all(isnan, p.partials[1])
-        @test all(isnan, p.partials[2])
-        @test all(isnan, p.partials[3])
-
-        # Despite user-side trashing, itp still reproduces the original value:
-        # the build-time copy into `nodal_derivs.partials` decoupled it.
-        val_after = itp((0.5, 0.5))
-        @test val_after == val_before
-        @test !isnan(val_after)
-    end
-
-    # ── Persistent: the stored packed buffer is also independent (a third
-    #    snapshot — mutate itp.nodal_derivs internally, user data untouched).
-    @testset "Persistent: user data unaffected by itp internal mutation" begin
-        x = range(0.0, 1.0, length=4)
-        y = range(0.0, 1.0, length=4)
-        data = [xi*yj for xi in x, yj in y]
-        original_data = copy(data)
-        p = HermitePartials(
-            (1, 0) => [yj for xi in x, yj in y],
-            (0, 1) => [xi for xi in x, yj in y],
-            (1, 1) => ones(4, 4),
-        )
-        itp = hermite_interp((x, y), data, p)
-        # Stomp the internal packed buffer
-        fill!(itp.nodal_derivs.partials, 99.0)
-        # User's `data` is unchanged
-        @test data == original_data
-    end
-
-    # ── One-shot: each call snapshots the *current* user data. Mutating
-    #    between calls is safe and reflected in the next return.
-    @testset "One-shot: snapshots current data per call" begin
-        x = range(0.0, 1.0, length=5)
-        y = range(0.0, 1.0, length=5)
-        data = [xi*yj for xi in x, yj in y]
-        p = HermitePartials(
-            (1, 0) => [yj for xi in x, yj in y],
-            (0, 1) => [xi for xi in x, yj in y],
-            (1, 1) => ones(5, 5),
-        )
-        v1 = hermite_interp((x, y), data, p, (0.5, 0.5))
-        # Replace data in-place with a constant; result must follow.
-        # Partials still describe the OLD data, but for cubic Hermite the
-        # value at a node is the corresponding data entry exactly — so at
-        # interior the eval is a polynomial mix of {data, partials}. Easier
-        # invariant: at a *grid node* the eval reduces to `data[i, j]`.
-        data .= 7.5
-        v2 = hermite_interp((x, y), data, p, (x[3], y[3]))   # grid node
-        @test v2 == 7.5
-        # And the original call shouldn't have been retroactively affected
-        # (no aliasing back into user's array via the pool).
-        @test v1 == 0.25   # x[3]*y[3] when data was xi*yj; sanity
-    end
-end
-
-@testset "Hermite ND — Pool-based oneshot zero-alloc" begin
-    # All measurements live inside one function so locals are type-stable and
-    # `@allocated` reports the steady-state, post-warmup cost (no @testset
-    # try/catch artifacts). Bulk-loop divisor confirms per-call alloc.
-
-    function _measure_nobc(n_iters)
-        x = range(0.0, 1.0, length=20)
-        y = range(0.0, 1.0, length=20)
-        data = [xi*yj for xi in x, yj in y]
-        p = HermitePartials(
-            (1, 0) => [yj for xi in x, yj in y],
-            (0, 1) => [xi for xi in x, yj in y],
-            (1, 1) => ones(20, 20),
-        )
-        # warmup
-        hermite_interp((x, y), data, p, (0.5, 0.5))
-        function loop!(out, x, y, data, p, queries, n)
-            @inbounds for k in 1:n
-                out[k] = hermite_interp((x, y), data, p, queries[k])
-            end
-            return nothing
+        # 1. Grid nodes — exact
+        for i in 1:length(x), j in 1:length(y)
+            @test itp((x[i], y[j])) ≈ data[i, j] atol = 1.0e-12
         end
-        queries = [(0.1 + 0.0001*k, 0.5) for k in 1:n_iters]
-        out = Vector{Float64}(undef, n_iters)
-        loop!(out, x, y, data, p, queries, n_iters)
-        return @allocated loop!(out, x, y, data, p, queries, n_iters)
-    end
 
-    function _measure_excl(n_iters)
-        xp = range(0.0, 2π * 19/20, length=20)
-        yp = range(0.0, 2π * 19/20, length=20)
-        dp = [sin(xi)*cos(yj) for xi in xp, yj in yp]
-        pp = HermitePartials(
-            (1, 0) => [ cos(xi)*cos(yj) for xi in xp, yj in yp],
-            (0, 1) => [-sin(xi)*sin(yj) for xi in xp, yj in yp],
-            (1, 1) => [-cos(xi)*sin(yj) for xi in xp, yj in yp],
-        )
-        bc = (PeriodicBC(endpoint = :exclusive), PeriodicBC(endpoint = :exclusive))
-        hermite_interp((xp, yp), dp, pp, (0.5, 0.5); bc)
-        function loop!(out, xp, yp, dp, pp, queries, n, bc)
-            @inbounds for k in 1:n
-                out[k] = hermite_interp((xp, yp), dp, pp, queries[k]; bc)
-            end
-            return nothing
+        # 2. Random interior points — exact for bicubic polynomial
+        for (qx, qy) in [(0.13, 0.42), (-0.51, 1.1), (1.32, -0.7), (0.0, 0.0), (1.0, 1.0)]
+            @test itp((qx, qy)) ≈ F(qx, qy) atol = 1.0e-10
         end
-        queries = [(0.1 + 0.0001*k, 0.5) for k in 1:n_iters]
-        out = Vector{Float64}(undef, n_iters)
-        loop!(out, xp, yp, dp, pp, queries, n_iters, bc)
-        return @allocated loop!(out, xp, yp, dp, pp, queries, n_iters, bc)
+
+        # 3. Derivative queries
+        for (qx, qy) in [(0.13, 0.42), (-0.51, 1.1)]
+            @test itp((qx, qy); deriv = (DerivOp(1), DerivOp(0))) ≈ Fx(qx, qy) atol = 1.0e-10
+            @test itp((qx, qy); deriv = (DerivOp(0), DerivOp(1))) ≈ Fy(qx, qy) atol = 1.0e-10
+            @test itp((qx, qy); deriv = (DerivOp(1), DerivOp(1))) ≈ Fxy(qx, qy) atol = 1.0e-10
+        end
     end
 
-    function _measure_inc(n_iters)
-        xi2 = range(0.0, 2π, length=20)
-        yi2 = range(0.0, 2π, length=20)
-        di = [cos(xi)*cos(yj) for xi in xi2, yj in yi2]
-        pi2 = HermitePartials(
-            (1, 0) => [-sin(xi)*cos(yj) for xi in xi2, yj in yi2],
-            (0, 1) => [-cos(xi)*sin(yj) for xi in xi2, yj in yi2],
-            (1, 1) => [ sin(xi)*sin(yj) for xi in xi2, yj in yi2],
+    @testset "Hermite ND — Cardinal cross-validation (central FDM partials)" begin
+        # The key test the user explicitly requested:
+        # Feed Hermite ND with manually-computed central-FDM partials, compare
+        # to `cardinal_interp` ND on the same data. They should agree at
+        # interior query points (boundary handling may differ; sticking to
+        # interior cells for strict equivalence).
+
+        F(x, y) = sin(0.7x) * cos(0.5y) + 0.3x * y
+
+        x = collect(range(0.0, 4.0, length = 12))
+        y = collect(range(0.0, 3.0, length = 10))
+        data = [F(xi, yj) for xi in x, yj in y]
+
+        # Central FDM partials
+        dfdx_fdm = _central_fdm_along_axis(data, x, 1)
+        dfdy_fdm = _central_fdm_along_axis(data, y, 2)
+        d2_fdm = _central_fdm_along_axis(dfdx_fdm, y, 2)
+
+        p = HermitePartials((1, 0) => dfdx_fdm, (0, 1) => dfdy_fdm, (1, 1) => d2_fdm)
+        itp_h = hermite_interp((x, y), data, p)
+        itp_c = cardinal_interp((x, y), data)
+
+        # Interior query points (away from boundary by at least 2 cells).
+        # Cardinal's boundary FDM treatment may differ from our forward/backward
+        # at edges — interior queries are where the two surfaces should agree.
+        interior_queries = [
+            (x[4], y[4]),         # exact node, both must return data exactly
+            (x[6] + 0.13, y[5] + 0.07),  # interior point
+            (x[7] + 0.31, y[6] - 0.09),
+            (x[8] - 0.04, y[7] + 0.02),
+        ]
+        for (qx, qy) in interior_queries
+            vh = itp_h((qx, qy))
+            vc = itp_c((qx, qy))
+            @test vh ≈ vc atol = 1.0e-10
+        end
+    end
+
+    @testset "Hermite ND — One-shot variants" begin
+        F(x, y) = 0.4 + 0.7x - 0.3y + 0.5x * y + 0.2x^2 * y - 0.1y^3
+        Fx(x, y) = 0.7 + 0.5y + 0.4x * y
+        Fy(x, y) = -0.3 + 0.5x + 0.2x^2 - 0.3y^2
+        Fxy(x, y) = 0.5 + 0.4x
+
+        x = collect(range(0.0, 2.0, length = 6))
+        y = collect(range(-1.0, 1.0, length = 5))
+
+        data = [F(xi, yj) for xi in x, yj in y]
+        p = HermitePartials(
+            (1, 0) => [Fx(xi, yj)  for xi in x, yj in y],
+            (0, 1) => [Fy(xi, yj)  for xi in x, yj in y],
+            (1, 1) => [Fxy(xi, yj) for xi in x, yj in y],
         )
+
+        # Scalar one-shot
+        v = hermite_interp((x, y), data, p, (0.33, 0.42))
+        @test v ≈ F(0.33, 0.42) atol = 1.0e-10
+
+        # Batch one-shot (allocating)
+        queries = [(0.13, -0.42), (0.77, 0.51), (1.23, 0.83)]
+        out_batch = hermite_interp((x, y), data, p, queries)
+        @test out_batch ≈ [F(qx, qy) for (qx, qy) in queries] atol = 1.0e-10
+
+        # Batch one-shot (in-place)
+        out_inplace = Vector{Float64}(undef, length(queries))
+        hermite_interp!(out_inplace, (x, y), data, p, queries)
+        @test out_inplace ≈ out_batch atol = 1.0e-12
+
+        # Allocating batch output must use the promoted value type, not just the
+        # data eltype; otherwise non-real / wider partials can throw InexactError.
+        data_real = zeros(2, 2)
+        p_complex = HermitePartials(
+            (1, 0) => fill(1.0 + 1.0im, 2, 2),
+            (0, 1) => fill(0.0 + 0.0im, 2, 2),
+            (1, 1) => fill(0.0 + 0.0im, 2, 2),
+        )
+        q_complex = (0.3, 0.6)
+        scalar_complex = hermite_interp((0.0:1.0:1.0, 0.0:1.0:1.0), data_real, p_complex, q_complex)
+        batch_complex = hermite_interp((0.0:1.0:1.0, 0.0:1.0:1.0), data_real, p_complex, [q_complex])
+        @test batch_complex isa Vector{ComplexF64}
+        @test batch_complex == [scalar_complex]
+    end
+
+    @testset "Hermite ND — Periodic :inclusive" begin
+        # f(x, y) = cos(x) * cos(y); both axes periodic of period 2π
+        F(x, y) = cos(x) * cos(y)
+        Fx(x, y) = -sin(x) * cos(y)
+        Fy(x, y) = -cos(x) * sin(y)
+        Fxy(x, y) = sin(x) * sin(y)
+
+        # Inclusive: grid includes both endpoints; data periodic in both axes.
+        n = 17
+        x = collect(range(0.0, 2π, length = n))   # inclusive endpoints
+        y = collect(range(0.0, 2π, length = n))
+
+        data = [F(xi, yj) for xi in x, yj in y]
+        p = HermitePartials(
+            (1, 0) => [Fx(xi, yj)  for xi in x, yj in y],
+            (0, 1) => [Fy(xi, yj)  for xi in x, yj in y],
+            (1, 1) => [Fxy(xi, yj) for xi in x, yj in y],
+        )
+
         bc = (PeriodicBC(endpoint = :inclusive), PeriodicBC(endpoint = :inclusive))
-        hermite_interp((xi2, yi2), di, pi2, (0.5, 0.5); bc)
-        function loop!(out, xi2, yi2, di, pi2, queries, n, bc)
-            @inbounds for k in 1:n
-                out[k] = hermite_interp((xi2, yi2), di, pi2, queries[k]; bc)
+        itp = hermite_interp((x, y), data, p; bc)
+
+        # Endpoints must match exactly (data was constructed periodic)
+        for qx in [0.13, 0.71, 1.5, 3.0, 5.4, 6.2]
+            for qy in [0.21, 0.55, 1.1, 2.7, 4.4, 5.9]
+                v = itp((qx, qy))
+                @test v ≈ F(qx, qy) atol = 5.0e-3   # cubic Hermite + analytic partials → small surface error
             end
-            return nothing
         end
-        queries = [(0.1 + 0.0001*k, 0.5) for k in 1:n_iters]
-        out = Vector{Float64}(undef, n_iters)
-        loop!(out, xi2, yi2, di, pi2, queries, n_iters, bc)
-        return @allocated loop!(out, xi2, yi2, di, pi2, queries, n_iters, bc)
     end
 
-    function _measure_batch_inplace()
-        x = range(0.0, 1.0, length=20)
-        y = range(0.0, 1.0, length=20)
-        data = [xi*yj for xi in x, yj in y]
+    @testset "Hermite ND — Periodic :exclusive (extension)" begin
+        F(x, y) = sin(x) * cos(y)
+        Fx(x, y) = cos(x) * cos(y)
+        Fy(x, y) = -sin(x) * sin(y)
+        Fxy(x, y) = -cos(x) * sin(y)
+
+        # Exclusive: grid does NOT include the last (wrap) point.
+        # length(x) == n, x[end] + step(x) == x[1] + 2π.
+        # Keep as `range` so `period` is inferable from `step(x)*length(x)`
+        # (Vector grids require an explicit `period` kwarg).
+        n = 16
+        x = range(0.0, 2π * (n - 1) / n, length = n)
+        y = range(0.0, 2π * (n - 1) / n, length = n)
+
+        data = [F(xi, yj) for xi in x, yj in y]
         p = HermitePartials(
-            (1, 0) => [yj for xi in x, yj in y],
-            (0, 1) => [xi for xi in x, yj in y],
-            (1, 1) => ones(20, 20),
+            (1, 0) => [Fx(xi, yj)  for xi in x, yj in y],
+            (0, 1) => [Fy(xi, yj)  for xi in x, yj in y],
+            (1, 1) => [Fxy(xi, yj) for xi in x, yj in y],
         )
-        queries = [(0.13, 0.42), (0.77, 0.51), (0.23, 0.83)]
-        out = Vector{Float64}(undef, 3)
-        hermite_interp!(out, (x, y), data, p, queries)
-        return @allocated hermite_interp!(out, (x, y), data, p, queries)
+
+        bc = (PeriodicBC(endpoint = :exclusive), PeriodicBC(endpoint = :exclusive))
+        itp = hermite_interp((x, y), data, p; bc)
+
+        # After build, size(itp) reflects extension (n+1 per axis).
+        @test size(itp) == (n + 1, n + 1)
+
+        # Evaluate at points across (including past the user's last grid point — must wrap)
+        for qx in [0.13, 1.5, 3.0, 5.4]
+            for qy in [0.21, 1.1, 2.7, 5.9]
+                v = itp((qx, qy))
+                @test v ≈ F(qx, qy) atol = 5.0e-3
+            end
+        end
+
+        # Round-trip: value at xq must equal value at xq + 2π (within wrap-aware extrap, but
+        # PeriodicBC at build time bakes in the wrap so domain query inside [0, 2π) is exact)
+        @test itp((0.3, 0.5)) ≈ itp((0.3, 0.5))
     end
 
-    function _measure_persistent_eval()
-        x = range(0.0, 1.0, length=20)
-        y = range(0.0, 1.0, length=20)
-        data = [xi*yj for xi in x, yj in y]
-        p = HermitePartials(
-            (1, 0) => [yj for xi in x, yj in y],
-            (0, 1) => [xi for xi in x, yj in y],
-            (1, 1) => ones(20, 20),
-        )
-        itp = hermite_interp((x, y), data, p)
-        itp((0.5, 0.5))
-        return @allocated itp((0.7, 0.3))
+    @testset "Hermite ND — Input isolation (persistent copies, oneshot snapshots)" begin
+        # ── Persistent: build snapshots inputs; user mutations after build are
+        #    not visible to the interpolant.
+        @testset "Persistent: itp isolated from post-build user mutation" begin
+            x = range(0.0, 1.0, length = 5)
+            y = range(0.0, 1.0, length = 5)
+            data = [xi * yj for xi in x, yj in y]
+            dfdx = [yj for xi in x, yj in y]
+            dfdy = [xi for xi in x, yj in y]
+            d2 = ones(5, 5)
+            p = HermitePartials((1, 0) => dfdx, (0, 1) => dfdy, (1, 1) => d2)
+
+            itp = hermite_interp((x, y), data, p)
+            val_before = itp((0.5, 0.5))
+
+            # Trash every user-owned input array
+            fill!(data, NaN)
+            fill!(dfdx, NaN)
+            fill!(dfdy, NaN)
+            fill!(d2, NaN)
+            # `p.partials[k]` is the *same array* as the dfdx/dfdy/d2 we just
+            # nuked — these are aliases established by `HermitePartials`
+            # (zero-copy when eltypes match). Confirm:
+            @test all(isnan, p.partials[1])
+            @test all(isnan, p.partials[2])
+            @test all(isnan, p.partials[3])
+
+            # Despite user-side trashing, itp still reproduces the original value:
+            # the build-time copy into `nodal_derivs.partials` decoupled it.
+            val_after = itp((0.5, 0.5))
+            @test val_after == val_before
+            @test !isnan(val_after)
+        end
+
+        # ── Persistent: the stored packed buffer is also independent (a third
+        #    snapshot — mutate itp.nodal_derivs internally, user data untouched).
+        @testset "Persistent: user data unaffected by itp internal mutation" begin
+            x = range(0.0, 1.0, length = 4)
+            y = range(0.0, 1.0, length = 4)
+            data = [xi * yj for xi in x, yj in y]
+            original_data = copy(data)
+            p = HermitePartials(
+                (1, 0) => [yj for xi in x, yj in y],
+                (0, 1) => [xi for xi in x, yj in y],
+                (1, 1) => ones(4, 4),
+            )
+            itp = hermite_interp((x, y), data, p)
+            # Stomp the internal packed buffer
+            fill!(itp.nodal_derivs.partials, 99.0)
+            # User's `data` is unchanged
+            @test data == original_data
+        end
+
+        # ── One-shot: each call snapshots the *current* user data. Mutating
+        #    between calls is safe and reflected in the next return.
+        @testset "One-shot: snapshots current data per call" begin
+            x = range(0.0, 1.0, length = 5)
+            y = range(0.0, 1.0, length = 5)
+            data = [xi * yj for xi in x, yj in y]
+            p = HermitePartials(
+                (1, 0) => [yj for xi in x, yj in y],
+                (0, 1) => [xi for xi in x, yj in y],
+                (1, 1) => ones(5, 5),
+            )
+            v1 = hermite_interp((x, y), data, p, (0.5, 0.5))
+            # Replace data in-place with a constant; result must follow.
+            # Partials still describe the OLD data, but for cubic Hermite the
+            # value at a node is the corresponding data entry exactly — so at
+            # interior the eval is a polynomial mix of {data, partials}. Easier
+            # invariant: at a *grid node* the eval reduces to `data[i, j]`.
+            data .= 7.5
+            v2 = hermite_interp((x, y), data, p, (x[3], y[3]))   # grid node
+            @test v2 == 7.5
+            # And the original call shouldn't have been retroactively affected
+            # (no aliasing back into user's array via the pool).
+            @test v1 == 0.25   # x[3]*y[3] when data was xi*yj; sanity
+        end
     end
 
-    # Bulk-loop measurements amortize single-call setup noise.
-    # 1000-iter bulk / 1000 must be exactly 0.
-    @test _measure_nobc(1000) == 0
-    @test _measure_excl(1000) == 0
-    @test _measure_inc(1000)  == 0
-    # Single-call batch & persistent eval (already inside function barrier).
-    @test _measure_batch_inplace() <= ALLOC_THRESHOLD
-    @test _measure_persistent_eval() <= ALLOC_THRESHOLD
-end
+    @testset "Hermite ND — Pool-based oneshot zero-alloc" begin
+        # All measurements live inside one function so locals are type-stable and
+        # `@allocated` reports the steady-state, post-warmup cost (no @testset
+        # try/catch artifacts). Bulk-loop divisor confirms per-call alloc.
+
+        function _measure_nobc(n_iters)
+            x = range(0.0, 1.0, length = 20)
+            y = range(0.0, 1.0, length = 20)
+            data = [xi * yj for xi in x, yj in y]
+            p = HermitePartials(
+                (1, 0) => [yj for xi in x, yj in y],
+                (0, 1) => [xi for xi in x, yj in y],
+                (1, 1) => ones(20, 20),
+            )
+            # warmup
+            hermite_interp((x, y), data, p, (0.5, 0.5))
+            function loop!(out, x, y, data, p, queries, n)
+                @inbounds for k in 1:n
+                    out[k] = hermite_interp((x, y), data, p, queries[k])
+                end
+                return nothing
+            end
+            queries = [(0.1 + 0.0001 * k, 0.5) for k in 1:n_iters]
+            out = Vector{Float64}(undef, n_iters)
+            loop!(out, x, y, data, p, queries, n_iters)
+            return @allocated loop!(out, x, y, data, p, queries, n_iters)
+        end
+
+        function _measure_excl(n_iters)
+            xp = range(0.0, 2π * 19 / 20, length = 20)
+            yp = range(0.0, 2π * 19 / 20, length = 20)
+            dp = [sin(xi) * cos(yj) for xi in xp, yj in yp]
+            pp = HermitePartials(
+                (1, 0) => [ cos(xi) * cos(yj) for xi in xp, yj in yp],
+                (0, 1) => [-sin(xi) * sin(yj) for xi in xp, yj in yp],
+                (1, 1) => [-cos(xi) * sin(yj) for xi in xp, yj in yp],
+            )
+            bc = (PeriodicBC(endpoint = :exclusive), PeriodicBC(endpoint = :exclusive))
+            hermite_interp((xp, yp), dp, pp, (0.5, 0.5); bc)
+            function loop!(out, xp, yp, dp, pp, queries, n, bc)
+                @inbounds for k in 1:n
+                    out[k] = hermite_interp((xp, yp), dp, pp, queries[k]; bc)
+                end
+                return nothing
+            end
+            queries = [(0.1 + 0.0001 * k, 0.5) for k in 1:n_iters]
+            out = Vector{Float64}(undef, n_iters)
+            loop!(out, xp, yp, dp, pp, queries, n_iters, bc)
+            return @allocated loop!(out, xp, yp, dp, pp, queries, n_iters, bc)
+        end
+
+        function _measure_inc(n_iters)
+            xi2 = range(0.0, 2π, length = 20)
+            yi2 = range(0.0, 2π, length = 20)
+            di = [cos(xi) * cos(yj) for xi in xi2, yj in yi2]
+            pi2 = HermitePartials(
+                (1, 0) => [-sin(xi) * cos(yj) for xi in xi2, yj in yi2],
+                (0, 1) => [-cos(xi) * sin(yj) for xi in xi2, yj in yi2],
+                (1, 1) => [ sin(xi) * sin(yj) for xi in xi2, yj in yi2],
+            )
+            bc = (PeriodicBC(endpoint = :inclusive), PeriodicBC(endpoint = :inclusive))
+            hermite_interp((xi2, yi2), di, pi2, (0.5, 0.5); bc)
+            function loop!(out, xi2, yi2, di, pi2, queries, n, bc)
+                @inbounds for k in 1:n
+                    out[k] = hermite_interp((xi2, yi2), di, pi2, queries[k]; bc)
+                end
+                return nothing
+            end
+            queries = [(0.1 + 0.0001 * k, 0.5) for k in 1:n_iters]
+            out = Vector{Float64}(undef, n_iters)
+            loop!(out, xi2, yi2, di, pi2, queries, n_iters, bc)
+            return @allocated loop!(out, xi2, yi2, di, pi2, queries, n_iters, bc)
+        end
+
+        function _measure_batch_inplace()
+            x = range(0.0, 1.0, length = 20)
+            y = range(0.0, 1.0, length = 20)
+            data = [xi * yj for xi in x, yj in y]
+            p = HermitePartials(
+                (1, 0) => [yj for xi in x, yj in y],
+                (0, 1) => [xi for xi in x, yj in y],
+                (1, 1) => ones(20, 20),
+            )
+            queries = [(0.13, 0.42), (0.77, 0.51), (0.23, 0.83)]
+            out = Vector{Float64}(undef, 3)
+            hermite_interp!(out, (x, y), data, p, queries)
+            return @allocated hermite_interp!(out, (x, y), data, p, queries)
+        end
+
+        function _measure_persistent_eval()
+            x = range(0.0, 1.0, length = 20)
+            y = range(0.0, 1.0, length = 20)
+            data = [xi * yj for xi in x, yj in y]
+            p = HermitePartials(
+                (1, 0) => [yj for xi in x, yj in y],
+                (0, 1) => [xi for xi in x, yj in y],
+                (1, 1) => ones(20, 20),
+            )
+            itp = hermite_interp((x, y), data, p)
+            itp((0.5, 0.5))
+            return @allocated itp((0.7, 0.3))
+        end
+
+        # Bulk-loop measurements amortize single-call setup noise.
+        # 1000-iter bulk / 1000 must be exactly 0.
+        @test _measure_nobc(1000) == 0
+        @test _measure_excl(1000) == 0
+        @test _measure_inc(1000) == 0
+        # Single-call batch & persistent eval (already inside function barrier).
+        @test _measure_batch_inplace() <= ALLOC_THRESHOLD
+        @test _measure_persistent_eval() <= ALLOC_THRESHOLD
+    end
 
 end  # @testitem
-

--- a/test/test_hermite_nd_partials.jl
+++ b/test/test_hermite_nd_partials.jl
@@ -525,4 +525,256 @@
         @test _measure_persistent_eval() <= ALLOC_THRESHOLD
     end
 
+    @testset "Hermite ND — N=3 full mixed partials (exactness + vector calculus)" begin
+        # f = P(x)·Q(y)·R(z), each factor a polynomial of degree ≤ 3, so f lies
+        # in the per-cell tensor-product cubic span and is reproduced exactly
+        # when fed the analytic partials. This is the only coverage that
+        # compiles/exercises the @generated fill / wrap / seam code at N=3
+        # (everything else is N=2). At N=3 there are 2^3-1 = 7 partial arrays.
+        P(x) = 1.0 + 0.5x - 0.3x^2 + 0.2x^3
+        Q(y) = 0.7 - 0.4y + 0.6y^2
+        R(z) = 1.0 + 0.3z + 0.1z^2 - 0.05z^3
+        Px(x) = 0.5 - 0.6x + 0.6x^2
+        Qy(y) = -0.4 + 1.2y
+        Rz(z) = 0.3 + 0.2z - 0.15z^2
+
+        f(x, y, z) = P(x) * Q(y) * R(z)
+        fx(x, y, z) = Px(x) * Q(y) * R(z)
+        fy(x, y, z) = P(x) * Qy(y) * R(z)
+        fz(x, y, z) = P(x) * Q(y) * Rz(z)
+        fxy(x, y, z) = Px(x) * Qy(y) * R(z)
+        fxz(x, y, z) = Px(x) * Q(y) * Rz(z)
+        fyz(x, y, z) = P(x) * Qy(y) * Rz(z)
+        fxyz(x, y, z) = Px(x) * Qy(y) * Rz(z)
+
+        x = range(-1.0, 1.5, length = 6)
+        y = range(0.0, 1.2, length = 5)
+        z = range(-0.5, 1.0, length = 7)
+
+        data = [f(xi, yj, zk) for xi in x, yj in y, zk in z]
+        p = HermitePartials(
+            (1, 0, 0) => [fx(xi, yj, zk)   for xi in x, yj in y, zk in z],
+            (0, 1, 0) => [fy(xi, yj, zk)   for xi in x, yj in y, zk in z],
+            (0, 0, 1) => [fz(xi, yj, zk)   for xi in x, yj in y, zk in z],
+            (1, 1, 0) => [fxy(xi, yj, zk)  for xi in x, yj in y, zk in z],
+            (1, 0, 1) => [fxz(xi, yj, zk)  for xi in x, yj in y, zk in z],
+            (0, 1, 1) => [fyz(xi, yj, zk)  for xi in x, yj in y, zk in z],
+            (1, 1, 1) => [fxyz(xi, yj, zk) for xi in x, yj in y, zk in z],
+        )
+        @test p isa HermitePartials{3, Float64, 7}
+
+        itp = hermite_interp((x, y, z), data, p)
+        @test ndims(itp) == 3
+        @test size(itp) == (6, 5, 7)
+        @test FastInterpolations.num_partials(itp) == 8   # 2^3
+
+        # Grid nodes — exact
+        for i in 1:length(x), j in 1:length(y), k in 1:length(z)
+            @test itp((x[i], y[j], z[k])) ≈ data[i, j, k] atol = 1.0e-10
+        end
+        # Interior queries — exact (f ∈ tensor-product cubic span)
+        for (qx, qy, qz) in [(-0.3, 0.42, 0.13), (1.1, 0.9, -0.2), (0.0, 0.5, 0.5)]
+            @test itp((qx, qy, qz)) ≈ f(qx, qy, qz) atol = 1.0e-9
+        end
+
+        # Vector calculus via the AbstractInterpolantND protocol at N=3
+        qx, qy, qz = 0.21, 0.66, 0.34
+        g = gradient(itp, (qx, qy, qz))
+        @test g[1] ≈ fx(qx, qy, qz) atol = 1.0e-8
+        @test g[2] ≈ fy(qx, qy, qz) atol = 1.0e-8
+        @test g[3] ≈ fz(qx, qy, qz) atol = 1.0e-8
+
+        H = hessian(itp, (qx, qy, qz))
+        @test size(H) == (3, 3)
+        @test H[1, 2] ≈ H[2, 1] atol = 1.0e-9
+        @test H[1, 3] ≈ H[3, 1] atol = 1.0e-9
+        @test H[2, 3] ≈ H[3, 2] atol = 1.0e-9
+        @test laplacian(itp, (qx, qy, qz)) ≈ H[1, 1] + H[2, 2] + H[3, 3] atol = 1.0e-9
+
+        # Third mixed derivative + one-shot at N=3
+        @test itp((qx, qy, qz); deriv = (DerivOp(1), DerivOp(1), DerivOp(1))) ≈ fxyz(qx, qy, qz) atol = 1.0e-8
+        @test hermite_interp((x, y, z), data, p, (qx, qy, qz)) ≈ f(qx, qy, qz) atol = 1.0e-9
+    end
+
+    @testset "Hermite ND — Inclusive seam validation throws on mismatch" begin
+        n = 6
+        x = range(0.0, 2π, length = n)
+        y = range(0.0, 2π, length = n)
+        bc = (PeriodicBC(endpoint = :inclusive), PeriodicBC(endpoint = :inclusive))
+
+        # (a) data endpoints unequal under :inclusive → throw on the data array
+        data_bad = [xi * yj for xi in x, yj in y]   # data[1,:]=0 ≠ data[end,:]=2π·yj
+        p_any = HermitePartials(
+            (1, 0) => [yj for xi in x, yj in y],
+            (0, 1) => [xi for xi in x, yj in y],
+            (1, 1) => ones(n, n),
+        )
+        @test_throws ArgumentError hermite_interp((x, y), data_bad, p_any; bc)
+
+        # (b) data periodic but one partial array is NOT → throw on that partial
+        data_ok = [cos(xi) * cos(yj) for xi in x, yj in y]
+        p_bad = HermitePartials(
+            (1, 0) => [-sin(xi) * cos(yj) for xi in x, yj in y],
+            (0, 1) => [-cos(xi) * sin(yj) for xi in x, yj in y],
+            (1, 1) => [xi * yj for xi in x, yj in y],   # mask 3: non-periodic seam
+        )
+        @test_throws ArgumentError hermite_interp((x, y), data_ok, p_bad; bc)
+    end
+
+    @testset "Hermite ND — Extrapolation modes (Clamp / Fill / Wrap / NoExtrap)" begin
+        F(x, y) = 0.4 + 0.7x - 0.3y + 0.5x * y + 0.2x^2 * y - 0.1y^3
+        Fx(x, y) = 0.7 + 0.5y + 0.4x * y
+        Fy(x, y) = -0.3 + 0.5x + 0.2x^2 - 0.3y^2
+        Fxy(x, y) = 0.5 + 0.4x
+
+        x = range(0.0, 2.0, length = 6)
+        y = range(-1.0, 1.0, length = 5)
+        data = [F(xi, yj) for xi in x, yj in y]
+        p = HermitePartials(
+            (1, 0) => [Fx(xi, yj)  for xi in x, yj in y],
+            (0, 1) => [Fy(xi, yj)  for xi in x, yj in y],
+            (1, 1) => [Fxy(xi, yj) for xi in x, yj in y],
+        )
+        yq = 0.3
+        x_above = 2.7   # past x[end] = 2.0
+
+        # ClampExtrap: OOB query clamps to the domain boundary
+        itp_clamp = hermite_interp((x, y), data, p; extrap = ClampExtrap())
+        @test itp_clamp((x_above, yq)) ≈ itp_clamp((2.0, yq)) atol = 1.0e-12
+
+        # FillExtrap: OOB returns the fill value exactly
+        itp_fill = hermite_interp((x, y), data, p; extrap = FillExtrap(0.0))
+        @test itp_fill((x_above, yq)) === 0.0
+        itp_nan = hermite_interp((x, y), data, p; extrap = FillExtrap(NaN))
+        @test isnan(itp_nan((x_above, yq)))
+
+        # NoExtrap (default): OOB throws
+        itp_no = hermite_interp((x, y), data, p)
+        @test_throws DomainError itp_no((x_above, yq))
+
+        # One-shot FillExtrap exercises the `_try_fill_oob` early-return branch
+        @test hermite_interp((x, y), data, p, (x_above, yq); extrap = FillExtrap(0.0)) === 0.0
+        # One-shot NoExtrap OOB throws via `_validate_nd_domain`
+        @test_throws DomainError hermite_interp((x, y), data, p, (x_above, yq))
+
+        # WrapExtrap + PeriodicBC: a query past the domain wraps around
+        xp = range(0.0, 2π, length = 9)
+        yp = range(0.0, 2π, length = 9)
+        Fp(x, y) = cos(x) * cos(y)
+        dp = [Fp(xi, yj) for xi in xp, yj in yp]
+        pp = HermitePartials(
+            (1, 0) => [-sin(xi) * cos(yj) for xi in xp, yj in yp],
+            (0, 1) => [-cos(xi) * sin(yj) for xi in xp, yj in yp],
+            (1, 1) => [ sin(xi) * sin(yj) for xi in xp, yj in yp],
+        )
+        bc = (PeriodicBC(endpoint = :inclusive), PeriodicBC(endpoint = :inclusive))
+        itp_wrap = hermite_interp((xp, yp), dp, pp; bc, extrap = WrapExtrap())
+        @test itp_wrap((0.7 + 2π, 1.1)) ≈ itp_wrap((0.7, 1.1)) atol = 1.0e-10
+    end
+
+    @testset "Hermite ND — Vector (non-Range) grid exclusive periodic" begin
+        # `collect` → Vector grids, which take the `vcat` (persistent) and
+        # pooled `copyto!` (one-shot) extension branches; Range grids use the
+        # range-preserving branch instead, so those paths were untested.
+        F(x, y) = sin(x) * cos(y)
+        Fx(x, y) = cos(x) * cos(y)
+        Fy(x, y) = -sin(x) * sin(y)
+        Fxy(x, y) = -cos(x) * sin(y)
+
+        n = 16
+        xv = collect(range(0.0, 2π * (n - 1) / n, length = n))
+        yv = collect(range(0.0, 2π * (n - 1) / n, length = n))
+        data = [F(xi, yj) for xi in xv, yj in yv]
+        p = HermitePartials(
+            (1, 0) => [Fx(xi, yj)  for xi in xv, yj in yv],
+            (0, 1) => [Fy(xi, yj)  for xi in xv, yj in yv],
+            (1, 1) => [Fxy(xi, yj) for xi in xv, yj in yv],
+        )
+        # Vector grids require an explicit period.
+        bc = (
+            PeriodicBC(endpoint = :exclusive, period = 2π),
+            PeriodicBC(endpoint = :exclusive, period = 2π),
+        )
+
+        itp = hermite_interp((xv, yv), data, p; bc)
+        @test size(itp) == (n + 1, n + 1)             # extended along both axes
+        @test !(itp.grids[1] isa AbstractRange)        # confirm the Vector branch ran
+        for qx in [0.13, 1.5, 3.0, 5.4], qy in [0.21, 1.1, 2.7, 5.9]
+            @test itp((qx, qy)) ≈ F(qx, qy) atol = 5.0e-3
+        end
+
+        # One-shot over Vector grids exercises the pooled `copyto!` extension.
+        v_persist = itp((0.83, 2.4))
+        v_oneshot = hermite_interp((xv, yv), data, p, (0.83, 2.4); bc)
+        @test v_oneshot ≈ v_persist atol = 1.0e-10
+    end
+
+    @testset "Hermite ND — Higher-order & one-shot derivatives" begin
+        # Bicubic polynomial → every partial derivative reproduced exactly.
+        a, b, c, dd = 0.7, 1.3, -0.4, 2.1
+        e, ff, gg, hh = -0.6, 0.5, 0.3, -0.2
+        ii, jj = 0.15, -0.25
+        F(x, y) = a + b * x + c * y + dd * x * y + e * x^2 + ff * y^2 + gg * x^2 * y + hh * x * y^2 + ii * x^3 + jj * y^3
+        Fx(x, y) = b + dd * y + 2e * x + 2gg * x * y + hh * y^2 + 3ii * x^2
+        Fy(x, y) = c + dd * x + 2ff * y + gg * x^2 + 2hh * x * y + 3jj * y^2
+        Fxy(x, y) = dd + 2gg * x + 2hh * y
+        Fxx(x, y) = 2e + 2gg * y + 6ii * x
+        Fyy(x, y) = 2ff + 2hh * x + 6jj * y
+        Fxxx = 6ii
+
+        x = collect(range(-1.0, 1.5, length = 8))
+        y = collect(range(-0.8, 1.2, length = 7))
+        data = [F(xi, yj) for xi in x, yj in y]
+        p = HermitePartials(
+            (1, 0) => [Fx(xi, yj)  for xi in x, yj in y],
+            (0, 1) => [Fy(xi, yj)  for xi in x, yj in y],
+            (1, 1) => [Fxy(xi, yj) for xi in x, yj in y],
+        )
+        itp = hermite_interp((x, y), data, p)
+        qx, qy = 0.37, -0.21
+
+        # Higher-order persistent derivatives (only 1st-order was covered before)
+        @test itp((qx, qy); deriv = (DerivOp(2), DerivOp(0))) ≈ Fxx(qx, qy) atol = 1.0e-9
+        @test itp((qx, qy); deriv = (DerivOp(0), DerivOp(2))) ≈ Fyy(qx, qy) atol = 1.0e-9
+        @test itp((qx, qy); deriv = (DerivOp(3), DerivOp(0))) ≈ Fxxx atol = 1.0e-8
+
+        # One-shot deriv kwarg (scalar + batch) — previously untested
+        @test hermite_interp((x, y), data, p, (qx, qy); deriv = (DerivOp(1), DerivOp(0))) ≈ Fx(qx, qy) atol = 1.0e-9
+        @test hermite_interp((x, y), data, p, (qx, qy); deriv = (DerivOp(1), DerivOp(1))) ≈ Fxy(qx, qy) atol = 1.0e-9
+        qs = [(0.1, 0.2), (-0.5, 0.7), (1.1, -0.3)]
+        out = hermite_interp((x, y), data, p, qs; deriv = (DerivOp(1), DerivOp(0)))
+        @test out ≈ [Fx(qx2, qy2) for (qx2, qy2) in qs] atol = 1.0e-9
+    end
+
+    @testset "Hermite ND — Introspection & wrong-K rejection" begin
+        x = range(0.0, 1.0, length = 4)
+        y = range(0.0, 1.0, length = 4)
+        data = [xi * yj for xi in x, yj in y]
+        p = HermitePartials(
+            (1, 0) => [yj for xi in x, yj in y],
+            (0, 1) => [xi for xi in x, yj in y],
+            (1, 1) => ones(4, 4),
+        )
+        itp = hermite_interp((x, y), data, p)
+
+        @test ndims(itp) == 2
+        @test size(itp) == (4, 4)
+        @test axes(itp) === itp.grids
+        @test FastInterpolations.num_partials(itp) == 4
+        @test FastInterpolations.num_partials(typeof(itp)) == 4
+
+        # show methods must not error and must name the type
+        s_compact = sprint(show, itp)
+        s_plain = sprint((io, v) -> show(io, MIME"text/plain"(), v), itp)
+        @test occursin("CubicHermiteInterpolantND", s_compact)
+        @test occursin("CubicHermiteInterpolantND", s_plain)
+
+        # Directly constructed wrong-K HermitePartials (bypassing the public
+        # constructor's K == 2^N-1 guard) must be rejected by the build.
+        A = zeros(4, 4)
+        bad = HermitePartials{2, Float64, 2, Matrix{Float64}}((A, A))
+        @test_throws ArgumentError hermite_interp((x, y), data, bad)
+        @test_throws ArgumentError hermite_interp((x, y), data, bad, (0.5, 0.5))  # one-shot path
+    end
+
 end  # @testitem


### PR DESCRIPTION
## Summary

`hermite_interp` was 1D-only. For ND, users who already have their own mixed partials had no entry point — only the auto-slope methods (`pchip_interp` / `cardinal_interp` / `akima_interp`), which estimate partials from the data and discard the user's. This PR adds the **ND forward path**: pass the partials directly and evaluate. (Reverse-mode AD is out of scope — see below.)

```julia
partials = HermitePartials((1, 0) => dfdx, (0, 1) => dfdy, (1, 1) => d2fdxdy)
itp = hermite_interp((x, y), data, partials)
itp((qx, qy))                                   # value
itp((qx, qy); deriv = (DerivOp(1), DerivOp(0))) # ∂f/∂x

hermite_interp((x, y), data, partials, (qx, qy))    # one-shot scalar
hermite_interp((x, y), data, partials, queries)     # one-shot batch
hermite_interp!(out, (x, y), data, partials, queries)
```

## Key changes

- New exported API: `CubicHermiteInterpolantND`, `HermitePartials`, and `hermite_interp(grids, data, partials; bc, extrap, search)` — persistent build plus one-shot (scalar / batch / in-place, zero-alloc after warmup).
- Per-axis `bc` / `extrap` / `search` (a single value broadcasts, or an `NTuple{N}`). BCs: `NoBC` and `PeriodicBC{:inclusive, :exclusive}`; other families are rejected at build time (user partials supersede BC-derived ones).
- Reuses existing internals — no new kernels. Values + all `2^N − 1` mixed partials pack into the shared `_NodalDerivativesND` layout, so evaluation routes through the existing tensor-product `_eval_nd_cell`. The type subtypes `AbstractInterpolantND`, so `gradient` / `hessian` / `laplacian` and `nodal_partials(itp, order)` work for free. Generic in `N` (tested to N=3).
- Additive trait overrides on shared files (no behavior change for existing types): `nodal_partials` support, `NoBC` display dispatches, and the reverse-mode AD traits raising a clear error (see Out of scope).

## Performance

`@belapsed` minimum, Float64, single-thread, this machine.

| Grid    | Build     | Persistent eval | One-shot scalar | One-shot batch / query |
|---      |---:       |---:             |---:             |---:                    |
| 20×20   |  0.39 µs  |  7.8 ns         |  0.37 µs        | 12 ns                  |
| 100×100 |  7.92 µs  |  7.8 ns         |  7.60 µs        | 84 ns                  |
| 300×300 |  69.4 µs  |  7.8 ns         |  69.6 µs        | 705 ns                 |

Persistent eval is grid-size independent (reads `4^N` cache-adjacent slots). One-shot is zero-alloc after warmup via a `@with_pool` buffer (regression-tested with a 1000-iter bulk loop).

## Out of scope

- **Reverse-mode AD (adjoint).** The persistent callable subtypes `AbstractInterpolantND`, so the generic ND rrules reach it; rather than a confusing `MethodError`, the adjoint traits raise a clear "not implemented" error. Forward `gradient` / `hessian` / `laplacian` are unaffected. The full ND adjoint is a direct generalization of the 1D Hermite pullback (`(f̄_y, f̄_dy)` → `(f̄_data, f̄_partials...)`) and warrants its own PR.