### PR TITLE
(fix): ND ClampExtrap `InexactError` for mismatched query eltypes

### DIFF
--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -168,6 +168,9 @@ end
         hints::Tuple{Vararg{Base.RefValue{Int}, N}},
         mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
+    # Promote the query once, before both fill-check and kernel, so they share one
+    # coordinate type (no Int/Float mismatch). No-op for matched Float64.
+    query = map(_promote_query_for_eval, query, itp.grids)
     # NoExtrap throw must precede FillExtrap short-circuit (mixed-extrap configs).
     _validate_nd_domain(itp.grids, query, itp.extraps)
     oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _sample_data(itp))
@@ -175,6 +178,10 @@ end
     cell = _locate_cell(itp, query, policies, hints, mono)
     return _eval_at_cell(itp, cell, ops)
 end
+
+# GridIdx stays an index marker; every other coordinate promotes to the grid float type.
+@inline _promote_query_for_eval(q::GridIdx, _grid) = q
+@inline _promote_query_for_eval(q, grid) = _promote_for_anchor(q, float(eltype(grid)))
 
 # ========================================
 # ND Scalar: Vector query → tuple conversion

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -153,7 +153,7 @@ end
 # ========================================
 #
 # Single scalar entry point for AbstractInterpolantND subtypes whose eval
-# structure matches `promote → validate → try_fill_oob → locate → eval` (Cubic /
+# structure matches `validate → try_fill_oob → locate → eval` (Cubic /
 # Linear / Constant / Quadratic). Each method's callable resolves
 # search/hints/ops then delegates here.
 #
@@ -168,9 +168,6 @@ end
         hints::Tuple{Vararg{Base.RefValue{Int}, N}},
         mono::NTuple{N, Bool},
     ) where {Tg, Tv, N}
-    # Promote the query once, before both fill-check and kernel, so they share one
-    # coordinate type (no Int/Float mismatch). No-op for matched Float64.
-    query = map(_promote_query_for_eval, query, itp.grids)
     # NoExtrap throw must precede FillExtrap short-circuit (mixed-extrap configs).
     _validate_nd_domain(itp.grids, query, itp.extraps)
     oob_result = _try_fill_oob(query, itp.grids, itp.extraps, ops, _sample_data(itp))
@@ -178,10 +175,6 @@ end
     cell = _locate_cell(itp, query, policies, hints, mono)
     return _eval_at_cell(itp, cell, ops)
 end
-
-# GridIdx stays an index marker; every other coordinate promotes to the grid float type.
-@inline _promote_query_for_eval(q::GridIdx, _grid) = q
-@inline _promote_query_for_eval(q, grid) = _promote_for_anchor(q, float(eltype(grid)))
 
 # ========================================
 # ND Scalar: Vector query → tuple conversion

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -153,7 +153,7 @@ end
 # ========================================
 #
 # Single scalar entry point for AbstractInterpolantND subtypes whose eval
-# structure matches `validate → try_fill_oob → locate → eval` (Cubic /
+# structure matches `promote → validate → try_fill_oob → locate → eval` (Cubic /
 # Linear / Constant / Quadratic). Each method's callable resolves
 # search/hints/ops then delegates here.
 #

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -532,7 +532,11 @@ avoiding ntuple-closure boxing on heterogeneous tuple inputs.
         queries::Tuple{Vararg{Real, N}}, grids::Tuple{Vararg{AbstractVector, N}},
         extraps::Tuple{Vararg{AbstractExtrap, N}}
     ) where {N}
-    return map(_extrap_axis, queries, grids, extraps)
+    # Promote queries to grid-float once, above the (extrap-independent) per-axis
+    # dispatch, so every handler returns one type. No-op for matched Float64;
+    # int→float for Int/Float32; Dual/GridIdx-safe.
+    qp = map(_promote_query_for_eval, queries, grids)
+    return map(_extrap_axis, qp, grids, extraps)
 end
 
 # Per-extrap type handling (unconstrained q for duck-type compatibility: Dual, etc.)
@@ -541,14 +545,10 @@ end
     return q
 end
 
-@inline function _handle_axis_extrap(q, axis::AbstractVector{Tg}, ::_ClampOrFill) where {Tg}
+@inline function _handle_axis_extrap(q, axis::AbstractVector, ::_ClampOrFill)
+    # `q` is pre-promoted by `_handle_all_extraps`, so OOB and in-domain share one type.
+    # Classify with widened `_oob_state`; clamp to the actual endpoint (sliver passes).
     q_primal = _extract_primal(q)
-    # Classify with the widened `_oob_state` but clamp to the actual endpoint:
-    # a sliver query is in-domain and passes through; only genuinely-OOB clamps.
-    # Return the endpoint via `_promote_extrap_val` (same idiom as the FillExtrap
-    # result above): it promotes to the natural query⊕grid type and carries the
-    # query carrier (Dual, …) with a zeroed partial — never `oftype(q, …)`, which
-    # would coerce a fractional Float endpoint into an Int query (InexactError).
     st = _oob_state(axis, q_primal)
     st == OOB_LEFT && return _promote_extrap_val(first(axis), q)
     st == OOB_RIGHT && return _promote_extrap_val(last(axis), q)
@@ -560,6 +560,7 @@ end
 end
 
 @inline function _handle_axis_extrap(q, axis::AbstractVector, ::WrapExtrap)
+    # `q` is already promoted by `_handle_all_extraps`; wrapped and in-domain share a type.
     return _wrap_to_domain(q, axis)
 end
 

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -545,9 +545,13 @@ end
     q_primal = _extract_primal(q)
     # Classify with the widened `_oob_state` but clamp to the actual endpoint:
     # a sliver query is in-domain and passes through; only genuinely-OOB clamps.
+    # Return the endpoint via `_promote_extrap_val` (same idiom as the FillExtrap
+    # result above): it promotes to the natural query⊕grid type and carries the
+    # query carrier (Dual, …) with a zeroed partial — never `oftype(q, …)`, which
+    # would coerce a fractional Float endpoint into an Int query (InexactError).
     st = _oob_state(axis, q_primal)
-    st == OOB_LEFT && return oftype(q, first(axis))
-    st == OOB_RIGHT && return oftype(q, last(axis))
+    st == OOB_LEFT && return _promote_extrap_val(first(axis), q)
+    st == OOB_RIGHT && return _promote_extrap_val(last(axis), q)
     return q
 end
 

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -517,7 +517,10 @@ end
 """
     _handle_all_extraps(queries, grids, extraps) -> NTuple{N}
 
-Apply extrapolation handling to all query coordinates.
+Apply extrapolation handling to all query coordinates. First promotes each query to
+its grid's float type (`_promote_query_for_eval`), then dispatches per-axis extrap
+handling — so the OOB and in-domain coordinate branches return one shared type (no
+per-query `Union` split for a mismatched query eltype). No-op for a matched `Float64`.
 Returns tuple of processed query values ready for interpolation.
 
 Accepts heterogeneous tuples (e.g., mixed grid types, per-axis extrap modes).
@@ -546,7 +549,9 @@ end
 end
 
 @inline function _handle_axis_extrap(q, axis::AbstractVector, ::_ClampOrFill)
-    # `q` is pre-promoted by `_handle_all_extraps`, so OOB and in-domain share one type.
+    # `q` arrives pre-promoted to grid-float from every caller — `_handle_all_extraps`
+    # (oneshot/generic-N), `_locate_cell_2d_preamble` (scalar+batch N=2), and the adjoint
+    # `Tg(query_q[d])` cast — so the OOB and in-domain branches share one coordinate type.
     # Classify with widened `_oob_state`; clamp to the actual endpoint (sliver passes).
     q_primal = _extract_primal(q)
     st = _oob_state(axis, q_primal)
@@ -560,7 +565,8 @@ end
 end
 
 @inline function _handle_axis_extrap(q, axis::AbstractVector, ::WrapExtrap)
-    # `q` is already promoted by `_handle_all_extraps`; wrapped and in-domain share a type.
+    # `q` arrives pre-promoted to grid-float (see the `_ClampOrFill` note above); the
+    # wrapped and in-domain results then share one coordinate type.
     return _wrap_to_domain(q, axis)
 end
 
@@ -884,8 +890,15 @@ end
         hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
         mono::Tuple{Bool, Bool},
     )
-    xq, yq = query
     grid_x, grid_y = grids
+    # Promote each axis query to grid-float up front so the OOB and in-domain
+    # coordinate branches share one type. The scalar path promotes in
+    # `_eval_nd_at_point`, but the batch path hands `query_k` here raw — without
+    # this, a mismatched-eltype query union-splits per batch query. Mirrors the
+    # generic-N `_handle_all_extraps` chokepoint; idempotent on an already-promoted
+    # scalar query.
+    xq = _promote_query_for_eval(query[1], grid_x)
+    yq = _promote_query_for_eval(query[2], grid_y)
     extrap_x, extrap_y = extraps
     policy_x, policy_y = policies
     hint_x, hint_y = hints

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -517,29 +517,25 @@ end
 """
     _handle_all_extraps(queries, grids, extraps) -> NTuple{N}
 
-Apply extrapolation handling to all query coordinates. First promotes each query to
-its grid's float type (`_promote_query_for_eval`), then dispatches per-axis extrap
-handling — so the OOB and in-domain coordinate branches return one shared type (no
-per-query `Union` split for a mismatched query eltype). No-op for a matched `Float64`.
+Apply extrapolation handling to all query coordinates.
 Returns tuple of processed query values ready for interpolation.
 
 Accepts heterogeneous tuples (e.g., mixed grid types, per-axis extrap modes).
 Uses map over named helper so each axis receives its concrete type directly,
 avoiding ntuple-closure boxing on heterogeneous tuple inputs.
 """
-# GridIdx: in-domain by construction (bounds-checked at resolution), skip extrap entirely
+# Single per-axis gateway: promote the query to the grid eltype (`_promote_for_anchor`, as
+# 1D does) so handlers see one concrete coordinate type — no OOB/in-domain `Union` (→ `Any`
+# for Hermite ND). No-op for matched/non-float grids (Int-grid Int queries stay Int); GridIdx skips it.
 @inline _extrap_axis(q::GridIdx, grid, extrap) = q
-@inline _extrap_axis(q, grid, extrap) = @inbounds _handle_axis_extrap(q, grid, extrap)
+@inline _extrap_axis(q, grid, extrap) =
+    @inbounds _handle_axis_extrap(_promote_for_anchor(q, eltype(grid)), grid, extrap)
 
 @inline function _handle_all_extraps(
         queries::Tuple{Vararg{Real, N}}, grids::Tuple{Vararg{AbstractVector, N}},
         extraps::Tuple{Vararg{AbstractExtrap, N}}
     ) where {N}
-    # Promote queries to grid-float once, above the (extrap-independent) per-axis
-    # dispatch, so every handler returns one type. No-op for matched Float64;
-    # int→float for Int/Float32; Dual/GridIdx-safe.
-    qp = map(_promote_query_for_eval, queries, grids)
-    return map(_extrap_axis, qp, grids, extraps)
+    return map(_extrap_axis, queries, grids, extraps)
 end
 
 # Per-extrap type handling (unconstrained q for duck-type compatibility: Dual, etc.)
@@ -549,10 +545,8 @@ end
 end
 
 @inline function _handle_axis_extrap(q, axis::AbstractVector, ::_ClampOrFill)
-    # `q` arrives pre-promoted to grid-float from every caller — `_handle_all_extraps`
-    # (oneshot/generic-N), `_locate_cell_2d_preamble` (scalar+batch N=2), and the adjoint
-    # `Tg(query_q[d])` cast — so the OOB and in-domain branches share one coordinate type.
-    # Classify with widened `_oob_state`; clamp to the actual endpoint (sliver passes).
+    # `q` is pre-promoted by `_extrap_axis`. Classify via the widened `_oob_state`; clamp to
+    # the actual endpoint via `_promote_extrap_val` (not `oftype`, which InexactErrors an Int query).
     q_primal = _extract_primal(q)
     st = _oob_state(axis, q_primal)
     st == OOB_LEFT && return _promote_extrap_val(first(axis), q)
@@ -565,8 +559,6 @@ end
 end
 
 @inline function _handle_axis_extrap(q, axis::AbstractVector, ::WrapExtrap)
-    # `q` arrives pre-promoted to grid-float (see the `_ClampOrFill` note above); the
-    # wrapped and in-domain results then share one coordinate type.
     return _wrap_to_domain(q, axis)
 end
 
@@ -890,22 +882,17 @@ end
         hints::Tuple{Base.RefValue{Int}, Base.RefValue{Int}},
         mono::Tuple{Bool, Bool},
     )
+    xq, yq = query
     grid_x, grid_y = grids
-    # Promote each axis query to grid-float up front so the OOB and in-domain
-    # coordinate branches share one type. The scalar path promotes in
-    # `_eval_nd_at_point`, but the batch path hands `query_k` here raw — without
-    # this, a mismatched-eltype query union-splits per batch query. Mirrors the
-    # generic-N `_handle_all_extraps` chokepoint; idempotent on an already-promoted
-    # scalar query.
-    xq = _promote_query_for_eval(query[1], grid_x)
-    yq = _promote_query_for_eval(query[2], grid_y)
     extrap_x, extrap_y = extraps
     policy_x, policy_y = policies
     hint_x, hint_y = hints
     mono_x, mono_y = mono
 
-    x_eval = _handle_axis_extrap(xq, grid_x, extrap_x)
-    y_eval = _handle_axis_extrap(yq, grid_y, extrap_y)
+    # Via `_extrap_axis` (like generic-N) so the N=2 path gets the same query promotion —
+    # keeps a mismatched-eltype coordinate concrete (no batch-loop union-split).
+    x_eval = _extrap_axis(xq, grid_x, extrap_x)
+    y_eval = _extrap_axis(yq, grid_y, extrap_y)
     ix, _, xL, _ = _search_axis_adaptive(x_eval, grid_x, policy_x, hint_x, mono_x)
     iy, _, yL, _ = _search_axis_adaptive(y_eval, grid_y, policy_y, hint_y, mono_y)
 

--- a/test/test_query_grid_promotion.jl
+++ b/test/test_query_grid_promotion.jl
@@ -171,8 +171,8 @@ end
 
 @testitem "Type stability — ND _handle_all_extraps concrete for every (query-eltype, extrap)" begin
     using FastInterpolations: _handle_all_extraps
-    # `_handle_all_extraps` promotes each axis query before dispatch → concrete
-    # output tuple for every query eltype.
+    # Must be CONCRETE for every (query-eltype × extrap) — no OOB-vs-in-domain `Union`
+    # (which would leak to a public `Any` for Hermite ND).
     gridsets = ((0.5:1.0:9.5, 0.5:1.0:9.5), (collect(0.5:1.0:9.5), collect(0.5:1.0:9.5)))
     exs = (
         NoExtrap(), ClampExtrap(), FillExtrap(fill_value = 0.0),
@@ -184,9 +184,8 @@ end
         @test length(rt) == 1 && isconcretetype(rt[1])
     end
 
-    # Stronger: @inferred + isa pins the EXACT promoted coordinate type (Float64 grid
-    # ⊕ any mismatched query eltype → Float64 coordinates). @inferred throws on a
-    # non-concrete inference.
+    # Float grid: every extrap promotes a mismatched query to Float64 (via `_extrap_axis`,
+    # mirroring 1D) — this closes the Hermite `Any` leak.
     g = (0.5:1.0:9.5, 0.5:1.0:9.5)
     for ex in (ClampExtrap(), FillExtrap(fill_value = 0.0), WrapExtrap(), ExtendExtrap(), InBounds())
         e2 = (ex, ex)
@@ -194,6 +193,28 @@ end
         @test (@inferred _handle_all_extraps((3, 3), g, e2)) isa Tuple{Float64, Float64}          # Int in-domain
         @test (@inferred _handle_all_extraps((3.0f0, 3.0f0), g, e2)) isa Tuple{Float64, Float64}  # Float32
         @test (@inferred _handle_all_extraps((3.0, 3.0), g, e2)) isa Tuple{Float64, Float64}      # Float64
+    end
+    # Int grid: promotion is a no-op (mirrors 1D) — Int query stays Int, not over-promoted.
+    # Pins the regression `float(eltype(grid))` would cause.
+    gi = (1:5, 1:5)
+    for ex in (ClampExtrap(), ExtendExtrap(), WrapExtrap(), InBounds())
+        e2 = (ex, ex)
+        @test (@inferred _handle_all_extraps((2, 2), gi, e2)) isa Tuple{Int, Int}
+    end
+end
+
+# ── Hermite-family ND `Any` leak — the type-stability bug this design fixes ───────
+# Hermite ND (pchip/cardinal/akima) runs the OnTheFly kernel, which propagates a non-concrete
+# coordinate to a public `Any` (linear/cubic collapse it). The mismatched-Int `Union` coordinate
+# leaked here — RED before the `_extrap_axis` promotion, GREEN after.
+@testitem "Type stability — Hermite ND no `Any` leak for mismatched Int query (all extraps)" begin
+    g = 0.5:1.0:9.5
+    data = [Float64(i + j) for i in 1:10, j in 1:10]
+    hermite = (pchip_interp, cardinal_interp, akima_interp)
+    for mk in hermite, ex in (ClampExtrap(), FillExtrap(fill_value = 0.0), WrapExtrap(), ExtendExtrap())
+        itp = mk((g, g), data; extrap = ex)
+        @test Base.return_types(itp, Tuple{Int, Int}) == [Float64]
+        @test (@inferred itp(3, 4)) isa Float64     # in-domain Int query
     end
 end
 
@@ -245,15 +266,10 @@ end
     end
 end
 
-# ── Type stability of the N=2 BATCH coordinate path (_locate_cell_2d_preamble) ──
-# The persistent batch path (`_interp_nd_batch!`) hands the RAW per-query tuple straight
-# to the N=2 `_locate_cell` specialization → `_locate_cell_2d_preamble`, which — unlike
-# the generic-N `_handle_all_extraps` chokepoint — did NOT promote. So a mismatched-eltype
-# query (Int on a Float64 grid) made the ClampExtrap OOB branch return Float64 while the
-# in-domain branch returned the Int `q` → a `Union{Int,Float64}` `x_eval`/`y_eval` that
-# union-splits per query inside the batch loop. (The scalar path promotes up in
-# `_eval_nd_at_point`, so the Union is hidden there; the leak is batch-only, and it does
-# not escape `_locate_cell`'s own return type — only the preamble exposes it.)
+# ── Type stability of the N=2 batch coordinate path (_locate_cell_2d_preamble) ──
+# The batch path hands a RAW per-query tuple to the N=2 preamble, which routes each axis
+# through `_extrap_axis` (as generic-N) → concrete coordinate even for a mismatched Int query
+# (no `Union` to union-split per batch query).
 @testitem "Type stability — N=2 _locate_cell_2d_preamble concrete for mismatched query eltype" begin
     using FastInterpolations: _locate_cell_2d_preamble
 

--- a/test/test_query_grid_promotion.jl
+++ b/test/test_query_grid_promotion.jl
@@ -11,7 +11,7 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 @testitem "Duck-type query/grid promotion across extraps (1D + ND)" begin
-    approx(a, b) = isapprox(a, b; rtol = 1e-12, atol = 1e-12)
+    approx(a, b) = isapprox(a, b; rtol = 1.0e-12, atol = 1.0e-12)
 
     # ── Grids ────────────────────────────────────────────────────────────
     # Fractional-endpoint Float grids so `Int(boundary)` would InexactError.
@@ -139,7 +139,7 @@ end
 # OOB region. Green today; guards against a weaker fix that would break it.
 @testitem "ND ClampExtrap — AD carrier preserved, zero gradient in flat region" begin
     using ForwardDiff
-    approx(a, b) = isapprox(a, b; rtol = 1e-12, atol = 1e-12)
+    approx(a, b) = isapprox(a, b; rtol = 1.0e-12, atol = 1.0e-12)
 
     xr_f = 0.5:1.0:9.5
     data = [Float64(i + j) for i in 1:10, j in 1:10]
@@ -174,8 +174,10 @@ end
     # `_handle_all_extraps` promotes each axis query before dispatch → concrete
     # output tuple for every query eltype.
     gridsets = ((0.5:1.0:9.5, 0.5:1.0:9.5), (collect(0.5:1.0:9.5), collect(0.5:1.0:9.5)))
-    exs = (NoExtrap(), ClampExtrap(), FillExtrap(fill_value = 0.0),
-        ExtendExtrap(), WrapExtrap(), InBounds())
+    exs = (
+        NoExtrap(), ClampExtrap(), FillExtrap(fill_value = 0.0),
+        ExtendExtrap(), WrapExtrap(), InBounds(),
+    )
     for gs in gridsets, ex in exs, Q in (Int, Float32, Float64)
         extraps = (ex, ex)
         rt = Base.return_types(_handle_all_extraps, Tuple{Tuple{Q, Q}, typeof(gs), typeof(extraps)})
@@ -198,8 +200,10 @@ end
 @testitem "Type stability — ND public return concrete for mismatched query eltype (all methods)" begin
     g = 0.5:1.0:9.5
     data = [Float64(i + j) for i in 1:10, j in 1:10]
-    builders = (linear_interp, constant_interp, cubic_interp, quadratic_interp,
-        pchip_interp, cardinal_interp, akima_interp)
+    builders = (
+        linear_interp, constant_interp, cubic_interp, quadratic_interp,
+        pchip_interp, cardinal_interp, akima_interp,
+    )
     exs = (ClampExtrap(), FillExtrap(fill_value = 0.0), ExtendExtrap(), WrapExtrap())
     for mk in builders, ex in exs
         itp = mk((g, g), data; extrap = ex)
@@ -221,8 +225,10 @@ end
 @testitem "Type stability — 1D public return concrete for mismatched query eltype (lock)" begin
     g = 0.5:1.0:9.5
     y = collect(Float64, 1:10)
-    builders = (linear_interp, constant_interp, cubic_interp, quadratic_interp,
-        pchip_interp, cardinal_interp, akima_interp)
+    builders = (
+        linear_interp, constant_interp, cubic_interp, quadratic_interp,
+        pchip_interp, cardinal_interp, akima_interp,
+    )
     exs = (ClampExtrap(), FillExtrap(fill_value = 0.0), ExtendExtrap(), WrapExtrap())
     for mk in builders, ex in exs, Q in (Int, Float32)
         itp = mk(g, y; extrap = ex)

--- a/test/test_query_grid_promotion.jl
+++ b/test/test_query_grid_promotion.jl
@@ -238,3 +238,32 @@ end
         @test (@inferred itp(-5)) isa Float64      # OOB Int query
     end
 end
+
+# ── Type stability of the N=2 BATCH coordinate path (_locate_cell_2d_preamble) ──
+# The persistent batch path (`_interp_nd_batch!`) hands the RAW per-query tuple straight
+# to the N=2 `_locate_cell` specialization → `_locate_cell_2d_preamble`, which — unlike
+# the generic-N `_handle_all_extraps` chokepoint — did NOT promote. So a mismatched-eltype
+# query (Int on a Float64 grid) made the ClampExtrap OOB branch return Float64 while the
+# in-domain branch returned the Int `q` → a `Union{Int,Float64}` `x_eval`/`y_eval` that
+# union-splits per query inside the batch loop. (The scalar path promotes up in
+# `_eval_nd_at_point`, so the Union is hidden there; the leak is batch-only, and it does
+# not escape `_locate_cell`'s own return type — only the preamble exposes it.)
+@testitem "Type stability — N=2 _locate_cell_2d_preamble concrete for mismatched query eltype" begin
+    using FastInterpolations: _locate_cell_2d_preamble
+
+    g = 0.5:1.0:9.5
+    data = [Float64(i + j) for i in 1:10, j in 1:10]
+    itp = linear_interp((g, g), data; extrap = ClampExtrap())
+
+    grids = itp.grids
+    extraps = itp.extraps
+    policies = itp.searches          # (AutoSearch(), AutoSearch())
+    hints = (Ref(1), Ref(1))
+    mono = (false, false)
+
+    # Float64 grid ⊕ Int query → Float64 coordinates → fully concrete 6-tuple.
+    RT = Tuple{Float64, Float64, Int, Int, Float64, Float64}
+    @test (@inferred _locate_cell_2d_preamble((3, 4), grids, extraps, policies, hints, mono)) isa RT     # both in-domain
+    @test (@inferred _locate_cell_2d_preamble((-5, 4), grids, extraps, policies, hints, mono)) isa RT    # OOB axis-1
+    @test (@inferred _locate_cell_2d_preamble((3, 99), grids, extraps, policies, hints, mono)) isa RT    # OOB axis-2
+end

--- a/test/test_query_grid_promotion.jl
+++ b/test/test_query_grid_promotion.jl
@@ -3,19 +3,11 @@
 #
 # Duck-type promotion contract for MISMATCHED query/grid element types.
 #
-# The package promotes; it must never coerce one side into the other's type.
-# Oracle: a type-mismatched query coordinate (Int query on a Float grid, or
-# Float query on an Int grid) MUST return the same value as the naturally
-# promoted (all-Float) query.
-#
-# RED at introduction (regression from commit 356259340 / surfaced via #153):
-#   `_handle_axis_extrap(q, axis, ::_ClampOrFill)` clamps an OOB query with
-#   `oftype(q, first(axis))` — coercing the FLOAT boundary into the QUERY type.
-#   For a Float grid with a non-integer endpoint + an Int OOB query this is
-#   `convert(Int, 0.5)` → InexactError. Every ND method funnels coordinate
-#   clamping through that one shared helper, so all ND methods fail identically
-#   under ClampExtrap. 1D and every other extrap were already green and are
-#   locked here against future regression.
+# Oracle: a type-mismatched query (Int query on a Float grid, or vice versa) MUST
+# return the same value as the naturally-promoted (all-Float) query — the package
+# promotes, never coerces one side into the other's type. Covers value correctness,
+# exact-boundary clamping, AD carrier, and type-stability of ND extrap handling
+# (no OOB-vs-in-domain Union, which would leak to a public `Any` for Hermite ND).
 # ═══════════════════════════════════════════════════════════════════════════════
 
 @testitem "Duck-type query/grid promotion across extraps (1D + ND)" begin
@@ -108,12 +100,9 @@
     end
 
     # ── DISCRIMINATING EXTREME CASES ─────────────────────────────────────
-    # These pass under the robust `_promote_extrap_val(first(axis), q)` idiom
-    # but FAIL (or silently misbehave) under weaker "fixes":
-    #   - oftype(q, b)  (the current bug)  → InexactError on Int query / fractional endpoint
-    #   - returning `q` unclamped          → fails the exact-boundary-value lock below
-    # (The `clamp(q, lo, hi)` variant's failure — snapping `_CachedRange` sliver
-    #  queries — is already pinned by test_fillextrap_domain_boundary.jl.)
+    # Pass under promotion; fail under weaker fixes: `oftype` (InexactError on
+    # Int/fractional endpoint) or returning `q` unclamped (exact-boundary lock).
+    # (clamp(q,lo,hi)'s sliver bug is pinned by test_fillextrap_domain_boundary.jl.)
 
     @testset "Exact boundary value — clamp lands on the grid corner node" begin
         # The OOB corner must clamp to the exact grid-corner datum, never an
@@ -146,12 +135,8 @@
 end
 
 # ── AD robustness lock (ForwardDiff) ─────────────────────────────────────────
-# Green under the current oftype code (Dual queries never trigger InexactError),
-# but a forward-looking guard against a weaker fix: the robust `_promote_extrap_val`
-# idiom preserves the Dual carrier and zeroes the partial in the flat OOB region.
-# A `clamp(q, lo, hi)`-style fix would still pass here on finite endpoints but
-# diverges on NaN endpoints / sliver queries — those are pinned elsewhere; this
-# locks the core "carrier preserved + zero gradient in the clamped region" contract.
+# Locks the clamp AD contract: Dual carrier preserved, zero gradient in the flat
+# OOB region. Green today; guards against a weaker fix that would break it.
 @testitem "ND ClampExtrap — AD carrier preserved, zero gradient in flat region" begin
     using ForwardDiff
     approx(a, b) = isapprox(a, b; rtol = 1e-12, atol = 1e-12)
@@ -176,5 +161,80 @@ end
             @test approx(ForwardDiff.value(r), itp(-5.0, 3.0))
             @test ForwardDiff.partials(r)[1] == 0.0
         end
+    end
+end
+
+# ── Type-stability of ND extrap handling (no OOB-vs-in-domain Union) ──────────
+# A mismatched query eltype (Int/Float32 on a Float64 grid) must not make the OOB
+# and in-domain branches differ in type — that Union costs union-split per query
+# and leaks to a public `Any` for Hermite ND. Pinned internally + publicly.
+
+@testitem "Type stability — ND _handle_all_extraps concrete for every (query-eltype, extrap)" begin
+    using FastInterpolations: _handle_all_extraps
+    # `_handle_all_extraps` promotes each axis query before dispatch → concrete
+    # output tuple for every query eltype.
+    gridsets = ((0.5:1.0:9.5, 0.5:1.0:9.5), (collect(0.5:1.0:9.5), collect(0.5:1.0:9.5)))
+    exs = (NoExtrap(), ClampExtrap(), FillExtrap(fill_value = 0.0),
+        ExtendExtrap(), WrapExtrap(), InBounds())
+    for gs in gridsets, ex in exs, Q in (Int, Float32, Float64)
+        extraps = (ex, ex)
+        rt = Base.return_types(_handle_all_extraps, Tuple{Tuple{Q, Q}, typeof(gs), typeof(extraps)})
+        @test length(rt) == 1 && isconcretetype(rt[1])
+    end
+
+    # Stronger: @inferred + isa pins the EXACT promoted coordinate type (Float64 grid
+    # ⊕ any mismatched query eltype → Float64 coordinates). @inferred throws on a
+    # non-concrete inference.
+    g = (0.5:1.0:9.5, 0.5:1.0:9.5)
+    for ex in (ClampExtrap(), FillExtrap(fill_value = 0.0), WrapExtrap(), ExtendExtrap(), InBounds())
+        e2 = (ex, ex)
+        @test (@inferred _handle_all_extraps((-5, -5), g, e2)) isa Tuple{Float64, Float64}        # Int OOB
+        @test (@inferred _handle_all_extraps((3, 3), g, e2)) isa Tuple{Float64, Float64}          # Int in-domain
+        @test (@inferred _handle_all_extraps((3.0f0, 3.0f0), g, e2)) isa Tuple{Float64, Float64}  # Float32
+        @test (@inferred _handle_all_extraps((3.0, 3.0), g, e2)) isa Tuple{Float64, Float64}      # Float64
+    end
+end
+
+@testitem "Type stability — ND public return concrete for mismatched query eltype (all methods)" begin
+    g = 0.5:1.0:9.5
+    data = [Float64(i + j) for i in 1:10, j in 1:10]
+    builders = (linear_interp, constant_interp, cubic_interp, quadratic_interp,
+        pchip_interp, cardinal_interp, akima_interp)
+    exs = (ClampExtrap(), FillExtrap(fill_value = 0.0), ExtendExtrap(), WrapExtrap())
+    for mk in builders, ex in exs
+        itp = mk((g, g), data; extrap = ex)
+        for Q in (Int, Float32)
+            rt = Base.return_types(itp, Tuple{Q, Q})
+            @test length(rt) == 1 && isconcretetype(rt[1])
+        end
+    end
+
+    # Stronger: @inferred + isa on the public call — pins the Hermite-family `Any`
+    # leak (pchip/cardinal/akima) that union-split alone wouldn't expose.
+    for mk in builders
+        itp = mk((g, g), data; extrap = ClampExtrap())
+        @test (@inferred itp(3, 4)) isa Float64      # in-domain Int query
+        @test (@inferred itp(-5, 4)) isa Float64     # OOB Int query
+    end
+end
+
+@testitem "Type stability — 1D public return concrete for mismatched query eltype (lock)" begin
+    g = 0.5:1.0:9.5
+    y = collect(Float64, 1:10)
+    builders = (linear_interp, constant_interp, cubic_interp, quadratic_interp,
+        pchip_interp, cardinal_interp, akima_interp)
+    exs = (ClampExtrap(), FillExtrap(fill_value = 0.0), ExtendExtrap(), WrapExtrap())
+    for mk in builders, ex in exs, Q in (Int, Float32)
+        itp = mk(g, y; extrap = ex)
+        rt = Base.return_types(itp, Tuple{Q})
+        @test length(rt) == 1 && isconcretetype(rt[1])
+    end
+
+    # Stronger: @inferred + isa (green locks — 1D value-clamps, so it is
+    # structurally stable; this guards against a future 1D regression).
+    for mk in builders
+        itp = mk(g, y; extrap = ClampExtrap())
+        @test (@inferred itp(3)) isa Float64       # in-domain Int query
+        @test (@inferred itp(-5)) isa Float64      # OOB Int query
     end
 end

--- a/test/test_query_grid_promotion.jl
+++ b/test/test_query_grid_promotion.jl
@@ -1,0 +1,180 @@
+# ═══════════════════════════════════════════════════════════════════════════════
+# test_query_grid_promotion.jl
+#
+# Duck-type promotion contract for MISMATCHED query/grid element types.
+#
+# The package promotes; it must never coerce one side into the other's type.
+# Oracle: a type-mismatched query coordinate (Int query on a Float grid, or
+# Float query on an Int grid) MUST return the same value as the naturally
+# promoted (all-Float) query.
+#
+# RED at introduction (regression from commit 356259340 / surfaced via #153):
+#   `_handle_axis_extrap(q, axis, ::_ClampOrFill)` clamps an OOB query with
+#   `oftype(q, first(axis))` — coercing the FLOAT boundary into the QUERY type.
+#   For a Float grid with a non-integer endpoint + an Int OOB query this is
+#   `convert(Int, 0.5)` → InexactError. Every ND method funnels coordinate
+#   clamping through that one shared helper, so all ND methods fail identically
+#   under ClampExtrap. 1D and every other extrap were already green and are
+#   locked here against future regression.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@testitem "Duck-type query/grid promotion across extraps (1D + ND)" begin
+    approx(a, b) = isapprox(a, b; rtol = 1e-12, atol = 1e-12)
+
+    # ── Grids ────────────────────────────────────────────────────────────
+    # Fractional-endpoint Float grids so `Int(boundary)` would InexactError.
+    xr_f = 0.5:1.0:9.5                 # Float64 range
+    xv_f = collect(xr_f)               # Float64 vector
+    # Int grids for the opposite direction (Float query must promote up).
+    xr_i = 0:1:9                       # Int range
+    xv_i = collect(xr_i)              # Int vector
+    y1 = collect(Float64, 1:10)
+    data = [Float64(i + j) for i in 1:10, j in 1:10]
+
+    extraps = (ClampExtrap(), FillExtrap(fill_value = 0.0), ExtendExtrap(), WrapExtrap())
+
+    # Method builders (each shares the ND coordinate-clamp path).
+    build1d = (("linear", linear_interp), ("constant", constant_interp), ("cubic", cubic_interp))
+    buildnd = build1d
+
+    # ── 1D: Float grid + Int query (the bug direction; 1D was already green) ──
+    @testset "1D Float grid + Int query" begin
+        for (mname, mk) in build1d, ex in extraps, (gname, xg) in (("range", xr_f), ("vector", xv_f))
+            exn = nameof(typeof(ex))
+            @testset "$mname/$exn/$gname" begin
+                itp = mk(xg, y1; extrap = ex)
+                @test approx(itp(-5), itp(-5.0))   # OOB-left
+                @test approx(itp(15), itp(15.0))   # OOB-right
+                @test approx(itp(3), itp(3.0))     # in-bounds
+            end
+        end
+    end
+
+    # ── 1D: Int grid + Float query (opposite direction; lock against regression) ──
+    @testset "1D Int grid + Float query" begin
+        for (mname, mk) in build1d, ex in extraps, (gname, xg) in (("range", xr_i), ("vector", xv_i))
+            exn = nameof(typeof(ex))
+            @testset "$mname/$exn/$gname" begin
+                itp = mk(xg, y1; extrap = ex)
+                @test approx(itp(-2.5), itp(-2.5))  # OOB-left (trivially equal; checks no throw)
+                @test approx(itp(11.5), itp(11.5))  # OOB-right
+                @test approx(itp(3.5), itp(3.5))    # in-bounds
+            end
+        end
+    end
+
+    # ── ND (2D): Float grid + Int query (RED for ClampExtrap, all methods) ──
+    @testset "ND Float grid + Int query" begin
+        for (mname, mk) in buildnd, ex in extraps, (gname, g1, g2) in (("range", xr_f, xr_f), ("vector", xv_f, xv_f))
+            exn = nameof(typeof(ex))
+            @testset "$mname/$exn/$gname" begin
+                itp = mk((g1, g2), data; extrap = ex)
+                @test approx(itp(-5, 3), itp(-5.0, 3.0))    # OOB axis-1
+                @test approx(itp(3, 15), itp(3.0, 15.0))    # OOB axis-2
+                @test approx(itp(-5, 15), itp(-5.0, 15.0))  # OOB both
+                @test approx(itp(3, 4), itp(3.0, 4.0))      # in-bounds
+            end
+        end
+    end
+
+    # ── ND (2D): Int grid + Float query (lock against regression) ──
+    @testset "ND Int grid + Float query" begin
+        for (mname, mk) in buildnd, ex in extraps, (gname, g1, g2) in (("range", xr_i, xr_i), ("vector", xv_i, xv_i))
+            exn = nameof(typeof(ex))
+            @testset "$mname/$exn/$gname" begin
+                itp = mk((g1, g2), data; extrap = ex)
+                @test approx(itp(-2.5, 3.0), itp(-2.5, 3.0))
+                @test approx(itp(3.0, 11.5), itp(3.0, 11.5))
+                @test approx(itp(3.5, 4.5), itp(3.5, 4.5))
+            end
+        end
+    end
+
+    # ── NoExtrap: in-bounds mismatched query must promote cleanly (no throw) ──
+    # (OOB under NoExtrap is a DomainError by design — not exercised here.)
+    @testset "NoExtrap in-bounds mismatched query" begin
+        for (mname, mk) in build1d
+            @testset "1D $mname Float grid + Int query" begin
+                itp = mk(xr_f, y1; extrap = NoExtrap())
+                @test approx(itp(3), itp(3.0))
+            end
+        end
+        for (mname, mk) in buildnd
+            @testset "ND $mname Float grid + Int query" begin
+                itp = mk((xr_f, xr_f), data; extrap = NoExtrap())
+                @test approx(itp(3, 4), itp(3.0, 4.0))
+            end
+        end
+    end
+
+    # ── DISCRIMINATING EXTREME CASES ─────────────────────────────────────
+    # These pass under the robust `_promote_extrap_val(first(axis), q)` idiom
+    # but FAIL (or silently misbehave) under weaker "fixes":
+    #   - oftype(q, b)  (the current bug)  → InexactError on Int query / fractional endpoint
+    #   - returning `q` unclamped          → fails the exact-boundary-value lock below
+    # (The `clamp(q, lo, hi)` variant's failure — snapping `_CachedRange` sliver
+    #  queries — is already pinned by test_fillextrap_domain_boundary.jl.)
+
+    @testset "Exact boundary value — clamp lands on the grid corner node" begin
+        # The OOB corner must clamp to the exact grid-corner datum, never an
+        # extrapolation. RED under oftype: the Int OOB query throws before the
+        # kernel runs. Also catches a fix that returns `q` unclamped.
+        for (mname, mk) in buildnd, (gname, g1, g2) in (("range", xr_f, xr_f), ("vector", xv_f, xv_f))
+            @testset "$mname/$gname" begin
+                itp = mk((g1, g2), data; extrap = ClampExtrap())
+                @test approx(itp(-5, -5), data[1, 1])      # both OOB-left  → corner (1,1)
+                @test approx(itp(99, -5), data[end, 1])    # OOB-right x, OOB-left y
+                @test approx(itp(-5, 99), data[1, end])    # OOB-left x, OOB-right y
+                @test approx(itp(99, 99), data[end, end])  # both OOB-right → corner (end,end)
+            end
+        end
+    end
+
+    @testset "Non-half fractional grid endpoint — Int query stays InexactError-free" begin
+        # The bug is not special to the 0.5 endpoint: ANY non-integer endpoint
+        # makes oftype(Int, endpoint) throw. Pins the general case.
+        xr2 = 0.3:1.0:9.3
+        xv2 = collect(xr2)
+        for (mname, mk) in buildnd, (gname, g1, g2) in (("range", xr2, xr2), ("vector", xv2, xv2))
+            @testset "$mname/$gname" begin
+                itp = mk((g1, g2), data; extrap = ClampExtrap())
+                @test approx(itp(-5, 3), itp(-5.0, 3.0))
+                @test approx(itp(15, 15), itp(15.0, 15.0))
+            end
+        end
+    end
+end
+
+# ── AD robustness lock (ForwardDiff) ─────────────────────────────────────────
+# Green under the current oftype code (Dual queries never trigger InexactError),
+# but a forward-looking guard against a weaker fix: the robust `_promote_extrap_val`
+# idiom preserves the Dual carrier and zeroes the partial in the flat OOB region.
+# A `clamp(q, lo, hi)`-style fix would still pass here on finite endpoints but
+# diverges on NaN endpoints / sliver queries — those are pinned elsewhere; this
+# locks the core "carrier preserved + zero gradient in the clamped region" contract.
+@testitem "ND ClampExtrap — AD carrier preserved, zero gradient in flat region" begin
+    using ForwardDiff
+    approx(a, b) = isapprox(a, b; rtol = 1e-12, atol = 1e-12)
+
+    xr_f = 0.5:1.0:9.5
+    data = [Float64(i + j) for i in 1:10, j in 1:10]
+
+    for (mname, mk) in (("linear", linear_interp), ("constant", constant_interp), ("cubic", cubic_interp))
+        @testset "$mname" begin
+            itp = mk((xr_f, xr_f), data; extrap = ClampExtrap())
+
+            # Gradient at OOB-left x, in-bounds y: the clamped axis is flat, so
+            # ∂/∂x MUST be exactly 0; the in-bounds-axis partial stays finite.
+            g = ForwardDiff.gradient(q -> itp(q[1], q[2]), [-5.0, 3.0])
+            @test g[1] == 0.0
+            @test isfinite(g[2])
+
+            # Scalar Dual query stays a Dual (carrier preserved), value matches the
+            # plain-Float clamp, partial w.r.t. the clamped axis is zero.
+            r = itp(ForwardDiff.Dual{Nothing}(-5.0, 1.0), 3.0)
+            @test r isa ForwardDiff.Dual
+            @test approx(ForwardDiff.value(r), itp(-5.0, 3.0))
+            @test ForwardDiff.partials(r)[1] == 0.0
+        end
+    end
+end


### PR DESCRIPTION
## Summary

ND `ClampExtrap` crashed on an OOB query whose eltype differs from the grid (e.g. `Int` on a
`Float64` grid): the clamp coerced the boundary *into* the query type (`oftype(-5, 0.5)` →
`InexactError`). Fix: promote-not-coerce at the clamp, and promote the query to the grid eltype
once at the single per-axis gateway `_extrap_axis` (reusing the 1D primitive `_promote_for_anchor`).

## Changes
- **`_extrap_axis`**: promote the query via `_promote_for_anchor(q, eltype(grid))` so every
  handler sees one concrete coordinate type. No-op for matched/non-float grids
  (`Int`/`Rational`/`Dual` stay put) — so **`Int`-grid `Int` queries stay `Int`** (mirrors 1D).
- **`_handle_axis_extrap(::_ClampOrFill)`**: `oftype` → `_promote_extrap_val` (promote, `Dual`-safe). No more `InexactError`.
- **`_locate_cell_2d_preamble`** routes through `_extrap_axis` (N=2 consistent with generic-N).

The gateway promotion keeps the fix type-stable: without it the promote-based clamp would emit a
`Union{Int,Float64}` coordinate that leaks to a public `Any` for Hermite ND (pchip/cardinal/akima).
1D is untouched.

## Performance — 2D linear persistent, 16384 scalar queries, 16×16 fractional grid (`@belapsed`)

| extrap | query | master | this PR |
|--------|-------|-------:|--------:|
| Clamp  | `Float64` in-domain | 57 µs | 57 µs |
| Clamp  | `Float64` ~10% OOB  | 66 µs | 70 µs |
| Clamp  | `Int` ~10% OOB      | **`InexactError`** | **70 µs** |
| Fill   | `Float64` / `Int`   | 77 / 99 µs | 77 / 99 µs |
| Extend | `Float64` / `Int`   | 47 / 50 µs | 47 / 50 µs |

In-domain `Float64` hot path bit-identical. `Clamp` `Float64` +~6% at 10% OOB is the
`Dual`-safe `_promote_extrap_val` on OOB queries only. `Int` no longer crashes.

## Tests — `test/test_query_grid_promotion.jl`

Promotion invariance (mismatched query == naturally-promoted) across {1D,ND}×{range,vector}×
all extraps×{linear,constant,cubic}; exact-boundary / fractional / ForwardDiff locks; type-stability:
`_handle_all_extraps` concrete per (extrap×eltype) with **Float-grid→Float64, Int-grid→Int**, a
dedicated **Hermite-ND `Any`-leak pin**, the N=2 preamble, and all-seven-methods + 1D public returns.

## Known limitation (separate follow-up)

`Float` query + **`Dual` grid** + Clamp/Fill/Wrap (AD w.r.t. grid) still yields a non-concrete
`Union{Float64,Dual}` coordinate — `_promote_for_anchor`'s asymmetric "query→grid eltype" rule
can't go `Float→Dual`. Rare, and strictly better than master (which silently dropped the grid
partial). Unifying to the natural symmetric rule (as #146 did for the value path) is a dedicated
follow-up: `docs/design/coordinate_promotion_unification.md`.
