### PR TITLE
Fix reverse-mode AD for PCHIP/Akima one-shot interpolation (Enzyme)

### DIFF
--- a/ext/FastInterpolationsEnzymeExt.jl
+++ b/ext/FastInterpolationsEnzymeExt.jl
@@ -94,6 +94,86 @@ function EnzymeRules.reverse(
 end
 
 # ════════════════════════════════════════
+# Hermite family (PCHIP / Akima) — 1D data-adjoint (∂/∂data)
+# ════════════════════════════════════════
+# PCHIP and Akima compute their slopes as a nonlinear function of the data, so
+# their adjoint must be built as `f_adjoint(x, y, xq)`. The generic rules above
+# build `f_adjoint(x, xq)`, which has no method for these two (→ MethodError).
+# These concrete-type rules are strictly more specific than the Union-based
+# generic rules and thread `f.val` through, mirroring the specialized rrules in
+# the ChainRulesCore extension.
+const _DataDependentMethod = Union{typeof(pchip_interp), typeof(akima_interp)}
+
+function EnzymeRules.augmented_primal(
+        config::EnzymeRules.RevConfig,
+        func::Const{<:_DataDependentMethod},
+        RT::Type{<:Annotation},
+        x::Const{<:AbstractVector{Tg}},
+        f::Duplicated{<:AbstractVector},
+        xq::Const{<:AbstractVector{<:Real}};
+        kwargs...
+    ) where {Tg <: AbstractFloat}
+    y = func.val(x.val, f.val, xq.val; kwargs...)
+    primal = EnzymeRules.needs_primal(config) ? y : nothing
+    shadow = EnzymeRules.needs_shadow(config) ? zero(y) : nothing
+    adj = _adjoint_func(func.val)(x.val, f.val, xq.val; kwargs...)
+    deriv = get(kwargs, :deriv, EvalValue())
+    return EnzymeRules.AugmentedReturn(primal, shadow, (adj, deriv, shadow))
+end
+
+function EnzymeRules.reverse(
+        config::EnzymeRules.RevConfig,
+        func::Const{<:_DataDependentMethod},
+        ::Type{RT},
+        tape,
+        x::Const{<:AbstractVector{Tg}},
+        f::Duplicated{<:AbstractVector},
+        xq::Const{<:AbstractVector{<:Real}};
+        kwargs...
+    ) where {Tg <: AbstractFloat, RT}
+    adj, deriv_op, dy = tape
+    if dy !== nothing
+        f_bar = adj(dy; deriv = deriv_op)
+        f.dval .+= f_bar
+        dy .= zero(eltype(dy))
+    end
+    return (nothing, nothing, nothing)
+end
+
+function EnzymeRules.augmented_primal(
+        config::EnzymeRules.RevConfig,
+        func::Const{<:_DataDependentMethod},
+        RT::Type{<:Annotation},
+        x::Const{<:AbstractVector{Tg}},
+        f::Duplicated{<:AbstractVector},
+        xq::Const{<:Real};
+        kwargs...
+    ) where {Tg <: AbstractFloat}
+    y = func.val(x.val, f.val, xq.val; kwargs...)
+    primal = EnzymeRules.needs_primal(config) ? y : nothing
+    shadow = EnzymeRules.needs_shadow(config) ? zero(y) : nothing
+    adj = _adjoint_func(func.val)(x.val, f.val, [xq.val]; kwargs...)
+    deriv = get(kwargs, :deriv, EvalValue())
+    return EnzymeRules.AugmentedReturn(primal, shadow, (adj, deriv))
+end
+
+function EnzymeRules.reverse(
+        config::EnzymeRules.RevConfig,
+        func::Const{<:_DataDependentMethod},
+        dret::Active,
+        tape,
+        x::Const{<:AbstractVector{Tg}},
+        f::Duplicated{<:AbstractVector},
+        xq::Const{<:Real};
+        kwargs...
+    ) where {Tg <: AbstractFloat}
+    adj, deriv_op = tape
+    f_bar = adj([dret.val]; deriv = deriv_op)
+    f.dval .+= f_bar
+    return (nothing, nothing, nothing)
+end
+
+# ════════════════════════════════════════
 # 1D Scalar query — ∂/∂xq (f::Const, xq::Active)
 # ════════════════════════════════════════
 # Generic for all 4 types: computes derivative via DerivOp(1).

--- a/ext/FastInterpolationsEnzymeExt.jl
+++ b/ext/FastInterpolationsEnzymeExt.jl
@@ -111,13 +111,15 @@ function EnzymeRules.augmented_primal(
         x::Const{<:AbstractVector{Tg}},
         f::Duplicated{<:AbstractVector},
         xq::Const{<:AbstractVector{<:Real}};
+        deriv::DerivOp = EvalValue(),
         kwargs...
     ) where {Tg <: AbstractFloat}
-    y = func.val(x.val, f.val, xq.val; kwargs...)
+    y = func.val(x.val, f.val, xq.val; deriv = deriv, kwargs...)
     primal = EnzymeRules.needs_primal(config) ? y : nothing
     shadow = EnzymeRules.needs_shadow(config) ? zero(y) : nothing
+    # `deriv` extracted explicitly — it is an apply-time arg; the adjoint
+    # constructor (pchip/akima) accepts bc/extrap only and would `MethodError`.
     adj = _adjoint_func(func.val)(x.val, f.val, xq.val; kwargs...)
-    deriv = get(kwargs, :deriv, EvalValue())
     return EnzymeRules.AugmentedReturn(primal, shadow, (adj, deriv, shadow))
 end
 
@@ -147,13 +149,15 @@ function EnzymeRules.augmented_primal(
         x::Const{<:AbstractVector{Tg}},
         f::Duplicated{<:AbstractVector},
         xq::Const{<:Real};
+        deriv::DerivOp = EvalValue(),
         kwargs...
     ) where {Tg <: AbstractFloat}
-    y = func.val(x.val, f.val, xq.val; kwargs...)
+    y = func.val(x.val, f.val, xq.val; deriv = deriv, kwargs...)
     primal = EnzymeRules.needs_primal(config) ? y : nothing
     shadow = EnzymeRules.needs_shadow(config) ? zero(y) : nothing
+    # `deriv` extracted explicitly — it is an apply-time arg; the adjoint
+    # constructor (pchip/akima) accepts bc/extrap only and would `MethodError`.
     adj = _adjoint_func(func.val)(x.val, f.val, [xq.val]; kwargs...)
-    deriv = get(kwargs, :deriv, EvalValue())
     return EnzymeRules.AugmentedReturn(primal, shadow, (adj, deriv))
 end
 

--- a/test/ext/test_autodiff_Enzyme.jl
+++ b/test/ext/test_autodiff_Enzyme.jl
@@ -619,6 +619,86 @@ else
                 end
             end
 
+            # ════════════════════════════════════════════════════════════════════════
+            # PCHIP / AKIMA DATA-ADJOINT with deriv=DerivOp(1) via EnzymeRules
+            # ════════════════════════════════════════════════════════════════════════
+            # Regression guard: the one-shot data-adjoint `augmented_primal` must extract
+            # `deriv` explicitly and NOT forward it to pchip_adjoint/akima_adjoint, whose
+            # constructors accept bc/extrap only. Differentiating a derivative-evaluation
+            # w.r.t. DATA must match ForwardDiff (and must not raise MethodError).
+
+            @testset "PCHIP data-adjoint, deriv=DerivOp(1) — Enzyme" begin
+                using ForwardDiff
+
+                x = collect(0.0:0.5:5.0)
+                f_data = sin.(x)
+                xq_vec = [0.75, 1.25, 2.75, 3.5, 4.25]
+
+                @testset "Vector query" begin
+                    loss_d1(y, x, xq) = sum(pchip_interp(x, y, xq; deriv = DerivOp(1), extrap = ExtendExtrap()))
+                    df = zeros(length(f_data))
+                    Enzyme.autodiff(
+                        Enzyme.Reverse, loss_d1, Enzyme.Active,
+                        Enzyme.Duplicated(copy(f_data), df),
+                        Enzyme.Const(x), Enzyme.Const(xq_vec)
+                    )
+                    g_fd = ForwardDiff.gradient(
+                        y -> sum(pchip_interp(x, y, xq_vec; deriv = DerivOp(1), extrap = ExtendExtrap())), f_data
+                    )
+                    @test df ≈ g_fd atol = 1.0e-10
+                end
+
+                @testset "Scalar query" begin
+                    loss_d1s(y, x, xq) = pchip_interp(x, y, xq; deriv = DerivOp(1), extrap = ExtendExtrap())
+                    df = zeros(length(f_data))
+                    Enzyme.autodiff(
+                        Enzyme.Reverse, loss_d1s, Enzyme.Active,
+                        Enzyme.Duplicated(copy(f_data), df),
+                        Enzyme.Const(x), Enzyme.Const(1.25)
+                    )
+                    g_fd = ForwardDiff.gradient(
+                        y -> pchip_interp(x, y, 1.25; deriv = DerivOp(1), extrap = ExtendExtrap()), f_data
+                    )
+                    @test df ≈ g_fd atol = 1.0e-10
+                end
+            end
+
+            @testset "Akima data-adjoint, deriv=DerivOp(1) — Enzyme" begin
+                using ForwardDiff
+
+                x = collect(0.0:0.5:5.0)
+                f_data = sin.(x)
+                xq_vec = [0.75, 1.25, 2.75, 3.5, 4.25]
+
+                @testset "Vector query" begin
+                    loss_d1(y, x, xq) = sum(akima_interp(x, y, xq; deriv = DerivOp(1), extrap = ExtendExtrap()))
+                    df = zeros(length(f_data))
+                    Enzyme.autodiff(
+                        Enzyme.Reverse, loss_d1, Enzyme.Active,
+                        Enzyme.Duplicated(copy(f_data), df),
+                        Enzyme.Const(x), Enzyme.Const(xq_vec)
+                    )
+                    g_fd = ForwardDiff.gradient(
+                        y -> sum(akima_interp(x, y, xq_vec; deriv = DerivOp(1), extrap = ExtendExtrap())), f_data
+                    )
+                    @test df ≈ g_fd atol = 1.0e-10
+                end
+
+                @testset "Scalar query" begin
+                    loss_d1s(y, x, xq) = akima_interp(x, y, xq; deriv = DerivOp(1), extrap = ExtendExtrap())
+                    df = zeros(length(f_data))
+                    Enzyme.autodiff(
+                        Enzyme.Reverse, loss_d1s, Enzyme.Active,
+                        Enzyme.Duplicated(copy(f_data), df),
+                        Enzyme.Const(x), Enzyme.Const(1.25)
+                    )
+                    g_fd = ForwardDiff.gradient(
+                        y -> akima_interp(x, y, 1.25; deriv = DerivOp(1), extrap = ExtendExtrap()), f_data
+                    )
+                    @test df ≈ g_fd atol = 1.0e-10
+                end
+            end
+
             # ════════════════════════════════════════════════════════════════
             # ND struct API — ∂/∂data via constructor + eval EnzymeRules
             # ════════════════════════════════════════════════════════════════

--- a/test/ext/test_autodiff_Enzyme.jl
+++ b/test/ext/test_autodiff_Enzyme.jl
@@ -538,6 +538,87 @@ else
                 end
             end
 
+            # ════════════════════════════════════════════════════════════════════════
+            # PCHIP DATA-ADJOINT (∂f/∂y) via EnzymeRules
+            # ════════════════════════════════════════════════════════════════════════
+            # PCHIP/Akima slopes are nonlinear in the data, so the reverse pass goes
+            # through pchip_adjoint(x, y, xq) / akima_adjoint(x, y, xq). Differentiate
+            # w.r.t. DATA (f) and cross-validate against ForwardDiff (exact at kinks too).
+
+            @testset "PCHIP data-adjoint (∂f/∂y) — Enzyme via EnzymeRules" begin
+                using ForwardDiff
+
+                x = collect(0.0:0.5:5.0)
+                f_data = sin.(x)
+                xq_vec = [0.75, 1.25, 2.75, 3.5, 4.25]
+                y_obs = cos.(xq_vec)
+
+                @testset "Vector query — L2 loss" begin
+                    loss_enz(y, y_obs, x, xq) = sum(abs2, pchip_interp(x, y, xq; extrap = ExtendExtrap()) .- y_obs)
+                    df = zeros(length(f_data))
+                    Enzyme.autodiff(
+                        Enzyme.Reverse, loss_enz, Enzyme.Active,
+                        Enzyme.Duplicated(copy(f_data), df),
+                        Enzyme.Const(y_obs), Enzyme.Const(x), Enzyme.Const(xq_vec)
+                    )
+                    g_fd = ForwardDiff.gradient(
+                        y -> sum(abs2, pchip_interp(x, y, xq_vec; extrap = ExtendExtrap()) .- y_obs), f_data
+                    )
+                    @test df ≈ g_fd atol = 1.0e-10
+                end
+
+                @testset "Scalar query" begin
+                    loss_scalar(y, x, xq) = pchip_interp(x, y, xq; extrap = ExtendExtrap())
+                    df = zeros(length(f_data))
+                    Enzyme.autodiff(
+                        Enzyme.Reverse, loss_scalar, Enzyme.Active,
+                        Enzyme.Duplicated(copy(f_data), df),
+                        Enzyme.Const(x), Enzyme.Const(1.25)
+                    )
+                    g_fd = ForwardDiff.gradient(y -> pchip_interp(x, y, 1.25; extrap = ExtendExtrap()), f_data)
+                    @test df ≈ g_fd atol = 1.0e-10
+                end
+            end
+
+            # ════════════════════════════════════════════════════════════════════════
+            # AKIMA DATA-ADJOINT (∂f/∂y) via EnzymeRules
+            # ════════════════════════════════════════════════════════════════════════
+
+            @testset "Akima data-adjoint (∂f/∂y) — Enzyme via EnzymeRules" begin
+                using ForwardDiff
+
+                x = collect(0.0:0.5:5.0)
+                f_data = sin.(x)
+                xq_vec = [0.75, 1.25, 2.75, 3.5, 4.25]
+                y_obs = cos.(xq_vec)
+
+                @testset "Vector query — L2 loss" begin
+                    loss_enz(y, y_obs, x, xq) = sum(abs2, akima_interp(x, y, xq; extrap = ExtendExtrap()) .- y_obs)
+                    df = zeros(length(f_data))
+                    Enzyme.autodiff(
+                        Enzyme.Reverse, loss_enz, Enzyme.Active,
+                        Enzyme.Duplicated(copy(f_data), df),
+                        Enzyme.Const(y_obs), Enzyme.Const(x), Enzyme.Const(xq_vec)
+                    )
+                    g_fd = ForwardDiff.gradient(
+                        y -> sum(abs2, akima_interp(x, y, xq_vec; extrap = ExtendExtrap()) .- y_obs), f_data
+                    )
+                    @test df ≈ g_fd atol = 1.0e-10
+                end
+
+                @testset "Scalar query" begin
+                    loss_scalar(y, x, xq) = akima_interp(x, y, xq; extrap = ExtendExtrap())
+                    df = zeros(length(f_data))
+                    Enzyme.autodiff(
+                        Enzyme.Reverse, loss_scalar, Enzyme.Active,
+                        Enzyme.Duplicated(copy(f_data), df),
+                        Enzyme.Const(x), Enzyme.Const(1.25)
+                    )
+                    g_fd = ForwardDiff.gradient(y -> akima_interp(x, y, 1.25; extrap = ExtendExtrap()), f_data)
+                    @test df ≈ g_fd atol = 1.0e-10
+                end
+            end
+
             # ════════════════════════════════════════════════════════════════
             # ND struct API — ∂/∂data via constructor + eval EnzymeRules
             # ════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Reverse-mode AD through the 3-arg one-shot `pchip_interp(x, y, xq)` and
`akima_interp(x, y, xq)` throws a `MethodError` under **Enzyme**. This adds the
specialized 1D data-adjoint `EnzymeRules` for the PCHIP/Akima family — mirroring
the specialized `rrule`s that already exist for them in the ChainRulesCore
extension.

## Reproducer

```julia
using FastInterpolations, Enzyme
x = collect(range(0, 1, length = 9)); y = sin.(2π .* x); q = 0.42
obj(v) = pchip_interp(x, v, q; extrap = ExtendExtrap())
dy = zero(y)
Enzyme.autodiff(set_runtime_activity(Reverse), obj, Active, Duplicated(y, dy))
# ERROR: MethodError: no method matching pchip_adjoint(::Vector{Float64}, ::Vector{Float64}; extrap::ExtendExtrap)
```

(same for `akima_interp`).

## Root cause

The generic 1D `EnzymeRules` build the reverse-pass adjoint as
`_adjoint_func(func)(x, xq; kwargs...)`. That is correct for the data-*independent*
adjoints (`linear`/`cubic`/`quadratic`/`constant`/`cardinal`, whose adjoint is
`f_adjoint(x, xq)`), but PCHIP and Akima compute their slopes as a nonlinear
function of the data, so their adjoint constructors are `pchip_adjoint(x, y, xq)` /
`akima_adjoint(x, y, xq)` — the `y` argument is missing, hence the `MethodError`.

The **ChainRulesCore extension already handles this** with dedicated concrete-type
`rrule`s for `pchip_interp`/`akima_interp` (with an explanatory comment); the Enzyme
extension was simply missing the parallel specialization. (Zygote/ChainRules is
therefore unaffected — and the existing periodic-BC test in
`test/ext/test_autodiff_Zygote.jl` already covers it.)

## Fix

Add specialized 1D `∂/∂data` `EnzymeRules` (`augmented_primal` + `reverse`, vector
and scalar query) dispatching on
`Const{<:Union{typeof(pchip_interp), typeof(akima_interp)}}`. These are strictly
more specific than the generic `_InterpMethod` rules (so they win, like the CRC
`rrule`s do) and thread `f.val` into the adjoint constructor. No existing rule is
modified.

## Tests

Adds PCHIP and Akima `∂/∂data` testsets to `test/ext/test_autodiff_Enzyme.jl` (the
file already had linear/cubic/quadratic/constant but not these two), checking the
reverse-mode gradient against `ForwardDiff` for vector and scalar queries, with
`extrap = ExtendExtrap()`.

Full `test/ext/test_autodiff_Enzyme.jl` on Julia 1.12.6 (Enzyme 0.13.159):
**72 pass, 2 broken (pre-existing), 0 fail**. PCHIP/Akima reverse-mode gradients
match ForwardDiff to ~1e-11. (Akima's only disagreement with centered finite
differences is at slope-limiter kinks, where ForwardDiff disagrees identically —
i.e. the adjoint is exact and FD straddles the kink.)
