### PR TITLE
(feat): 1D entry point for the unified `interp`/`interp!` API

### DIFF
--- a/src/FastInterpolations.jl
+++ b/src/FastInterpolations.jl
@@ -20,6 +20,7 @@ include("akima/akima.jl")
 include("core/coeff_policy.jl")  # AutoCoeffs resolution (after method types + strategy types, before hetero)
 include("hetero/hetero.jl")
 include("hetero/local_hermite_nd_forward.jl")  # pchip/cardinal/akima ND forwarders to `interp`
+include("hetero/interp_1d.jl")  # 1D bare-vector entry points for `interp`/`interp!`
 
 # Derivative view wrapper (depends on all interpolant types)
 include("derivative_view.jl")

--- a/src/hetero/interp_1d.jl
+++ b/src/hetero/interp_1d.jl
@@ -1,0 +1,131 @@
+# ============================================================================
+# Unified API — 1D bare-vector entry points
+# ============================================================================
+# `interp`/`interp!` for genuine 1D data, where the grid and values are bare
+# `AbstractVector`s rather than the ND `(grids, data)` tuple form. These route
+# directly to the dedicated 1D functions (`cubic_interp`, `linear_interp`, …):
+#
+#     interp(x, y; method=CubicInterp())            === cubic_interp(x, y)
+#     interp(x, y, q; method=CubicInterp())         === cubic_interp(x, y, q)
+#     interp(x, y, qs; method=CubicInterp())        === cubic_interp(x, y, qs)
+#     interp!(out, x, y, qs; method=CubicInterp())  === cubic_interp!(out, x, y, qs)
+#
+# Routing is a single per-method trait, `_interp1d_route`, mirroring the
+# `_build_hetero_axis_package` idiom: each method maps to its dedicated
+# (allocating, in-place) function pair plus the method-specific keyword options
+# (`bc` / `side` / `tension`). The four public forms below consume that trait
+# generically, so the kwarg wiring for each form is written exactly once and a
+# new method family is a one-line addition.
+#
+# Zero-cost: `_interp1d_route(method)` dispatches on the concrete `method` type,
+# so the returned tuple is fully concrete (function singletons carry no data;
+# the options NamedTuple holds the method's fields). The compiler scalar-replaces
+# the tuple and constant-folds the `opts...` keyword splat — the wrapper emits
+# the same code, with the same allocation profile, as calling the dedicated
+# function by hand.
+#
+# Non-ambiguous with the ND forms (hetero_oneshot.jl / hetero_interpolant.jl):
+# those require `NTuple{N,AbstractVector}` as the first positional argument,
+# while these take a bare `AbstractVector` — dispatch separates them cleanly.
+#
+# Only kwargs common to every dedicated 1D function are exposed. `coeffs`
+# (Hermite-family only) and batch-form `hint` (Hermite-family only) are left to
+# each dedicated function's own defaults rather than forwarded conditionally.
+
+# ----------------------------------------------------------------------------
+# Per-method routing trait: (allocating fn, in-place fn, method-specific kwargs)
+# ----------------------------------------------------------------------------
+@inline _interp1d_route(m::CubicInterp)     = (cubic_interp,     cubic_interp!,     (; bc = m.bc))
+@inline _interp1d_route(m::LinearInterp)    = (linear_interp,    linear_interp!,    (; bc = m.bc))
+@inline _interp1d_route(m::QuadraticInterp) = (quadratic_interp, quadratic_interp!, (; bc = m.bc))
+@inline _interp1d_route(m::ConstantInterp)  = (constant_interp,  constant_interp!,  (; side = m.side, bc = m.bc))
+@inline _interp1d_route(m::PchipInterp)     = (pchip_interp,     pchip_interp!,     (; bc = m.bc))
+@inline _interp1d_route(m::CardinalInterp)  = (cardinal_interp,  cardinal_interp!,  (; bc = m.bc, tension = m.tension))
+@inline _interp1d_route(m::AkimaInterp)     = (akima_interp,     akima_interp!,     (; bc = m.bc))
+
+# ----------------------------------------------------------------------------
+# Public forms — each consumes the routing trait generically.
+# ----------------------------------------------------------------------------
+
+"""
+    interp(x::AbstractVector, y::AbstractVector; method, extrap=NoExtrap(), search=AutoSearch())
+
+Build a 1D interpolant. Equivalent to calling the dedicated 1D constructor for
+`method` directly (e.g. `method=CubicInterp()` → `cubic_interp(x, y)`), with the
+method's boundary condition / side / tension forwarded.
+
+```julia
+itp = interp(x, y; method = CubicInterp())              # === cubic_interp(x, y)
+itp = interp(x, y; method = LinearInterp(bc = PeriodicBC()))
+itp = interp(x, y; method = CardinalInterp(tension = 0.5))
+```
+"""
+@inline function interp(
+        x::AbstractVector,
+        y::AbstractVector;
+        method::AbstractInterpMethod,
+        extrap::AbstractExtrap = NoExtrap(),
+        search::AbstractSearchPolicy = AutoSearch(),
+    )
+    fn, _, opts = _interp1d_route(method)
+    return fn(x, y; opts..., extrap = extrap, search = search)
+end
+
+"""
+    interp(x::AbstractVector, y::AbstractVector, q::Real; method, deriv=EvalValue(), extrap=NoExtrap(), search=AutoSearch(), hint=nothing)
+
+One-shot 1D interpolation at a single point. Equivalent to the dedicated 1D
+one-shot call (e.g. `cubic_interp(x, y, q)`), with the method's options forwarded.
+"""
+@inline function interp(
+        x::AbstractVector,
+        y::AbstractVector,
+        q::Real;
+        method::AbstractInterpMethod,
+        deriv::DerivOp = EvalValue(),
+        extrap::AbstractExtrap = NoExtrap(),
+        search::AbstractSearchPolicy = AutoSearch(),
+        hint::Union{Nothing, Base.RefValue{Int}} = nothing,
+    )
+    fn, _, opts = _interp1d_route(method)
+    return fn(x, y, q; opts..., deriv = deriv, extrap = extrap, search = search, hint = hint)
+end
+
+"""
+    interp(x::AbstractVector, y::AbstractVector, queries::AbstractVector{<:Real}; method, deriv=EvalValue(), extrap=NoExtrap(), search=AutoSearch())
+
+Allocating one-shot 1D interpolation at multiple points. Returns a `Vector`.
+Equivalent to the dedicated 1D batch call (e.g. `cubic_interp(x, y, queries)`).
+"""
+@inline function interp(
+        x::AbstractVector,
+        y::AbstractVector,
+        queries::AbstractVector{<:Real};
+        method::AbstractInterpMethod,
+        deriv::DerivOp = EvalValue(),
+        extrap::AbstractExtrap = NoExtrap(),
+        search::AbstractSearchPolicy = AutoSearch(),
+    )
+    fn, _, opts = _interp1d_route(method)
+    return fn(x, y, queries; opts..., deriv = deriv, extrap = extrap, search = search)
+end
+
+"""
+    interp!(output::AbstractVector, x::AbstractVector, y::AbstractVector, queries::AbstractVector{<:Real}; method, deriv=EvalValue(), extrap=NoExtrap(), search=AutoSearch())
+
+In-place one-shot 1D interpolation at multiple points. Writes into `output`.
+Equivalent to the dedicated 1D in-place call (e.g. `cubic_interp!(output, x, y, queries)`).
+"""
+@inline function interp!(
+        output::AbstractVector,
+        x::AbstractVector,
+        y::AbstractVector,
+        queries::AbstractVector{<:Real};
+        method::AbstractInterpMethod,
+        deriv::DerivOp = EvalValue(),
+        extrap::AbstractExtrap = NoExtrap(),
+        search::AbstractSearchPolicy = AutoSearch(),
+    )
+    _, fn!, opts = _interp1d_route(method)
+    return fn!(output, x, y, queries; opts..., deriv = deriv, extrap = extrap, search = search)
+end

--- a/src/hetero/interp_1d.jl
+++ b/src/hetero/interp_1d.jl
@@ -43,6 +43,25 @@
 @inline _interp1d_route(m::CardinalInterp) = (cardinal_interp, cardinal_interp!, (; bc = m.bc, tension = m.tension))
 @inline _interp1d_route(m::AkimaInterp) = (akima_interp, akima_interp!, (; bc = m.bc))
 
+# Fallback for any other `AbstractInterpMethod`. The public `interp`/`interp!`
+# keyword type is `AbstractInterpMethod`, so reachable-but-unroutable methods
+# (`NoInterp`, `CubicHermiteInterp`) would otherwise surface a `MethodError` on
+# this internal helper. They have no 1D bare-vector mapping by design —
+# `CubicHermiteInterp` carries no slopes to feed `hermite_interp`, and `NoInterp`
+# is an ND axis marker queried via `GridIdx` — so reject with a clear message.
+# `@noinline` keeps the error path off the hot path; the seven concrete routes
+# above are strictly more specific, so valid calls still dispatch (and inline)
+# directly with no added cost.
+@noinline _throw_unsupported_1d_method(m::AbstractInterpMethod) = throw(
+    ArgumentError(
+        "$(nameof(typeof(m))) is not supported by the 1D `interp(x, y; method=…)` API. " *
+            "Supported: CubicInterp, LinearInterp, QuadraticInterp, ConstantInterp, PchipInterp, " *
+            "CardinalInterp, AkimaInterp. (CubicHermiteInterp needs user-supplied slopes — use " *
+            "`hermite_interp` directly; NoInterp applies only to ND axes via GridIdx.)"
+    )
+)
+_interp1d_route(m::AbstractInterpMethod) = _throw_unsupported_1d_method(m)
+
 # ----------------------------------------------------------------------------
 # Public forms — each consumes the routing trait generically.
 # ----------------------------------------------------------------------------

--- a/src/hetero/interp_1d.jl
+++ b/src/hetero/interp_1d.jl
@@ -35,13 +35,13 @@
 # ----------------------------------------------------------------------------
 # Per-method routing trait: (allocating fn, in-place fn, method-specific kwargs)
 # ----------------------------------------------------------------------------
-@inline _interp1d_route(m::CubicInterp)     = (cubic_interp,     cubic_interp!,     (; bc = m.bc))
-@inline _interp1d_route(m::LinearInterp)    = (linear_interp,    linear_interp!,    (; bc = m.bc))
+@inline _interp1d_route(m::CubicInterp) = (cubic_interp, cubic_interp!, (; bc = m.bc))
+@inline _interp1d_route(m::LinearInterp) = (linear_interp, linear_interp!, (; bc = m.bc))
 @inline _interp1d_route(m::QuadraticInterp) = (quadratic_interp, quadratic_interp!, (; bc = m.bc))
-@inline _interp1d_route(m::ConstantInterp)  = (constant_interp,  constant_interp!,  (; side = m.side, bc = m.bc))
-@inline _interp1d_route(m::PchipInterp)     = (pchip_interp,     pchip_interp!,     (; bc = m.bc))
-@inline _interp1d_route(m::CardinalInterp)  = (cardinal_interp,  cardinal_interp!,  (; bc = m.bc, tension = m.tension))
-@inline _interp1d_route(m::AkimaInterp)     = (akima_interp,     akima_interp!,     (; bc = m.bc))
+@inline _interp1d_route(m::ConstantInterp) = (constant_interp, constant_interp!, (; side = m.side, bc = m.bc))
+@inline _interp1d_route(m::PchipInterp) = (pchip_interp, pchip_interp!, (; bc = m.bc))
+@inline _interp1d_route(m::CardinalInterp) = (cardinal_interp, cardinal_interp!, (; bc = m.bc, tension = m.tension))
+@inline _interp1d_route(m::AkimaInterp) = (akima_interp, akima_interp!, (; bc = m.bc))
 
 # ----------------------------------------------------------------------------
 # Public forms — each consumes the routing trait generically.

--- a/test/test_unified_api_1d.jl
+++ b/test/test_unified_api_1d.jl
@@ -219,6 +219,25 @@ end
     @test (@inferred interp!(out, x, y, qs; method = CardinalInterp(tension = 0.5))) isa typeof(out)
 end
 
+@testitem "Unified 1D API: unsupported method gives a clear ArgumentError" begin
+    # NoInterp and CubicHermiteInterp are exported `AbstractInterpMethod`s with no
+    # 1D bare-vector routing (NoInterp is an ND/GridIdx axis marker; CubicHermiteInterp
+    # carries no slopes). They must fail with a clear ArgumentError naming the supported
+    # methods — not a MethodError on the internal `_interp1d_route`.
+    x = collect(range(0.0, 2π, length = 9))
+    y = sin.(x)
+    q = 1.234
+    qs = [0.5, 1.5, 2.5]
+    out = similar(qs)
+
+    @test_throws ArgumentError interp(x, y; method = NoInterp())
+    @test_throws ArgumentError interp(x, y, q; method = NoInterp())
+    @test_throws ArgumentError interp(x, y, qs; method = NoInterp())
+    @test_throws ArgumentError interp!(out, x, y, qs; method = NoInterp())
+    @test_throws ArgumentError interp(x, y; method = CubicHermiteInterp())
+    @test_throws ArgumentError interp(x, y, q; method = CubicHermiteInterp())
+end
+
 @testitem "Unified 1D API: bare-vector call equals legacy 1-tuple workaround" begin
     # The direct 1D form must agree with the historical ND-via-1-tuple call.
     x = collect(range(0.0, 2π, length = 9))

--- a/test/test_unified_api_1d.jl
+++ b/test/test_unified_api_1d.jl
@@ -29,34 +29,34 @@
 
     # Cubic — bc forwarded; result must equal cubic_interp(x, y; bc=...) and be a CubicInterpolant
     @test interp(x, y; method = CubicInterp()) isa CubicInterpolant
-    @test interp(x, y; method = CubicInterp())(q) ≈ cubic_interp(x, y; bc = CubicFit())(q) rtol = 1e-12
-    @test interp(x, y; method = CubicInterp(ZeroCurvBC()))(q) ≈ cubic_interp(x, y; bc = ZeroCurvBC())(q) rtol = 1e-12
+    @test interp(x, y; method = CubicInterp())(q) ≈ cubic_interp(x, y; bc = CubicFit())(q) rtol = 1.0e-12
+    @test interp(x, y; method = CubicInterp(ZeroCurvBC()))(q) ≈ cubic_interp(x, y; bc = ZeroCurvBC())(q) rtol = 1.0e-12
 
     # Linear — bc forwarded; result must be a LinearInterpolant
     @test interp(x, y; method = LinearInterp()) isa LinearInterpolant
-    @test interp(x, y; method = LinearInterp())(q) ≈ linear_interp(x, y; bc = NoBC())(q) rtol = 1e-12
+    @test interp(x, y; method = LinearInterp())(q) ≈ linear_interp(x, y; bc = NoBC())(q) rtol = 1.0e-12
 
     # Quadratic
     @test interp(x, y; method = QuadraticInterp()) isa QuadraticInterpolant
-    @test interp(x, y; method = QuadraticInterp())(q) ≈ quadratic_interp(x, y)(q) rtol = 1e-12
+    @test interp(x, y; method = QuadraticInterp())(q) ≈ quadratic_interp(x, y)(q) rtol = 1.0e-12
 
     # Constant — side forwarded
     @test interp(x, y; method = ConstantInterp()) isa ConstantInterpolant
-    @test interp(x, y; method = ConstantInterp())(q) ≈ constant_interp(x, y)(q) rtol = 1e-12
-    @test interp(x, y; method = ConstantInterp(LeftSide()))(q) ≈ constant_interp(x, y; side = LeftSide())(q) rtol = 1e-12
+    @test interp(x, y; method = ConstantInterp())(q) ≈ constant_interp(x, y)(q) rtol = 1.0e-12
+    @test interp(x, y; method = ConstantInterp(LeftSide()))(q) ≈ constant_interp(x, y; side = LeftSide())(q) rtol = 1.0e-12
 
     # PCHIP
     @test interp(x, y; method = PchipInterp()) isa PchipInterpolant1D
-    @test interp(x, y; method = PchipInterp())(q) ≈ pchip_interp(x, y)(q) rtol = 1e-12
+    @test interp(x, y; method = PchipInterp())(q) ≈ pchip_interp(x, y)(q) rtol = 1.0e-12
 
     # Cardinal — tension forwarded
     @test interp(x, y; method = CardinalInterp()) isa CardinalInterpolant1D
-    @test interp(x, y; method = CardinalInterp())(q) ≈ cardinal_interp(x, y)(q) rtol = 1e-12
-    @test interp(x, y; method = CardinalInterp(tension = 0.5))(q) ≈ cardinal_interp(x, y; tension = 0.5)(q) rtol = 1e-12
+    @test interp(x, y; method = CardinalInterp())(q) ≈ cardinal_interp(x, y)(q) rtol = 1.0e-12
+    @test interp(x, y; method = CardinalInterp(tension = 0.5))(q) ≈ cardinal_interp(x, y; tension = 0.5)(q) rtol = 1.0e-12
 
     # Akima
     @test interp(x, y; method = AkimaInterp()) isa AkimaInterpolant1D
-    @test interp(x, y; method = AkimaInterp())(q) ≈ akima_interp(x, y)(q) rtol = 1e-12
+    @test interp(x, y; method = AkimaInterp())(q) ≈ akima_interp(x, y)(q) rtol = 1.0e-12
 end
 
 @testitem "Unified 1D API: scalar one-shot interp(x, y, q; method=...)" begin
@@ -64,16 +64,16 @@ end
     y = sin.(x)
     q = 1.234
 
-    @test interp(x, y, q; method = CubicInterp()) ≈ cubic_interp(x, y, q) rtol = 1e-12
-    @test interp(x, y, q; method = CubicInterp(ZeroCurvBC())) ≈ cubic_interp(x, y, q; bc = ZeroCurvBC()) rtol = 1e-12
-    @test interp(x, y, q; method = LinearInterp()) ≈ linear_interp(x, y, q) rtol = 1e-12
-    @test interp(x, y, q; method = QuadraticInterp()) ≈ quadratic_interp(x, y, q) rtol = 1e-12
-    @test interp(x, y, q; method = ConstantInterp()) ≈ constant_interp(x, y, q) rtol = 1e-12
-    @test interp(x, y, q; method = ConstantInterp(LeftSide())) ≈ constant_interp(x, y, q; side = LeftSide()) rtol = 1e-12
-    @test interp(x, y, q; method = PchipInterp()) ≈ pchip_interp(x, y, q) rtol = 1e-12
-    @test interp(x, y, q; method = CardinalInterp()) ≈ cardinal_interp(x, y, q) rtol = 1e-12
-    @test interp(x, y, q; method = CardinalInterp(tension = 0.5)) ≈ cardinal_interp(x, y, q; tension = 0.5) rtol = 1e-12
-    @test interp(x, y, q; method = AkimaInterp()) ≈ akima_interp(x, y, q) rtol = 1e-12
+    @test interp(x, y, q; method = CubicInterp()) ≈ cubic_interp(x, y, q) rtol = 1.0e-12
+    @test interp(x, y, q; method = CubicInterp(ZeroCurvBC())) ≈ cubic_interp(x, y, q; bc = ZeroCurvBC()) rtol = 1.0e-12
+    @test interp(x, y, q; method = LinearInterp()) ≈ linear_interp(x, y, q) rtol = 1.0e-12
+    @test interp(x, y, q; method = QuadraticInterp()) ≈ quadratic_interp(x, y, q) rtol = 1.0e-12
+    @test interp(x, y, q; method = ConstantInterp()) ≈ constant_interp(x, y, q) rtol = 1.0e-12
+    @test interp(x, y, q; method = ConstantInterp(LeftSide())) ≈ constant_interp(x, y, q; side = LeftSide()) rtol = 1.0e-12
+    @test interp(x, y, q; method = PchipInterp()) ≈ pchip_interp(x, y, q) rtol = 1.0e-12
+    @test interp(x, y, q; method = CardinalInterp()) ≈ cardinal_interp(x, y, q) rtol = 1.0e-12
+    @test interp(x, y, q; method = CardinalInterp(tension = 0.5)) ≈ cardinal_interp(x, y, q; tension = 0.5) rtol = 1.0e-12
+    @test interp(x, y, q; method = AkimaInterp()) ≈ akima_interp(x, y, q) rtol = 1.0e-12
 end
 
 @testitem "Unified 1D API: scalar one-shot forwards deriv and extrap" begin
@@ -83,12 +83,12 @@ end
 
     # deriv kwarg routed to the dedicated one-shot
     @test interp(x, y, q; method = CubicInterp(), deriv = DerivOp(1)) ≈
-        cubic_interp(x, y, q; deriv = DerivOp(1)) rtol = 1e-12
+        cubic_interp(x, y, q; deriv = DerivOp(1)) rtol = 1.0e-12
 
     # extrap kwarg routed to the dedicated one-shot (out-of-bounds query)
     q_oob = 10.0
     @test interp(x, y, q_oob; method = CubicInterp(), extrap = ClampExtrap()) ≈
-        cubic_interp(x, y, q_oob; extrap = ClampExtrap()) rtol = 1e-12
+        cubic_interp(x, y, q_oob; extrap = ClampExtrap()) rtol = 1.0e-12
 end
 
 @testitem "Unified 1D API: batch allocating interp(x, y, qs; method=...)" begin
@@ -96,13 +96,13 @@ end
     y = sin.(x)
     qs = [0.5, 1.5, 2.5, 3.0, 5.0]
 
-    @test interp(x, y, qs; method = CubicInterp()) ≈ cubic_interp(x, y, qs) rtol = 1e-12
-    @test interp(x, y, qs; method = LinearInterp()) ≈ linear_interp(x, y, qs) rtol = 1e-12
-    @test interp(x, y, qs; method = QuadraticInterp()) ≈ quadratic_interp(x, y, qs) rtol = 1e-12
-    @test interp(x, y, qs; method = ConstantInterp()) ≈ constant_interp(x, y, qs) rtol = 1e-12
-    @test interp(x, y, qs; method = PchipInterp()) ≈ pchip_interp(x, y, qs) rtol = 1e-12
-    @test interp(x, y, qs; method = CardinalInterp()) ≈ cardinal_interp(x, y, qs) rtol = 1e-12
-    @test interp(x, y, qs; method = AkimaInterp()) ≈ akima_interp(x, y, qs) rtol = 1e-12
+    @test interp(x, y, qs; method = CubicInterp()) ≈ cubic_interp(x, y, qs) rtol = 1.0e-12
+    @test interp(x, y, qs; method = LinearInterp()) ≈ linear_interp(x, y, qs) rtol = 1.0e-12
+    @test interp(x, y, qs; method = QuadraticInterp()) ≈ quadratic_interp(x, y, qs) rtol = 1.0e-12
+    @test interp(x, y, qs; method = ConstantInterp()) ≈ constant_interp(x, y, qs) rtol = 1.0e-12
+    @test interp(x, y, qs; method = PchipInterp()) ≈ pchip_interp(x, y, qs) rtol = 1.0e-12
+    @test interp(x, y, qs; method = CardinalInterp()) ≈ cardinal_interp(x, y, qs) rtol = 1.0e-12
+    @test interp(x, y, qs; method = AkimaInterp()) ≈ akima_interp(x, y, qs) rtol = 1.0e-12
 end
 
 @testitem "Unified 1D API: in-place batch interp!(out, x, y, qs; method=...)" begin
@@ -115,15 +115,15 @@ end
 
     interp!(out_new, x, y, qs; method = CubicInterp())
     cubic_interp!(out_ref, x, y, qs)
-    @test out_new ≈ out_ref rtol = 1e-12
+    @test out_new ≈ out_ref rtol = 1.0e-12
 
     interp!(out_new, x, y, qs; method = LinearInterp())
     linear_interp!(out_ref, x, y, qs)
-    @test out_new ≈ out_ref rtol = 1e-12
+    @test out_new ≈ out_ref rtol = 1.0e-12
 
     interp!(out_new, x, y, qs; method = AkimaInterp())
     akima_interp!(out_ref, x, y, qs)
-    @test out_new ≈ out_ref rtol = 1e-12
+    @test out_new ≈ out_ref rtol = 1.0e-12
 end
 
 @testitem "Unified 1D API: allocation parity with dedicated 1D functions" begin
@@ -226,7 +226,7 @@ end
     q = 1.234
 
     @test interp(x, y; method = CubicInterp())(q) ≈
-        interp((x,), reshape(y, :); method = (CubicInterp(),))((q,)) rtol = 1e-12
+        interp((x,), reshape(y, :); method = (CubicInterp(),))((q,)) rtol = 1.0e-12
     @test interp(x, y, q; method = LinearInterp()) ≈
-        interp((x,), reshape(y, :), (q,); method = (LinearInterp(),)) rtol = 1e-12
+        interp((x,), reshape(y, :), (q,); method = (LinearInterp(),)) rtol = 1.0e-12
 end

--- a/test/test_unified_api_1d.jl
+++ b/test/test_unified_api_1d.jl
@@ -1,0 +1,232 @@
+# ============================================================================
+# Unified 1D API: interp(x, y; method=...) / interp!(...)
+# ============================================================================
+# Goal: a bare-AbstractVector 1D call to the unified API must route to the
+# dedicated 1D function and be *identical* to it. Today only the ND forms
+# (NTuple grids) exist, so 1D users must write the tuple workaround
+# `interp((x,), y; method=(CubicInterp(),))`. These tests pin the desired
+# direct form:
+#
+#     interp(x, y; method=CubicInterp())            === cubic_interp(x, y)
+#     interp(x, y, q; method=CubicInterp())         === cubic_interp(x, y, q)
+#     interp(x, y, qs; method=CubicInterp())        === cubic_interp(x, y, qs)
+#     interp!(out, x, y, qs; method=CubicInterp())  === cubic_interp!(out, x, y, qs)
+#
+# Every assertion compares the new unified call against the dedicated 1D
+# function invoked with the *same* options forwarded from the method struct
+# (bc / side / tension), so the tests are self-consistent regardless of
+# default values.
+#
+# RED expectation: all new `interp(::AbstractVector, ::AbstractVector; ...)`
+# calls fail with MethodError (no such method) — the first positional arg is
+# a Vector, while every existing method requires an NTuple of grids there.
+# ============================================================================
+
+@testitem "Unified 1D API: persistent interp(x, y; method=...) routes to dedicated 1D types" begin
+    x = collect(range(0.0, 2π, length = 9))
+    y = sin.(x)
+    q = 1.234
+
+    # Cubic — bc forwarded; result must equal cubic_interp(x, y; bc=...) and be a CubicInterpolant
+    @test interp(x, y; method = CubicInterp()) isa CubicInterpolant
+    @test interp(x, y; method = CubicInterp())(q) ≈ cubic_interp(x, y; bc = CubicFit())(q) rtol = 1e-12
+    @test interp(x, y; method = CubicInterp(ZeroCurvBC()))(q) ≈ cubic_interp(x, y; bc = ZeroCurvBC())(q) rtol = 1e-12
+
+    # Linear — bc forwarded; result must be a LinearInterpolant
+    @test interp(x, y; method = LinearInterp()) isa LinearInterpolant
+    @test interp(x, y; method = LinearInterp())(q) ≈ linear_interp(x, y; bc = NoBC())(q) rtol = 1e-12
+
+    # Quadratic
+    @test interp(x, y; method = QuadraticInterp()) isa QuadraticInterpolant
+    @test interp(x, y; method = QuadraticInterp())(q) ≈ quadratic_interp(x, y)(q) rtol = 1e-12
+
+    # Constant — side forwarded
+    @test interp(x, y; method = ConstantInterp()) isa ConstantInterpolant
+    @test interp(x, y; method = ConstantInterp())(q) ≈ constant_interp(x, y)(q) rtol = 1e-12
+    @test interp(x, y; method = ConstantInterp(LeftSide()))(q) ≈ constant_interp(x, y; side = LeftSide())(q) rtol = 1e-12
+
+    # PCHIP
+    @test interp(x, y; method = PchipInterp()) isa PchipInterpolant1D
+    @test interp(x, y; method = PchipInterp())(q) ≈ pchip_interp(x, y)(q) rtol = 1e-12
+
+    # Cardinal — tension forwarded
+    @test interp(x, y; method = CardinalInterp()) isa CardinalInterpolant1D
+    @test interp(x, y; method = CardinalInterp())(q) ≈ cardinal_interp(x, y)(q) rtol = 1e-12
+    @test interp(x, y; method = CardinalInterp(tension = 0.5))(q) ≈ cardinal_interp(x, y; tension = 0.5)(q) rtol = 1e-12
+
+    # Akima
+    @test interp(x, y; method = AkimaInterp()) isa AkimaInterpolant1D
+    @test interp(x, y; method = AkimaInterp())(q) ≈ akima_interp(x, y)(q) rtol = 1e-12
+end
+
+@testitem "Unified 1D API: scalar one-shot interp(x, y, q; method=...)" begin
+    x = collect(range(0.0, 2π, length = 9))
+    y = sin.(x)
+    q = 1.234
+
+    @test interp(x, y, q; method = CubicInterp()) ≈ cubic_interp(x, y, q) rtol = 1e-12
+    @test interp(x, y, q; method = CubicInterp(ZeroCurvBC())) ≈ cubic_interp(x, y, q; bc = ZeroCurvBC()) rtol = 1e-12
+    @test interp(x, y, q; method = LinearInterp()) ≈ linear_interp(x, y, q) rtol = 1e-12
+    @test interp(x, y, q; method = QuadraticInterp()) ≈ quadratic_interp(x, y, q) rtol = 1e-12
+    @test interp(x, y, q; method = ConstantInterp()) ≈ constant_interp(x, y, q) rtol = 1e-12
+    @test interp(x, y, q; method = ConstantInterp(LeftSide())) ≈ constant_interp(x, y, q; side = LeftSide()) rtol = 1e-12
+    @test interp(x, y, q; method = PchipInterp()) ≈ pchip_interp(x, y, q) rtol = 1e-12
+    @test interp(x, y, q; method = CardinalInterp()) ≈ cardinal_interp(x, y, q) rtol = 1e-12
+    @test interp(x, y, q; method = CardinalInterp(tension = 0.5)) ≈ cardinal_interp(x, y, q; tension = 0.5) rtol = 1e-12
+    @test interp(x, y, q; method = AkimaInterp()) ≈ akima_interp(x, y, q) rtol = 1e-12
+end
+
+@testitem "Unified 1D API: scalar one-shot forwards deriv and extrap" begin
+    x = collect(range(0.0, 2π, length = 9))
+    y = sin.(x)
+    q = 1.234
+
+    # deriv kwarg routed to the dedicated one-shot
+    @test interp(x, y, q; method = CubicInterp(), deriv = DerivOp(1)) ≈
+        cubic_interp(x, y, q; deriv = DerivOp(1)) rtol = 1e-12
+
+    # extrap kwarg routed to the dedicated one-shot (out-of-bounds query)
+    q_oob = 10.0
+    @test interp(x, y, q_oob; method = CubicInterp(), extrap = ClampExtrap()) ≈
+        cubic_interp(x, y, q_oob; extrap = ClampExtrap()) rtol = 1e-12
+end
+
+@testitem "Unified 1D API: batch allocating interp(x, y, qs; method=...)" begin
+    x = collect(range(0.0, 2π, length = 9))
+    y = sin.(x)
+    qs = [0.5, 1.5, 2.5, 3.0, 5.0]
+
+    @test interp(x, y, qs; method = CubicInterp()) ≈ cubic_interp(x, y, qs) rtol = 1e-12
+    @test interp(x, y, qs; method = LinearInterp()) ≈ linear_interp(x, y, qs) rtol = 1e-12
+    @test interp(x, y, qs; method = QuadraticInterp()) ≈ quadratic_interp(x, y, qs) rtol = 1e-12
+    @test interp(x, y, qs; method = ConstantInterp()) ≈ constant_interp(x, y, qs) rtol = 1e-12
+    @test interp(x, y, qs; method = PchipInterp()) ≈ pchip_interp(x, y, qs) rtol = 1e-12
+    @test interp(x, y, qs; method = CardinalInterp()) ≈ cardinal_interp(x, y, qs) rtol = 1e-12
+    @test interp(x, y, qs; method = AkimaInterp()) ≈ akima_interp(x, y, qs) rtol = 1e-12
+end
+
+@testitem "Unified 1D API: in-place batch interp!(out, x, y, qs; method=...)" begin
+    x = collect(range(0.0, 2π, length = 9))
+    y = sin.(x)
+    qs = [0.5, 1.5, 2.5, 3.0, 5.0]
+
+    out_new = similar(qs)
+    out_ref = similar(qs)
+
+    interp!(out_new, x, y, qs; method = CubicInterp())
+    cubic_interp!(out_ref, x, y, qs)
+    @test out_new ≈ out_ref rtol = 1e-12
+
+    interp!(out_new, x, y, qs; method = LinearInterp())
+    linear_interp!(out_ref, x, y, qs)
+    @test out_new ≈ out_ref rtol = 1e-12
+
+    interp!(out_new, x, y, qs; method = AkimaInterp())
+    akima_interp!(out_ref, x, y, qs)
+    @test out_new ≈ out_ref rtol = 1e-12
+end
+
+@testitem "Unified 1D API: allocation parity with dedicated 1D functions" begin
+    # The routing must add ZERO allocation: interp(x, y, ...; method=M) must
+    # allocate exactly what the dedicated M_interp(x, y, ...) call allocates.
+    # Setup + warmup + @allocated all live inside one function (a true function
+    # barrier) so locals are concretely typed and @allocated is artifact-free.
+
+    function scalar_parity()
+        x = collect(range(0.0, 2π, length = 9)); y = sin.(x); q = 1.234
+        interp(x, y, q; method = CubicInterp()); cubic_interp(x, y, q)  # warmup
+        a_uni = @allocated interp(x, y, q; method = CubicInterp())
+        a_dir = @allocated cubic_interp(x, y, q)
+        return a_uni, a_dir
+    end
+
+    function inplace_parity()
+        x = collect(range(0.0, 2π, length = 9)); y = sin.(x)
+        qs = [0.5, 1.5, 2.5, 3.0, 5.0]; out = similar(qs)
+        interp!(out, x, y, qs; method = CubicInterp()); cubic_interp!(out, x, y, qs)  # warmup
+        a_uni = @allocated interp!(out, x, y, qs; method = CubicInterp())
+        a_dir = @allocated cubic_interp!(out, x, y, qs)
+        return a_uni, a_dir
+    end
+
+    function batch_parity()
+        x = collect(range(0.0, 2π, length = 9)); y = sin.(x)
+        qs = [0.5, 1.5, 2.5, 3.0, 5.0]
+        interp(x, y, qs; method = CubicInterp()); cubic_interp(x, y, qs)  # warmup
+        a_uni = @allocated interp(x, y, qs; method = CubicInterp())
+        a_dir = @allocated cubic_interp(x, y, qs)
+        return a_uni, a_dir
+    end
+
+    function persistent_parity()
+        x = collect(range(0.0, 2π, length = 9)); y = sin.(x)
+        interp(x, y; method = CubicInterp()); cubic_interp(x, y)  # warmup
+        a_uni = @allocated interp(x, y; method = CubicInterp())
+        a_dir = @allocated cubic_interp(x, y)
+        return a_uni, a_dir
+    end
+
+    let (a_uni, a_dir) = scalar_parity()
+        @test a_uni == a_dir
+    end
+    let (a_uni, a_dir) = inplace_parity()
+        @test a_uni == a_dir   # in-place: both zero after warmup
+    end
+    let (a_uni, a_dir) = batch_parity()
+        @test a_uni == a_dir
+    end
+    let (a_uni, a_dir) = persistent_parity()
+        @test a_uni == a_dir
+    end
+end
+
+@testitem "Unified 1D API: routing is type-stable (compile-time method resolution)" begin
+    using Test: @inferred
+    x = collect(range(0.0, 2π, length = 9)); y = sin.(x); q = 1.234
+    qs = [0.5, 1.5, 2.5]
+    out = similar(qs)
+
+    # `@inferred` throws unless the call is fully type-stable: if the routing were
+    # a runtime branch it would produce a `Union` return and fail here. Pairing
+    # `@inferred` with `isa typeof(<dedicated call>)` additionally pins that the
+    # inferred concrete type is *exactly* the dedicated function's return type —
+    # i.e. the wrapper resolves the method at compile time and adds nothing.
+    # All 7 families are covered so every `opts` NamedTuple shape is exercised;
+    # Constant (side+bc) and Cardinal (bc+tension) are the two-field-`opts` cases
+    # most at risk of inference loss through the keyword splat.
+
+    # --- persistent build: returns the dedicated 1D interpolant type ---
+    @test (@inferred interp(x, y; method = CubicInterp())) isa typeof(cubic_interp(x, y))
+    @test (@inferred interp(x, y; method = LinearInterp())) isa typeof(linear_interp(x, y))
+    @test (@inferred interp(x, y; method = QuadraticInterp())) isa typeof(quadratic_interp(x, y))
+    @test (@inferred interp(x, y; method = ConstantInterp(LeftSide()))) isa typeof(constant_interp(x, y; side = LeftSide()))
+    @test (@inferred interp(x, y; method = PchipInterp())) isa typeof(pchip_interp(x, y))
+    @test (@inferred interp(x, y; method = CardinalInterp(tension = 0.5))) isa typeof(cardinal_interp(x, y; tension = 0.5))
+    @test (@inferred interp(x, y; method = AkimaInterp())) isa typeof(akima_interp(x, y))
+
+    # --- scalar one-shot: returns the dedicated scalar value type ---
+    @test (@inferred interp(x, y, q; method = CubicInterp())) isa typeof(cubic_interp(x, y, q))
+    @test (@inferred interp(x, y, q; method = LinearInterp())) isa typeof(linear_interp(x, y, q))
+    @test (@inferred interp(x, y, q; method = QuadraticInterp())) isa typeof(quadratic_interp(x, y, q))
+    @test (@inferred interp(x, y, q; method = ConstantInterp(LeftSide()))) isa typeof(constant_interp(x, y, q; side = LeftSide()))
+    @test (@inferred interp(x, y, q; method = PchipInterp())) isa typeof(pchip_interp(x, y, q))
+    @test (@inferred interp(x, y, q; method = CardinalInterp(tension = 0.5))) isa typeof(cardinal_interp(x, y, q; tension = 0.5))
+    @test (@inferred interp(x, y, q; method = AkimaInterp())) isa typeof(akima_interp(x, y, q))
+
+    # --- batch allocating + in-place: returns the dedicated Vector / output type ---
+    @test (@inferred interp(x, y, qs; method = CubicInterp())) isa typeof(cubic_interp(x, y, qs))
+    @test (@inferred interp!(out, x, y, qs; method = CubicInterp())) isa typeof(out)
+    @test (@inferred interp!(out, x, y, qs; method = CardinalInterp(tension = 0.5))) isa typeof(out)
+end
+
+@testitem "Unified 1D API: bare-vector call equals legacy 1-tuple workaround" begin
+    # The direct 1D form must agree with the historical ND-via-1-tuple call.
+    x = collect(range(0.0, 2π, length = 9))
+    y = sin.(x)
+    q = 1.234
+
+    @test interp(x, y; method = CubicInterp())(q) ≈
+        interp((x,), reshape(y, :); method = (CubicInterp(),))((q,)) rtol = 1e-12
+    @test interp(x, y, q; method = LinearInterp()) ≈
+        interp((x,), reshape(y, :), (q,); method = (LinearInterp(),)) rtol = 1e-12
+end


### PR DESCRIPTION
## Summary

1D data can now use the unified API directly, without the ND 1-tuple workaround:

```julia
# before
interp((x,), y; method = (CubicInterp(),))

# now
interp(x, y; method = CubicInterp())          # === cubic_interp(x, y)
interp(x, y, q; method = CubicInterp())       # === cubic_interp(x, y, q)
interp(x, y, qs; method = CubicInterp())      # === cubic_interp(x, y, qs)
interp!(out, x, y, qs; method = CubicInterp())# === cubic_interp!(out, x, y, qs)
```

Works for all 7 method families: `CubicInterp`, `LinearInterp`, `QuadraticInterp`, `ConstantInterp`, `PchipInterp`, `CardinalInterp`, `AkimaInterp`. Method options are forwarded (`bc`, plus `side` for Constant and `tension` for Cardinal).

## Implementation

A single per-method routing trait `_interp1d_route` maps each method to its dedicated `(allocating, in-place)` function pair plus its option `NamedTuple`, consumed by four generic public forms — mirroring the existing `_build_hetero_axis_package` idiom.

Routing resolves entirely at compile time (concrete `method` dispatch + `@inline`), so the wrapper emits the same code with the same allocation profile as calling the dedicated function directly. Non-ambiguous with the ND forms: these take a bare `AbstractVector` first argument, the ND methods require `NTuple{N,AbstractVector}`.

## Tests

`test/test_unified_api_1d.jl` covers, across the 7 families × 4 forms:

- **value equivalence** with the dedicated 1D functions (and the legacy 1-tuple path),
- **allocation parity** — `@allocated` of the unified call equals the dedicated call,
- **type stability** — `@inferred` + `isa typeof(<dedicated call>)`.

## Files

- `src/hetero/interp_1d.jl` (new)
- `src/FastInterpolations.jl` (one `include`)
- `test/test_unified_api_1d.jl` (new)
