### PR TITLE
(fix): _CachedRange boundary OOB misclassification on x86_64

### DIFF
--- a/src/akima/akima_adjoint.jl
+++ b/src/akima/akima_adjoint.jl
@@ -611,7 +611,7 @@ function akima_adjoint(
 
     # NoExtrap: validate queries against extended domain.
     if extrap_eff isa NoExtrap
-        x_lo, x_hi = first(x_ext), last(x_ext)
+        x_lo, x_hi = _domain_bounds(x_ext)  # widened: accept true endpoint
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
             (_extract_primal(x_lo) <= xq_i <= _extract_primal(x_hi)) || throw(

--- a/src/akima/akima_adjoint.jl
+++ b/src/akima/akima_adjoint.jl
@@ -611,13 +611,7 @@ function akima_adjoint(
 
     # NoExtrap: validate queries against extended domain.
     if extrap_eff isa NoExtrap
-        x_lo, x_hi = _domain_bounds(x_ext)  # widened: accept true endpoint
-        @inbounds for i in eachindex(xq_p)
-            xq_i = xq_p[i]
-            (_extract_primal(x_lo) <= xq_i <= _extract_primal(x_hi)) || throw(
-                DomainError(xq_i, "query point outside domain [$(_extract_primal(x_lo)), $(_extract_primal(x_hi))]")
-            )
-        end
+        _validate_domain(x_ext, xq_p)
     end
 
     # Bake anchors against the extended axis.

--- a/src/cardinal/cardinal_adjoint.jl
+++ b/src/cardinal/cardinal_adjoint.jl
@@ -283,13 +283,7 @@ function cardinal_adjoint(
 
     # NoExtrap: validate queries against extended domain.
     if extrap_eff isa NoExtrap
-        x_lo, x_hi = map(_extract_primal, _domain_bounds(x_ext))  # widened: accept true endpoint
-        @inbounds for i in eachindex(xq_p)
-            xq_i = xq_p[i]
-            (x_lo <= xq_i <= x_hi) || throw(
-                DomainError(xq_i, "query point outside domain [$x_lo, $x_hi]")
-            )
-        end
+        _validate_domain(x_ext, xq_p)
     end
 
     # Wrap the extended grid for cached `h`/`inv_h` (matches forward

--- a/src/cardinal/cardinal_adjoint.jl
+++ b/src/cardinal/cardinal_adjoint.jl
@@ -283,7 +283,7 @@ function cardinal_adjoint(
 
     # NoExtrap: validate queries against extended domain.
     if extrap_eff isa NoExtrap
-        x_lo, x_hi = _extract_primal(first(x_ext)), _extract_primal(last(x_ext))
+        x_lo, x_hi = map(_extract_primal, _domain_bounds(x_ext))  # widened: accept true endpoint
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
             (x_lo <= xq_i <= x_hi) || throw(

--- a/src/constant/constant_adjoint.jl
+++ b/src/constant/constant_adjoint.jl
@@ -169,12 +169,11 @@ original query position, so scatter can skip OOB contributions.
 function _fixup_constant_anchor_state!(
         anchors::Vector{_ConstantAnchoredQuery{Tg, Tq}},
         xq_original::AbstractVector,
-        x_lo, x_hi
+        x::AbstractVector
     ) where {Tg, Tq}
     @inbounds for i in eachindex(anchors)
-        xq_i = xq_original[i]
-        (x_lo <= xq_i <= x_hi) && continue
-        state = xq_i < x_lo ? OOB_LEFT : OOB_RIGHT
+        state = _oob_state(x, xq_original[i])
+        state == IN_DOMAIN && continue
         aq = anchors[i]
         anchors[i] = _ConstantAnchoredQuery{Tg, Tq}(
             aq.stencil, aq.xq, state, aq.h, aq.dL
@@ -248,27 +247,18 @@ function constant_adjoint(
     # NoExtrap: validate all queries in-domain (uses x_axis bounds, which include
     # the virtual seam endpoint for `:exclusive`).
     if extrap_eff isa NoExtrap
-        x_lo_p, x_hi_p = map(_extract_primal, _domain_bounds(x_axis))  # widened: accept true endpoint
-        @inbounds for i in eachindex(xq_p)
-            xq_i = xq_p[i]
-            (x_lo_p <= xq_i <= x_hi_p) || throw(
-                DomainError(xq_i, "query point outside domain [$x_lo_p, $x_hi_p]")
-            )
-        end
+        _validate_domain(x_axis, xq_p)
     end
 
     # Build anchored queries with extrap-specific preprocessing
     wrap = extrap_eff isa WrapExtrap
     if extrap_eff isa _ClampOrFill || extrap_eff isa ExtendExtrap
         # For constant interp, ExtendExtrap == ClampExtrap (slope=0).
-        # Clamp OOB queries to boundary for correct anchor geometry.
-        # Then restore side flags so scatter can skip OOB contributions.
-        # Safe (widened) bounds for classification — clamp/fixup against these so
-        # a query at the true `_CachedRange` endpoint stays in-domain.
-        x_lo_p, x_hi_p = map(_extract_primal, _domain_bounds(x_axis))
-        xq_clamped = clamp.(xq_p, x_lo_p, x_hi_p)
+        # OOB queries get actual-endpoint geometry (`_clamp_to_grid`); `_fixup`
+        # restores side flags from the widened (`_oob_state`) classification.
+        xq_clamped = _clamp_to_grid.(xq_p, Ref(x_axis))
         anchors = _anchor_query(x_axis, xq_clamped, Val(:constant), false)
-        _fixup_constant_anchor_state!(anchors, xq_p, x_lo_p, x_hi_p)
+        _fixup_constant_anchor_state!(anchors, xq_p, x_axis)
     else
         # WrapExtrap: wraps to domain (covers periodic auto-promotion).
         # NoExtrap: already validated in-domain above.

--- a/src/constant/constant_adjoint.jl
+++ b/src/constant/constant_adjoint.jl
@@ -160,26 +160,34 @@ end
 # ========================================
 
 """
-Restore `state` flags for anchors built with clamped query positions.
+    _bake_constant_clampfill_anchors(x, xq) -> Vector{_ConstantAnchoredQuery}
 
-When ClampExtrap/FillExtrap queries are clamped before anchoring, the anchor
-gets `state=IN_DOMAIN` (inside). This restores the correct OOB state flag based on the
-original query position, so scatter can skip OOB contributions.
+Single-pass ClampExtrap/FillExtrap/ExtendExtrap adjoint anchor builder
+(`ExtendExtrap == ClampExtrap` for constant interp, slope 0).
+
+Clamps each query to the actual grid endpoints (`_clamp_to_grid`) for valid
+boundary geometry, anchors it, then restores the OOB side flag from the widened
+(`_oob_state`) classification for genuinely-OOB queries (scatter skips/keeps per
+extrap). In-domain and endpoint-sliver queries keep the anchor as built.
+
+Fuses the former clamp-broadcast + `_anchor_query` + state-fixup three passes
+into one loop — no transient clamped-query array. Construction-time only.
 """
-function _fixup_constant_anchor_state!(
-        anchors::Vector{_ConstantAnchoredQuery{Tg, Tq}},
-        xq_original::AbstractVector,
-        x::AbstractVector
-    ) where {Tg, Tq}
-    @inbounds for i in eachindex(anchors)
-        state = _oob_state(x, xq_original[i])
-        state == IN_DOMAIN && continue
-        aq = anchors[i]
-        anchors[i] = _ConstantAnchoredQuery{Tg, Tq}(
-            aq.stencil, aq.xq, state, aq.h, aq.dL
-        )
+function _bake_constant_clampfill_anchors(
+        x::AbstractVector{Tg},
+        xq::AbstractVector{Tq},
+        searcher::P = _to_searcher(LinearBinarySearch())
+    ) where {Tg, Tq <: Real, P <: Searcher}
+    searcher_resolved = _resolve_searcher_for_grid(x, searcher)
+    output = Vector{_ConstantAnchoredQuery{Tg, promote_type(Tg, Tq)}}(undef, length(xq))
+    @inbounds for k in eachindex(xq)
+        xq_raw = xq[k]
+        aq = _constant_anchor_query_impl(x, _clamp_to_grid(xq_raw, x), false, searcher_resolved)
+        state = _oob_state(x, xq_raw)
+        output[k] = state == IN_DOMAIN ? aq :
+            typeof(aq)(aq.stencil, aq.xq, state, aq.h, aq.dL)
     end
-    return nothing
+    return output
 end
 
 # ========================================
@@ -253,12 +261,10 @@ function constant_adjoint(
     # Build anchored queries with extrap-specific preprocessing
     wrap = extrap_eff isa WrapExtrap
     if extrap_eff isa _ClampOrFill || extrap_eff isa ExtendExtrap
-        # For constant interp, ExtendExtrap == ClampExtrap (slope=0).
-        # OOB queries get actual-endpoint geometry (`_clamp_to_grid`); `_fixup`
-        # restores side flags from the widened (`_oob_state`) classification.
-        xq_clamped = _clamp_to_grid.(xq_p, Ref(x_axis))
-        anchors = _anchor_query(x_axis, xq_clamped, Val(:constant), false)
-        _fixup_constant_anchor_state!(anchors, xq_p, x_axis)
+        # For constant interp, ExtendExtrap == ClampExtrap (slope=0). OOB queries
+        # get actual-endpoint geometry; the widened (`_oob_state`) classification
+        # restores side flags. Single fused pass (no temp array).
+        anchors = _bake_constant_clampfill_anchors(x_axis, xq_p)
     else
         # WrapExtrap: wraps to domain (covers periodic auto-promotion).
         # NoExtrap: already validated in-domain above.

--- a/src/constant/constant_adjoint.jl
+++ b/src/constant/constant_adjoint.jl
@@ -248,7 +248,7 @@ function constant_adjoint(
     # NoExtrap: validate all queries in-domain (uses x_axis bounds, which include
     # the virtual seam endpoint for `:exclusive`).
     if extrap_eff isa NoExtrap
-        x_lo_p, x_hi_p = _extract_primal(first(x_axis)), _extract_primal(last(x_axis))
+        x_lo_p, x_hi_p = map(_extract_primal, _domain_bounds(x_axis))  # widened: accept true endpoint
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
             (x_lo_p <= xq_i <= x_hi_p) || throw(
@@ -263,7 +263,9 @@ function constant_adjoint(
         # For constant interp, ExtendExtrap == ClampExtrap (slope=0).
         # Clamp OOB queries to boundary for correct anchor geometry.
         # Then restore side flags so scatter can skip OOB contributions.
-        x_lo_p, x_hi_p = _extract_primal(first(x_axis)), _extract_primal(last(x_axis))
+        # Safe (widened) bounds for classification — clamp/fixup against these so
+        # a query at the true `_CachedRange` endpoint stays in-domain.
+        x_lo_p, x_hi_p = map(_extract_primal, _domain_bounds(x_axis))
         xq_clamped = clamp.(xq_p, x_lo_p, x_hi_p)
         anchors = _anchor_query(x_axis, xq_clamped, Val(:constant), false)
         _fixup_constant_anchor_state!(anchors, xq_p, x_lo_p, x_hi_p)

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -83,8 +83,9 @@ end
         searcher::S
     ) where {Tg, Tv, Tq <: Real, S <: Searcher}
     xi_primal = _extract_primal(xi)
-    xi_primal < _extract_primal(first(x)) && return _eval_extrapolation(op, first(y), extrap, xi)
-    xi_primal > _extract_primal(last(x)) && return _eval_extrapolation(op, last(y), extrap, xi)
+    st = _oob_state(x, xi_primal)
+    st == OOB_LEFT && return _eval_extrapolation(op, first(y), extrap, xi)
+    st == OOB_RIGHT && return _eval_extrapolation(op, last(y), extrap, xi)
     return _constant_eval_at_point(x, y, xi, InBounds(), side, op, searcher)
 end
 

--- a/src/constant/nd/constant_nd_adjoint.jl
+++ b/src/constant/nd/constant_nd_adjoint.jl
@@ -54,13 +54,9 @@ function _bake_constant_nd_anchors(
             h = _get_h(grids[d], idx)
             dL = xq_d - xL
 
-            # Determine OOB side flag
-            is_oob = xq_raw < first(grids[d]) || xq_raw > last(grids[d])
-            state_flag = if is_oob
-                xq_raw < first(grids[d]) ? OOB_LEFT : OOB_RIGHT
-            else
-                IN_DOMAIN
-            end
+            # OOB side flag via the shared (widened) classifier — a query at the
+            # true `_CachedRange` endpoint is IN_DOMAIN, matching the forward.
+            state_flag = _oob_state(grids[d], xq_raw)
 
             return _ConstantAnchoredQuery{Tg, Tq}(_IdxPair(idx, idxR), xq_d, state_flag, h, dL)
         end

--- a/src/core/anchor_common.jl
+++ b/src/core/anchor_common.jl
@@ -26,16 +26,11 @@ const OOB_RIGHT = 0x02
 
 Classify query `xq` against grid `x` as `IN_DOMAIN`, `OOB_LEFT`, or `OOB_RIGHT`.
 
-The single source of truth for every "is `xq` in domain, and if not which side?"
-decision — `_anchor_loc` and every scalar/one-shot eval site route through here.
-Bounds come from [`_domain_bounds`](@ref), so classification matches the batch
-path (`_is_all_inbounds`) and the `_CachedRange` widened bracket (≈1 ULP past the
-stored `first`/`last` on the x86_64 fast path) is handled in exactly one place —
-a query at the *true* endpoint is `IN_DOMAIN`, not falsely OOB.
-
-`_extract_primal` on both bounds and query so a Float query at the boundary
-against a Dual grid endpoint classifies on primal value alone (no-op on plain
-Float / `_CachedRange` fields).
+Single source of truth for the in-domain / which-side decision: bounds come from
+[`_domain_bounds`](@ref), so it matches the batch path and the `_CachedRange`
+widened bracket is handled in one place (a query at the true endpoint is
+`IN_DOMAIN`). `_extract_primal` on bounds and query keeps it partial-sign
+independent for Dual grids.
 """
 @inline function _oob_state(x::AbstractVector, xq::Real)
     lo, hi = _domain_bounds(x)
@@ -105,8 +100,8 @@ Dual type. The interval search uses `_extract_primal(xq)` for comparisons.
         wrap::Bool,
         policy::P = DEFAULT_SEARCHER
     ) where {Tg, Tq <: Real, P <: Searcher}
-    # Actual grid span (= x[1], x[n]) — used only for wrap-fold geometry, so the
-    # periodic period stays exactly `last - first` (not the widened bracket).
+    # Actual grid span — used only for wrap-fold geometry (period stays exactly
+    # `last - first`, not the widened bracket).
     x_min, x_max = first(x), last(x)
 
     # Use primal value for comparisons (supports ForwardDiff.Dual)
@@ -116,11 +111,9 @@ Dual type. The interval search uses `_extract_primal(xq)` for comparisons.
     # query at the true endpoint is IN_DOMAIN, consistent with the batch path).
     state = _oob_state(x, xq_primal)
 
-    # Handle wrapping (for extrap=WrapExtrap() or periodic mode)
-    # Generic _wrap_to_domain handles AD primal extraction and returns Tg.
-    # Closed-domain convention: an IN_DOMAIN query never wraps. Only strictly-OOB
-    # queries take the slow `mod()` path (which folds against the actual grid
-    # span x_min/x_max), then re-classify (the folded query is in-domain).
+    # WrapExtrap/periodic: an IN_DOMAIN query never wraps. Strictly-OOB queries
+    # take the `mod()` path (folds against the actual span x_min/x_max, returns
+    # Tg with AD primal handled), then re-classify.
     if wrap && state != IN_DOMAIN
         xq = _wrap_to_domain(xq, x_min, x_max)
         xq_primal = xq  # xq is now Tg, no need for _extract_primal

--- a/src/core/anchor_common.jl
+++ b/src/core/anchor_common.jl
@@ -82,7 +82,9 @@ end
     _anchor_loc(x, xq, wrap, policy) -> _AnchorLoc{Tg, Tq}
 
 Shared interval location for all interpolation methods.
-Performs: wrap → domain state classification → interval search.
+Performs: domain-state classification (`_oob_state`, widened `_CachedRange`
+bracket) → wrap-fold only for OOB queries when `wrap` (then re-classify) →
+interval search (boundary cell for OOB, `search_interval` otherwise).
 
 Returns `_AnchorLoc` with NO geometry — each method computes its own
 h/inv_h/dL/dR from `xL`, `xR`, `xq` as needed.

--- a/src/core/anchor_common.jl
+++ b/src/core/anchor_common.jl
@@ -18,6 +18,34 @@ const OOB_LEFT = 0x01
 const OOB_RIGHT = 0x02
 
 # ========================================
+# _oob_state: shared OOB classifier (single source of truth)
+# ========================================
+
+"""
+    _oob_state(x, xq) -> UInt8
+
+Classify query `xq` against grid `x` as `IN_DOMAIN`, `OOB_LEFT`, or `OOB_RIGHT`.
+
+The single source of truth for every "is `xq` in domain, and if not which side?"
+decision — `_anchor_loc` and every scalar/one-shot eval site route through here.
+Bounds come from [`_domain_bounds`](@ref), so classification matches the batch
+path (`_is_all_inbounds`) and the `_CachedRange` widened bracket (≈1 ULP past the
+stored `first`/`last` on the x86_64 fast path) is handled in exactly one place —
+a query at the *true* endpoint is `IN_DOMAIN`, not falsely OOB.
+
+`_extract_primal` on both bounds and query so a Float query at the boundary
+against a Dual grid endpoint classifies on primal value alone (no-op on plain
+Float / `_CachedRange` fields).
+"""
+@inline function _oob_state(x::AbstractVector, xq::Real)
+    lo, hi = _domain_bounds(x)
+    xqp = _extract_primal(xq)
+    xqp < _extract_primal(lo) && return OOB_LEFT
+    xqp > _extract_primal(hi) && return OOB_RIGHT
+    return IN_DOMAIN
+end
+
+# ========================================
 # _AnchorLoc: Location-Only Result
 # ========================================
 
@@ -75,35 +103,33 @@ Dual type. The interval search uses `_extract_primal(xq)` for comparisons.
         wrap::Bool,
         policy::P = DEFAULT_SEARCHER
     ) where {Tg, Tq <: Real, P <: Searcher}
+    # Actual grid span (= x[1], x[n]) — used only for wrap-fold geometry, so the
+    # periodic period stays exactly `last - first` (not the widened bracket).
     x_min, x_max = first(x), last(x)
 
     # Use primal value for comparisons (supports ForwardDiff.Dual)
     xq_primal = _extract_primal(xq)
 
+    # Classify via the shared `_oob_state` (widened `_CachedRange` bracket → a
+    # query at the true endpoint is IN_DOMAIN, consistent with the batch path).
+    state = _oob_state(x, xq_primal)
+
     # Handle wrapping (for extrap=WrapExtrap() or periodic mode)
     # Generic _wrap_to_domain handles AD primal extraction and returns Tg.
-    # Closed-domain convention: `xq == x_max` is in-domain — no wrap needed.
-    # Only strictly-OOB queries (`xq < x_min` or `xq > x_max`) take the slow
-    # `mod()` path inside `_wrap_to_domain` (which itself uses `xi <= x_max`).
-    if wrap && (xq_primal < x_min || xq_primal > x_max)
+    # Closed-domain convention: an IN_DOMAIN query never wraps. Only strictly-OOB
+    # queries take the slow `mod()` path (which folds against the actual grid
+    # span x_min/x_max), then re-classify (the folded query is in-domain).
+    if wrap && state != IN_DOMAIN
         xq = _wrap_to_domain(xq, x_min, x_max)
         xq_primal = xq  # xq is now Tg, no need for _extract_primal
-    end
-
-    # Classify domain state
-    state = if xq_primal < x_min
-        OOB_LEFT
-    elseif xq_primal > x_max
-        OOB_RIGHT
-    else
-        IN_DOMAIN
+        state = _oob_state(x, xq_primal)
     end
 
     # Find interval
     # For outside-domain points, use boundary intervals for weight computation
-    idx, xL, xR = if xq_primal < x_min
+    idx, xL, xR = if state == OOB_LEFT
         @inbounds (1, x[1], x[2])
-    elseif xq_primal > x_max
+    elseif state == OOB_RIGHT
         n = length(x)
         @inbounds (n - 1, x[n - 1], x[n])
     else

--- a/src/core/nd_adjoint_scatter.jl
+++ b/src/core/nd_adjoint_scatter.jl
@@ -204,7 +204,9 @@ function _bake_nd_anchors_generic(
             inv_h = _get_inv_h(grids[d], idx)
             t = (xq_d - xL) * inv_h
             dL = xq_d - xL
-            is_oob = xq_raw < first(grids[d]) || xq_raw > last(grids[d])
+            # Widened classification (matches forward `_oob_state`): a query at
+            # the true `_CachedRange` endpoint is in-domain, not zeroed-OOB.
+            is_oob = _oob_state(grids[d], xq_raw) != IN_DOMAIN
             return (idx, weight_fn(d, t, h, inv_h, dL), is_oob)
         end
         indices = ntuple(d -> idx_and_weights[d][1], Val(N))

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -72,13 +72,9 @@ Returns `false` at compile time when no axis has FillExtrap (dead-code eliminate
     fill_dims = [d for d in 1:N if fieldtype(E, d) <: FillExtrap]
     isempty(fill_dims) && return :(false)
 
-    oob_checks = [
-        :(
-                let qp = _extract_primal(query[$d])
-                    qp < first(grids[$d]) || qp > last(grids[$d])
-            end
-            ) for d in fill_dims
-    ]
+    # Per-axis OOB via the shared `_oob_state` (widened `_CachedRange` bracket →
+    # a query at the true endpoint is in-domain, matching the 1D paths).
+    oob_checks = [:(_oob_state(grids[$d], query[$d]) != IN_DOMAIN) for d in fill_dims]
     oob_expr = length(oob_checks) == 1 ? oob_checks[1] :
         foldl((a, b) -> :($a || $b), oob_checks)
 
@@ -107,13 +103,9 @@ Accepts both scalar `ops::AbstractEvalOp` and tuple `ops::Tuple{Vararg{AbstractE
     fill_dims = [d for d in 1:N if fieldtype(E, d) <: FillExtrap]
     isempty(fill_dims) && return :(nothing)
 
-    oob_checks = [
-        :(
-                let qp = _extract_primal(query[$d])
-                    qp < first(grids[$d]) || qp > last(grids[$d])
-            end
-            ) for d in fill_dims
-    ]
+    # Per-axis OOB via the shared `_oob_state` (widened `_CachedRange` bracket →
+    # a query at the true endpoint is in-domain, matching the 1D paths).
+    oob_checks = [:(_oob_state(grids[$d], query[$d]) != IN_DOMAIN) for d in fill_dims]
     oob_expr = length(oob_checks) == 1 ? oob_checks[1] :
         foldl((a, b) -> :($a || $b), oob_checks)
 
@@ -551,9 +543,12 @@ end
 
 @inline function _handle_axis_extrap(q, axis::AbstractVector{Tg}, ::_ClampOrFill) where {Tg}
     q_primal = _extract_primal(q)
-    lo, hi = first(axis), last(axis)
-    q_primal < lo && return oftype(q, lo)
-    q_primal > hi && return oftype(q, hi)
+    # Classify with the shared (widened) `_oob_state`, but clamp to the *actual*
+    # endpoint — a query in the `_CachedRange` widened sliver is in-domain and
+    # passes through unclamped; only genuinely-OOB queries clamp to first/last.
+    st = _oob_state(axis, q_primal)
+    st == OOB_LEFT && return oftype(q, first(axis))
+    st == OOB_RIGHT && return oftype(q, last(axis))
     return q
 end
 

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -543,9 +543,8 @@ end
 
 @inline function _handle_axis_extrap(q, axis::AbstractVector{Tg}, ::_ClampOrFill) where {Tg}
     q_primal = _extract_primal(q)
-    # Classify with the shared (widened) `_oob_state`, but clamp to the *actual*
-    # endpoint — a query in the `_CachedRange` widened sliver is in-domain and
-    # passes through unclamped; only genuinely-OOB queries clamp to first/last.
+    # Classify with the widened `_oob_state` but clamp to the actual endpoint:
+    # a sliver query is in-domain and passes through; only genuinely-OOB clamps.
     st = _oob_state(axis, q_primal)
     st == OOB_LEFT && return oftype(q, first(axis))
     st == OOB_RIGHT && return oftype(q, last(axis))

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -43,10 +43,9 @@ end
 # Arg order `(xq, x)`: matches the 3-arg primitive `(xq, x_min, x_max)` —
 # the operand always comes first; axis bounds (or extracted bounds) follow.
 @inline function _wrap_to_domain(xq, x::AbstractVector)
-    # In-domain by the safe (widened) bounds → no fold. The `_CachedRange`
-    # widened sliver just past the stored `last` is the true endpoint, not a
-    # wrap-around point — folding it would jump to `first`. Genuinely-OOB queries
-    # fold against the *actual* grid span (exact period `last - first`).
+    # In-domain by the widened bounds → no fold (the sliver just past `last` is the
+    # true endpoint, not a wrap point). Genuinely-OOB queries fold against the
+    # actual grid span (exact period `last - first`).
     _is_inbounds(x, xq) && return xq
     return _wrap_to_domain(xq, first(x), last(x))
 end

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -42,8 +42,14 @@ end
 #
 # Arg order `(xq, x)`: matches the 3-arg primitive `(xq, x_min, x_max)` —
 # the operand always comes first; axis bounds (or extracted bounds) follow.
-@inline _wrap_to_domain(xq, x::AbstractVector) =
-    _wrap_to_domain(xq, first(x), last(x))
+@inline function _wrap_to_domain(xq, x::AbstractVector)
+    # In-domain by the safe (widened) bounds → no fold. The `_CachedRange`
+    # widened sliver just past the stored `last` is the true endpoint, not a
+    # wrap-around point — folding it would jump to `first`. Genuinely-OOB queries
+    # fold against the *actual* grid span (exact period `last - first`).
+    _is_inbounds(x, xq) && return xq
+    return _wrap_to_domain(xq, first(x), last(x))
+end
 # Wrapper-specific overload lives in `periodic_axis.jl` where
 # `_ExclusivePeriodicAxis` is defined.
 

--- a/src/core/periodic_axis.jl
+++ b/src/core/periodic_axis.jl
@@ -102,6 +102,13 @@ Base.IndexStyle(::Type{<:_ExclusivePeriodicAxis}) = IndexLinear()
 @inline Base.first(g::_ExclusivePeriodicAxis) = @inbounds g.inner[1]
 @inline Base.last(g::_ExclusivePeriodicAxis) = g._x_max
 
+# Classification bounds propagate the inner's widened LEFT endpoint (the inner
+# `_CachedRange` may round `first` inward of the true endpoint on the x86_64 fast
+# path), so a query at the inner's true left endpoint is in-domain and maps to
+# the first cell instead of folding to the seam. Right bound is the virtual seam
+# `_x_max`; wrap-fold geometry stays on the actual `inner[1]`/`_x_max`.
+@inline _domain_bounds(g::_ExclusivePeriodicAxis) = (_domain_bounds(g.inner)[1], g._x_max)
+
 # Forward `step` to inner — meaningful only when inner is a Range/`_CachedRange`
 # (uniform-spacing). Vector inners will hit the inner's `MethodError(::step)`,
 # which is the desired behavior: callers asking for `step` already assume a
@@ -236,8 +243,14 @@ end
 #   - `g.inner[1]` instead of `first(g)` → `inner.lo` directly (no Base.first
 #     dispatch through wrapper → inner getindex chain).
 #   - `g._x_max` → cached field, single load.
-@inline _wrap_to_domain(xq, g::_ExclusivePeriodicAxis) =
-    _wrap_to_domain(xq, @inbounds(g.inner[1]), g._x_max)
+@inline function _wrap_to_domain(xq, g::_ExclusivePeriodicAxis)
+    # In-domain by the inner's widened bounds → no fold; the inner `_CachedRange`
+    # may have rounded its left endpoint inward of the true value, and that true
+    # endpoint must stay in the first cell rather than fold to the seam. Only
+    # genuinely-OOB queries fold against the actual seam span `[inner[1], _x_max]`.
+    _is_inbounds(g, xq) && return xq
+    return _wrap_to_domain(xq, @inbounds(g.inner[1]), g._x_max)
+end
 
 # 4-arg `(g, idx, xL, xR)` form. Search already produced all four; dispatch
 # picks the per-type cheapest path.

--- a/src/core/periodic_axis.jl
+++ b/src/core/periodic_axis.jl
@@ -102,11 +102,9 @@ Base.IndexStyle(::Type{<:_ExclusivePeriodicAxis}) = IndexLinear()
 @inline Base.first(g::_ExclusivePeriodicAxis) = @inbounds g.inner[1]
 @inline Base.last(g::_ExclusivePeriodicAxis) = g._x_max
 
-# Classification bounds propagate the inner's widened LEFT endpoint (the inner
-# `_CachedRange` may round `first` inward of the true endpoint on the x86_64 fast
-# path), so a query at the inner's true left endpoint is in-domain and maps to
-# the first cell instead of folding to the seam. Right bound is the virtual seam
-# `_x_max`; wrap-fold geometry stays on the actual `inner[1]`/`_x_max`.
+# Classification bounds: inner's widened left endpoint (so the true left endpoint
+# maps to the first cell, not the seam) + the virtual seam `_x_max`. Wrap-fold
+# geometry still uses the actual `inner[1]`/`_x_max`.
 @inline _domain_bounds(g::_ExclusivePeriodicAxis) = (_domain_bounds(g.inner)[1], g._x_max)
 
 # Forward `step` to inner — meaningful only when inner is a Range/`_CachedRange`
@@ -244,10 +242,9 @@ end
 #     dispatch through wrapper → inner getindex chain).
 #   - `g._x_max` → cached field, single load.
 @inline function _wrap_to_domain(xq, g::_ExclusivePeriodicAxis)
-    # In-domain by the inner's widened bounds → no fold; the inner `_CachedRange`
-    # may have rounded its left endpoint inward of the true value, and that true
-    # endpoint must stay in the first cell rather than fold to the seam. Only
-    # genuinely-OOB queries fold against the actual seam span `[inner[1], _x_max]`.
+    # In-domain by the inner's widened bounds → no fold (the true left endpoint
+    # must stay in the first cell, not fold to the seam). Only genuinely-OOB
+    # queries fold against the actual seam span `[inner[1], _x_max]`.
     _is_inbounds(g, xq) && return xq
     return _wrap_to_domain(xq, @inbounds(g.inner[1]), g._x_max)
 end

--- a/src/core/query_protocol.jl
+++ b/src/core/query_protocol.jl
@@ -118,6 +118,17 @@ end
 #
 # Non-NoExtrap axes are no-ops via _check_domain dispatch.
 
+# 1D NoExtrap domain validation: throw `DomainError` for any out-of-domain query.
+# Routes per-query through `_check_domain`, so the `_CachedRange` widened-bracket
+# acceptance is applied and the error reports the physical endpoints — callers
+# (the 1D adjoints) never touch `_domain_bounds` directly.
+@inline function _validate_domain(axis::AbstractVector, queries::AbstractVector)
+    @inbounds for i in eachindex(queries)
+        _check_domain(axis, queries[i], NoExtrap())
+    end
+    return nothing
+end
+
 # Scalar point: per-axis scalar check (for oneshot single-point paths)
 # Uses map (not for-loop) to dispatch per-element with concrete types,
 # avoiding Union boxing on heterogeneous extrap tuples.

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -547,6 +547,14 @@ end
     return _extract_primal(lo) <= xqp <= _extract_primal(hi)
 end
 
+# Clamp a query to the grid's *physical* span `[first(x), last(x)]` — the actual
+# endpoints, never the widened `_domain_bounds` bracket. Adjoint anchor builders
+# use this to give an OOB query valid boundary geometry, while classification
+# (`_oob_state`/`_is_inbounds`) independently reads the widened bounds. Keeping
+# the two apart is what stops the acceptance cushion from leaking into geometry.
+@inline _clamp_to_grid(xq::Real, x::AbstractVector) =
+    clamp(xq, _extract_primal(first(x)), _extract_primal(last(x)))
+
 """
 True iff every element of `queries` lies in the closed domain
 `[first(x), last(x)]`. Enables batch-level fast paths that elide per-query

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -521,37 +521,26 @@ end
     return _is_all_inbounds(x, xi) ? InBounds() : e
 end
 
-# ----------------------------------------
-# Safe domain bounds — single axis-dispatched source of truth.
-#
-# `(lo, hi)` are the bounds every in-domain test classifies against: the batch
-# `_is_all_inbounds`, the scalar `_is_inbounds`, and the per-query classify in
-# `_anchor_loc`. Routing them all through here means they never disagree at a
-# boundary query.
-#
-# Plain `AbstractVector` → exact endpoints. `_CachedRange` → `domain_lo`/
-# `domain_hi`, which are ≈1 ULP wider than the stored `lo`/`hi` on the x86_64
-# TwicePrecision fast path (where `first`/`last` can round inward of the true
-# endpoint). Classifying against the widened bounds keeps a query at the *true*
-# endpoint in-domain instead of falsely OOB.
+# Safe domain bounds — single axis-dispatched source of truth for every in-domain
+# test (`_is_all_inbounds`, `_is_inbounds`, `_oob_state`), so they never disagree
+# at a boundary query. Plain `AbstractVector` → exact `first/last`; `_CachedRange`
+# → `domain_lo/hi`, ≈1 ULP wider than the stored `lo/hi` on the x86_64 fast path,
+# keeping a query at the true endpoint in-domain instead of falsely OOB.
 @inline _domain_bounds(x::AbstractVector) = (first(x), last(x))
 @inline _domain_bounds(x::_CachedRange) = (x.domain_lo, x.domain_hi)
 
-# Scalar in-domain test. `_extract_primal` on both bounds and the query so a
-# Float query at the boundary against a Dual grid endpoint classifies on primal
-# value alone (partial-sign independent) — same rationale as `_is_all_inbounds`.
-# No-op on the plain-Float `_CachedRange` fields.
+# Scalar in-domain test. `_extract_primal` on bounds and query keeps it partial-
+# sign independent for Dual grids (no-op on plain-Float `_CachedRange` fields).
 @inline function _is_inbounds(x::AbstractVector, xq::Real)
     lo, hi = _domain_bounds(x)
     xqp = _extract_primal(xq)
     return _extract_primal(lo) <= xqp <= _extract_primal(hi)
 end
 
-# Clamp a query to the grid's *physical* span `[first(x), last(x)]` — the actual
-# endpoints, never the widened `_domain_bounds` bracket. Adjoint anchor builders
-# use this to give an OOB query valid boundary geometry, while classification
-# (`_oob_state`/`_is_inbounds`) independently reads the widened bounds. Keeping
-# the two apart is what stops the acceptance cushion from leaking into geometry.
+# Clamp a query to the grid's physical span `[first(x), last(x)]`, never the
+# widened `_domain_bounds` bracket — adjoint anchor builders use it for valid OOB
+# boundary geometry while classification reads the widened bounds (keeps the
+# acceptance cushion out of geometry).
 @inline _clamp_to_grid(xq::Real, x::AbstractVector) =
     clamp(xq, _extract_primal(first(x)), _extract_primal(last(x)))
 
@@ -571,15 +560,10 @@ Uses two `&&`-chained reductions rather than `extrema`:
 1.13 fixes the SIMD issue, but the short-circuit advantage remains for
 the OOB slow-path, so this form stays preferred even post-1.10-LTS.
 """
-# `_extract_primal` is required on the bounds here because ForwardDiff's
-# `Real <= Dual` comparison includes partial-sign tie-breaking at equal
-# primals — so a Float query exactly at the boundary against a Dual grid
-# endpoint can flip in/out of bounds based on the partial sign alone (see
-# `test/ext/test_linear_dual_grid.jl` "Domain boundary: primal-based NoExtrap
-# check (partial-independent)"). Inline calls keep the `&&` short-circuit
-# intact. Routes through `_domain_bounds`, so the `_CachedRange` widened
-# bracket is handled in one place (no `_extract_primal` cost on its plain-Float
-# fields — the call is the identity there).
+# `_extract_primal` on the bounds: ForwardDiff's `Real <= Dual` tie-breaks on the
+# partial sign at equal primals, so a Float query at the boundary against a Dual
+# grid endpoint must classify on primal alone (see test/ext/test_linear_dual_grid.jl).
+# Routes through `_domain_bounds` (widened bracket in one place); `&&` short-circuits.
 @inline function _is_all_inbounds(x::AbstractVector, queries::AbstractVector{<:Real})
     isempty(queries) && return true
     lo, hi = _domain_bounds(x)

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -521,6 +521,32 @@ end
     return _is_all_inbounds(x, xi) ? InBounds() : e
 end
 
+# ----------------------------------------
+# Safe domain bounds — single axis-dispatched source of truth.
+#
+# `(lo, hi)` are the bounds every in-domain test classifies against: the batch
+# `_is_all_inbounds`, the scalar `_is_inbounds`, and the per-query classify in
+# `_anchor_loc`. Routing them all through here means they never disagree at a
+# boundary query.
+#
+# Plain `AbstractVector` → exact endpoints. `_CachedRange` → `domain_lo`/
+# `domain_hi`, which are ≈1 ULP wider than the stored `lo`/`hi` on the x86_64
+# TwicePrecision fast path (where `first`/`last` can round inward of the true
+# endpoint). Classifying against the widened bounds keeps a query at the *true*
+# endpoint in-domain instead of falsely OOB.
+@inline _domain_bounds(x::AbstractVector) = (first(x), last(x))
+@inline _domain_bounds(x::_CachedRange) = (x.domain_lo, x.domain_hi)
+
+# Scalar in-domain test. `_extract_primal` on both bounds and the query so a
+# Float query at the boundary against a Dual grid endpoint classifies on primal
+# value alone (partial-sign independent) — same rationale as `_is_all_inbounds`.
+# No-op on the plain-Float `_CachedRange` fields.
+@inline function _is_inbounds(x::AbstractVector, xq::Real)
+    lo, hi = _domain_bounds(x)
+    xqp = _extract_primal(xq)
+    return _extract_primal(lo) <= xqp <= _extract_primal(hi)
+end
+
 """
 True iff every element of `queries` lies in the closed domain
 `[first(x), last(x)]`. Enables batch-level fast paths that elide per-query
@@ -537,25 +563,20 @@ Uses two `&&`-chained reductions rather than `extrema`:
 1.13 fixes the SIMD issue, but the short-circuit advantage remains for
 the OOB slow-path, so this form stays preferred even post-1.10-LTS.
 """
-# `_extract_primal` is required on `first(x)` / `last(x)` here because
-# ForwardDiff's `Real <= Dual` comparison includes partial-sign tie-breaking
-# at equal primals — so a Float query exactly at the boundary against a
-# Dual grid endpoint can flip in/out of bounds based on the partial sign
-# alone (see `test/ext/test_linear_dual_grid.jl` "Domain boundary:
-# primal-based NoExtrap check (partial-independent)"). Inline calls keep
-# the `&&` short-circuit intact.
+# `_extract_primal` is required on the bounds here because ForwardDiff's
+# `Real <= Dual` comparison includes partial-sign tie-breaking at equal
+# primals — so a Float query exactly at the boundary against a Dual grid
+# endpoint can flip in/out of bounds based on the partial sign alone (see
+# `test/ext/test_linear_dual_grid.jl` "Domain boundary: primal-based NoExtrap
+# check (partial-independent)"). Inline calls keep the `&&` short-circuit
+# intact. Routes through `_domain_bounds`, so the `_CachedRange` widened
+# bracket is handled in one place (no `_extract_primal` cost on its plain-Float
+# fields — the call is the identity there).
 @inline function _is_all_inbounds(x::AbstractVector, queries::AbstractVector{<:Real})
     isempty(queries) && return true
-    return minimum(queries) >= _extract_primal(first(x)) &&
-        maximum(queries) <= _extract_primal(last(x))
-end
-
-# `_CachedRange`: `domain_lo`/`domain_hi` (≈1 ULP wider than `lo`/`hi` on
-# x86_64 TwicePrecision normalization) for safe bounds. Fields are typed
-# `T <: AbstractFloat` per the struct, so no `_extract_primal` is needed.
-@inline function _is_all_inbounds(x::_CachedRange, queries::AbstractVector{<:Real})
-    isempty(queries) && return true
-    return minimum(queries) >= x.domain_lo && maximum(queries) <= x.domain_hi
+    lo, hi = _domain_bounds(x)
+    return minimum(queries) >= _extract_primal(lo) &&
+        maximum(queries) <= _extract_primal(hi)
 end
 
 # ========================================

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -365,6 +365,17 @@ Promote grid and query vectors for adjoint construction.
 
 Shared pattern across all 1D adjoint builders: cubic, linear, quadratic,
 constant, pchip, cardinal, akima.
+
+!!! note "Adjoint queries must be plain real numbers"
+    Adjoint constructors do not support `ForwardDiff.Dual` (or other non-grid-
+    eltype) *query* points: the anchor structs pin the query type to the grid
+    type `Tg` (e.g. `_LinearAnchoredQuery{Tg, Tg}`) and the Hermite-family weight
+    kernels are homogeneous in `Tg`, so a Dual query fails to construct. This is
+    a long-standing limitation, independent of the `_oob_state`/`_clamp_to_grid`
+    boundary helpers (which themselves preserve duck-type). For query-position
+    derivatives, differentiate the *forward* eval — it preserves `Dual` queries
+    end-to-end. (`constant_adjoint` happens to accept Dual queries because it
+    keeps a separate query-type param, but that is not a guaranteed contract.)
 """
 @inline function _promote_adjoint_inputs(
         x::AbstractVector,
@@ -457,17 +468,23 @@ _promote_for_anchor(dual, Float64)   # → dual (preserved Dual type)
 @noinline _throw_domain_error(xi, x_min, x_max) =
     throw(DomainError(xi, "query point outside interpolation domain [$x_min, $x_max]"))
 
+# `_extract_primal(xi)` (query) as well as the bounds: at equal primals
+# ForwardDiff's `Dual <=> Real` tie-breaks on the partial sign, so a Dual query
+# exactly at the boundary would flip in/out of domain by its derivative direction
+# alone — same partial-independence rationale as `_is_all_inbounds`/`_oob_state`.
 "Scalar domain check for NoExtrap: throws DomainError if out of domain."
 @inline function _check_domain(x::AbstractVector, xi::Real, ::NoExtrap)
+    xip = _extract_primal(xi)
     x_min, x_max = _extract_primal(first(x)), _extract_primal(last(x))
-    (xi < x_min || xi > x_max) && _throw_domain_error(xi, x_min, x_max)
+    (xip < x_min || xip > x_max) && _throw_domain_error(xi, x_min, x_max)
     return nothing
 end
 
 # _CachedRange: use domain_lo/domain_hi (wider bracket on x86_64 fast path).
 @inline function _check_domain(x::_CachedRange, xi::Real, ::NoExtrap)
+    xip = _extract_primal(xi)
     lo, hi = _extract_primal(x.domain_lo), _extract_primal(x.domain_hi)
-    (xi < lo || xi > hi) && _throw_domain_error(xi, _extract_primal(x.lo), _extract_primal(x.hi))
+    (xip < lo || xip > hi) && _throw_domain_error(xi, _extract_primal(x.lo), _extract_primal(x.hi))
     return nothing
 end
 

--- a/src/cubic/cubic_adjoint.jl
+++ b/src/cubic/cubic_adjoint.jl
@@ -455,7 +455,9 @@ function cubic_adjoint(
     wrap = extrap isa WrapExtrap
     if extrap isa Union{ClampExtrap, FillExtrap}
         # Clamp OOB queries to boundary for valid anchor indices, then fix weights
-        x_lo, x_hi = first(cache.x), last(cache.x)
+        # Safe (widened) bounds for classification — clamp/fixup against these so
+        # a query at the true `_CachedRange` endpoint stays in-domain.
+        x_lo, x_hi = _domain_bounds(cache.x)
         xq_clamped = clamp.(xq_p, x_lo, x_hi)
         anchors = _anchor_query(cache.x, xq_clamped, Val(:cubic), false)
         _fixup_clampfill_anchors!(anchors, xq_p, x_lo, x_hi, extrap)

--- a/src/cubic/cubic_adjoint.jl
+++ b/src/cubic/cubic_adjoint.jl
@@ -352,35 +352,49 @@ end
 # ========================================
 
 """
-Fix anchor weights for OOB queries under ClampExtrap or FillExtrap.
+    _bake_cubic_clampfill_anchors(x, xq, extrap) -> Vector{_CubicAnchoredQuery}
 
-- **ClampExtrap**: forward returns `f[boundary]` for EvalValue, `0` for derivatives.
-  Keep w0 (clamped to boundary gives correct [1,0,0,0] or [0,1,0,0] weights),
-  zero out w1/w2/w3 (derivatives are zero for constant extrapolation).
+Single-pass ClampExtrap/FillExtrap adjoint anchor builder.
+
+Clamps each query to the actual grid endpoints (`_clamp_to_grid`) for valid
+boundary-cell geometry, anchors it, then bakes the OOB weight semantics for
+genuinely-OOB queries (widened `_is_inbounds` classification):
+
+- **ClampExtrap**: forward returns `f[boundary]` for EvalValue, `0` for
+  derivatives. Keep w0 (clamped boundary weights = [1,0,0,0] or [0,1,0,0]),
+  zero w1/w2/w3.
 - **FillExtrap**: forward returns fill constant → gradient w.r.t. f is zero.
-  Zero out all weights (w0/w1/w2/w3).
+  Zero all weights.
 
-Modifies `anchors` in-place by replacing OOB entries with corrected structs.
-Only called at construction time; no runtime overhead.
+In-domain and endpoint-sliver queries keep the anchor as built. Fuses the
+former clamp-broadcast + `_anchor_query` + weight-fixup three passes into one
+loop — no transient clamped-query array. Construction-time only.
 """
-function _fixup_clampfill_anchors!(
-        anchors::Vector{_CubicAnchoredQuery{Tg, Tg}},
-        xq_original::AbstractVector{Tg},
-        x::AbstractVector{Tg},
-        extrap::AbstractExtrap
-    ) where {Tg}
+function _bake_cubic_clampfill_anchors(
+        x::AbstractVector{T},
+        xq::AbstractVector{S},
+        extrap::AbstractExtrap,
+        searcher::P = _to_searcher(LinearBinarySearch())
+    ) where {T, S <: Real, P <: Searcher}
+    searcher_resolved = _resolve_searcher_for_grid(x, searcher)
     keep_w0 = extrap isa ClampExtrap
-    z = zero(Tg)
-    @inbounds for i in eachindex(anchors)
-        _is_inbounds(x, xq_original[i]) && continue
-        aq = anchors[i]
-        w0_new = keep_w0 ? aq.w0 : (z, z, z, z)
-        anchors[i] = _CubicAnchoredQuery{Tg, Tg}(
-            getfield(aq, :stencil), aq.xq, IN_DOMAIN,
-            w0_new, (z, z, z, z), (z, z), (z, z)
-        )
+    z = zero(T)
+    z4 = (z, z, z, z)
+    output = Vector{_CubicAnchoredQuery{T, T}}(undef, length(xq))
+    @inbounds for k in eachindex(xq)
+        xq_raw = xq[k]
+        aq = _anchor_query_impl(x, _promote_for_anchor(_clamp_to_grid(xq_raw, x), T), false, searcher_resolved)
+        if _is_inbounds(x, xq_raw)
+            output[k] = aq
+        else
+            w0_new = keep_w0 ? aq.w0 : z4
+            output[k] = _CubicAnchoredQuery{T, T}(
+                getfield(aq, :stencil), aq.xq, IN_DOMAIN,
+                w0_new, z4, (z, z), (z, z)
+            )
+        end
     end
-    return nothing
+    return output
 end
 
 # ========================================
@@ -454,11 +468,9 @@ function cubic_adjoint(
     # Build anchored queries with extrap-specific preprocessing
     wrap = extrap isa WrapExtrap
     if extrap isa Union{ClampExtrap, FillExtrap}
-        # OOB queries get actual-endpoint geometry (`_clamp_to_grid`); `_fixup`
-        # classifies via the widened (`_is_inbounds`) bounds.
-        xq_clamped = _clamp_to_grid.(xq_p, Ref(cache.x))
-        anchors = _anchor_query(cache.x, xq_clamped, Val(:cubic), false)
-        _fixup_clampfill_anchors!(anchors, xq_p, cache.x, extrap)
+        # OOB queries get actual-endpoint geometry; the widened (`_is_inbounds`)
+        # classification bakes OOB weights. Single fused pass (no temp array).
+        anchors = _bake_cubic_clampfill_anchors(cache.x, xq_p, extrap)
     else
         anchors = _anchor_query(cache.x, xq_p, Val(:cubic), wrap)
     end

--- a/src/cubic/cubic_adjoint.jl
+++ b/src/cubic/cubic_adjoint.jl
@@ -366,13 +366,13 @@ Only called at construction time; no runtime overhead.
 function _fixup_clampfill_anchors!(
         anchors::Vector{_CubicAnchoredQuery{Tg, Tg}},
         xq_original::AbstractVector{Tg},
-        x_lo::Tg, x_hi::Tg,
+        x::AbstractVector{Tg},
         extrap::AbstractExtrap
     ) where {Tg}
     keep_w0 = extrap isa ClampExtrap
     z = zero(Tg)
     @inbounds for i in eachindex(anchors)
-        (x_lo <= xq_original[i] <= x_hi) && continue
+        _is_inbounds(x, xq_original[i]) && continue
         aq = anchors[i]
         w0_new = keep_w0 ? aq.w0 : (z, z, z, z)
         anchors[i] = _CubicAnchoredQuery{Tg, Tg}(
@@ -454,13 +454,11 @@ function cubic_adjoint(
     # Build anchored queries with extrap-specific preprocessing
     wrap = extrap isa WrapExtrap
     if extrap isa Union{ClampExtrap, FillExtrap}
-        # Clamp OOB queries to boundary for valid anchor indices, then fix weights
-        # Safe (widened) bounds for classification — clamp/fixup against these so
-        # a query at the true `_CachedRange` endpoint stays in-domain.
-        x_lo, x_hi = _domain_bounds(cache.x)
-        xq_clamped = clamp.(xq_p, x_lo, x_hi)
+        # OOB queries get actual-endpoint geometry (`_clamp_to_grid`); `_fixup`
+        # classifies via the widened (`_is_inbounds`) bounds.
+        xq_clamped = _clamp_to_grid.(xq_p, Ref(cache.x))
         anchors = _anchor_query(cache.x, xq_clamped, Val(:cubic), false)
-        _fixup_clampfill_anchors!(anchors, xq_p, x_lo, x_hi, extrap)
+        _fixup_clampfill_anchors!(anchors, xq_p, cache.x, extrap)
     else
         anchors = _anchor_query(cache.x, xq_p, Val(:cubic), wrap)
     end

--- a/src/cubic/cubic_eval.jl
+++ b/src/cubic/cubic_eval.jl
@@ -75,8 +75,9 @@ end
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq = _resolve_grididx(xq, x)
     xq_primal = _extract_primal(xq)
-    xq_primal < first(x) && return _eval_extrapolation(op, first(y), extrap, xq)
-    xq_primal > last(x) && return _eval_extrapolation(op, last(y), extrap, xq)
+    st = _oob_state(x, xq_primal)
+    st == OOB_LEFT && return _eval_extrapolation(op, first(y), extrap, xq)
+    st == OOB_RIGHT && return _eval_extrapolation(op, last(y), extrap, xq)
     return _eval_cubic_at_point(x, y, z, xq, InBounds(), op, searcher)
 end
 

--- a/src/cubic/cubic_oneshot.jl
+++ b/src/cubic/cubic_oneshot.jl
@@ -215,7 +215,7 @@ Pool-based exclusive extension: zero-alloc after warmup.
     # inside `_eval_cubic_at_point(::WrapExtrap)`). OOB queries fall to
     # the wrap path. Mirrors the batch loop's function-barrier pattern.
     xq_p = _extract_primal(xq)
-    return if first(cache.x) <= xq_p <= last(cache.x)
+    return if _is_inbounds(cache.x, xq_p)
         _eval_cubic_at_point(cache.x, y_p, z, xq, InBounds(), op, searcher)
     else
         _eval_cubic_at_point(cache.x, y_p, z, xq, WrapExtrap(), op, searcher)

--- a/src/hermite/hermite_adjoint.jl
+++ b/src/hermite/hermite_adjoint.jl
@@ -101,7 +101,9 @@ function _bake_hermite_adjoint_anchors(
         xq::AbstractVector,
         extrap::AbstractExtrap
     ) where {Tg}
-    x_lo, x_hi = first(x), last(x)
+    # Safe (widened) classification bounds — matches the forward `_oob_state`, so
+    # a query at the true `_CachedRange` endpoint is in-domain, not zeroed-OOB.
+    x_lo, x_hi = _domain_bounds(x)
 
     need_clamp = extrap isa Union{ClampExtrap, FillExtrap}
     wrap = extrap isa WrapExtrap
@@ -433,7 +435,7 @@ function hermite_adjoint(
 
     # NoExtrap: validate all queries in-domain
     if extrap isa NoExtrap
-        x_lo, x_hi = first(x_p), last(x_p)
+        x_lo, x_hi = _domain_bounds(x_p)  # widened: accept true endpoint
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
             (_extract_primal(x_lo) <= xq_i <= _extract_primal(x_hi)) || throw(

--- a/src/hermite/hermite_adjoint.jl
+++ b/src/hermite/hermite_adjoint.jl
@@ -101,10 +101,9 @@ function _bake_hermite_adjoint_anchors(
         xq::AbstractVector,
         extrap::AbstractExtrap
     ) where {Tg}
-    # Safe (widened) classification bounds — matches the forward `_oob_state`, so
-    # a query at the true `_CachedRange` endpoint is in-domain, not zeroed-OOB.
-    x_lo, x_hi = _domain_bounds(x)
-
+    # Classification (`_is_inbounds`, widened bounds) and clamp geometry
+    # (`_clamp_to_grid`, actual endpoints) stay in separate helpers; the wrap
+    # routes through the 2-arg axis-aware form, so the widened bracket never leaks.
     need_clamp = extrap isa Union{ClampExtrap, FillExtrap}
     wrap = extrap isa WrapExtrap
 
@@ -114,7 +113,7 @@ function _bake_hermite_adjoint_anchors(
 
         # Preprocess query point based on extrap mode
         xq_eval = if need_clamp
-            clamp(xq_raw, x_lo, x_hi)
+            _clamp_to_grid(xq_raw, x)
         elseif wrap
             _wrap_to_domain(xq_raw, x)
         else
@@ -131,7 +130,7 @@ function _bake_hermite_adjoint_anchors(
         w0, w1, w2, w3 = _compute_hermite_adjoint_weights(t, h, inv_h)
 
         # OOB weight fixup (bake into weights at construction)
-        is_oob = xq_raw < x_lo || xq_raw > x_hi
+        is_oob = !_is_inbounds(x, xq_raw)
         if is_oob
             z = zero(Tg)
             z4 = (z, z, z, z)
@@ -435,13 +434,7 @@ function hermite_adjoint(
 
     # NoExtrap: validate all queries in-domain
     if extrap isa NoExtrap
-        x_lo, x_hi = _domain_bounds(x_p)  # widened: accept true endpoint
-        @inbounds for i in eachindex(xq_p)
-            xq_i = xq_p[i]
-            (_extract_primal(x_lo) <= xq_i <= _extract_primal(x_hi)) || throw(
-                DomainError(xq_i, "query point outside domain [$(_extract_primal(x_lo)), $(_extract_primal(x_hi))]")
-            )
-        end
+        _validate_domain(x_p, xq_p)
     end
 
     # Caching wrap (transient — used only for anchor baking). Range from

--- a/src/hermite/hermite_eval.jl
+++ b/src/hermite/hermite_eval.jl
@@ -59,11 +59,9 @@ end
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq = _resolve_grididx(xq, x)
     xq_primal = _extract_primal(xq)
-    if xq_primal < _extract_primal(first(x))
-        return _eval_extrapolation(op, first(y), extrap, xq)
-    elseif xq_primal > _extract_primal(last(x))
-        return _eval_extrapolation(op, last(y), extrap, xq)
-    end
+    st = _oob_state(x, xq_primal)
+    st == OOB_LEFT && return _eval_extrapolation(op, first(y), extrap, xq)
+    st == OOB_RIGHT && return _eval_extrapolation(op, last(y), extrap, xq)
     return _hermite_eval_at_point(x, y, dy, xq, InBounds(), op, searcher)
 end
 
@@ -170,11 +168,9 @@ end
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq = _resolve_grididx(xq, x)
     xq_primal = _extract_primal(xq)
-    if xq_primal < _extract_primal(first(x))
-        return _eval_extrapolation(op, first(y), extrap, xq)
-    elseif xq_primal > _extract_primal(last(x))
-        return _eval_extrapolation(op, last(y), extrap, xq)
-    end
+    st = _oob_state(x, xq_primal)
+    st == OOB_LEFT && return _eval_extrapolation(op, first(y), extrap, xq)
+    st == OOB_RIGHT && return _eval_extrapolation(op, last(y), extrap, xq)
     return _hermite_eval_at_point(x, y, sm, xq, InBounds(), op, searcher)
 end
 

--- a/src/linear/linear_adjoint.jl
+++ b/src/linear/linear_adjoint.jl
@@ -174,12 +174,11 @@ original query position, so scatter can skip OOB contributions.
 function _fixup_linear_anchor_state!(
         anchors::Vector{<:_LinearAnchoredQuery},
         xq_original::AbstractVector,
-        x_lo, x_hi
+        x::AbstractVector
     )
     @inbounds for i in eachindex(anchors)
-        xq_i = xq_original[i]
-        (x_lo <= xq_i <= x_hi) && continue
-        state = xq_i < x_lo ? OOB_LEFT : OOB_RIGHT
+        state = _oob_state(x, xq_original[i])
+        state == IN_DOMAIN && continue
         aq = anchors[i]
         anchors[i] = typeof(aq)(
             aq.stencil, aq.xq, state, aq.xL, aq.h, aq.inv_h, aq.alpha
@@ -252,26 +251,17 @@ function linear_adjoint(
     # NoExtrap: validate all queries in-domain (uses x_axis bounds, which include
     # the virtual seam endpoint for `:exclusive`). Use primal for Dual grid boundaries.
     if extrap_eff isa NoExtrap
-        x_lo, x_hi = map(_extract_primal, _domain_bounds(x_axis))  # widened: accept true endpoint
-        @inbounds for i in eachindex(xq_p)
-            xq_i = xq_p[i]
-            (x_lo <= xq_i <= x_hi) || throw(
-                DomainError(xq_i, "query point outside domain [$x_lo, $x_hi]")
-            )
-        end
+        _validate_domain(x_axis, xq_p)
     end
 
     # Build anchored queries with extrap-specific preprocessing
     wrap = extrap_eff isa WrapExtrap
     if extrap_eff isa _ClampOrFill
-        # Clamp OOB queries to boundary for correct anchor weights (alpha ∈ [0,1]).
-        # Then restore side flags so scatter can skip OOB contributions.
-        # Safe (widened) bounds for classification — clamp/fixup against these so
-        # a query at the true `_CachedRange` endpoint stays in-domain.
-        x_lo_p, x_hi_p = map(_extract_primal, _domain_bounds(x_axis))
-        xq_clamped = clamp.(xq_p, x_lo_p, x_hi_p)
+        # OOB queries get actual-endpoint geometry (`_clamp_to_grid`); `_fixup`
+        # restores the side flags from the widened (`_oob_state`) classification.
+        xq_clamped = _clamp_to_grid.(xq_p, Ref(x_axis))
         anchors = _anchor_query(x_axis, xq_clamped, Val(:linear), false)
-        _fixup_linear_anchor_state!(anchors, xq_p, x_lo_p, x_hi_p)
+        _fixup_linear_anchor_state!(anchors, xq_p, x_axis)
     else
         # ExtendExtrap: OOB uses boundary interval with extrapolated alpha (correct)
         # WrapExtrap: wraps to domain (correct; covers periodic auto-promotion)

--- a/src/linear/linear_adjoint.jl
+++ b/src/linear/linear_adjoint.jl
@@ -165,26 +165,35 @@ end
 # ========================================
 
 """
-Restore `state` flags for anchors built with clamped query positions.
+    _bake_linear_clampfill_anchors(x, xq) -> Vector{_LinearAnchoredQuery}
 
-When ClampExtrap/FillExtrap queries are clamped before anchoring, the anchor
-gets `state=IN_DOMAIN` (inside). This restores the correct OOB state flag based on the
-original query position, so scatter can skip OOB contributions.
+Single-pass ClampExtrap/FillExtrap adjoint anchor builder.
+
+Each query is clamped to the *actual* grid endpoints (`_clamp_to_grid`) for
+valid boundary-cell geometry, anchored, then genuinely-OOB queries get their
+side flag restored from the widened (`_oob_state`) classification so scatter
+skips (FillExtrap) or keeps (ClampExtrap) the boundary weight per extrap. An
+in-domain or endpoint-sliver query keeps the anchor as built.
+
+Fuses the former clamp-broadcast + `_anchor_query` + state-fixup three passes
+into one loop, dropping the transient clamped-query array. Construction-time
+only; the apply path consumes the baked anchors unchanged.
 """
-function _fixup_linear_anchor_state!(
-        anchors::Vector{<:_LinearAnchoredQuery},
-        xq_original::AbstractVector,
-        x::AbstractVector
-    )
-    @inbounds for i in eachindex(anchors)
-        state = _oob_state(x, xq_original[i])
-        state == IN_DOMAIN && continue
-        aq = anchors[i]
-        anchors[i] = typeof(aq)(
-            aq.stencil, aq.xq, state, aq.xL, aq.h, aq.inv_h, aq.alpha
-        )
+function _bake_linear_clampfill_anchors(
+        x::AbstractVector{Tg},
+        xq::AbstractVector{Tq},
+        searcher::P = _to_searcher(LinearBinarySearch())
+    ) where {Tg, Tq <: Real, P <: Searcher}
+    searcher_resolved = _resolve_searcher_for_grid(x, searcher)
+    output = Vector{_LinearAnchoredQuery{Tg, promote_type(Tq, Tg)}}(undef, length(xq))
+    @inbounds for k in eachindex(xq)
+        xq_raw = xq[k]
+        aq = _linear_anchor_query_impl(x, _clamp_to_grid(xq_raw, x), false, searcher_resolved)
+        state = _oob_state(x, xq_raw)
+        output[k] = state == IN_DOMAIN ? aq :
+            typeof(aq)(aq.stencil, aq.xq, state, aq.xL, aq.h, aq.inv_h, aq.alpha)
     end
-    return nothing
+    return output
 end
 
 # ========================================
@@ -257,11 +266,9 @@ function linear_adjoint(
     # Build anchored queries with extrap-specific preprocessing
     wrap = extrap_eff isa WrapExtrap
     if extrap_eff isa _ClampOrFill
-        # OOB queries get actual-endpoint geometry (`_clamp_to_grid`); `_fixup`
-        # restores the side flags from the widened (`_oob_state`) classification.
-        xq_clamped = _clamp_to_grid.(xq_p, Ref(x_axis))
-        anchors = _anchor_query(x_axis, xq_clamped, Val(:linear), false)
-        _fixup_linear_anchor_state!(anchors, xq_p, x_axis)
+        # OOB queries get actual-endpoint geometry; the widened (`_oob_state`)
+        # classification restores side flags. Single fused pass (no temp array).
+        anchors = _bake_linear_clampfill_anchors(x_axis, xq_p)
     else
         # ExtendExtrap: OOB uses boundary interval with extrapolated alpha (correct)
         # WrapExtrap: wraps to domain (correct; covers periodic auto-promotion)

--- a/src/linear/linear_adjoint.jl
+++ b/src/linear/linear_adjoint.jl
@@ -252,7 +252,7 @@ function linear_adjoint(
     # NoExtrap: validate all queries in-domain (uses x_axis bounds, which include
     # the virtual seam endpoint for `:exclusive`). Use primal for Dual grid boundaries.
     if extrap_eff isa NoExtrap
-        x_lo, x_hi = _extract_primal(first(x_axis)), _extract_primal(last(x_axis))
+        x_lo, x_hi = map(_extract_primal, _domain_bounds(x_axis))  # widened: accept true endpoint
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
             (x_lo <= xq_i <= x_hi) || throw(
@@ -266,7 +266,9 @@ function linear_adjoint(
     if extrap_eff isa _ClampOrFill
         # Clamp OOB queries to boundary for correct anchor weights (alpha ∈ [0,1]).
         # Then restore side flags so scatter can skip OOB contributions.
-        x_lo_p, x_hi_p = _extract_primal(first(x_axis)), _extract_primal(last(x_axis))
+        # Safe (widened) bounds for classification — clamp/fixup against these so
+        # a query at the true `_CachedRange` endpoint stays in-domain.
+        x_lo_p, x_hi_p = map(_extract_primal, _domain_bounds(x_axis))
         xq_clamped = clamp.(xq_p, x_lo_p, x_hi_p)
         anchors = _anchor_query(x_axis, xq_clamped, Val(:linear), false)
         _fixup_linear_anchor_state!(anchors, xq_p, x_lo_p, x_hi_p)

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -260,11 +260,9 @@ end
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq = _resolve_grididx(xq, x)
     xq_primal = _extract_primal(xq)
-    if xq_primal < first(x)
-        return _eval_extrapolation(op, first(y), extrap, xq)
-    elseif xq_primal > last(x)
-        return _eval_extrapolation(op, last(y), extrap, xq)
-    end
+    st = _oob_state(x, xq_primal)
+    st == OOB_LEFT && return _eval_extrapolation(op, first(y), extrap, xq)
+    st == OOB_RIGHT && return _eval_extrapolation(op, last(y), extrap, xq)
     return _linear_eval_at_point(x, y, xq, InBounds(), op, searcher)
 end
 

--- a/src/linear/nd/linear_nd_adjoint.jl
+++ b/src/linear/nd/linear_nd_adjoint.jl
@@ -52,7 +52,9 @@ function _bake_linear_nd_anchors(
             h = _get_h(grids[d], idx)
             inv_h = _get_inv_h(grids[d], idx)
             α = (xq_d - xL) * inv_h
-            is_oob = xq_raw < first(grids[d]) || xq_raw > last(grids[d])
+            # Widened classification (matches forward `_oob_state`): a query at
+            # the true `_CachedRange` endpoint is in-domain, not zeroed-OOB.
+            is_oob = _oob_state(grids[d], xq_raw) != IN_DOMAIN
             w_val = (one(Tg) - α, α)
             w_der = (-inv_h, inv_h)
             return (idx, w_val, w_der, is_oob)

--- a/src/pchip/pchip_adjoint.jl
+++ b/src/pchip/pchip_adjoint.jl
@@ -429,13 +429,7 @@ function pchip_adjoint(
     # fires inside `_periodic_extend_1d` for periodic BCs, so non-periodic
     # NoExtrap still validates here).
     if extrap_eff isa NoExtrap
-        x_lo, x_hi = _domain_bounds(x_ext)  # widened: accept true endpoint
-        @inbounds for i in eachindex(xq_p)
-            xq_i = xq_p[i]
-            (_extract_primal(x_lo) <= xq_i <= _extract_primal(x_hi)) || throw(
-                DomainError(xq_i, "query point outside domain [$(_extract_primal(x_lo)), $(_extract_primal(x_hi))]")
-            )
-        end
+        _validate_domain(x_ext, xq_p)
     end
 
     # Bake anchors against the extended axis. `_cache_axis(x_ext, NoBC())`

--- a/src/pchip/pchip_adjoint.jl
+++ b/src/pchip/pchip_adjoint.jl
@@ -429,7 +429,7 @@ function pchip_adjoint(
     # fires inside `_periodic_extend_1d` for periodic BCs, so non-periodic
     # NoExtrap still validates here).
     if extrap_eff isa NoExtrap
-        x_lo, x_hi = first(x_ext), last(x_ext)
+        x_lo, x_hi = _domain_bounds(x_ext)  # widened: accept true endpoint
         @inbounds for i in eachindex(xq_p)
             xq_i = xq_p[i]
             (_extract_primal(x_lo) <= xq_i <= _extract_primal(x_hi)) || throw(

--- a/src/quadratic/quadratic_adjoint.jl
+++ b/src/quadratic/quadratic_adjoint.jl
@@ -87,11 +87,9 @@ function _bake_quadratic_adjoint_anchors(
         xq::AbstractVector{Tg},
         extrap::AbstractExtrap
     ) where {Tg}
-    # Safe (widened) classification bounds — matches the forward `_oob_state`, so
-    # a query at the true `_CachedRange` endpoint is in-domain, not zeroed-OOB.
-    x_lo, x_hi = _domain_bounds(x)
-
-    # For ClampExtrap/FillExtrap, clamp queries to domain before anchoring
+    # Classification (`_is_inbounds`, widened bounds) and clamp geometry
+    # (`_clamp_to_grid`, actual endpoints) stay in separate helpers, so the
+    # widened acceptance cushion never leaks into the clamp target or wrap period.
     need_clamp = extrap isa Union{ClampExtrap, FillExtrap}
     wrap = extrap isa WrapExtrap
 
@@ -101,9 +99,9 @@ function _bake_quadratic_adjoint_anchors(
 
         # Preprocess query point based on extrap mode
         xq_eval = if need_clamp
-            clamp(xq_raw, x_lo, x_hi)
+            _clamp_to_grid(xq_raw, x)
         elseif wrap
-            _wrap_to_domain(xq_raw, x_lo, x_hi)
+            _wrap_to_domain(xq_raw, x)   # 2-arg axis-aware: actual period + in-domain guard
         else
             xq_raw
         end
@@ -120,7 +118,7 @@ function _bake_quadratic_adjoint_anchors(
         w0, w1, w2 = _compute_quadratic_adjoint_weights(t, h, inv_h)
 
         # OOB weight fixup (bake into weights at construction)
-        is_oob = xq_raw < x_lo || xq_raw > x_hi
+        is_oob = !_is_inbounds(x, xq_raw)
         if is_oob
             z = zero(Tg)
             z3 = (z, z, z)
@@ -616,13 +614,7 @@ function quadratic_adjoint(
 
     # Validate domain for NoExtrap
     if extrap isa NoExtrap
-        x_lo, x_hi = _domain_bounds(x_p)  # widened: accept true endpoint
-        for i in eachindex(xq_p)
-            xq_i = xq_p[i]
-            (x_lo <= xq_i <= x_hi) || throw(
-                DomainError(xq_i, "query point outside domain [$x_lo, $x_hi]")
-            )
-        end
+        _validate_domain(x_p, xq_p)
     end
 
     # Cache axis for bake loop + per-apply `_compute_mincurv_C` reuse.

--- a/src/quadratic/quadratic_adjoint.jl
+++ b/src/quadratic/quadratic_adjoint.jl
@@ -87,7 +87,9 @@ function _bake_quadratic_adjoint_anchors(
         xq::AbstractVector{Tg},
         extrap::AbstractExtrap
     ) where {Tg}
-    x_lo, x_hi = first(x), last(x)
+    # Safe (widened) classification bounds — matches the forward `_oob_state`, so
+    # a query at the true `_CachedRange` endpoint is in-domain, not zeroed-OOB.
+    x_lo, x_hi = _domain_bounds(x)
 
     # For ClampExtrap/FillExtrap, clamp queries to domain before anchoring
     need_clamp = extrap isa Union{ClampExtrap, FillExtrap}
@@ -614,7 +616,7 @@ function quadratic_adjoint(
 
     # Validate domain for NoExtrap
     if extrap isa NoExtrap
-        x_lo, x_hi = first(x_p), last(x_p)
+        x_lo, x_hi = _domain_bounds(x_p)  # widened: accept true endpoint
         for i in eachindex(xq_p)
             xq_i = xq_p[i]
             (x_lo <= xq_i <= x_hi) || throw(

--- a/src/quadratic/quadratic_oneshot.jl
+++ b/src/quadratic/quadratic_oneshot.jl
@@ -67,8 +67,9 @@ end
         searcher::S
     ) where {Tg, Tv, Tc, Tq, S <: Searcher}
     xq_primal = _extract_primal(xq)
-    xq_primal < _extract_primal(first(x)) && return _eval_extrapolation(op, first(y), extrap, xq)
-    xq_primal > _extract_primal(last(x)) && return _eval_extrapolation(op, last(y), extrap, xq)
+    st = _oob_state(x, xq_primal)
+    st == OOB_LEFT && return _eval_extrapolation(op, first(y), extrap, xq)
+    st == OOB_RIGHT && return _eval_extrapolation(op, last(y), extrap, xq)
     return _quadratic_eval_at_point(x, y, a, d, xq, InBounds(), op, searcher)
 end
 

--- a/test/test_fillextrap_adjoint_boundary.jl
+++ b/test/test_fillextrap_adjoint_boundary.jl
@@ -25,22 +25,22 @@
     rowsum(adj) = sum(vec(Base.Matrix(adj)))
 
     # Data-independent adjoints (linear in y, no y argument).
-    @test rowsum(linear_adjoint(crR, 2.0; extrap = fv))                    ≈ 1.0  atol = 1.0e-9
-    @test rowsum(linear_adjoint(crL, 1.0; extrap = fv))                    ≈ 1.0  atol = 1.0e-9
-    @test rowsum(cubic_adjoint(crR, 2.0; extrap = fv))                     ≈ 1.0  atol = 1.0e-9
-    @test rowsum(cubic_adjoint(crL, 1.0; extrap = fv))                     ≈ 1.0  atol = 1.0e-9
-    @test rowsum(quadratic_adjoint(crR, 2.0; extrap = fv))                 ≈ 1.0  atol = 1.0e-9
-    @test rowsum(quadratic_adjoint(crL, 1.0; extrap = fv))                 ≈ 1.0  atol = 1.0e-9
-    @test rowsum(constant_adjoint(crR, 2.0; extrap = fv))                  ≈ 1.0  atol = 1.0e-9
-    @test rowsum(constant_adjoint(crL, 1.0; extrap = fv))                  ≈ 1.0  atol = 1.0e-9
-    @test rowsum(cardinal_adjoint(crR, 2.0; tension = 0.0, extrap = fv))   ≈ 1.0  atol = 1.0e-9
-    @test rowsum(cardinal_adjoint(crL, 1.0; tension = 0.0, extrap = fv))   ≈ 1.0  atol = 1.0e-9
+    @test rowsum(linear_adjoint(crR, 2.0; extrap = fv)) ≈ 1.0  atol = 1.0e-9
+    @test rowsum(linear_adjoint(crL, 1.0; extrap = fv)) ≈ 1.0  atol = 1.0e-9
+    @test rowsum(cubic_adjoint(crR, 2.0; extrap = fv)) ≈ 1.0  atol = 1.0e-9
+    @test rowsum(cubic_adjoint(crL, 1.0; extrap = fv)) ≈ 1.0  atol = 1.0e-9
+    @test rowsum(quadratic_adjoint(crR, 2.0; extrap = fv)) ≈ 1.0  atol = 1.0e-9
+    @test rowsum(quadratic_adjoint(crL, 1.0; extrap = fv)) ≈ 1.0  atol = 1.0e-9
+    @test rowsum(constant_adjoint(crR, 2.0; extrap = fv)) ≈ 1.0  atol = 1.0e-9
+    @test rowsum(constant_adjoint(crL, 1.0; extrap = fv)) ≈ 1.0  atol = 1.0e-9
+    @test rowsum(cardinal_adjoint(crR, 2.0; tension = 0.0, extrap = fv)) ≈ 1.0  atol = 1.0e-9
+    @test rowsum(cardinal_adjoint(crL, 1.0; tension = 0.0, extrap = fv)) ≈ 1.0  atol = 1.0e-9
 
     # Data-dependent adjoints (slope-from-data; need y).
-    @test rowsum(pchip_adjoint(crR, y, 2.0; extrap = fv))                  ≈ 1.0  atol = 1.0e-9
-    @test rowsum(pchip_adjoint(crL, y, 1.0; extrap = fv))                  ≈ 1.0  atol = 1.0e-9
-    @test rowsum(akima_adjoint(crR, y, 2.0; extrap = fv))                  ≈ 1.0  atol = 1.0e-9
-    @test rowsum(akima_adjoint(crL, y, 1.0; extrap = fv))                  ≈ 1.0  atol = 1.0e-9
+    @test rowsum(pchip_adjoint(crR, y, 2.0; extrap = fv)) ≈ 1.0  atol = 1.0e-9
+    @test rowsum(pchip_adjoint(crL, y, 1.0; extrap = fv)) ≈ 1.0  atol = 1.0e-9
+    @test rowsum(akima_adjoint(crR, y, 2.0; extrap = fv)) ≈ 1.0  atol = 1.0e-9
+    @test rowsum(akima_adjoint(crL, y, 1.0; extrap = fv)) ≈ 1.0  atol = 1.0e-9
 end
 
 @testitem "ND adjoint boundary FillExtrap — sensitivity sums to 1 at the corner" setup = [InwardCR] begin
@@ -55,13 +55,17 @@ end
     # 2D adjoint ∂out/∂data at an in-domain corner must sum to 1 (value
     # interpolation reproduces constants). The per-axis `is_oob` flag (computed
     # from raw first/last) misclassified the corner → weights zeroed → sum 0.
-    @test rowsum(linear_adjoint((crx, cry), corner; extrap = fv))    ≈ 1.0  atol = 1.0e-9
-    @test rowsum(cubic_adjoint((crx, cry), corner; extrap = fv))     ≈ 1.0  atol = 1.0e-9
-    @test rowsum(constant_adjoint((crx, cry), corner; extrap = fv))  ≈ 1.0  atol = 1.0e-9
+    @test rowsum(linear_adjoint((crx, cry), corner; extrap = fv)) ≈ 1.0  atol = 1.0e-9
+    @test rowsum(cubic_adjoint((crx, cry), corner; extrap = fv)) ≈ 1.0  atol = 1.0e-9
+    @test rowsum(constant_adjoint((crx, cry), corner; extrap = fv)) ≈ 1.0  atol = 1.0e-9
     @test rowsum(quadratic_adjoint((crx, cry), corner; extrap = fv)) ≈ 1.0  atol = 1.0e-9
     # Heterogeneous per-axis methods route through the shared ND anchor builder.
-    @test rowsum(hetero_adjoint((crx, cry), corner;
-        methods = (LinearInterp(), CubicInterp()), extrap = fv)) ≈ 1.0  atol = 1.0e-9
+    @test rowsum(
+        hetero_adjoint(
+            (crx, cry), corner;
+            methods = (LinearInterp(), CubicInterp()), extrap = fv
+        )
+    ) ≈ 1.0  atol = 1.0e-9
 
     # Left corner (both axes round inward from below).
     crxL = inward_cr_left(1.0, 3.0, n)
@@ -104,4 +108,40 @@ end
         cubic_interp(cr, y, 2.0; extrap = fv)  atol = 1.0e-9
     @test sum(vec(Base.Matrix(constant_adjoint(cr, 2.0; extrap = fv))) .* y) ≈
         constant_interp(cr, y, 2.0; extrap = fv)  atol = 1.0e-9
+end
+
+@testitem "Adjoint golden-rule (transpose identity) on widened _CachedRange boundary" setup = [InwardCR] begin
+    using FastInterpolations
+    using LinearAlgebra: dot
+    # Golden rule for an interpolant linear in the data f: the adjoint IS Wᵀ, so
+    #   ⟨W·f, ȳ⟩ == ⟨f, Wᵀȳ⟩   ⇔   dot(itp.(xq), ȳ) == dot(f, adj(ȳ)).
+    # Checked on the synthetic widened `_CachedRange` (stored lo/hi rounded inward,
+    # domain_lo/hi recover the true endpoints) with the query set INCLUDING the
+    # true endpoint (the 1-ULP sliver). This pins the fused ClampExtrap/FillExtrap
+    # adjoint builder to a map consistent with the forward at the widened boundary.
+    # (atol 1e-7 absorbs the intended ~1e-14 forward-sliver-vs-adjoint-snap gap:
+    #  forward leaves the sliver query at t⪆1, the adjoint clamps it to t==1.)
+    n = 5
+    f = [10.0, 20.0, 30.0, 40.0, 50.0]
+    ȳ = [1.0, -2.0, 3.0]
+
+    for (cr, ep) in ((inward_cr_right(0.0, 2.0, n), 2.0), (inward_cr_left(1.0, 3.0, n), 1.0))
+        xq = [ep, cr[2], cr[3]]          # true-endpoint sliver + two interior points
+        for extrap in (FillExtrap(-7.0), ClampExtrap())
+            for (madj, mfwd) in (
+                    (linear_adjoint, linear_interp),
+                    (cubic_adjoint, cubic_interp),
+                    (constant_adjoint, constant_interp),
+                    (quadratic_adjoint, quadratic_interp),
+                )
+                itp = mfwd(cr, f; extrap = extrap)
+                adj = madj(cr, xq; extrap = extrap)
+                @test dot(itp.(xq), ȳ) ≈ dot(f, adj(ȳ))  atol = 1.0e-7
+            end
+            # cardinal carries a tension kwarg (tension 0 ⇒ Catmull–Rom, linear in f)
+            itpc = cardinal_interp(cr, f; tension = 0.0, extrap = extrap)
+            adjc = cardinal_adjoint(cr, xq; tension = 0.0, extrap = extrap)
+            @test dot(itpc.(xq), ȳ) ≈ dot(f, adjc(ȳ))  atol = 1.0e-7
+        end
+    end
 end

--- a/test/test_fillextrap_adjoint_boundary.jl
+++ b/test/test_fillextrap_adjoint_boundary.jl
@@ -43,6 +43,33 @@
     @test rowsum(akima_adjoint(crL, y, 1.0; extrap = fv))                  ≈ 1.0  atol = 1.0e-9
 end
 
+@testitem "ND adjoint boundary FillExtrap — sensitivity sums to 1 at the corner" setup = [InwardCR] begin
+    using FastInterpolations
+    n = 5
+    crx = inward_cr_both(0.0, 2.0, n)
+    cry = inward_cr_both(0.0, 2.0, n)
+    fv = FillExtrap(0.0)
+    rowsum(adj) = sum(Base.Matrix(adj))
+    corner = (2.0, 2.0)   # both axes at the true endpoint
+
+    # 2D adjoint ∂out/∂data at an in-domain corner must sum to 1 (value
+    # interpolation reproduces constants). The per-axis `is_oob` flag (computed
+    # from raw first/last) misclassified the corner → weights zeroed → sum 0.
+    @test rowsum(linear_adjoint((crx, cry), corner; extrap = fv))    ≈ 1.0  atol = 1.0e-9
+    @test rowsum(cubic_adjoint((crx, cry), corner; extrap = fv))     ≈ 1.0  atol = 1.0e-9
+    @test rowsum(constant_adjoint((crx, cry), corner; extrap = fv))  ≈ 1.0  atol = 1.0e-9
+    @test rowsum(quadratic_adjoint((crx, cry), corner; extrap = fv)) ≈ 1.0  atol = 1.0e-9
+    # Heterogeneous per-axis methods route through the shared ND anchor builder.
+    @test rowsum(hetero_adjoint((crx, cry), corner;
+        methods = (LinearInterp(), CubicInterp()), extrap = fv)) ≈ 1.0  atol = 1.0e-9
+
+    # Left corner (both axes round inward from below).
+    crxL = inward_cr_left(1.0, 3.0, n)
+    cryL = inward_cr_left(1.0, 3.0, n)
+    @test rowsum(linear_adjoint((crxL, cryL), (1.0, 1.0); extrap = fv)) ≈ 1.0  atol = 1.0e-9
+    @test rowsum(cubic_adjoint((crxL, cryL), (1.0, 1.0); extrap = fv)) ≈ 1.0  atol = 1.0e-9
+end
+
 @testitem "Adjoint boundary NoExtrap — true endpoint accepted (no DomainError)" setup = [InwardCR] begin
     using FastInterpolations
     n = 5

--- a/test/test_fillextrap_adjoint_boundary.jl
+++ b/test/test_fillextrap_adjoint_boundary.jl
@@ -1,0 +1,80 @@
+# ════════════════════════════════════════════════════════════════════════════
+# RED-phase guards: the reverse-mode adjoint must classify a range-grid boundary
+# query the same way the forward eval does. The forward fix routed every forward
+# OOB decision through `_oob_state`/`_domain_bounds`; the adjoints still derived
+# OOB state from raw `first`/`last`, so a query at the true endpoint was clamped
+# and flagged OOB → its scatter contribution was skipped → an all-zero
+# sensitivity row (FillExtrap), instead of the boundary cell's weights.
+#
+# Contract: at an in-domain boundary query the adjoint `∂out/∂y` must sum to 1
+# (value interpolation reproduces constants — perturbing every y by +c shifts the
+# output by +c). The bug makes the row all-zero, so the sum is 0.
+#
+# Uses the same synthetic widened `_CachedRange` (`InwardCR` snippet, defined in
+# test_fillextrap_domain_boundary.jl), so the x86 bug reproduces on any arch.
+# ════════════════════════════════════════════════════════════════════════════
+
+@testitem "Adjoint boundary FillExtrap — sensitivity row sums to 1 at the true endpoint" setup = [InwardCR] begin
+    using FastInterpolations
+    n = 5
+    crR = inward_cr_right(0.0, 2.0, n)   # query true endpoint 2.0 (> stored hi)
+    crL = inward_cr_left(1.0, 3.0, n)    # query true endpoint 1.0 (< stored lo)
+    y = collect(10.0:10.0:50.0)
+    fv = FillExtrap(0.0)
+
+    rowsum(adj) = sum(vec(Base.Matrix(adj)))
+
+    # Data-independent adjoints (linear in y, no y argument).
+    @test rowsum(linear_adjoint(crR, 2.0; extrap = fv))                    ≈ 1.0  atol = 1.0e-9
+    @test rowsum(linear_adjoint(crL, 1.0; extrap = fv))                    ≈ 1.0  atol = 1.0e-9
+    @test rowsum(cubic_adjoint(crR, 2.0; extrap = fv))                     ≈ 1.0  atol = 1.0e-9
+    @test rowsum(cubic_adjoint(crL, 1.0; extrap = fv))                     ≈ 1.0  atol = 1.0e-9
+    @test rowsum(quadratic_adjoint(crR, 2.0; extrap = fv))                 ≈ 1.0  atol = 1.0e-9
+    @test rowsum(quadratic_adjoint(crL, 1.0; extrap = fv))                 ≈ 1.0  atol = 1.0e-9
+    @test rowsum(constant_adjoint(crR, 2.0; extrap = fv))                  ≈ 1.0  atol = 1.0e-9
+    @test rowsum(constant_adjoint(crL, 1.0; extrap = fv))                  ≈ 1.0  atol = 1.0e-9
+    @test rowsum(cardinal_adjoint(crR, 2.0; tension = 0.0, extrap = fv))   ≈ 1.0  atol = 1.0e-9
+    @test rowsum(cardinal_adjoint(crL, 1.0; tension = 0.0, extrap = fv))   ≈ 1.0  atol = 1.0e-9
+
+    # Data-dependent adjoints (slope-from-data; need y).
+    @test rowsum(pchip_adjoint(crR, y, 2.0; extrap = fv))                  ≈ 1.0  atol = 1.0e-9
+    @test rowsum(pchip_adjoint(crL, y, 1.0; extrap = fv))                  ≈ 1.0  atol = 1.0e-9
+    @test rowsum(akima_adjoint(crR, y, 2.0; extrap = fv))                  ≈ 1.0  atol = 1.0e-9
+    @test rowsum(akima_adjoint(crL, y, 1.0; extrap = fv))                  ≈ 1.0  atol = 1.0e-9
+end
+
+@testitem "Adjoint boundary NoExtrap — true endpoint accepted (no DomainError)" setup = [InwardCR] begin
+    using FastInterpolations
+    n = 5
+    crR = inward_cr_right(0.0, 2.0, n)
+    crL = inward_cr_left(1.0, 3.0, n)
+    y = collect(10.0:10.0:50.0)
+    no = NoExtrap()
+    # Forward NoExtrap accepts the true endpoint (it checks `domain_lo/hi`); the
+    # adjoint validation must agree, not throw a DomainError one ULP early.
+    @test (linear_adjoint(crR, 2.0; extrap = no); true)
+    @test (linear_adjoint(crL, 1.0; extrap = no); true)
+    @test (constant_adjoint(crR, 2.0; extrap = no); true)
+    @test (cubic_adjoint(crR, 2.0; extrap = no); true)
+    @test (quadratic_adjoint(crR, 2.0; extrap = no); true)
+    @test (cardinal_adjoint(crR, 2.0; tension = 0.0, extrap = no); true)
+    @test (pchip_adjoint(crR, y, 2.0; extrap = no); true)
+    @test (akima_adjoint(crR, y, 2.0; extrap = no); true)
+end
+
+@testitem "Adjoint boundary — reverse matches forward (Matrix·y ≈ itp) for linear-in-y methods" setup = [InwardCR] begin
+    using FastInterpolations
+    n = 5
+    cr = inward_cr_right(0.0, 2.0, n)
+    y = collect(10.0:10.0:50.0)
+    fv = FillExtrap(-7.0)   # distinctive fill: a leak would show as ≈ -7, not y[end]
+
+    # For methods whose interpolant is linear in y, the adjoint IS the forward
+    # linear map, so Matrix(adj)·y must equal the forward value at the boundary.
+    @test sum(vec(Base.Matrix(linear_adjoint(cr, 2.0; extrap = fv))) .* y) ≈
+        linear_interp(cr, y, 2.0; extrap = fv)  atol = 1.0e-9
+    @test sum(vec(Base.Matrix(cubic_adjoint(cr, 2.0; extrap = fv))) .* y) ≈
+        cubic_interp(cr, y, 2.0; extrap = fv)  atol = 1.0e-9
+    @test sum(vec(Base.Matrix(constant_adjoint(cr, 2.0; extrap = fv))) .* y) ≈
+        constant_interp(cr, y, 2.0; extrap = fv)  atol = 1.0e-9
+end

--- a/test/test_fillextrap_adjoint_boundary.jl
+++ b/test/test_fillextrap_adjoint_boundary.jl
@@ -1,17 +1,11 @@
 # ════════════════════════════════════════════════════════════════════════════
-# RED-phase guards: the reverse-mode adjoint must classify a range-grid boundary
-# query the same way the forward eval does. The forward fix routed every forward
-# OOB decision through `_oob_state`/`_domain_bounds`; the adjoints still derived
-# OOB state from raw `first`/`last`, so a query at the true endpoint was clamped
-# and flagged OOB → its scatter contribution was skipped → an all-zero
-# sensitivity row (FillExtrap), instead of the boundary cell's weights.
+# The reverse-mode adjoint must classify a range-grid boundary query the same way
+# the forward eval does. Previously the adjoints derived OOB state from raw
+# `first`/`last`, so a query at the true endpoint was flagged OOB → its scatter
+# contribution skipped → an all-zero sensitivity row under FillExtrap.
 #
-# Contract: at an in-domain boundary query the adjoint `∂out/∂y` must sum to 1
-# (value interpolation reproduces constants — perturbing every y by +c shifts the
-# output by +c). The bug makes the row all-zero, so the sum is 0.
-#
-# Uses the same synthetic widened `_CachedRange` (`InwardCR` snippet, defined in
-# test_fillextrap_domain_boundary.jl), so the x86 bug reproduces on any arch.
+# Contract: at an in-domain boundary query `∂out/∂y` sums to 1 (value interp
+# reproduces constants). Uses the synthetic widened `_CachedRange` (`InwardCR`).
 # ════════════════════════════════════════════════════════════════════════════
 
 @testitem "Adjoint boundary FillExtrap — sensitivity row sums to 1 at the true endpoint" setup = [InwardCR] begin

--- a/test/test_fillextrap_domain_boundary.jl
+++ b/test/test_fillextrap_domain_boundary.jl
@@ -214,3 +214,71 @@ end
     @test linear_interp(cr, y, 0.0; bc = bc, deriv = DerivOp(1)) ≈
         linear_interp(xref, y, 0.0; bc = bc, deriv = DerivOp(1))  atol = 1.0e-9
 end
+
+# ════════════════════════════════════════════════════════════════════════════
+# Duck-type (ForwardDiff.Dual query) preservation through the boundary helpers
+# and the forward eval. The boundary classifier/clamp helpers must classify a
+# Dual query by its primal and preserve the Dual TYPE — including at the widened
+# `_CachedRange` sliver. (Adjoint constructors do NOT support Dual queries — a
+# pre-existing struct-level limitation, see `_promote_adjoint_inputs` — so only
+# the helper + forward contract is pinned here.)
+# ════════════════════════════════════════════════════════════════════════════
+
+@testitem "Boundary helpers preserve duck-type (ForwardDiff.Dual queries)" setup = [InwardCR] begin
+    using FastInterpolations
+    using FastInterpolations: _oob_state, _is_inbounds, _clamp_to_grid,
+        IN_DOMAIN, OOB_LEFT, OOB_RIGHT
+    import ForwardDiff
+    Dl = ForwardDiff.Dual
+    n = 5
+    cr = inward_cr_right(0.0, 2.0, n)   # widened _CachedRange; domain_hi recovers true endpoint 2.0
+
+    # Classification reads the Dual via its primal — including the widened sliver:
+    # the true endpoint (== domain_hi, one ULP past the stored `last`) is IN_DOMAIN.
+    @test _oob_state(cr, Dl(1.0, 1.0)) == IN_DOMAIN
+    @test _oob_state(cr, Dl(2.0, 1.0)) == IN_DOMAIN     # true endpoint (sliver)
+    @test _oob_state(cr, Dl(2.5, 1.0)) == OOB_RIGHT
+    @test _oob_state(cr, Dl(-0.5, 1.0)) == OOB_LEFT
+    @test _is_inbounds(cr, Dl(2.0, 1.0))
+    @test !_is_inbounds(cr, Dl(2.5, 1.0))
+
+    # `_clamp_to_grid` preserves the Dual TYPE; in-domain keeps the partial, a
+    # genuinely-OOB query clamps to the actual endpoint with a zeroed partial
+    # (a clamped value sits at a constant boundary → zero query-sensitivity).
+    c_in = _clamp_to_grid(Dl(1.0, 1.0), cr)
+    @test c_in isa ForwardDiff.Dual
+    @test ForwardDiff.value(c_in) == 1.0
+    @test ForwardDiff.partials(c_in)[1] == 1.0
+    c_oob = _clamp_to_grid(Dl(2.5, 1.0), cr)
+    @test c_oob isa ForwardDiff.Dual
+    @test ForwardDiff.value(c_oob) == last(cr)          # clamped to the actual endpoint
+    @test ForwardDiff.partials(c_oob)[1] == 0.0
+end
+
+@testitem "Boundary forward eval preserves duck-type (Dual query at widened endpoint)" setup = [InwardCR] begin
+    using FastInterpolations
+    import ForwardDiff
+    Dl = ForwardDiff.Dual
+    n = 5
+    y = collect(10.0:10.0:50.0)
+    crR = inward_cr_right(0.0, 2.0, n)
+    ref = collect(range(0.0, 2.0, n))
+    qd = Dl(2.0, 1.0)   # Dual query AT the true endpoint (== domain_hi, the sliver)
+
+    # Forward eval keeps the query's Dual type and value across extrap modes; the
+    # true endpoint is in-domain, so FillExtrap must NOT leak the fill value.
+    for m in (linear_interp, cubic_interp, quadratic_interp, constant_interp)
+        for E in (FillExtrap(-999.0), ClampExtrap(), NoExtrap())
+            r = m(crR, y, qd; extrap = E)
+            @test r isa ForwardDiff.Dual
+            @test ForwardDiff.value(r) ≈ m(ref, y, 2.0; extrap = E)  atol = 1.0e-7
+            @test ForwardDiff.value(r) != -999.0
+        end
+    end
+
+    # Sharp guard: the Dual partial = d(interp)/d(query). At the in-domain true
+    # endpoint it is the boundary-cell slope, NOT 0 (0 would mean the sliver was
+    # misclassified OOB and fill/clamp flattened it).
+    rL = linear_interp(crR, y, qd; extrap = FillExtrap(0.0))
+    @test ForwardDiff.partials(rL)[1] ≈ (y[end] - y[end - 1]) / crR.h  atol = 1.0e-6
+end

--- a/test/test_fillextrap_domain_boundary.jl
+++ b/test/test_fillextrap_domain_boundary.jl
@@ -1,22 +1,11 @@
 # ════════════════════════════════════════════════════════════════════════════
-# RED-phase guards: range-grid boundary OOB classification must use the
-# axis-aware *safe* domain bounds (`domain_lo`/`domain_hi`), not raw
-# `first(x)`/`last(x)`.
-#
-# Root cause: on the x86_64 `_CachedRange` fast path the stored `lo`/`hi`
-# (`first`/`last`) can round 1 ULP *inward* of the true endpoint; the widened
-# `domain_lo`/`domain_hi` are the safe cushion. Forward-eval OOB classification
-# (scalar `_anchor_loc`, one-shot, ND) reads `first/last`, so a query at the
-# *true* endpoint (== `domain_hi`) is misclassified out-of-bounds and FillExtrap
-# returns the fill value instead of the boundary value. The BATCH path is
-# already correct (it dispatches `_is_all_inbounds` on axis type), so these
-# tests pin every scalar/one-shot/ND path to agree with the batch reference.
-#
-# These tests inject a synthetic `_CachedRange` whose `hi` rounds inward and
-# whose `domain_hi` recovers the true endpoint. The struct survives the
-# `_to_float(::_CachedRange{T}, ::Type{T}) = x` identity passthrough, so the
-# bug reproduces deterministically on ANY architecture (incl. aarch64, where
-# real range inputs never trigger the x86_64 widening).
+# Range-grid boundary OOB classification must use the axis-aware widened bounds
+# (`domain_lo`/`domain_hi`), not raw `first`/`last`: on the x86_64 `_CachedRange`
+# fast path the stored `lo`/`hi` can round 1 ULP inward of the true endpoint, so a
+# query at the true endpoint (== `domain_hi`) is otherwise flagged OOB and
+# FillExtrap leaks the fill. The batch path already classifies on `domain_lo/hi`;
+# these tests pin every scalar/one-shot/ND path to it. The synthetic `_CachedRange`
+# below forces the inward rounding, so the bug reproduces on any architecture.
 # ════════════════════════════════════════════════════════════════════════════
 
 @testsnippet InwardCR begin
@@ -38,10 +27,8 @@
         return _CachedRange{Float64, Float64}(lo, hi, h, inv(h), n, prevfloat(lo), hi)
     end
 
-    # Both endpoints inward (the real x86 case where `first` AND `last` round
-    # toward the interior): stored `lo = nextfloat(true_lo)`, `hi = prevfloat(true_hi)`,
-    # `domain = [true_lo, true_hi]`. Used to mirror the KernelDensity.jl pattern
-    # (`pdf(k, k.x, k.y)` queries every grid point, incl. both boundaries).
+    # Both endpoints inward (the real x86 case): stored `lo`/`hi` round toward
+    # the interior, `domain_lo`/`domain_hi` recover the true endpoints.
     function inward_cr_both(true_lo, true_hi, n)
         lo = nextfloat(true_lo)
         hi = prevfloat(true_hi)
@@ -125,13 +112,11 @@ end
     end
 end
 
-@testitem "Boundary FillExtrap(0) — ND full-grid boundary (KernelDensity.jl pdf pattern)" setup = [InwardCR] begin
+@testitem "Boundary FillExtrap(0) — ND full-grid boundary" setup = [InwardCR] begin
     using FastInterpolations
-    # Direct mirror of the real KernelDensity.jl failure: `pdf(k, k.x, k.y)` on a
-    # 2D range grid with FillExtrap(0) returned an all-zero first row because the
-    # boundary grid point (queried at its true value) was misclassified OOB and
-    # leaked the 0 fill. Here both axes round inward (x86 fast path), fill = 0,
-    # and we evaluate the boundary rows/columns — none may collapse to 0.
+    # Both axes round inward (x86 fast path), fill = 0. A boundary grid point
+    # queried at its true value must interpolate, not collapse to the 0 fill —
+    # i.e. no boundary row/column may go all-zero.
     n = 5
     crx = inward_cr_both(0.0, 2.0, n)
     cry = inward_cr_both(0.0, 2.0, n)

--- a/test/test_fillextrap_domain_boundary.jl
+++ b/test/test_fillextrap_domain_boundary.jl
@@ -1,0 +1,191 @@
+# ════════════════════════════════════════════════════════════════════════════
+# RED-phase guards: range-grid boundary OOB classification must use the
+# axis-aware *safe* domain bounds (`domain_lo`/`domain_hi`), not raw
+# `first(x)`/`last(x)`.
+#
+# Root cause: on the x86_64 `_CachedRange` fast path the stored `lo`/`hi`
+# (`first`/`last`) can round 1 ULP *inward* of the true endpoint; the widened
+# `domain_lo`/`domain_hi` are the safe cushion. Forward-eval OOB classification
+# (scalar `_anchor_loc`, one-shot, ND) reads `first/last`, so a query at the
+# *true* endpoint (== `domain_hi`) is misclassified out-of-bounds and FillExtrap
+# returns the fill value instead of the boundary value. The BATCH path is
+# already correct (it dispatches `_is_all_inbounds` on axis type), so these
+# tests pin every scalar/one-shot/ND path to agree with the batch reference.
+#
+# These tests inject a synthetic `_CachedRange` whose `hi` rounds inward and
+# whose `domain_hi` recovers the true endpoint. The struct survives the
+# `_to_float(::_CachedRange{T}, ::Type{T}) = x` identity passthrough, so the
+# bug reproduces deterministically on ANY architecture (incl. aarch64, where
+# real range inputs never trigger the x86_64 widening).
+# ════════════════════════════════════════════════════════════════════════════
+
+@testsnippet InwardCR begin
+    using FastInterpolations: _CachedRange
+
+    # Right boundary: stored `hi = prevfloat(true_hi)` (1 ULP inward),
+    # `domain_hi = nextfloat(hi) = true_hi` (the cushion recovers it).
+    function inward_cr_right(lo, true_hi, n)
+        hi = prevfloat(true_hi)
+        h = (hi - lo) / (n - 1)
+        return _CachedRange{Float64, Float64}(lo, hi, h, inv(h), n, lo, nextfloat(hi))
+    end
+
+    # Left boundary: stored `lo = nextfloat(true_lo)` (1 ULP inward),
+    # `domain_lo = prevfloat(lo) = true_lo`.
+    function inward_cr_left(true_lo, hi, n)
+        lo = nextfloat(true_lo)
+        h = (hi - lo) / (n - 1)
+        return _CachedRange{Float64, Float64}(lo, hi, h, inv(h), n, prevfloat(lo), hi)
+    end
+
+    # Both endpoints inward (the real x86 case where `first` AND `last` round
+    # toward the interior): stored `lo = nextfloat(true_lo)`, `hi = prevfloat(true_hi)`,
+    # `domain = [true_lo, true_hi]`. Used to mirror the KernelDensity.jl pattern
+    # (`pdf(k, k.x, k.y)` queries every grid point, incl. both boundaries).
+    function inward_cr_both(true_lo, true_hi, n)
+        lo = nextfloat(true_lo)
+        hi = prevfloat(true_hi)
+        h = (hi - lo) / (n - 1)
+        return _CachedRange{Float64, Float64}(lo, hi, h, inv(h), n, prevfloat(lo), nextfloat(hi))
+    end
+end
+
+@testitem "Boundary FillExtrap — scalar persistent == batch (right endpoint)" setup = [InwardCR] begin
+    using FastInterpolations
+    n = 5
+    cr = inward_cr_right(0.0, 2.0, n)
+    y = [10.0, 20.0, 30.0, 40.0, 50.0]
+    fv = -999.0
+    true_hi = 2.0   # == cr.domain_hi, but > cr.hi
+    for m in (linear_interp, cubic_interp, quadratic_interp, constant_interp,
+            pchip_interp, cardinal_interp, akima_interp)
+        itp = m(cr, y; extrap = FillExtrap(fv))
+        scalar = itp(true_hi)
+        batch = itp([true_hi])[1]
+        @test scalar != fv                      # fill must NOT leak at the true boundary
+        @test scalar ≈ y[end]  atol = 1.0e-7    # returns the boundary value
+        @test scalar ≈ batch   atol = 1.0e-9    # scalar agrees with the correct batch path
+    end
+end
+
+@testitem "Boundary FillExtrap — scalar persistent == batch (left endpoint)" setup = [InwardCR] begin
+    using FastInterpolations
+    n = 5
+    cr = inward_cr_left(1.0, 3.0, n)
+    y = [10.0, 20.0, 30.0, 40.0, 50.0]
+    fv = -999.0
+    true_lo = 1.0   # == cr.domain_lo, but < cr.lo
+    for m in (linear_interp, cubic_interp, quadratic_interp, constant_interp,
+            pchip_interp, cardinal_interp, akima_interp)
+        itp = m(cr, y; extrap = FillExtrap(fv))
+        scalar = itp(true_lo)
+        batch = itp([true_lo])[1]
+        @test scalar != fv
+        @test scalar ≈ y[begin]  atol = 1.0e-7
+        @test scalar ≈ batch     atol = 1.0e-9
+    end
+end
+
+@testitem "Boundary FillExtrap — one-shot == batch (right endpoint)" setup = [InwardCR] begin
+    using FastInterpolations
+    n = 5
+    cr = inward_cr_right(0.0, 2.0, n)
+    y = [10.0, 20.0, 30.0, 40.0, 50.0]
+    fv = -999.0
+    true_hi = 2.0
+    for m in (linear_interp, cubic_interp, quadratic_interp, constant_interp,
+            pchip_interp, cardinal_interp, akima_interp)
+        oneshot = m(cr, y, true_hi; extrap = FillExtrap(fv))
+        batch = m(cr, y, [true_hi]; extrap = FillExtrap(fv))[1]
+        @test oneshot != fv
+        @test oneshot ≈ y[end]  atol = 1.0e-7
+        @test oneshot ≈ batch   atol = 1.0e-9
+    end
+end
+
+@testitem "Boundary FillExtrap — ND corner query returns the corner, not fill" setup = [InwardCR] begin
+    using FastInterpolations
+    n = 5
+    crx = inward_cr_right(0.0, 2.0, n)
+    cry = inward_cr_right(0.0, 2.0, n)
+    data = [10.0 * i + j for i in 1:n, j in 1:n]
+    fv = -999.0
+    corner = (2.0, 2.0)   # both axes at their true endpoint
+    for m in (linear_interp, cubic_interp, constant_interp)
+        itp = m((crx, cry), data; extrap = FillExtrap(fv))
+        scalar = itp(corner)
+        @test scalar != fv
+        @test scalar ≈ data[end, end]  atol = 1.0e-7
+    end
+end
+
+@testitem "Boundary FillExtrap(0) — ND full-grid boundary (KernelDensity.jl pdf pattern)" setup = [InwardCR] begin
+    using FastInterpolations
+    # Direct mirror of the real KernelDensity.jl failure: `pdf(k, k.x, k.y)` on a
+    # 2D range grid with FillExtrap(0) returned an all-zero first row because the
+    # boundary grid point (queried at its true value) was misclassified OOB and
+    # leaked the 0 fill. Here both axes round inward (x86 fast path), fill = 0,
+    # and we evaluate the boundary rows/columns — none may collapse to 0.
+    n = 5
+    crx = inward_cr_both(0.0, 2.0, n)
+    cry = inward_cr_both(0.0, 2.0, n)
+    data = [10.0 * i + j for i in 1:n, j in 1:n]   # every entry nonzero
+    lo, hi = 0.0, 2.0                              # == domain_lo / domain_hi
+    mid = crx[3]                                   # an interior grid point
+    for m in (linear_interp, cubic_interp, constant_interp)
+        itp = m((crx, cry), data; extrap = FillExtrap(0.0))
+        # Four corners return the corner density (not the 0 fill).
+        @test itp((lo, lo)) ≈ data[1, 1]  atol = 1.0e-7
+        @test itp((lo, hi)) ≈ data[1, n]  atol = 1.0e-7
+        @test itp((hi, lo)) ≈ data[n, 1]  atol = 1.0e-7
+        @test itp((hi, hi)) ≈ data[n, n]  atol = 1.0e-7
+        # Boundary edges (one axis at the true endpoint) — the "first row/column"
+        # case: must interpolate, not collapse to the 0 fill.
+        @test itp((lo, mid)) != 0.0
+        @test itp((hi, mid)) != 0.0
+        @test itp((mid, lo)) != 0.0
+        @test itp((mid, hi)) != 0.0
+    end
+end
+
+@testitem "Boundary FillExtrap — scalar and batch must not disagree" setup = [InwardCR] begin
+    using FastInterpolations
+    # The sharpest statement of the bug: the same interpolant returns the fill
+    # value for a scalar query but the boundary value for the batch of one.
+    n = 5
+    y = [10.0, 20.0, 30.0, 40.0, 50.0]
+    fv = -999.0
+    crR = inward_cr_right(0.0, 2.0, n)
+    itpR = linear_interp(crR, y; extrap = FillExtrap(fv))
+    @test itpR(2.0) ≈ itpR([2.0])[1]  atol = 1.0e-9
+    crL = inward_cr_left(1.0, 3.0, n)
+    itpL = linear_interp(crL, y; extrap = FillExtrap(fv))
+    @test itpL(1.0) ≈ itpL([1.0])[1]  atol = 1.0e-9
+end
+
+@testitem "Boundary WrapExtrap — true endpoint is in-domain (returns y[end])" setup = [InwardCR] begin
+    using FastInterpolations
+    # WrapExtrap shares the same `first/last` classification: a query at the
+    # true endpoint must be treated as the closed-domain boundary (y[end]),
+    # not wrapped back to y[1].
+    n = 5
+    cr = inward_cr_right(0.0, 2.0, n)
+    y = [10.0, 20.0, 30.0, 40.0, 50.0]
+    scalar = linear_interp(cr, y, 2.0; extrap = WrapExtrap())
+    batch = linear_interp(cr, y, [2.0]; extrap = WrapExtrap())[1]
+    @test scalar ≈ y[end]  atol = 1.0e-7
+    @test scalar ≈ batch   atol = 1.0e-9
+end
+
+@testitem "Boundary derivative — slope at the true endpoint, not zero" setup = [InwardCR] begin
+    using FastInterpolations
+    # ClampExtrap value is correct either way (y[end]), but the DERIVATIVE
+    # exposes the misclassification: OOB-clamp yields a flat (zero) derivative,
+    # while the correct in-domain classification yields the boundary slope.
+    n = 5
+    cr = inward_cr_right(0.0, 2.0, n)
+    y = [10.0, 20.0, 30.0, 40.0, 50.0]
+    g = linear_interp(cr, y, 2.0; extrap = ClampExtrap(), deriv = DerivOp(1))
+    @test g != 0.0
+    @test g ≈ (y[end] - y[end - 1]) / cr.h  atol = 1.0e-6
+end

--- a/test/test_fillextrap_domain_boundary.jl
+++ b/test/test_fillextrap_domain_boundary.jl
@@ -57,8 +57,10 @@ end
     y = [10.0, 20.0, 30.0, 40.0, 50.0]
     fv = -999.0
     true_hi = 2.0   # == cr.domain_hi, but > cr.hi
-    for m in (linear_interp, cubic_interp, quadratic_interp, constant_interp,
-            pchip_interp, cardinal_interp, akima_interp)
+    for m in (
+            linear_interp, cubic_interp, quadratic_interp, constant_interp,
+            pchip_interp, cardinal_interp, akima_interp,
+        )
         itp = m(cr, y; extrap = FillExtrap(fv))
         scalar = itp(true_hi)
         batch = itp([true_hi])[1]
@@ -75,8 +77,10 @@ end
     y = [10.0, 20.0, 30.0, 40.0, 50.0]
     fv = -999.0
     true_lo = 1.0   # == cr.domain_lo, but < cr.lo
-    for m in (linear_interp, cubic_interp, quadratic_interp, constant_interp,
-            pchip_interp, cardinal_interp, akima_interp)
+    for m in (
+            linear_interp, cubic_interp, quadratic_interp, constant_interp,
+            pchip_interp, cardinal_interp, akima_interp,
+        )
         itp = m(cr, y; extrap = FillExtrap(fv))
         scalar = itp(true_lo)
         batch = itp([true_lo])[1]
@@ -93,8 +97,10 @@ end
     y = [10.0, 20.0, 30.0, 40.0, 50.0]
     fv = -999.0
     true_hi = 2.0
-    for m in (linear_interp, cubic_interp, quadratic_interp, constant_interp,
-            pchip_interp, cardinal_interp, akima_interp)
+    for m in (
+            linear_interp, cubic_interp, quadratic_interp, constant_interp,
+            pchip_interp, cardinal_interp, akima_interp,
+        )
         oneshot = m(cr, y, true_hi; extrap = FillExtrap(fv))
         batch = m(cr, y, [true_hi]; extrap = FillExtrap(fv))[1]
         @test oneshot != fv

--- a/test/test_fillextrap_domain_boundary.jl
+++ b/test/test_fillextrap_domain_boundary.jl
@@ -189,3 +189,37 @@ end
     @test g != 0.0
     @test g ≈ (y[end] - y[end - 1]) / cr.h  atol = 1.0e-6
 end
+
+@testitem "Boundary Series — true endpoint returns the boundary curve" setup = [InwardCR] begin
+    using FastInterpolations
+    # Series interpolants classify via `_anchor_loc`, so a query at the true
+    # `_CachedRange` endpoint returns the boundary curve (matches the exact
+    # Vector grid), not an OOB result. Regression guard for the inherited fix.
+    n = 5
+    Y = [10.0 * i + j for i in 1:n, j in 1:2]
+    crL = inward_cr_left(1.0, 3.0, n)
+    refL = collect(range(1.0, 3.0, n))
+    crR = inward_cr_right(0.0, 2.0, n)
+    refR = collect(range(0.0, 2.0, n))
+    for m in (linear_interp, quadratic_interp, cubic_interp, constant_interp)
+        @test m(crL, Series(Y))(1.0) ≈ m(refL, Series(Y))(1.0)  atol = 1.0e-7
+        @test m(crR, Series(Y))(2.0) ≈ m(refR, Series(Y))(2.0)  atol = 1.0e-7
+    end
+end
+
+@testitem "Boundary exclusive-periodic — true endpoint uses first cell, not seam" setup = [InwardCR] begin
+    using FastInterpolations
+    # Inner `_CachedRange` with an inward-rounded left endpoint (lo = nextfloat(0),
+    # domain_lo = 0). Under `:exclusive` PeriodicBC the inner's widening does not
+    # reach `_ExclusivePeriodicAxis` classification, so the true left endpoint was
+    # wrapped to the seam cell. Value is y[1] either way; the derivative is the
+    # sharp guard — it must be the FIRST-cell slope, not the seam-cell slope.
+    cr = inward_cr_left(0.0, 1.0, 2)
+    xref = [0.0, 1.0]
+    y = [10.0, 30.0]
+    bc = PeriodicBC(endpoint = :exclusive, period = 2.0)
+    @test linear_interp(cr, y, 0.0; bc = bc) ≈
+        linear_interp(xref, y, 0.0; bc = bc)  atol = 1.0e-9
+    @test linear_interp(cr, y, 0.0; bc = bc, deriv = DerivOp(1)) ≈
+        linear_interp(xref, y, 0.0; bc = bc, deriv = DerivOp(1))  atol = 1.0e-9
+end


### PR DESCRIPTION
## Summary

A query at the true endpoint of a range grid could be misclassified out-of-bounds, so `FillExtrap` returned the fill value instead of the boundary value. This routes every out-of-bounds decision through one axis-aware classifier and adds boundary regression tests.

## Root cause

On x86_64, `_CachedRange` collapses a `StepRangeLen{TwicePrecision}` into plain scalar `lo`/`hi`, which can land ~1 ULP inward of the true endpoint; the struct already stored widened bounds (`domain_lo`/`domain_hi`) for this. The batch path used them and was correct, but the scalar / one-shot / ND / adjoint paths classified against raw `first`/`last`, so a query at the true endpoint was flagged OOB — leaking the fill (and giving a flat boundary derivative under `ClampExtrap`, wrapping to `y[1]` under `WrapExtrap`, or an all-zero adjoint row).

## Fix

A single classifier for "in domain, and if not which side?": `_domain_bounds` (widened for `_CachedRange`, exact otherwise), with `_oob_state` / `_is_inbounds` reading it and `_clamp_to_grid` clamping to the actual endpoints. Classification uses the widened bounds; all geometry (search, weights, clamp target, wrap period) stays on the actual endpoints, so the cushion never leaks into a coordinate. Every scalar / one-shot / ND / adjoint site routes through these.

## Refactor

The linear/constant/cubic adjoint constructors built ClampExtrap/FillExtrap anchors in three passes (clamp broadcast + anchor + fixup); these are fused into one `_bake_*_clampfill_anchors` loop, dropping the temp array. Behavior is unchanged; only construction-time work is reduced.

## Tests

`test/test_fillextrap_domain_boundary.jl` (forward scalar/one-shot/ND/Series, derivative, Wrap, exclusive-periodic) and `test/test_fillextrap_adjoint_boundary.jl` (sensitivity-row sum, NoExtrap acceptance, reverse-matches-forward, transpose-identity golden rule), both on a synthetic inward-rounded `_CachedRange`.