### PR TITLE
(fix+feat): widen + correct the `integrate` API's type promotion

### DIFF
--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -184,6 +184,16 @@ end
 # coefficients (cubic `z`, quadratic `a`/`d`, hermite `dy`) are solved before any query.
 @inline _coeff_op(h::Tg, yv::Tv) where {Tg, Tv} = yv + yv * inv(h)
 
+# `_integrate_op` (3-arg): the definite-integral element type — value × spacing.
+# ∫ ≈ Σ yᵢ·hᵢ is dimensionally distinct from the eval witnesses (which weight the value
+# by the dimensionless offset `dL/h`). `span` is the integration length (`b2 - xL` for a
+# partial cell, the cell width `h` for a full cell). The `inv(h)` term is load-bearing: it
+# floats Int grids (`inv(Int)::Float64`) and lifts Dual (`inv(Dual)::Dual`), so Tout is
+# correct for all-Int integrate (the kernels divide) and for AD-wrt-grid/bounds. Duck-safe:
+# `yv` sees only `*`/`+`, a subset of what the integral kernels already require.
+@inline _integrate_op(h::Tg, yv::Tv, span::Ts) where {Tg, Tv, Ts} =
+    yv * span + yv * (span * inv(h))
+
 """
     _promote_query_eltype(::Type{Tv}, q::Tuple) -> Type
 

--- a/src/hermite/hermite_integrate.jl
+++ b/src/hermite/hermite_integrate.jl
@@ -25,7 +25,8 @@ end
     ) where {Tg, Tv}
     x = itp.x
     y = itp.y
-    Tout = promote_type(Tv, Tg, typeof(x0), typeof(x1))
+    Tspan = promote_type(typeof(x0), typeof(x1))
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tspan)
     searcher = _resolve_search(x, x0, search, hint)
 
     # Axis-as-truth: `x` is the wrapped axis (`_CachedRange`/`_CachedVector`),
@@ -67,7 +68,8 @@ end
     ) where {Tg, Tv}
     x = itp.x
     y = itp.y
-    Tout = promote_type(Tv, Tg, typeof(x0), typeof(x1))
+    Tspan = promote_type(typeof(x0), typeof(x1))
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tspan)
     searcher = _resolve_search(x, x0, search, hint)
 
     in_domain = @inline (a, b) -> _integrate_hermite_onthefly_inner(

--- a/src/integral/integrate_api.jl
+++ b/src/integral/integrate_api.jl
@@ -276,8 +276,8 @@ end
         lo2::Tuple{Vararg{Any, N}},
         hi2::Tuple{Vararg{Any, N}}
     ) where {Tv, Tg, N}
-    Tout = promote_type(Tv, Tg, map(typeof, lo2)..., map(typeof, hi2)...)
-    return isconcretetype(Tout) ? Tout : Tv
+    Tspan = promote_type(map(typeof, lo2)..., map(typeof, hi2)...)
+    return _promote_eltype(_integrate_op, Tg, Tv, Tspan)
 end
 
 # ── CubicInterpolantND bounded ──

--- a/src/integral/integrate_api.jl
+++ b/src/integral/integrate_api.jl
@@ -16,11 +16,12 @@ end
         x0::Real, x1::Real;
         search::AbstractSearchPolicy = itp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg <: Real, Tv}
     x = itp.cache.x
     y = itp.y
     z = itp.z
-    Tout = promote_type(Tv, Tg, typeof(x0), typeof(x1))
+    Tspan = promote_type(typeof(x0), typeof(x1))
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tspan)
     searcher = _resolve_search(x, x0, search, hint)
 
     partial = @inline (i, xL, h, a2, b2) -> begin
@@ -46,10 +47,11 @@ end
         x0::Real, x1::Real;
         search::AbstractSearchPolicy = itp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg <: Real, Tv}
     x = itp.x
     y = itp.y
-    Tout = promote_type(Tv, Tg, typeof(x0), typeof(x1))
+    Tspan = promote_type(typeof(x0), typeof(x1))
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tspan)
     searcher = _resolve_search(x, x0, search, hint)
 
     partial = @inline (i, xL, h, a2, b2) -> begin
@@ -75,9 +77,10 @@ end
         x0::Real, x1::Real;
         search::AbstractSearchPolicy = itp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg <: Real, Tv}
     x = itp.x
-    Tout = promote_type(Tv, Tg, typeof(x0), typeof(x1))
+    Tspan = promote_type(typeof(x0), typeof(x1))
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tspan)
     searcher = _resolve_search(x, x0, search, hint)
 
     partial = @inline (i, xL, h, a2, b2) -> begin
@@ -103,8 +106,9 @@ end
         x0::Real, x1::Real;
         search::AbstractSearchPolicy = itp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv}
-    Tout = promote_type(Tv, Tg, typeof(x0), typeof(x1))
+    ) where {Tg <: Real, Tv}
+    Tspan = promote_type(typeof(x0), typeof(x1))
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tspan)
     searcher = _resolve_search(itp.x, x0, search, hint)
     return _integrate_constant_1d_impl(itp.x, itp.y, itp.side, itp.extrap, x0, x1, searcher, Tg, Tout)
 end
@@ -142,11 +146,12 @@ end
         x0::Real, x1::Real;
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg <: Real, Tv}
     x = sitp.cache.x
     y = sitp.y
     z = sitp.z
-    Tout = promote_type(Tv, Tg, typeof(x0), typeof(x1))
+    Tspan = promote_type(typeof(x0), typeof(x1))
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tspan)
     searcher = _resolve_search(x, x0, search, hint)
     n = n_series(sitp)
     results = Vector{Tout}(undef, n)
@@ -170,10 +175,11 @@ end
         x0::Real, x1::Real;
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg <: Real, Tv}
     x = sitp.x
     y = sitp.y
-    Tout = promote_type(Tv, Tg, typeof(x0), typeof(x1))
+    Tspan = promote_type(typeof(x0), typeof(x1))
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tspan)
     searcher = _resolve_search(x, x0, search, hint)
     n = n_series(sitp)
     results = Vector{Tout}(undef, n)
@@ -197,9 +203,10 @@ end
         x0::Real, x1::Real;
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg <: Real, Tv}
     x = sitp.x
-    Tout = promote_type(Tv, Tg, typeof(x0), typeof(x1))
+    Tspan = promote_type(typeof(x0), typeof(x1))
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tspan)
     searcher = _resolve_search(x, x0, search, hint)
     n = n_series(sitp)
     results = Vector{Tout}(undef, n)
@@ -223,8 +230,9 @@ end
         x0::Real, x1::Real;
         search::AbstractSearchPolicy = sitp.search_policy,
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
-    ) where {Tg <: AbstractFloat, Tv}
-    Tout = promote_type(Tv, Tg, typeof(x0), typeof(x1))
+    ) where {Tg <: Real, Tv}
+    Tspan = promote_type(typeof(x0), typeof(x1))
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tspan)
     searcher = _resolve_search(sitp.x, x0, search, hint)
     return _integrate_constant_series_1d(sitp.x, sitp.y, sitp.side, sitp.extrap, x0, x1, searcher, Tg, Tout)
 end

--- a/src/integral/integrate_common_1d.jl
+++ b/src/integral/integrate_common_1d.jl
@@ -118,16 +118,16 @@ end
 
     if i0 == i1
         h = _get_h(x, i0)
-        return sign * partial_fn(i0, xL0, h, lo, hi)
+        return convert(Tout, sign * partial_fn(i0, xL0, h, lo, hi))
     end
 
     h0 = _get_h(x, i0)
-    total = partial_fn(i0, xL0, h0, lo, xL0 + h0)
+    total = convert(Tout, partial_fn(i0, xL0, h0, lo, xL0 + h0))
     @inbounds for i in (i0 + 1):(i1 - 1)
-        total += full_fn(i, _get_h(x, i))
+        total += convert(Tout, full_fn(i, _get_h(x, i)))
     end
     h1 = _get_h(x, i1)
-    total += partial_fn(i1, xL1, h1, xL1, hi)
+    total += convert(Tout, partial_fn(i1, xL1, h1, xL1, hi))
 
     return sign * total
 end

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -97,9 +97,9 @@ end
 @inline function integrate(
         itp::AbstractInterpolant{Tg, Tv};
         search = nothing, hint = nothing
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg <: Real, Tv}
     x = _grid_1d(itp)
-    Tout = promote_type(Tv, Tg)
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
     return _integrate_1d_fulldomain(x, _full_cell_fn(itp), Tout)
 end
 
@@ -108,9 +108,9 @@ end
 @inline function integrate(
         itp::ConstantInterpolant{Tg, Tv};
         search = nothing, hint = nothing
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg <: Real, Tv}
     x = _grid_1d(itp)
-    Tout = promote_type(Tv, Tg)
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
     return _integrate_1d_fulldomain(x, _full_cell_fn(itp, itp.side), Tout)
 end
 
@@ -125,9 +125,9 @@ end
 @inline function integrate(
         sitp::AbstractSeriesInterpolant{Tg, Tv};
         search = nothing, hint = nothing
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg <: Real, Tv}
     x = _grid_1d(sitp)
-    Tout = promote_type(Tv, Tg)
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
     n = n_series(sitp)
     results = Vector{Tout}(undef, n)
     @inbounds for k in 1:n
@@ -140,9 +140,9 @@ end
 @inline function integrate(
         sitp::ConstantSeriesInterpolant{Tg, Tv};
         search = nothing, hint = nothing
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg <: Real, Tv}
     x = _grid_1d(sitp)
-    Tout = promote_type(Tv, Tg)
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
     n = n_series(sitp)
     results = Vector{Tout}(undef, n)
     @inbounds for k in 1:n
@@ -238,7 +238,7 @@ end
         search = nothing,
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
-    Tout = promote_type(Tv, Tg)
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
     total = Tout <: Number ? zero(Tout) : 0 * _nd_sample_value(itp)
     cell_ranges = ntuple(d -> 1:(length(itp.grids[d]) - 1), Val(N))
     for I in CartesianIndices(cell_ranges)
@@ -277,7 +277,7 @@ end
 # (PreCompute + OnTheFly via `_full_cell_fn`'s trait dispatch on `itp.dy`).
 function cumulative_integrate!(
         out::AbstractVector, itp::AbstractInterpolant{Tg, Tv}
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg <: Real, Tv}
     x = _grid_1d(itp)
     _check_cumulative_out(out, length(x))
     return _cumulative_integrate_1d!(out, x, _full_cell_fn(itp))
@@ -287,15 +287,15 @@ end
 # so `_full_cell_fn(itp, side)` dispatches to a distinct specialized method.
 function cumulative_integrate!(
         out::AbstractVector, itp::ConstantInterpolant{Tg, Tv}
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg <: Real, Tv}
     x = _grid_1d(itp)
     _check_cumulative_out(out, length(x))
     return _cumulative_integrate_1d!(out, x, _full_cell_fn(itp, itp.side))
 end
 
 # Allocating wrappers: allocate output vector then forward to the in-place path.
-function cumulative_integrate(itp::AbstractInterpolant{Tg, Tv}) where {Tg <: AbstractFloat, Tv}
-    Tout = promote_type(Tv, Tg)
+function cumulative_integrate(itp::AbstractInterpolant{Tg, Tv}) where {Tg <: Real, Tv}
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
     out = Vector{Tout}(undef, length(_grid_1d(itp)))
     return cumulative_integrate!(out, itp)
 end
@@ -303,9 +303,9 @@ end
 # Generic Series: catches Cubic, Linear, Quadratic series
 function cumulative_integrate(
         sitp::AbstractSeriesInterpolant{Tg, Tv}
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg <: Real, Tv}
     x = _grid_1d(sitp)
-    Tout = promote_type(Tv, Tg)
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
     n_pts = length(x)
     n_ser = n_series(sitp)
     result = Matrix{Tout}(undef, n_pts, n_ser)
@@ -318,9 +318,9 @@ end
 # Constant Series override: side is parametric → compiler knows concrete type
 function cumulative_integrate(
         sitp::ConstantSeriesInterpolant{Tg, Tv}
-    ) where {Tg <: AbstractFloat, Tv}
+    ) where {Tg <: Real, Tv}
     x = _grid_1d(sitp)
-    Tout = promote_type(Tv, Tg)
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
     n_pts = length(x)
     n_ser = n_series(sitp)
     result = Matrix{Tout}(undef, n_pts, n_ser)

--- a/src/integral/integrate_kernels.jl
+++ b/src/integral/integrate_kernels.jl
@@ -12,9 +12,9 @@
 # with pre-absorbed coefficients a4=a/4, b3=b/3, c2=c/2.
 @inline function _cubic_integral_kernel(
         ::_EvalIntegralPartial,
-        zL::Tv, zR::Tv, yL::Tv, yR::Tv,
+        zL::Tz, zR::Tz, yL::Ty, yR::Ty,
         h::Tg, u0::Td, u1::Td
-    ) where {Tv, Tg <: AbstractFloat, Td <: Real}
+    ) where {Tz, Ty, Tg <: Real, Td <: Real}
     inv_h = inv(h)
     a4 = (zR - zL) * (inv_h * inv(Tg(24)))   # a/4 = (zR-zL)/(24h)
     b3 = inv(Tg(6)) * zL                     # b/3 = zL/6
@@ -27,8 +27,8 @@ end
 # --- Full-cell integral: ∫_0^h S(u) du = h/2·(yL+yR) - h³/24·(zL+zR) ---
 @inline function _cubic_integral_kernel(
         ::_EvalIntegralCell,
-        zL::Tv, zR::Tv, yL::Tv, yR::Tv, h::Tg
-    ) where {Tv, Tg <: AbstractFloat}
+        zL::Tz, zR::Tz, yL::Ty, yR::Ty, h::Tg
+    ) where {Tz, Ty, Tg <: Real}
     h2 = h * h
     return (h / 2) * muladd(-(h2 * inv(Tg(12))), zL + zR, yL + yR)
 end
@@ -44,7 +44,7 @@ end
 @inline function _linear_integral_kernel(
         ::_EvalIntegralPartial,
         yL::Tv, yR::Tv, h::Tg, u0::Td, u1::Td
-    ) where {Tv, Tg <: AbstractFloat, Td <: Real}
+    ) where {Tv, Tg <: Real, Td <: Real}
     du = u1 - u0
     half_slope = (yR - yL) * inv(2h)
     return du * muladd(half_slope, u1 + u0, yL)
@@ -54,7 +54,7 @@ end
 @inline function _linear_integral_kernel(
         ::_EvalIntegralCell,
         yL::Tv, yR::Tv, h::Tg
-    ) where {Tv, Tg <: AbstractFloat}
+    ) where {Tv, Tg <: Real}
     return (h / 2) * (yL + yR)
 end
 
@@ -69,8 +69,8 @@ end
 # Horner form: F(u) = u·@evalpoly(u, y0, d/2, a/3)
 @inline function _quadratic_integral_kernel(
         ::_EvalIntegralPartial,
-        a::Tv, d::Tv, y0::Tv, u0::Td, u1::Td
-    ) where {Tv, Td <: Real}
+        a::Ta, d::Td2, y0::Ty, u0::Td, u1::Td
+    ) where {Ta, Td2, Ty, Td <: Real}
     a_3 = inv(Td(3)) * a
     d_2 = inv(Td(2)) * d
     return u1 * @evalpoly(u1, y0, d_2, a_3) -
@@ -80,8 +80,8 @@ end
 # --- Full-cell integral: ∫_0^h S(u) du = a/3·h³ + d/2·h² + y₀·h ---
 @inline function _quadratic_integral_kernel(
         ::_EvalIntegralCell,
-        a::Tv, d::Tv, y0::Tv, h::Tg
-    ) where {Tv, Tg <: AbstractFloat}
+        a::Ta, d::Td2, y0::Ty, h::Tg
+    ) where {Ta, Td2, Ty, Tg <: Real}
     return h * @evalpoly(h, y0, inv(Tg(2)) * d, inv(Tg(3)) * a)
 end
 
@@ -94,7 +94,7 @@ end
 @inline function _constant_integral_kernel(
         ::_EvalIntegralPartial,
         yL::Tv, yR::Tv, h::Tg, u0::Td, u1::Td, ::LeftSide
-    ) where {Tv, Tg <: AbstractFloat, Td <: Real}
+    ) where {Tv, Tg <: Real, Td <: Real}
     return yL * (u1 - u0)
 end
 
@@ -102,7 +102,7 @@ end
 @inline function _constant_integral_kernel(
         ::_EvalIntegralPartial,
         yL::Tv, yR::Tv, h::Tg, u0::Td, u1::Td, ::RightSide
-    ) where {Tv, Tg <: AbstractFloat, Td <: Real}
+    ) where {Tv, Tg <: Real, Td <: Real}
     return yR * (u1 - u0)
 end
 
@@ -110,7 +110,7 @@ end
 @inline function _constant_integral_kernel(
         ::_EvalIntegralPartial,
         yL::Tv, yR::Tv, h::Tg, u0::Td, u1::Td, ::NearestSide
-    ) where {Tv, Tg <: AbstractFloat, Td <: Real}
+    ) where {Tv, Tg <: Real, Td <: Real}
     mid = h / 2
     if u1 <= mid
         return yL * (u1 - u0)

--- a/test/test_dual_grid_coord_promotion.jl
+++ b/test/test_dual_grid_coord_promotion.jl
@@ -152,14 +152,10 @@ end
     end
 end
 
-# ── Derived quantities on a Dual grid: vector calculus (ND) must return a
-# concrete carrier (the audit flagged hand-coded promote_type in vector_calculus.jl).
-# RED would show Union/Any or a wrong eltype.
-# NOTE: `integrate`/`cumulative_integrate` are constrained to `Tg <: AbstractFloat`,
-# so a Dual grid throws a clean `ArgumentError` (an unimplemented-feature gap, NOT a
-# leak — no silent Union/Any). AD-w.r.t-grid through an integral is out of scope here. ──
-@testitem "Dual grid (AD-w.r.t-grid) — vector calculus stays concrete; integrate gap is a clean throw" begin
-    using ForwardDiff: Dual
+# ── Derived quantities on a Dual grid: vector calculus (ND) must return a concrete
+# carrier, and integrate now rides the grid (AD-w.r.t-grid through the integral). ──
+@testitem "Dual grid (AD-w.r.t-grid) — vector calculus + integrate stay concrete Dual" begin
+    using ForwardDiff: Dual, value
     mkdual(r) = [Dual{Nothing}(Float64(v), 1.0) for v in r]
     g = mkdual(0.5:1.0:9.5)
     y = collect(Float64, 1:10)
@@ -176,9 +172,11 @@ end
         @test L isa Dual && isconcretetype(typeof(L))
     end
 
-    # integrate on a Dual grid: a clean ArgumentError (feature gap), not a silent leak.
+    # integrate on a Dual grid: rides the grid, value matches the Float64-grid reference.
     itp1 = linear_interp(g, y)
-    @test_throws ArgumentError integrate(itp1, 1.0, 5.0)
+    I = integrate(itp1, 1.0, 5.0)
+    @test I isa Dual
+    @test value(I) ≈ integrate(linear_interp(value.(g), y), 1.0, 5.0)
 end
 
 # ── Quadratic ND completeness (the public-ND test above omits quadratic). ──

--- a/test/test_integral_promotion.jl
+++ b/test/test_integral_promotion.jl
@@ -19,11 +19,11 @@
 end
 
 @testitem "integrate — Constant 1D over all-Int grid floats to Float64" begin
-    x  = collect(1:10)            # Vector{Int} grid
-    y  = collect(1:10) .^ 2       # Vector{Int} data
+    x = collect(1:10)            # Vector{Int} grid
+    y = collect(1:10) .^ 2       # Vector{Int} data
     xf = float.(x); yf = float.(y)
     for side in (LeftSide(), RightSide(), NearestSide())
-        itp_i = constant_interp(x,  y;  side = side)
+        itp_i = constant_interp(x, y; side = side)
         itp_f = constant_interp(xf, yf; side = side)
         # bounded (Int bounds) — @inferred pins type stability, isa pins the concrete type
         r = @inferred integrate(itp_i, 2, 7)
@@ -43,11 +43,11 @@ end
 @testitem "integrate — Dual grid (AD wrt nodes) returns concrete Dual for non-Hermite 1D" begin
     using ForwardDiff: Dual, value
     mkdual(r) = [Dual{Nothing}(Float64(v), 1.0) for v in r]
-    g  = mkdual(0.5:1.0:9.5)
+    g = mkdual(0.5:1.0:9.5)
     gf = value.(g)                       # Float64 reference grid
-    y  = collect(Float64, 1:10)
+    y = collect(Float64, 1:10)
     for mk in (linear_interp, cubic_interp, quadratic_interp, constant_interp)
-        itp  = mk(g,  y)
+        itp = mk(g, y)
         itpf = mk(gf, y)
         I = @inferred integrate(itp, 1.0, 5.0)        # @inferred pins concrete-Dual stability
         @test I isa Dual{Nothing, Float64, 1}
@@ -58,7 +58,7 @@ end
 @testitem "integrate — Dual-grid partial matches finite difference (AD-wrt-grid correctness)" begin
     using ForwardDiff: Dual, value, partials
     xb = collect(0.5:1.0:9.5)
-    y  = collect(Float64, 1:10)
+    y = collect(Float64, 1:10)
     # I(s) = ∫_{1.3}^{4.7} of the interpolant built on the grid scaled by s. Bounds avoid
     # nodes (0.5,1.5,…) and Constant NearestSide midpoints (1,2,…) so I(s) is smooth at s=1
     # for every family (no subgradient kink), making the AD partial comparable to a finite diff.
@@ -75,8 +75,10 @@ end
 @testitem "integrate — non-Constant 1D Int grids stay correct (regression pin)" begin
     x = collect(1:10); y = float.(collect(1:10) .^ 2)
     xf = float.(x)
-    for mk in (linear_interp, cubic_interp, quadratic_interp,
-               pchip_interp, cardinal_interp, akima_interp)
+    for mk in (
+            linear_interp, cubic_interp, quadratic_interp,
+            pchip_interp, cardinal_interp, akima_interp,
+        )
         @test (@inferred integrate(mk(x, y), 2.0, 7.0)) ≈ integrate(mk(xf, y), 2.0, 7.0)
     end
 end

--- a/test/test_integral_promotion.jl
+++ b/test/test_integral_promotion.jl
@@ -79,3 +79,18 @@ end
         @test integrate(ii, (2.0, 2.0), (5.0, 5.0)) ≈ integrate(ff, (2.0, 2.0), (5.0, 5.0))
     end
 end
+
+@testitem "integrate — Float-path values + zero-alloc unchanged after witness routing" setup = [AllocConstants] begin
+    x = collect(range(0.0, 1.0, length = 21))
+    y = @. 3x - 1
+    # Affine reference: ∫_a^b (3x-1) dx = [1.5x² - x]_a^b
+    a, b = 0.15, 0.85
+    itp = linear_interp(x, y; extrap = NoExtrap())
+    @test integrate(itp, a, b) ≈ (1.5b^2 - b) - (1.5a^2 - a) atol = 1.0e-12
+
+    # Zero-alloc on the Float path, measured in a function barrier (avoids @testset
+    # try/catch polluting @allocated).
+    probe(it, p, q) = (it(p); integrate(it, p, q); @allocated integrate(it, p, q))
+    probe(itp, a, b)                       # warmup/compile
+    @test probe(itp, a, b) <= ALLOC_THRESHOLD
+end

--- a/test/test_integral_promotion.jl
+++ b/test/test_integral_promotion.jl
@@ -1,6 +1,10 @@
 # Type-promotion contract for the integrate path: the `_integrate_op` witness floats
 # Int, lifts Dual, and stays duck-safe; integrate over Int/Dual grids returns the
 # right element type. Phase 1 of the integrate promotion modernization.
+#
+# Type stability is pinned with `@inferred` (return type is inferred + concrete) combined
+# with `isa` (the concrete type is the expected one); AD-wrt-grid correctness is pinned by
+# matching the ForwardDiff partial against a central finite difference.
 
 @testitem "_integrate_op witness eltype matrix" begin
     using FastInterpolations: _integrate_op, _promote_eltype
@@ -21,22 +25,22 @@ end
     for side in (LeftSide(), RightSide(), NearestSide())
         itp_i = constant_interp(x,  y;  side = side)
         itp_f = constant_interp(xf, yf; side = side)
-        # bounded (Int bounds)
-        r = integrate(itp_i, 2, 7)
+        # bounded (Int bounds) — @inferred pins type stability, isa pins the concrete type
+        r = @inferred integrate(itp_i, 2, 7)
         @test r isa Float64
         @test r ≈ integrate(itp_f, 2.0, 7.0)
         # full-domain
-        rf = integrate(itp_i)
+        rf = @inferred integrate(itp_i)
         @test rf isa Float64
         @test rf ≈ integrate(itp_f)
         # cumulative
-        rc = cumulative_integrate(itp_i)
-        @test eltype(rc) === Float64
+        rc = @inferred cumulative_integrate(itp_i)
+        @test rc isa Vector{Float64}
         @test rc ≈ cumulative_integrate(itp_f)
     end
 end
 
-@testitem "integrate — Dual grid (AD wrt nodes) returns Dual for non-Hermite 1D" begin
+@testitem "integrate — Dual grid (AD wrt nodes) returns concrete Dual for non-Hermite 1D" begin
     using ForwardDiff: Dual, value
     mkdual(r) = [Dual{Nothing}(Float64(v), 1.0) for v in r]
     g  = mkdual(0.5:1.0:9.5)
@@ -45,9 +49,26 @@ end
     for mk in (linear_interp, cubic_interp, quadratic_interp, constant_interp)
         itp  = mk(g,  y)
         itpf = mk(gf, y)
-        I = integrate(itp, 1.0, 5.0)
-        @test I isa Dual
+        I = @inferred integrate(itp, 1.0, 5.0)        # @inferred pins concrete-Dual stability
+        @test I isa Dual{Nothing, Float64, 1}
         @test value(I) ≈ integrate(itpf, 1.0, 5.0)
+    end
+end
+
+@testitem "integrate — Dual-grid partial matches finite difference (AD-wrt-grid correctness)" begin
+    using ForwardDiff: Dual, value, partials
+    xb = collect(0.5:1.0:9.5)
+    y  = collect(Float64, 1:10)
+    # I(s) = ∫_{1.3}^{4.7} of the interpolant built on the grid scaled by s. Bounds avoid
+    # nodes (0.5,1.5,…) and Constant NearestSide midpoints (1,2,…) so I(s) is smooth at s=1
+    # for every family (no subgradient kink), making the AD partial comparable to a finite diff.
+    Iof(mk, s) = integrate(mk(s .* xb, y), 1.3, 4.7)
+    hfd = 1.0e-6
+    for mk in (linear_interp, cubic_interp, quadratic_interp, constant_interp)
+        Id = Iof(mk, Dual{:t}(1.0, 1.0))                        # AD: dI/ds at s = 1
+        fd = (Iof(mk, 1.0 + hfd) - Iof(mk, 1.0 - hfd)) / (2hfd)  # central difference
+        @test value(Id) ≈ Iof(mk, 1.0)
+        @test partials(Id)[1] ≈ fd rtol = 1.0e-4
     end
 end
 
@@ -56,7 +77,7 @@ end
     xf = float.(x)
     for mk in (linear_interp, cubic_interp, quadratic_interp,
                pchip_interp, cardinal_interp, akima_interp)
-        @test integrate(mk(x, y), 2.0, 7.0) ≈ integrate(mk(xf, y), 2.0, 7.0)
+        @test (@inferred integrate(mk(x, y), 2.0, 7.0)) ≈ integrate(mk(xf, y), 2.0, 7.0)
     end
 end
 
@@ -68,15 +89,16 @@ end
     # ConstantND: the headline InexactError case.
     ci = constant_interp((xg, xg), data_i)
     cf = constant_interp((xf, xf), data_f)
-    rb = integrate(ci, (2, 2), (5, 5))
+    rb = @inferred integrate(ci, (2, 2), (5, 5))
     @test rb isa Float64
     @test rb ≈ integrate(cf, (2.0, 2.0), (5.0, 5.0))
-    @test integrate(ci) isa Float64
-    @test integrate(ci) ≈ integrate(cf)
+    rfd = @inferred integrate(ci)
+    @test rfd isa Float64
+    @test rfd ≈ integrate(cf)
     # Cubic/Linear/Quadratic ND already float at construction — regression pin.
     for mk in (linear_interp, cubic_interp, quadratic_interp)
         ii = mk((xg, xg), data_f); ff = mk((xf, xf), data_f)
-        @test integrate(ii, (2.0, 2.0), (5.0, 5.0)) ≈ integrate(ff, (2.0, 2.0), (5.0, 5.0))
+        @test (@inferred integrate(ii, (2.0, 2.0), (5.0, 5.0))) ≈ integrate(ff, (2.0, 2.0), (5.0, 5.0))
     end
 end
 

--- a/test/test_integral_promotion.jl
+++ b/test/test_integral_promotion.jl
@@ -59,3 +59,23 @@ end
         @test integrate(mk(x, y), 2.0, 7.0) ≈ integrate(mk(xf, y), 2.0, 7.0)
     end
 end
+
+@testitem "integrate — ND all-Int grid floats to Float64 (ConstantND InexactError fix)" begin
+    xg = collect(1:6)
+    data_i = [i + 2j for i in 1:6, j in 1:6]      # Int data
+    data_f = float.(data_i)
+    xf = float.(xg)
+    # ConstantND: the headline InexactError case.
+    ci = constant_interp((xg, xg), data_i)
+    cf = constant_interp((xf, xf), data_f)
+    rb = integrate(ci, (2, 2), (5, 5))
+    @test rb isa Float64
+    @test rb ≈ integrate(cf, (2.0, 2.0), (5.0, 5.0))
+    @test integrate(ci) isa Float64
+    @test integrate(ci) ≈ integrate(cf)
+    # Cubic/Linear/Quadratic ND already float at construction — regression pin.
+    for mk in (linear_interp, cubic_interp, quadratic_interp)
+        ii = mk((xg, xg), data_f); ff = mk((xf, xf), data_f)
+        @test integrate(ii, (2.0, 2.0), (5.0, 5.0)) ≈ integrate(ff, (2.0, 2.0), (5.0, 5.0))
+    end
+end

--- a/test/test_integral_promotion.jl
+++ b/test/test_integral_promotion.jl
@@ -1,0 +1,15 @@
+# Type-promotion contract for the integrate path: the `_integrate_op` witness floats
+# Int, lifts Dual, and stays duck-safe; integrate over Int/Dual grids returns the
+# right element type. Phase 1 of the integrate promotion modernization.
+
+@testitem "_integrate_op witness eltype matrix" begin
+    using FastInterpolations: _integrate_op, _promote_eltype
+    using ForwardDiff: Dual
+    D = Dual{Nothing, Float64, 1}
+    # (Tg, Tv, Tspan) → Tout
+    @test _promote_eltype(_integrate_op, Float64, Float64, Float64) === Float64
+    @test _promote_eltype(_integrate_op, Int, Int, Int) === Float64          # floats Int
+    @test _promote_eltype(_integrate_op, D, Float64, Float64) === D          # AD wrt grid
+    @test _promote_eltype(_integrate_op, Float64, Float64, D) === D          # AD wrt bounds
+    @test _promote_eltype(_integrate_op, Float64, Int, Float64) === Float64  # Int data floats
+end

--- a/test/test_integral_promotion.jl
+++ b/test/test_integral_promotion.jl
@@ -13,3 +13,49 @@
     @test _promote_eltype(_integrate_op, Float64, Float64, D) === D          # AD wrt bounds
     @test _promote_eltype(_integrate_op, Float64, Int, Float64) === Float64  # Int data floats
 end
+
+@testitem "integrate — Constant 1D over all-Int grid floats to Float64" begin
+    x  = collect(1:10)            # Vector{Int} grid
+    y  = collect(1:10) .^ 2       # Vector{Int} data
+    xf = float.(x); yf = float.(y)
+    for side in (LeftSide(), RightSide(), NearestSide())
+        itp_i = constant_interp(x,  y;  side = side)
+        itp_f = constant_interp(xf, yf; side = side)
+        # bounded (Int bounds)
+        r = integrate(itp_i, 2, 7)
+        @test r isa Float64
+        @test r ≈ integrate(itp_f, 2.0, 7.0)
+        # full-domain
+        rf = integrate(itp_i)
+        @test rf isa Float64
+        @test rf ≈ integrate(itp_f)
+        # cumulative
+        rc = cumulative_integrate(itp_i)
+        @test eltype(rc) === Float64
+        @test rc ≈ cumulative_integrate(itp_f)
+    end
+end
+
+@testitem "integrate — Dual grid (AD wrt nodes) returns Dual for non-Hermite 1D" begin
+    using ForwardDiff: Dual, value
+    mkdual(r) = [Dual{Nothing}(Float64(v), 1.0) for v in r]
+    g  = mkdual(0.5:1.0:9.5)
+    gf = value.(g)                       # Float64 reference grid
+    y  = collect(Float64, 1:10)
+    for mk in (linear_interp, cubic_interp, quadratic_interp, constant_interp)
+        itp  = mk(g,  y)
+        itpf = mk(gf, y)
+        I = integrate(itp, 1.0, 5.0)
+        @test I isa Dual
+        @test value(I) ≈ integrate(itpf, 1.0, 5.0)
+    end
+end
+
+@testitem "integrate — non-Constant 1D Int grids stay correct (regression pin)" begin
+    x = collect(1:10); y = float.(collect(1:10) .^ 2)
+    xf = float.(x)
+    for mk in (linear_interp, cubic_interp, quadratic_interp,
+               pchip_interp, cardinal_interp, akima_interp)
+        @test integrate(mk(x, y), 2.0, 7.0) ≈ integrate(mk(xf, y), 2.0, 7.0)
+    end
+end


### PR DESCRIPTION
## Summary

Brings `integrate`'s element-type handling in line with the rest of the library — a single, op-aware promotion rule that is both **wider** (now accepts integer and `Dual` grids) and **more correct** (no silent failures), continuing the #155/#156 promotion unification.

It fixes the all-`Int` integrate bug and enables forward-mode AD through integration, while leaving existing `Float` paths unchanged in behavior and performance.

## Changes

**`_integrate_op` witness** (`core/utils.jl`) — `yv*span + yv*(span*inv(h))`, the element-type witness for
the integral's value×spacing shape (joins `_coeff_op`/`_interp_op`). `inv(h)` floats `Int` and lifts `Dual`;
`yv` only sees `*`/`+`, so it stays duck-safe.

**Witness routing + gate relaxation** — every 1D and ND integrate `Tout` now routes through
`_promote_eltype(_integrate_op, …)`; the `Tg <: AbstractFloat` gate (1D API + full-domain + cumulative + the
8 integral kernels) relaxes to `Tg <: Real`. The cubic/quadratic integral kernels split their single value
type-param so a `Dual`-grid's slope coefficients (`Dual`) coexist with `Float` data — a pure signature
relaxation (identical arithmetic).

## Fixes & features

- **all-`Int` `Constant` integrate** — was `ArgumentError` (1D) / `InexactError` (ND `ConstantInterpolantND`);
  now returns `Float64`. (Linear/cubic/quadratic/Hermite already float their grid at construction, so they
  were unaffected.)
- **`Dual`-grid 1D integrate** (linear/cubic/quadratic/constant) — was a deliberate `ArgumentError`; now
  returns a concrete `Dual` matching the `Float`-grid value (Hermite already did). Forward-mode AD w.r.t. grid nodes.

## Tests

New `test/test_integral_promotion.jl`: witness eltype matrix; Constant-`Int` (1D + ND, all sides,
bounded/full-domain/cumulative); `Dual`-grid 1D (`@inferred` + concrete-type + value-match); **AD-partial
correctness** (ForwardDiff partial vs central finite difference); non-Constant `Int` regression pins; and a
`Float`-path value + zero-alloc guard. The former `Dual`-integrate `@test_throws` pin is flipped to a real AD
assertion.

Validation: the new-capability tests fail on `master` / pass on this branch (worktree A/B); zero-alloc
contract intact (`test_integral_allocation` green, guard at 0 bytes); **no perf regression** (mean
branch/master 0.98×, 0 of 20 integrate benchmarks >5% slower).

## Out of scope (follow-up)

Phase 2 — `Dual`-grid **ND** AD assertions, **AD-w.r.t-integration-bounds** (1D + an ND spike). Reverse-mode
(`rrule`/Zygote) `integrate` is a separate, larger effort.
