### PR TITLE
Allow Symbolics 6 by compiling out the Symbolics extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FastInterpolations"
 uuid = "9ea80cae-fc13-4c00-8066-6eaedb12f34b"
-version = "0.4.12"
+version = "0.4.11"
 authors = ["Min-Gu Yoo <mgyoo86@gmail.com>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FastInterpolations"
 uuid = "9ea80cae-fc13-4c00-8066-6eaedb12f34b"
-version = "0.4.11"
+version = "0.4.12"
 authors = ["Min-Gu Yoo <mgyoo86@gmail.com>"]
 
 [deps]
@@ -36,5 +36,5 @@ Preferences = "1"
 Printf = "1"
 RecipesBase = "1"
 SymbolicUtils = "3, 4"
-Symbolics = "7"
+Symbolics = "6, 7"
 julia = "1.10"

--- a/ext/FastInterpolationsSymbolicsExt.jl
+++ b/ext/FastInterpolationsSymbolicsExt.jl
@@ -27,6 +27,13 @@ using Symbolics
 using Symbolics: Num, unwrap, wrap
 import SymbolicUtils
 
+# This extension targets the Symbolics 7 / SymbolicUtils 4 symbolic API
+# (`SymbolicUtils.TypeT` / `ShapeT` / `@register_derivative`). On the older
+# Symbolics 6 / SymbolicUtils 3 generation that API is absent, so the symbolic
+# interpolation glue is compiled out and the extension loads as a no-op. Numeric
+# interpolation in the FastInterpolations core is unaffected on either generation.
+@static if isdefined(SymbolicUtils, :TypeT)
+
 # ========================================
 # 1D Interpolant Registration
 # ========================================
@@ -190,5 +197,7 @@ end
     new_d = DifferentiatedInterpolantND{Nargs, typeof(d.interp)}(d.interp, orders)
     SymbolicUtils.term(new_d, args...; type = Real)
 end
+
+end # @static if isdefined(SymbolicUtils, :TypeT)
 
 end # module

--- a/ext/FastInterpolationsSymbolicsExt.jl
+++ b/ext/FastInterpolationsSymbolicsExt.jl
@@ -34,169 +34,169 @@ import SymbolicUtils
 # interpolation in the FastInterpolations core is unaffected on either generation.
 @static if isdefined(SymbolicUtils, :TypeT)
 
-# ========================================
-# 1D Interpolant Registration
-# ========================================
+    # ========================================
+    # 1D Interpolant Registration
+    # ========================================
 
-# Wrapper function for symbolic registration. Using a regular function
-# (not a callable struct) avoids method ambiguity with concrete interpolant types.
-_fast_interp_eval(itp::AbstractInterpolant, t) = itp(t)
-_derivative_symbolic(itp::AbstractInterpolant, t, order::Integer) = itp(t; deriv = DerivOp(order))
+    # Wrapper function for symbolic registration. Using a regular function
+    # (not a callable struct) avoids method ambiguity with concrete interpolant types.
+    _fast_interp_eval(itp::AbstractInterpolant, t) = itp(t)
+    _derivative_symbolic(itp::AbstractInterpolant, t, order::Integer) = itp(t; deriv = DerivOp(order))
 
-# Register the wrapper and derivative functions with Symbolics
-@register_symbolic _fast_interp_eval(itp::AbstractInterpolant, t)
-@register_symbolic _derivative_symbolic(itp::AbstractInterpolant, t, order::Integer) false
+    # Register the wrapper and derivative functions with Symbolics
+    @register_symbolic _fast_interp_eval(itp::AbstractInterpolant, t)
+    @register_symbolic _derivative_symbolic(itp::AbstractInterpolant, t, order::Integer) false
 
-Base.nameof(itp::AbstractInterpolant) = :FastInterpolation
+    Base.nameof(itp::AbstractInterpolant) = :FastInterpolation
 
-# Type/shape promotions for _derivative_symbolic
-function SymbolicUtils.promote_symtype(
-        ::typeof(_derivative_symbolic), Ti::SymbolicUtils.TypeT,
-        Tt::SymbolicUtils.TypeT,
-        To::SymbolicUtils.TypeT
-    )
-    @assert Ti <: AbstractInterpolant
-    @assert Tt <: Real
-    @assert To <: Integer
-    return Real
-end
+    # Type/shape promotions for _derivative_symbolic
+    function SymbolicUtils.promote_symtype(
+            ::typeof(_derivative_symbolic), Ti::SymbolicUtils.TypeT,
+            Tt::SymbolicUtils.TypeT,
+            To::SymbolicUtils.TypeT
+        )
+        @assert Ti <: AbstractInterpolant
+        @assert Tt <: Real
+        @assert To <: Integer
+        return Real
+    end
 
-function SymbolicUtils.promote_shape(
-        ::typeof(_derivative_symbolic),
-        @nospecialize(shi::SymbolicUtils.ShapeT),
-        @nospecialize(sht::SymbolicUtils.ShapeT),
-        @nospecialize(sho::SymbolicUtils.ShapeT)
-    )
-    @assert !SymbolicUtils.is_array_shape(shi)
-    @assert !SymbolicUtils.is_array_shape(sht)
-    @assert !SymbolicUtils.is_array_shape(sho)
-    return SymbolicUtils.ShapeVecT()
-end
+    function SymbolicUtils.promote_shape(
+            ::typeof(_derivative_symbolic),
+            @nospecialize(shi::SymbolicUtils.ShapeT),
+            @nospecialize(sht::SymbolicUtils.ShapeT),
+            @nospecialize(sho::SymbolicUtils.ShapeT)
+        )
+        @assert !SymbolicUtils.is_array_shape(shi)
+        @assert !SymbolicUtils.is_array_shape(sht)
+        @assert !SymbolicUtils.is_array_shape(sho)
+        return SymbolicUtils.ShapeVecT()
+    end
 
-# Derivative chain rules:
-# d/dt _fast_interp_eval(itp, t) = _derivative_symbolic(itp, t, 1)
-@register_derivative _fast_interp_eval(itp, t) 2 _derivative_symbolic(itp, t, 1)
-# d/dt _derivative_symbolic(itp, t, n) = _derivative_symbolic(itp, t, n+1)
-@register_derivative _derivative_symbolic(itp, t, ord) 2 _derivative_symbolic(itp, t, ord + 1)
+    # Derivative chain rules:
+    # d/dt _fast_interp_eval(itp, t) = _derivative_symbolic(itp, t, 1)
+    @register_derivative _fast_interp_eval(itp, t) 2 _derivative_symbolic(itp, t, 1)
+    # d/dt _derivative_symbolic(itp, t, n) = _derivative_symbolic(itp, t, n+1)
+    @register_derivative _derivative_symbolic(itp, t, ord) 2 _derivative_symbolic(itp, t, ord + 1)
 
-# Redirect concrete interpolant callable methods to the registered wrapper.
-# This is needed because concrete types have (itp::ConcreteType)(xq; ...) methods
-# where xq is untyped, creating ambiguity if we defined on AbstractInterpolant.
-for T in [LinearInterpolant, CubicInterpolant, QuadraticInterpolant, ConstantInterpolant]
-    for symT in [Num, SymbolicUtils.BasicSymbolic{<:Real}]
-        @eval function (itp::$T)(t::$symT; kwargs...)
-            return _fast_interp_eval(itp, t)
+    # Redirect concrete interpolant callable methods to the registered wrapper.
+    # This is needed because concrete types have (itp::ConcreteType)(xq; ...) methods
+    # where xq is untyped, creating ambiguity if we defined on AbstractInterpolant.
+    for T in [LinearInterpolant, CubicInterpolant, QuadraticInterpolant, ConstantInterpolant]
+        for symT in [Num, SymbolicUtils.BasicSymbolic{<:Real}]
+            @eval function (itp::$T)(t::$symT; kwargs...)
+                return _fast_interp_eval(itp, t)
+            end
         end
     end
-end
 
-# ========================================
-# ND Interpolant Registration
-# ========================================
+    # ========================================
+    # ND Interpolant Registration
+    # ========================================
 
-# Wrapper struct for tracking derivative orders of ND interpolants.
-# Enables higher-order symbolic differentiation by accumulating per-axis orders.
-struct DifferentiatedInterpolantND{N, I <: AbstractInterpolantND}
-    interp::I
-    derivative_orders::NTuple{N, Int}
-end
-
-function (d::DifferentiatedInterpolantND{N})(args::Vararg{Real, N}) where {N}
-    deriv_ops = map(n -> DerivOp(n), d.derivative_orders)
-    return d.interp(args; deriv = deriv_ops)
-end
-
-Base.nameof(::AbstractInterpolantND) = :FastInterpolationND
-Base.nameof(::DifferentiatedInterpolantND) = :DifferentiatedFastInterpolationND
-
-# Helper for ND symbolic term construction
-function _symbolic_nd_call(itp, t_args, is_num::Bool)
-    args = is_num ? unwrap.(t_args) : t_args
-    res = SymbolicUtils.term(itp, args...; type = Real)
-    return is_num ? Num(res) : res
-end
-
-# Register ND callable for Num and BasicSymbolic argument types.
-# Must define on concrete types to avoid ambiguity with existing
-# (itp::ConcreteND)(query::Tuple{Vararg{Real, N}}) methods.
-#
-# Also add numeric varargs methods: build_function generates `itp(x, y)` (varargs)
-# but the numeric ND API uses `itp((x, y))` (tuple). This bridge enables compiled
-# symbolic expressions to call back into the numeric code correctly.
-for NDT in [CubicInterpolantND, LinearInterpolantND, QuadraticInterpolantND, ConstantInterpolantND]
-    # Numeric varargs → tuple conversion for compiled symbolic code
-    @eval function (itp::$NDT{Tg, Tv, N})(
-            args::Vararg{Real, N}; kwargs...
-        ) where {Tg, Tv, N}
-        return itp(args; kwargs...)
+    # Wrapper struct for tracking derivative orders of ND interpolants.
+    # Enables higher-order symbolic differentiation by accumulating per-axis orders.
+    struct DifferentiatedInterpolantND{N, I <: AbstractInterpolantND}
+        interp::I
+        derivative_orders::NTuple{N, Int}
     end
 
+    function (d::DifferentiatedInterpolantND{N})(args::Vararg{Real, N}) where {N}
+        deriv_ops = map(n -> DerivOp(n), d.derivative_orders)
+        return d.interp(args; deriv = deriv_ops)
+    end
+
+    Base.nameof(::AbstractInterpolantND) = :FastInterpolationND
+    Base.nameof(::DifferentiatedInterpolantND) = :DifferentiatedFastInterpolationND
+
+    # Helper for ND symbolic term construction
+    function _symbolic_nd_call(itp, t_args, is_num::Bool)
+        args = is_num ? unwrap.(t_args) : t_args
+        res = SymbolicUtils.term(itp, args...; type = Real)
+        return is_num ? Num(res) : res
+    end
+
+    # Register ND callable for Num and BasicSymbolic argument types.
+    # Must define on concrete types to avoid ambiguity with existing
+    # (itp::ConcreteND)(query::Tuple{Vararg{Real, N}}) methods.
+    #
+    # Also add numeric varargs methods: build_function generates `itp(x, y)` (varargs)
+    # but the numeric ND API uses `itp((x, y))` (tuple). This bridge enables compiled
+    # symbolic expressions to call back into the numeric code correctly.
+    for NDT in [CubicInterpolantND, LinearInterpolantND, QuadraticInterpolantND, ConstantInterpolantND]
+        # Numeric varargs → tuple conversion for compiled symbolic code
+        @eval function (itp::$NDT{Tg, Tv, N})(
+                args::Vararg{Real, N}; kwargs...
+            ) where {Tg, Tv, N}
+            return itp(args; kwargs...)
+        end
+
+        for symT in [Num, SymbolicUtils.BasicSymbolic{<:Real}]
+            is_num = symT === Num
+            # ND interpolant call via tuple: itp((sym_x, sym_y, ...))
+            @eval function (itp::$NDT{Tg, Tv, N})(
+                    t::NTuple{N, $symT}; kwargs...
+                ) where {Tg, Tv, N}
+                return _symbolic_nd_call(itp, t, $is_num)
+            end
+
+            # Varargs form: itp(sym_x, sym_y, ...)
+            @eval function (itp::$NDT{Tg, Tv, N})(
+                    t::Vararg{$symT, N}; kwargs...
+                ) where {Tg, Tv, N}
+                return _symbolic_nd_call(itp, t, $is_num)
+            end
+        end
+    end
+
+    # DifferentiatedInterpolantND symbolic calls
     for symT in [Num, SymbolicUtils.BasicSymbolic{<:Real}]
         is_num = symT === Num
-        # ND interpolant call via tuple: itp((sym_x, sym_y, ...))
-        @eval function (itp::$NDT{Tg, Tv, N})(
-                t::NTuple{N, $symT}; kwargs...
-            ) where {Tg, Tv, N}
-            return _symbolic_nd_call(itp, t, $is_num)
-        end
-
-        # Varargs form: itp(sym_x, sym_y, ...)
-        @eval function (itp::$NDT{Tg, Tv, N})(
-                t::Vararg{$symT, N}; kwargs...
-            ) where {Tg, Tv, N}
-            return _symbolic_nd_call(itp, t, $is_num)
+        @eval function (d::DifferentiatedInterpolantND{N})(
+                t::Vararg{$symT, N}
+            ) where {N}
+            return _symbolic_nd_call(d, t, $is_num)
         end
     end
-end
 
-# DifferentiatedInterpolantND symbolic calls
-for symT in [Num, SymbolicUtils.BasicSymbolic{<:Real}]
-    is_num = symT === Num
-    @eval function (d::DifferentiatedInterpolantND{N})(
-            t::Vararg{$symT, N}
-        ) where {N}
-        return _symbolic_nd_call(d, t, $is_num)
+    # Symtype promotion for ND interpolants
+    function SymbolicUtils.promote_symtype(::AbstractInterpolantND, ::Vararg)
+        return Real
     end
-end
 
-# Symtype promotion for ND interpolants
-function SymbolicUtils.promote_symtype(::AbstractInterpolantND, ::Vararg)
-    return Real
-end
-
-function SymbolicUtils.promote_symtype(::DifferentiatedInterpolantND, ::Vararg)
-    return Real
-end
-
-# Shape promotion: ND interpolants return scalars.
-# Must use the concrete ShapeT union type to avoid ambiguity with the generic fallback.
-const _ShapeT = SymbolicUtils.ShapeT
-
-function SymbolicUtils.promote_shape(::AbstractInterpolantND, ::Vararg{_ShapeT})
-    return SymbolicUtils.ShapeVecT()
-end
-
-function SymbolicUtils.promote_shape(::DifferentiatedInterpolantND, ::Vararg{_ShapeT})
-    return SymbolicUtils.ShapeVecT()
-end
-
-# Derivative rules for ND interpolants via @register_derivative.
-# d/d(arg_I) itp(args...) = DifferentiatedInterpolantND(itp, (0,...,1,...,0))(args...)
-for NDT in [CubicInterpolantND, LinearInterpolantND, QuadraticInterpolantND, ConstantInterpolantND]
-    @eval @register_derivative (itp::$NDT)(args...) I begin
-        orders = ntuple(j -> j == I ? 1 : 0, Val{Nargs}())
-        dinterp = DifferentiatedInterpolantND{Nargs, typeof(itp)}(itp, orders)
-        SymbolicUtils.term(dinterp, args...; type = Real)
+    function SymbolicUtils.promote_symtype(::DifferentiatedInterpolantND, ::Vararg)
+        return Real
     end
-end
 
-# Derivative rules for DifferentiatedInterpolantND: accumulate orders
-@register_derivative (d::DifferentiatedInterpolantND)(args...) I begin
-    orders_offset = ntuple(j -> j == I ? 1 : 0, Val{Nargs}())
-    orders = d.derivative_orders .+ orders_offset
-    new_d = DifferentiatedInterpolantND{Nargs, typeof(d.interp)}(d.interp, orders)
-    SymbolicUtils.term(new_d, args...; type = Real)
-end
+    # Shape promotion: ND interpolants return scalars.
+    # Must use the concrete ShapeT union type to avoid ambiguity with the generic fallback.
+    const _ShapeT = SymbolicUtils.ShapeT
+
+    function SymbolicUtils.promote_shape(::AbstractInterpolantND, ::Vararg{_ShapeT})
+        return SymbolicUtils.ShapeVecT()
+    end
+
+    function SymbolicUtils.promote_shape(::DifferentiatedInterpolantND, ::Vararg{_ShapeT})
+        return SymbolicUtils.ShapeVecT()
+    end
+
+    # Derivative rules for ND interpolants via @register_derivative.
+    # d/d(arg_I) itp(args...) = DifferentiatedInterpolantND(itp, (0,...,1,...,0))(args...)
+    for NDT in [CubicInterpolantND, LinearInterpolantND, QuadraticInterpolantND, ConstantInterpolantND]
+        @eval @register_derivative (itp::$NDT)(args...) I begin
+            orders = ntuple(j -> j == I ? 1 : 0, Val{Nargs}())
+            dinterp = DifferentiatedInterpolantND{Nargs, typeof(itp)}(itp, orders)
+            SymbolicUtils.term(dinterp, args...; type = Real)
+        end
+    end
+
+    # Derivative rules for DifferentiatedInterpolantND: accumulate orders
+    @register_derivative (d::DifferentiatedInterpolantND)(args...) I begin
+        orders_offset = ntuple(j -> j == I ? 1 : 0, Val{Nargs}())
+        orders = d.derivative_orders .+ orders_offset
+        new_d = DifferentiatedInterpolantND{Nargs, typeof(d.interp)}(d.interp, orders)
+        SymbolicUtils.term(new_d, args...; type = Real)
+    end
 
 end # @static if isdefined(SymbolicUtils, :TypeT)
 

--- a/test/ext/test_symbolics.jl
+++ b/test/ext/test_symbolics.jl
@@ -208,6 +208,43 @@ if SYMBOLICS_7_API
             duu_f = build_function(duu_expr, [u, v]; expression = Val{false})
             @test duu_f([u_val, v_val]) ≈ itp((u_val, v_val); deriv = DerivOp(2, 0))
         end
+
+        # ========================================
+        # Registration hook contracts (direct invocation)
+        # Pins the defensive promote_symtype/promote_shape overloads that the
+        # Symbolics term machinery only invokes on non-default tracing paths.
+        # ========================================
+        @testset "registration hook contracts" begin
+            ext = Base.get_extension(FastInterpolations, :FastInterpolationsSymbolicsExt)
+            scalar = SymbolicUtils.ShapeVecT()
+
+            x = collect(range(0.0, 1.0, 11))
+            y = sin.(2π .* x)
+            itp1 = cubic_interp(x, y; extrap = ExtendExtrap())
+
+            xg = range(0.0, 1.0, 11)
+            data = [sin(xi) * cos(yj) for xi in xg, yj in xg]
+            itpN = cubic_interp((xg, xg), data; extrap = ExtendExtrap())
+            d = ext.DifferentiatedInterpolantND(itpN, (1, 0))
+
+            # 1D wrapper hooks (_derivative_symbolic)
+            @test SymbolicUtils.promote_symtype(
+                ext._derivative_symbolic, typeof(itp1), Float64, Int
+            ) === Real
+            @test SymbolicUtils.promote_shape(
+                ext._derivative_symbolic, scalar, scalar, scalar
+            ) == scalar
+
+            # ND hooks (plain + differentiated)
+            @test SymbolicUtils.promote_symtype(itpN, Float64, Float64) === Real
+            @test SymbolicUtils.promote_shape(itpN, scalar, scalar) == scalar
+            @test SymbolicUtils.promote_symtype(d, Float64, Float64) === Real
+            @test SymbolicUtils.promote_shape(d, scalar, scalar) == scalar
+
+            # DifferentiatedInterpolantND identity + numeric callable
+            @test Base.nameof(d) === :DifferentiatedFastInterpolationND
+            @test d(0.3, 0.7) ≈ itpN((0.3, 0.7); deriv = DerivOp(1, 0))
+        end
     end
 else
     @info "Symbolics $(pkgversion(Symbolics)) / SymbolicUtils $(pkgversion(SymbolicUtils)): " *

--- a/test/ext/test_symbolics.jl
+++ b/test/ext/test_symbolics.jl
@@ -126,4 +126,69 @@ using Symbolics
         compiled_dv = dv_f([u_val, v_val])
         @test compiled_dv ≈ numeric_dv
     end
+
+    # ========================================
+    # nameof registration (1D + ND)
+    # ========================================
+    @testset "nameof" begin
+        x = collect(range(0.0, 1.0, 11))
+        y = sin.(2π .* x)
+        itp1 = cubic_interp(x, y; extrap = ExtendExtrap())
+        @test Base.nameof(itp1) === :FastInterpolation
+
+        xg = range(0.0, 1.0, 11)
+        yg = range(0.0, 1.0, 11)
+        data = [sin(xi) * cos(yj) for xi in xg, yj in yg]
+        itpN = cubic_interp((xg, yg), data; extrap = ExtendExtrap())
+        @test Base.nameof(itpN) === :FastInterpolationND
+    end
+
+    # ========================================
+    # ND varargs symbolic form: itp(u, v) (vs the tuple form itp((u, v)))
+    # ========================================
+    @testset "ND Symbolic Calling (varargs)" begin
+        xg = range(0.0, 1.0, 11)
+        yg = range(0.0, 1.0, 11)
+        data = [sin(xi) * cos(yj) for xi in xg, yj in yg]
+
+        @variables u v
+        itp = cubic_interp((xg, yg), data; extrap = ExtendExtrap())
+
+        expr = itp(u, v)
+        @test expr isa Num
+
+        f = build_function(expr, [u, v]; expression = Val{false})
+        u_val, v_val = 0.3, 0.7
+        @test f([u_val, v_val]) ≈ itp((u_val, v_val))
+    end
+
+    # ========================================
+    # Higher-order / mixed ND derivatives
+    # (exercises DifferentiatedInterpolantND accumulation + varargs path)
+    # ========================================
+    @testset "ND Symbolic Derivatives (higher-order)" begin
+        xg = range(0.0, 1.0, 21)
+        yg = range(0.0, 1.0, 21)
+        data = [sin(xi) * cos(yj) for xi in xg, yj in yg]
+
+        @variables u v
+        Du = Differential(u)
+        Dv = Differential(v)
+        itp = cubic_interp((xg, yg), data; extrap = ExtendExtrap())
+
+        expr = itp((u, v))
+        u_val, v_val = 0.3, 0.7
+
+        # Mixed second partial d²/dudv: accumulates orders on DifferentiatedInterpolantND
+        duv_expr = expand_derivatives(Du(Dv(expr)))
+        @test duv_expr isa Num
+        duv_f = build_function(duv_expr, [u, v]; expression = Val{false})
+        @test duv_f([u_val, v_val]) ≈ itp((u_val, v_val); deriv = DerivOp(1, 1))
+
+        # Pure second partial d²/du²
+        duu_expr = expand_derivatives(Du(Du(expr)))
+        @test duu_expr isa Num
+        duu_f = build_function(duu_expr, [u, v]; expression = Val{false})
+        @test duu_f([u_val, v_val]) ≈ itp((u_val, v_val); deriv = DerivOp(2, 0))
+    end
 end

--- a/test/ext/test_symbolics.jl
+++ b/test/ext/test_symbolics.jl
@@ -1,194 +1,280 @@
 using Test
 using FastInterpolations
 using Symbolics
+import SymbolicUtils
 
-@testset "Symbolics Registration" begin
-    # ========================================
-    # 1D Interpolant Registration
-    # ========================================
-    @testset "1D Symbolic Calling" begin
-        x = collect(range(0.0, 1.0, 11))
-        y = sin.(2π .* x)
+# Gate mirrors the `@static if isdefined(SymbolicUtils, :TypeT)` guard in
+# ext/FastInterpolationsSymbolicsExt.jl — keep the two predicates in lockstep.
+# On the Symbolics 6 / SymbolicUtils 3 generation the extension compiles out
+# as a no-op, so the symbolic-tracing tests cannot run; the else branch pins
+# the no-op contract instead. A runtime `if` is sufficient here (test files
+# are not precompiled); switch to `@static if` should Symbolics-7-only macros
+# ever appear in the gated body below.
+SYMBOLICS_7_API = isdefined(SymbolicUtils, :TypeT)
 
-        @variables t
+if SYMBOLICS_7_API
+    @testset "Symbolics extension active" begin
+        ext = Base.get_extension(FastInterpolations, :FastInterpolationsSymbolicsExt)
+        @test ext isa Module
+        @test isdefined(ext, :DifferentiatedInterpolantND)
+    end
 
-        for (name, itp) in [
-                ("linear", linear_interp(x, y; extrap = ExtendExtrap())),
-                ("cubic", cubic_interp(x, y; extrap = ExtendExtrap())),
-                ("constant", constant_interp(x, y; extrap = ExtendExtrap())),
-                ("quadratic", quadratic_interp(x, y; extrap = ExtendExtrap())),
-            ]
-            @testset "$name" begin
-                # Symbolic expression creation
-                expr = itp(t)
-                @test expr isa Num
+    @testset "Symbolics Registration" begin
+        # ========================================
+        # 1D Interpolant Registration
+        # ========================================
+        @testset "1D Symbolic Calling" begin
+            x = collect(range(0.0, 1.0, 11))
+            y = sin.(2π .* x)
 
-                # Compile to function and evaluate: symbolic roundtrip matches numeric
-                f = build_function(expr, t; expression = Val{false})
-                t_val = 0.3
-                numeric_val = itp(t_val)
-                compiled_val = f(t_val)
-                @test compiled_val ≈ numeric_val
+            @variables t
+
+            for (name, itp) in [
+                    ("linear", linear_interp(x, y; extrap = ExtendExtrap())),
+                    ("cubic", cubic_interp(x, y; extrap = ExtendExtrap())),
+                    ("constant", constant_interp(x, y; extrap = ExtendExtrap())),
+                    ("quadratic", quadratic_interp(x, y; extrap = ExtendExtrap())),
+                ]
+                @testset "$name" begin
+                    # Symbolic expression creation
+                    expr = itp(t)
+                    @test expr isa Num
+
+                    # Compile to function and evaluate: symbolic roundtrip matches numeric
+                    f = build_function(expr, t; expression = Val{false})
+                    t_val = 0.3
+                    numeric_val = itp(t_val)
+                    compiled_val = f(t_val)
+                    @test compiled_val ≈ numeric_val
+                end
             end
         end
+
+        # ========================================
+        # 1D Derivative Chain Rules
+        # ========================================
+        @testset "1D Symbolic Derivatives" begin
+            x = collect(range(0.0, 1.0, 101))
+            y = sin.(2π .* x)
+
+            @variables t
+            D = Differential(t)
+
+            # Cubic spline (supports up to 3rd derivative)
+            itp = cubic_interp(x, y; extrap = ExtendExtrap())
+
+            # First derivative: expand D(itp(t))
+            expr = itp(t)
+            dexpr = expand_derivatives(D(expr))
+            @test dexpr isa Num
+
+            # Compile derivative and compare to numeric
+            df = build_function(dexpr, t; expression = Val{false})
+            t_val = 0.3
+            numeric_deriv = itp(t_val; deriv = DerivOp(1))
+            compiled_deriv = df(t_val)
+            @test compiled_deriv ≈ numeric_deriv
+
+            # Second derivative
+            d2expr = expand_derivatives(D(D(expr)))
+            @test d2expr isa Num
+
+            d2f = build_function(d2expr, t; expression = Val{false})
+            numeric_d2 = itp(t_val; deriv = DerivOp(2))
+            compiled_d2 = d2f(t_val)
+            @test compiled_d2 ≈ numeric_d2
+        end
+
+        # ========================================
+        # ND Interpolant Registration
+        # ========================================
+        @testset "ND Symbolic Calling" begin
+            xg = range(0.0, 1.0, 11)
+            yg = range(0.0, 1.0, 11)
+            data = [sin(xi) * cos(yj) for xi in xg, yj in yg]
+
+            @variables u v
+            itp = cubic_interp((xg, yg), data; extrap = ExtendExtrap())
+
+            # Symbolic expression via tuple of Num
+            expr = itp((u, v))
+            @test expr isa Num
+
+            # Compile and evaluate
+            f = build_function(expr, [u, v]; expression = Val{false})
+            u_val, v_val = 0.3, 0.7
+            numeric_val = itp((u_val, v_val))
+            compiled_val = f([u_val, v_val])
+            @test compiled_val ≈ numeric_val
+        end
+
+        # ========================================
+        # ND Symbolic Derivatives
+        # ========================================
+        @testset "ND Symbolic Derivatives" begin
+            xg = range(0.0, 1.0, 21)
+            yg = range(0.0, 1.0, 21)
+            data = [sin(xi) * cos(yj) for xi in xg, yj in yg]
+
+            @variables u v
+            Du = Differential(u)
+            Dv = Differential(v)
+            itp = cubic_interp((xg, yg), data; extrap = ExtendExtrap())
+
+            # Create symbolic expression
+            expr = itp((u, v))
+
+            # Partial derivative w.r.t. u
+            du_expr = expand_derivatives(Du(expr))
+            @test du_expr isa Num
+
+            du_f = build_function(du_expr, [u, v]; expression = Val{false})
+            u_val, v_val = 0.3, 0.7
+            numeric_du = itp((u_val, v_val); deriv = DerivOp(1, 0))
+            compiled_du = du_f([u_val, v_val])
+            @test compiled_du ≈ numeric_du
+
+            # Partial derivative w.r.t. v
+            dv_expr = expand_derivatives(Dv(expr))
+            @test dv_expr isa Num
+
+            dv_f = build_function(dv_expr, [u, v]; expression = Val{false})
+            numeric_dv = itp((u_val, v_val); deriv = DerivOp(0, 1))
+            compiled_dv = dv_f([u_val, v_val])
+            @test compiled_dv ≈ numeric_dv
+        end
+
+        # ========================================
+        # nameof registration (1D + ND)
+        # ========================================
+        @testset "nameof" begin
+            x = collect(range(0.0, 1.0, 11))
+            y = sin.(2π .* x)
+            itp1 = cubic_interp(x, y; extrap = ExtendExtrap())
+            @test Base.nameof(itp1) === :FastInterpolation
+
+            xg = range(0.0, 1.0, 11)
+            yg = range(0.0, 1.0, 11)
+            data = [sin(xi) * cos(yj) for xi in xg, yj in yg]
+            itpN = cubic_interp((xg, yg), data; extrap = ExtendExtrap())
+            @test Base.nameof(itpN) === :FastInterpolationND
+        end
+
+        # ========================================
+        # ND varargs symbolic form: itp(u, v) (vs the tuple form itp((u, v)))
+        # ========================================
+        @testset "ND Symbolic Calling (varargs)" begin
+            xg = range(0.0, 1.0, 11)
+            yg = range(0.0, 1.0, 11)
+            data = [sin(xi) * cos(yj) for xi in xg, yj in yg]
+
+            @variables u v
+            itp = cubic_interp((xg, yg), data; extrap = ExtendExtrap())
+
+            expr = itp(u, v)
+            @test expr isa Num
+
+            f = build_function(expr, [u, v]; expression = Val{false})
+            u_val, v_val = 0.3, 0.7
+            @test f([u_val, v_val]) ≈ itp((u_val, v_val))
+        end
+
+        # ========================================
+        # Higher-order / mixed ND derivatives
+        # (exercises DifferentiatedInterpolantND accumulation + varargs path)
+        # ========================================
+        @testset "ND Symbolic Derivatives (higher-order)" begin
+            xg = range(0.0, 1.0, 21)
+            yg = range(0.0, 1.0, 21)
+            data = [sin(xi) * cos(yj) for xi in xg, yj in yg]
+
+            @variables u v
+            Du = Differential(u)
+            Dv = Differential(v)
+            itp = cubic_interp((xg, yg), data; extrap = ExtendExtrap())
+
+            expr = itp((u, v))
+            u_val, v_val = 0.3, 0.7
+
+            # Mixed second partial d²/dudv: accumulates orders on DifferentiatedInterpolantND
+            duv_expr = expand_derivatives(Du(Dv(expr)))
+            @test duv_expr isa Num
+            duv_f = build_function(duv_expr, [u, v]; expression = Val{false})
+            @test duv_f([u_val, v_val]) ≈ itp((u_val, v_val); deriv = DerivOp(1, 1))
+
+            # Pure second partial d²/du²
+            duu_expr = expand_derivatives(Du(Du(expr)))
+            @test duu_expr isa Num
+            duu_f = build_function(duu_expr, [u, v]; expression = Val{false})
+            @test duu_f([u_val, v_val]) ≈ itp((u_val, v_val); deriv = DerivOp(2, 0))
+        end
     end
+else
+    @info "Symbolics $(pkgversion(Symbolics)) / SymbolicUtils $(pkgversion(SymbolicUtils)): " *
+        "SymbolicUtils.TypeT absent, so FastInterpolationsSymbolicsExt is a no-op; " *
+        "running no-op contract tests instead of symbolic-tracing tests."
 
-    # ========================================
-    # 1D Derivative Chain Rules
-    # ========================================
-    @testset "1D Symbolic Derivatives" begin
-        x = collect(range(0.0, 1.0, 101))
-        y = sin.(2π .* x)
-
-        @variables t
-        D = Differential(t)
-
-        # Cubic spline (supports up to 3rd derivative)
-        itp = cubic_interp(x, y; extrap = ExtendExtrap())
-
-        # First derivative: expand D(itp(t))
-        expr = itp(t)
-        dexpr = expand_derivatives(D(expr))
-        @test dexpr isa Num
-
-        # Compile derivative and compare to numeric
-        df = build_function(dexpr, t; expression = Val{false})
-        t_val = 0.3
-        numeric_deriv = itp(t_val; deriv = DerivOp(1))
-        compiled_deriv = df(t_val)
-        @test compiled_deriv ≈ numeric_deriv
-
-        # Second derivative
-        d2expr = expand_derivatives(D(D(expr)))
-        @test d2expr isa Num
-
-        d2f = build_function(d2expr, t; expression = Val{false})
-        numeric_d2 = itp(t_val; deriv = DerivOp(2))
-        compiled_d2 = d2f(t_val)
-        @test compiled_d2 ≈ numeric_d2
-    end
-
-    # ========================================
-    # ND Interpolant Registration
-    # ========================================
-    @testset "ND Symbolic Calling" begin
-        xg = range(0.0, 1.0, 11)
-        yg = range(0.0, 1.0, 11)
-        data = [sin(xi) * cos(yj) for xi in xg, yj in yg]
-
-        @variables u v
-        itp = cubic_interp((xg, yg), data; extrap = ExtendExtrap())
-
-        # Symbolic expression via tuple of Num
-        expr = itp((u, v))
-        @test expr isa Num
-
-        # Compile and evaluate
-        f = build_function(expr, [u, v]; expression = Val{false})
-        u_val, v_val = 0.3, 0.7
-        numeric_val = itp((u_val, v_val))
-        compiled_val = f([u_val, v_val])
-        @test compiled_val ≈ numeric_val
-    end
-
-    # ========================================
-    # ND Symbolic Derivatives
-    # ========================================
-    @testset "ND Symbolic Derivatives" begin
-        xg = range(0.0, 1.0, 21)
-        yg = range(0.0, 1.0, 21)
-        data = [sin(xi) * cos(yj) for xi in xg, yj in yg]
-
-        @variables u v
-        Du = Differential(u)
-        Dv = Differential(v)
-        itp = cubic_interp((xg, yg), data; extrap = ExtendExtrap())
-
-        # Create symbolic expression
-        expr = itp((u, v))
-
-        # Partial derivative w.r.t. u
-        du_expr = expand_derivatives(Du(expr))
-        @test du_expr isa Num
-
-        du_f = build_function(du_expr, [u, v]; expression = Val{false})
-        u_val, v_val = 0.3, 0.7
-        numeric_du = itp((u_val, v_val); deriv = DerivOp(1, 0))
-        compiled_du = du_f([u_val, v_val])
-        @test compiled_du ≈ numeric_du
-
-        # Partial derivative w.r.t. v
-        dv_expr = expand_derivatives(Dv(expr))
-        @test dv_expr isa Num
-
-        dv_f = build_function(dv_expr, [u, v]; expression = Val{false})
-        numeric_dv = itp((u_val, v_val); deriv = DerivOp(0, 1))
-        compiled_dv = dv_f([u_val, v_val])
-        @test compiled_dv ≈ numeric_dv
-    end
-
-    # ========================================
-    # nameof registration (1D + ND)
-    # ========================================
-    @testset "nameof" begin
+    @testset "Symbolics 6 no-op extension contract" begin
+        # Vector grids on purpose: with Range grids the symbolic-call failure
+        # type changes from TypeError (boolean branch on a Num in the binary
+        # search) to MethodError (unsafe_trunc(Int, ::Num) in the direct
+        # range search).
         x = collect(range(0.0, 1.0, 11))
         y = sin.(2π .* x)
-        itp1 = cubic_interp(x, y; extrap = ExtendExtrap())
-        @test Base.nameof(itp1) === :FastInterpolation
+        data = [sin(xi) * cos(yj) for xi in x, yj in x]
 
-        xg = range(0.0, 1.0, 11)
-        yg = range(0.0, 1.0, 11)
-        data = [sin(xi) * cos(yj) for xi in xg, yj in yg]
-        itpN = cubic_interp((xg, yg), data; extrap = ExtendExtrap())
-        @test Base.nameof(itpN) === :FastInterpolationND
-    end
+        # Mirror of the constructor list in the "1D Symbolic Calling" testset
+        # of the Symbolics-7 branch above — update both together.
+        itps_1d = [
+            ("linear", linear_interp(x, y; extrap = ExtendExtrap())),
+            ("cubic", cubic_interp(x, y; extrap = ExtendExtrap())),
+            ("constant", constant_interp(x, y; extrap = ExtendExtrap())),
+            ("quadratic", quadratic_interp(x, y; extrap = ExtendExtrap())),
+        ]
+        itp_c = itps_1d[2][2]
+        itpN = cubic_interp((x, x), data; extrap = ExtendExtrap())
 
-    # ========================================
-    # ND varargs symbolic form: itp(u, v) (vs the tuple form itp((u, v)))
-    # ========================================
-    @testset "ND Symbolic Calling (varargs)" begin
-        xg = range(0.0, 1.0, 11)
-        yg = range(0.0, 1.0, 11)
-        data = [sin(xi) * cos(yj) for xi in xg, yj in yg]
+        @testset "extension loads as an empty no-op module" begin
+            ext = Base.get_extension(FastInterpolations, :FastInterpolationsSymbolicsExt)
+            @test ext isa Module
+            # Names defined only inside the extension's `@static if` block —
+            # update in lockstep with ext/FastInterpolationsSymbolicsExt.jl:
+            @test !isdefined(ext, :DifferentiatedInterpolantND)
+            @test !isdefined(ext, :_fast_interp_eval)
+        end
 
-        @variables u v
-        itp = cubic_interp((xg, yg), data; extrap = ExtendExtrap())
+        @testset "numeric core unaffected with Symbolics loaded" begin
+            for (name, itp) in itps_1d
+                @testset "$name" begin
+                    val = itp(0.3)
+                    @test val isa Float64
+                    @test isfinite(val)
+                end
+            end
+            @test itp_c(0.3) ≈ sin(2π * 0.3) atol = 1.0e-3
+            @test itp_c(0.3; deriv = DerivOp(1)) isa Float64
+            @test itpN((0.3, 0.7)) ≈ sin(0.3) * cos(0.7) atol = 1.0e-4
+            # numeric ND varargs is provided by the core protocol, not the extension:
+            @test itpN(0.3, 0.7) == itpN((0.3, 0.7))
+        end
 
-        expr = itp(u, v)
-        @test expr isa Num
+        @testset "symbolic calls throw instead of returning silent wrong results" begin
+            @variables t u v
+            for (name, itp) in itps_1d
+                @testset "$name" begin
+                    @test_throws TypeError itp(t)
+                end
+            end
+            @test_throws TypeError itpN((u, v))
+            @test_throws TypeError itpN(u, v)
+            @test_throws TypeError itpN(0.3, v)
+            # the derivative pipeline fails at the inner symbolic call itp_c(t):
+            @test_throws TypeError expand_derivatives(Differential(t)(itp_c(t)))
+        end
 
-        f = build_function(expr, [u, v]; expression = Val{false})
-        u_val, v_val = 0.3, 0.7
-        @test f([u_val, v_val]) ≈ itp((u_val, v_val))
-    end
-
-    # ========================================
-    # Higher-order / mixed ND derivatives
-    # (exercises DifferentiatedInterpolantND accumulation + varargs path)
-    # ========================================
-    @testset "ND Symbolic Derivatives (higher-order)" begin
-        xg = range(0.0, 1.0, 21)
-        yg = range(0.0, 1.0, 21)
-        data = [sin(xi) * cos(yj) for xi in xg, yj in yg]
-
-        @variables u v
-        Du = Differential(u)
-        Dv = Differential(v)
-        itp = cubic_interp((xg, yg), data; extrap = ExtendExtrap())
-
-        expr = itp((u, v))
-        u_val, v_val = 0.3, 0.7
-
-        # Mixed second partial d²/dudv: accumulates orders on DifferentiatedInterpolantND
-        duv_expr = expand_derivatives(Du(Dv(expr)))
-        @test duv_expr isa Num
-        duv_f = build_function(duv_expr, [u, v]; expression = Val{false})
-        @test duv_f([u_val, v_val]) ≈ itp((u_val, v_val); deriv = DerivOp(1, 1))
-
-        # Pure second partial d²/du²
-        duu_expr = expand_derivatives(Du(Du(expr)))
-        @test duu_expr isa Num
-        duu_f = build_function(duu_expr, [u, v]; expression = Val{false})
-        @test duu_f([u_val, v_val]) ≈ itp((u_val, v_val); deriv = DerivOp(2, 0))
+        @testset "nameof not registered" begin
+            @test_throws MethodError Base.nameof(itp_c)
+            @test_throws MethodError Base.nameof(itpN)
+        end
     end
 end


### PR DESCRIPTION
The FastInterpolationsSymbolicsExt weak compat pinned Symbolics = "7", which forces the entire environment to Symbolics 7 whenever Symbolics is present (weak compat is enforced even when the extension is unused). This made FastInterpolations 0.4.x unresolvable in ecosystems still on the Symbolics 6 / SymbolicUtils 3 / ModelingToolkit 9 generation (e.g. FUSE via ThermalSystemModels), breaking downstream builds.

Guard the extension body behind `isdefined(SymbolicUtils, :TypeT)` (the SymbolicUtils 4 API the extension relies on) so it compiles out as a no-op on the older generation, and widen the weak compat to Symbolics = "6, 7". Symbolics 7 keeps full symbolic-interpolation functionality; Symbolics 6 environments can install FastInterpolations with the extension simply inactive. Numeric interpolation is unaffected on either generation.

Verified: precompiles as a no-op under Symbolics 6.58 / SymbolicUtils 3.32 and precompiles + functions under Symbolics 7.26 / SymbolicUtils 4.