### PR TITLE
Widen Enzyme compat upper bound to 0.13

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ FastInterpolationsSymbolicsExt = ["Symbolics", "SymbolicUtils"]
 [compat]
 AdaptiveArrayPools = "0.3.6"
 ChainRulesCore = "1"
-Enzyme = "0.13.0 - 0.13.135"
+Enzyme = "0.13"
 ForwardDiff = "1"
 HelpPlots = "1"
 LinearAlgebra = "1"


### PR DESCRIPTION
## Summary

Widen the `Enzyme` `[compat]` upper bound from `0.13.0 - 0.13.135` to `0.13`.

## Why

`Enzyme` is a weak dependency, so this upper bound constrains the **entire
environment** of any downstream that also uses Enzyme — not just
FastInterpolations' own extension. The current ceiling (`≤ 0.13.135`) sits below
the latest Enzyme (0.13.159), so it transitively forces downgrades. In our
monorepo, adding FastInterpolations forces `Enzyme 0.13.152 → 0.13.135` and, via
the Enzyme↔GPUCompiler coupling, `GPUCompiler 1.13.3 → 1.9.1`.

## Verification

FastInterpolations and its Enzyme extension precompile cleanly and the AD-extension
tests pass against **Enzyme 0.13.159** on Julia 1.12.6, so the `0.13.135` ceiling
appears to be "latest at tag time" rather than a known incompatibility.

Happy to pair this with a CompatHelper config / a CI job that runs the AD extension
tests against the latest Enzyme so the bound stays current.
