### PR TITLE
(perf): unit-step fast path for `AbstractUnitRange` grids

### DIFF
--- a/src/core/axis_types.jl
+++ b/src/core/axis_types.jl
@@ -40,7 +40,17 @@ normalized to `_CachedRange` via `_to_float` at public API boundaries.
 - `domain_lo::T`, `domain_hi::T` — safe bounds for domain checks (= `lo`/`hi`
   on the exact path; widened by ≈1 ULP on the x86_64 TwicePrecision fast path)
 """
-struct _CachedRange{T, Tinv} <: AbstractRange{T}
+# Grid tag (3rd type param): a generic type-level marker for grid properties,
+# kept open so future kinds (log-spaced, reversed, …) — and `_CachedVector` —
+# can reuse `_AxisTag`. Only `_search_direct`/`_alpha_of` specialize on `_UnitStep`
+# (step ≡ 1, statically known → skip the ×inv_h/×h multiplies). Every other call
+# site dispatches on `::_CachedRange{T,Tinv}` (= `…{T,Tinv,Tag} where Tag`), which
+# matches all tags, so nothing else needs to change.
+abstract type _AxisTag end
+struct _Generic <: _AxisTag end    # default: step is a runtime field
+struct _UnitStep <: _AxisTag end   # step ≡ 1 (from an AbstractUnitRange grid)
+
+struct _CachedRange{T, Tinv, Tag <: _AxisTag} <: AbstractRange{T}
     lo::T
     hi::T
     h::T
@@ -50,10 +60,15 @@ struct _CachedRange{T, Tinv} <: AbstractRange{T}
     domain_hi::T
 end
 
-# Exact 5-arg ctor: `domain_lo == lo`, `domain_hi == hi` (non-TwicePrecision).
-@inline function _CachedRange{T, Tinv}(lo::T, hi::T, h::T, inv_h::Tinv, len::Int) where {T, Tinv}
-    return _CachedRange{T, Tinv}(lo, hi, h, inv_h, len, lo, hi)
-end
+# Default-tag convenience ctors: keep every existing `_CachedRange{T,Tinv}(…)`
+# call site (and `::_CachedRange{T,Tinv}` dispatch) working — fills `Tag=_Generic`.
+@inline _CachedRange{T, Tinv}(lo::T, hi::T, h::T, inv_h::Tinv, len::Int) where {T, Tinv} =
+    _CachedRange{T, Tinv, _Generic}(lo, hi, h, inv_h, len, lo, hi)
+@inline _CachedRange{T, Tinv}(lo::T, hi::T, h::T, inv_h::Tinv, len::Int, dlo::T, dhi::T) where {T, Tinv} =
+    _CachedRange{T, Tinv, _Generic}(lo, hi, h, inv_h, len, dlo, dhi)
+# 5-arg with explicit tag (exact domain = lo/hi) — used by the unit-step fast path.
+@inline _CachedRange{T, Tinv, Tag}(lo::T, hi::T, h::T, inv_h::Tinv, len::Int) where {T, Tinv, Tag} =
+    _CachedRange{T, Tinv, Tag}(lo, hi, h, inv_h, len, lo, hi)
 
 # Identity passthrough — re-wrapping would discard the cached fields.
 _CachedRange(x::_CachedRange) = x

--- a/src/core/cached_range.jl
+++ b/src/core/cached_range.jl
@@ -156,12 +156,24 @@ end
 @inline _convert_copy(r::_CachedRange{T, Tinv}, ::Type{T}) where {T, Tinv} = r
 @inline _convert_copy(r::_CachedRange, ::Type{T}) where {T} = _to_float(r, T)
 
-# 4-arg grid-based accessors: `(x, idx, xL, xR)`. All four are produced by
-# `search_interval`; the dispatch picks the cheapest field per axis type.
-# `_CachedRange` ignores all three because `h`/`inv_h` are scalar fields
-# (uniform spacing — same value for every cell).
-@inline _get_h(x::_CachedRange, ::Int, ::Real, ::Real) = x.h
-@inline _get_inv_h(x::_CachedRange, ::Int, ::Real, ::Real) = x.inv_h
+# `_get_h` / `_get_inv_h` accessors. A `_CachedRange` is uniform, so one cached
+# `h`/`inv_h` answers every cell: all shapes delegate to the no-arg form, where the
+# `_UnitStep` (h ≡ inv_h ≡ 1) literal `one(T)` lives — LLVM then folds every
+# downstream `×h`/`×inv_h` to identity.
+@inline _get_h(x::_CachedRange) = x.h
+@inline _get_inv_h(x::_CachedRange) = x.inv_h
+@inline _get_h(::_CachedRange{T, Tinv, _UnitStep}) where {T, Tinv} = one(T)
+@inline _get_inv_h(::_CachedRange{T, Tinv, _UnitStep}) where {T, Tinv} = one(Tinv)
+# idx-shaped forms — `(x, idx)` (solver/coeff) and `(x, idx, xL, xR)` (from
+# `search_interval`) — ignore the extra args and delegate to the no-arg form.
+@inline _get_h(x::_CachedRange, ::Int) = _get_h(x)
+@inline _get_inv_h(x::_CachedRange, ::Int) = _get_inv_h(x)
+@inline _get_h(x::_CachedRange, ::Int, ::Real, ::Real) = _get_h(x)
+@inline _get_inv_h(x::_CachedRange, ::Int, ::Real, ::Real) = _get_inv_h(x)
+
+# Raw `AbstractRange` (non-_CachedRange) fallback via `step()` — pre-normalization paths only.
+@inline _get_h(x::AbstractRange, ::Int) = step(x)
+@inline _get_inv_h(x::AbstractRange, ::Int) = inv(step(x))
 
 # ========================================
 # `_resolve_axis` — one-shot Range wrapping

--- a/src/core/cached_range.jl
+++ b/src/core/cached_range.jl
@@ -40,12 +40,13 @@ end
 # Without this method, any code that windows or slices a `_CachedRange` (e.g. the
 # Hermite ND cell-local OnTheFly path in hetero_eval.jl) would silently degrade
 # its grid to a non-range type.
-@inline function Base.getindex(r::_CachedRange{T, Tinv}, idx::AbstractUnitRange{<:Integer}) where {T, Tinv}
+# Slice preserves the axis tag (a sub-range of a unit-step grid is still unit-step).
+@inline function Base.getindex(r::_CachedRange{T, Tinv, Tag}, idx::AbstractUnitRange{<:Integer}) where {T, Tinv, Tag}
     @boundscheck checkbounds(r, idx)
     new_len = length(idx)
     # Empty slice: return a length-0 _CachedRange anchored at r.lo (callers that
     # would dereference this hit the same checkbounds wall they would on r itself).
-    new_len == 0 && return _CachedRange{T, Tinv}(r.lo, r.lo, r.h, r.inv_h, 0)
+    new_len == 0 && return _CachedRange{T, Tinv, Tag}(r.lo, r.lo, r.h, r.inv_h, 0)
     i_lo = Int(first(idx))
     i_hi = Int(last(idx))
     # Reuse cached endpoints when the slice touches them — preserves the exact-bit
@@ -53,7 +54,7 @@ end
     # any downstream Tg-precision comparison stable.
     new_lo = i_lo == 1 ? r.lo : muladd(i_lo - 1, r.h, r.lo)
     new_hi = i_hi == r.len ? r.hi : muladd(i_hi - 1, r.h, r.lo)
-    return _CachedRange{T, Tinv}(new_lo, new_hi, r.h, r.inv_h, new_len)
+    return _CachedRange{T, Tinv, Tag}(new_lo, new_hi, r.h, r.inv_h, new_len)
 end
 
 # `view` follows `getindex` semantics for ranges — both return a fresh range, no
@@ -78,6 +79,16 @@ function _to_float(x::AbstractRange, ::Type{T}) where {T}
     h = T(step(x))
     inv_h = inv(h)
     return _CachedRange{T, typeof(inv_h)}(T(first(x)), T(last(x)), h, inv_h, length(x))
+end
+
+# Unit-step fast-path: `AbstractUnitRange{<:Integer}` (`UnitRange`, `Base.OneTo`,
+# offset-array axes) has step ≡ 1 by type, so `h = inv_h = one(T)` — skip the
+# `step(x)` extraction and the `inv()` divide of the generic path. Bit-identical to
+# the generic result for a unit range (which computes `h = T(1)`, `inv_h = inv(1) =
+# one(T)`); both use the exact 5-arg ctor (`domain_lo = lo`, `domain_hi = hi`).
+# Image-axis grids (`Base.OneTo`) hit this on construction.
+@inline function _to_float(x::AbstractUnitRange, ::Type{T}) where {T}
+    return _CachedRange{T, T, _UnitStep}(T(first(x)), T(last(x)), one(T), one(T), length(x))
 end
 
 # x86_64: TwicePrecision first()/last() ~9ns each on Intel — bypass via plain-T muladd.
@@ -105,10 +116,10 @@ _to_float(x::_CachedRange{T, Tinv}, ::Type{T}) where {T, Tinv} = x
 # Uses 5-arg constructor (domain = exact). Any x86_64 domain widening from the source
 # is intentionally dropped: the type conversion itself introduces fresh rounding,
 # so re-widening would need to be based on the new FT, not the old T.
-function _to_float(x::_CachedRange, ::Type{T}) where {T}
+function _to_float(x::_CachedRange{S, Si, Tag}, ::Type{T}) where {S, Si, Tag, T}
     h = T(x.h)
     inv_h = inv(h)
-    return _CachedRange{T, typeof(inv_h)}(T(x.lo), T(x.hi), h, inv_h, x.len)
+    return _CachedRange{T, typeof(inv_h), Tag}(T(x.lo), T(x.hi), h, inv_h, x.len)
 end
 
 """
@@ -123,9 +134,9 @@ Dispatch:
 """
 # domain_hi = hi_new (exact): the extension uses cached plain-T fields only
 # (no TwicePrecision involved), so no additional rounding uncertainty.
-@inline function _to_float_adding_endpoint(x::_CachedRange{T, Tinv}, ::Type{T}) where {T, Tinv}
+@inline function _to_float_adding_endpoint(x::_CachedRange{T, Tinv, Tag}, ::Type{T}) where {T, Tinv, Tag}
     hi_new = x.hi + x.h
-    return _CachedRange{T, Tinv}(
+    return _CachedRange{T, Tinv, Tag}(
         x.lo, hi_new, x.h, x.inv_h, x.len + 1,
         x.domain_lo, hi_new
     )

--- a/src/core/cached_range.jl
+++ b/src/core/cached_range.jl
@@ -81,14 +81,14 @@ function _to_float(x::AbstractRange, ::Type{T}) where {T}
     return _CachedRange{T, typeof(inv_h)}(T(first(x)), T(last(x)), h, inv_h, length(x))
 end
 
-# Unit-step fast-path: `AbstractUnitRange{<:Integer}` (`UnitRange`, `Base.OneTo`,
-# offset-array axes) has step ≡ 1 by type, so `h = inv_h = one(T)` — skip the
-# `step(x)` extraction and the `inv()` divide of the generic path. Bit-identical to
-# the generic result for a unit range (which computes `h = T(1)`, `inv_h = inv(1) =
-# one(T)`); both use the exact 5-arg ctor (`domain_lo = lo`, `domain_hi = hi`).
-# Image-axis grids (`Base.OneTo`) hit this on construction.
+# Unit-step fast-path: `AbstractUnitRange` (`UnitRange`/`Base.OneTo`) has step ≡ 1 by
+# type, so the grid is built from literal constants (`h = one(T)`, `inv_h = one(Tinv)`)
+# with no runtime division — `inv` is only in the compile-time type
+# `Tinv = typeof(inv(oneunit(T)))` (Float64 for `T=Int`, `T` for Float, per the
+# `_CachedRange` contract; skips the generic path's runtime `inv(step(x))`).
 @inline function _to_float(x::AbstractUnitRange, ::Type{T}) where {T}
-    return _CachedRange{T, T, _UnitStep}(T(first(x)), T(last(x)), one(T), one(T), length(x))
+    Tinv = typeof(inv(oneunit(T)))
+    return _CachedRange{T, Tinv, _UnitStep}(T(first(x)), T(last(x)), one(T), one(Tinv), length(x))
 end
 
 # x86_64: TwicePrecision first()/last() ~9ns each on Intel — bypass via plain-T muladd.

--- a/src/core/cached_vector.jl
+++ b/src/core/cached_vector.jl
@@ -132,32 +132,16 @@ end
     _cache_axis_pooled(pool, _to_float(x, Tg))
 
 # ========================================
-# Unified 2-arg accessors: _get_h, _get_inv_h
+# _get_h / _get_inv_h accessors (Vector hierarchy)
 # ========================================
-#
-# After this file loads, the dispatch surface for `_get_h(grid, i)` is:
-#   _CachedVector → cached vector lookup (this file)
-#   _CachedRange  → cached scalar       (this file, also covers AbstractRange via inheritance)
-#   AbstractRange → step()              (this file, fallback for non-_CachedRange ranges)
-#   AbstractVector → on-the-fly diff    (this file, fallback for raw Vectors / one-shot path)
+# Vector forms only; the Range forms (`_CachedRange`, `AbstractRange`) live in cached_range.jl.
 
 # _CachedVector — cached vector lookup (most specific for AbstractVector hierarchy)
 @inline Base.@propagate_inbounds _get_h(x::_CachedVector, i::Int) = @inbounds x.h[i]
 @inline Base.@propagate_inbounds _get_inv_h(x::_CachedVector, i::Int) = @inbounds x.inv_h[i]
 
-# _CachedRange — cached scalar (most specific for AbstractRange hierarchy)
-@inline _get_h(x::_CachedRange, ::Int) = x.h
-@inline _get_inv_h(x::_CachedRange, ::Int) = x.inv_h
-
-# AbstractRange (non-_CachedRange) — uniform spacing via step()
-@inline _get_h(x::AbstractRange, ::Int) = step(x)
-@inline _get_inv_h(x::AbstractRange, ::Int) = inv(step(x))
-
-# AbstractVector — compute on-the-fly (one-shot path, no cache available).
-# Raw eltype preserved (`Int → Int`, `Rational → Rational`). Arithmetic kernels
-# that follow this with `inv_h * y * dL` auto-promote naturally — no need to
-# eager-Float here. `_get_inv_h` returns `typeof(inv(h))` (Float64 for Int h,
-# Rational for Rational h, T for Float T).
+# AbstractVector — on-the-fly diff (one-shot, no cache). Raw eltype preserved
+# (`Int→Int`, `Rational→Rational`); downstream kernels auto-promote, so no eager-Float.
 @inline Base.@propagate_inbounds _get_h(x::AbstractVector, i::Int) =
     @inbounds x[i + 1] - x[i]
 @inline Base.@propagate_inbounds _get_inv_h(x::AbstractVector, i::Int) =

--- a/src/core/search.jl
+++ b/src/core/search.jl
@@ -540,6 +540,18 @@ Uses precomputed `inv_h` (multiply instead of divide) for the index calculation.
     return idx, xL, xR
 end
 
+
+# Unit-step fast path (`_UnitStep` tag = step ≡ 1, statically known): drop the
+# `×inv_h` in the index and the `×h` muladd for the left edge — both are `×1`.
+# Bit-identical to the generic muladd path for a unit-step grid.
+@inline function _search_direct(x::_CachedRange{T, Tinv, _UnitStep}, xq::Real) where {T, Tinv}
+    idx = clamp(unsafe_trunc(Int, _extract_primal((xq - x.lo) + 1)), 1, x.len - 1)
+    xL = (idx - 1) + x.lo
+    xR = xL + x.h
+    return idx, xL, xR
+end
+
+
 """
     _search_binary(x::AbstractVector{T}, xq::Real) where {T<:Real}
 

--- a/src/core/search.jl
+++ b/src/core/search.jl
@@ -531,23 +531,17 @@ end
 `_CachedRange` specialization: geometry fields are plain `T`, `inv_h` is `Tinv`
 (equals `T` for Float grids, `Float64` for `T = Int`) — no TwicePrecision arithmetic.
 Uses precomputed `inv_h` (multiply instead of divide) for the index calculation.
+Pulls `h`/`inv_h` through the accessors so a `_UnitStep` grid (which returns the
+literal `one`) lets LLVM fold the `×inv_h` index muladd and the `×h` left-edge
+muladd to identity — no separate `_UnitStep` method needed.
 """
 @inline function _search_direct(x::_CachedRange{T, Tinv}, xq::Real) where {T, Tinv}
     # Primal-based index: see _search_direct(::AbstractRange, ...) comment.
-    idx = clamp(unsafe_trunc(Int, _extract_primal(muladd(xq - x.lo, x.inv_h, 1))), 1, x.len - 1)
-    xL = muladd(idx - 1, x.h, x.lo)
-    xR = xL + x.h
-    return idx, xL, xR
-end
-
-
-# Unit-step fast path (`_UnitStep` tag = step ≡ 1, statically known): drop the
-# `×inv_h` in the index and the `×h` muladd for the left edge — both are `×1`.
-# Bit-identical to the generic muladd path for a unit-step grid.
-@inline function _search_direct(x::_CachedRange{T, Tinv, _UnitStep}, xq::Real) where {T, Tinv}
-    idx = clamp(unsafe_trunc(Int, _extract_primal((xq - x.lo) + 1)), 1, x.len - 1)
-    xL = (idx - 1) + x.lo
-    xR = xL + x.h
+    inv_h = _get_inv_h(x)
+    h = _get_h(x)
+    idx = clamp(unsafe_trunc(Int, _extract_primal(muladd(xq - x.lo, inv_h, 1))), 1, x.len - 1)
+    xL = muladd(idx - 1, h, x.lo)
+    xR = xL + h
     return idx, xL, xR
 end
 

--- a/src/cubic/cubic_cache_pool.jl
+++ b/src/cubic/cubic_cache_pool.jl
@@ -43,13 +43,11 @@ Abstract type for cache entries. Subtypes must have:
 """
 abstract type AbstractCacheEntry{T <: AbstractFloat, X <: AbstractVector{T}} end
 
-# Map a user input grid type to the cache's wrapped axis type — mirrors `_to_float`
-# so the banked cache type matches the real grid: `Tinv = typeof(inv(oneunit(T)))`,
-# AbstractUnitRange → `_UnitStep` else `_Generic` (a wrapped `_CachedRange` keeps its
-# tag), Vector → `_CachedVector`, `:exclusive` → outer `_ExclusivePeriodicAxis`.
-@inline _cached_axis_type(::Type{<:AbstractRange}, ::Type{T}) where {T} = _CachedRange{T, typeof(inv(oneunit(T))), _Generic}
-@inline _cached_axis_type(::Type{<:AbstractUnitRange}, ::Type{T}) where {T} = _CachedRange{T, typeof(inv(oneunit(T))), _UnitStep}
-@inline _cached_axis_type(::Type{<:_CachedRange{S, Si, Tag}}, ::Type{T}) where {S, Si, Tag, T} = _CachedRange{T, typeof(inv(oneunit(T))), Tag}
+# Banked axis type for an already-normalized cache grid: `_CachedRange{T}` (tag preserved)
+# or `Vector{T}`. Raw ranges are `_to_float`-converted upstream, so they never reach here;
+# `:exclusive` adds an outer `_ExclusivePeriodicAxis`.
+@inline _cached_axis_type(::Type{<:_CachedRange{S, Si, Tag}}, ::Type{T}) where {S, Si, Tag, T} =
+    _CachedRange{T, typeof(inv(oneunit(T))), Tag}
 @inline _cached_axis_type(::Type{<:AbstractVector}, ::Type{T}) where {T} =
     _CachedVector{T, typeof(inv(oneunit(T)))}
 

--- a/src/cubic/cubic_cache_pool.jl
+++ b/src/cubic/cubic_cache_pool.jl
@@ -48,7 +48,12 @@ abstract type AbstractCacheEntry{T <: AbstractFloat, X <: AbstractVector{T}} end
 # Vector → `_CachedVector{T, Tinv}`. `:exclusive` periodic adds an outer
 # `_ExclusivePeriodicAxis` wrapper. Cubic always promotes to float, so pin
 # `Tinv = T` to keep `EntryType` concrete.
-@inline _cached_axis_type(::Type{<:AbstractRange}, ::Type{T}) where {T} = _CachedRange{T, T}
+# Mirror `_to_float`'s axis-tag decision so the banked cache type matches the
+# real grid type: AbstractUnitRange{<:Integer} → `_UnitStep`, else `_Generic`;
+# an already-wrapped `_CachedRange` preserves its tag.
+@inline _cached_axis_type(::Type{<:AbstractRange}, ::Type{T}) where {T} = _CachedRange{T, T, _Generic}
+@inline _cached_axis_type(::Type{<:AbstractUnitRange}, ::Type{T}) where {T} = _CachedRange{T, T, _UnitStep}
+@inline _cached_axis_type(::Type{<:_CachedRange{S, Si, Tag}}, ::Type{T}) where {S, Si, Tag, T} = _CachedRange{T, T, Tag}
 @inline _cached_axis_type(::Type{<:AbstractVector}, ::Type{T}) where {T} =
     _CachedVector{T, typeof(inv(oneunit(T)))}
 
@@ -714,7 +719,7 @@ end
 # _CachedRange: bank keyed on _CachedRange{T, T} (Tinv == T for Float grids).
 # objectid is deterministic for isbits → fast hit.
 @inline function _get_derivative_cache_impl(x::_CachedRange{T, T}, bc_pair::BCPair{L, R}) where {T <: AbstractFloat, L <: PointBC, R <: PointBC}
-    bank = _get_derivative_bank(_CachedRange{T, T}, bc_pair)
+    bank = _get_derivative_bank(typeof(x), bc_pair)   # concrete (carries the axis tag)
     return _lookup_or_insert!(bank, x, bc_pair)
 end
 
@@ -757,7 +762,7 @@ end
 
 # _CachedRange: bank keyed on _CachedRange{T, T} (Tinv == T for Float grids).
 @inline function _get_periodic_cache_impl(x::_CachedRange{T, T}, bc::PeriodicBC) where {T <: AbstractFloat}
-    bank = _get_periodic_bank(_CachedRange{T, T}, bc)
+    bank = _get_periodic_bank(typeof(x), bc)   # concrete (carries the axis tag)
     return _lookup_or_insert!(bank, x, bc)
 end
 

--- a/src/cubic/cubic_cache_pool.jl
+++ b/src/cubic/cubic_cache_pool.jl
@@ -43,17 +43,13 @@ Abstract type for cache entries. Subtypes must have:
 """
 abstract type AbstractCacheEntry{T <: AbstractFloat, X <: AbstractVector{T}} end
 
-# Map user input grid type to the cache's wrapped axis type. Mirrors
-# `_cache_axis(_convert_copy(x, T), bc)`: Range → `_CachedRange{T, T}`,
-# Vector → `_CachedVector{T, Tinv}`. `:exclusive` periodic adds an outer
-# `_ExclusivePeriodicAxis` wrapper. Cubic always promotes to float, so pin
-# `Tinv = T` to keep `EntryType` concrete.
-# Mirror `_to_float`'s axis-tag decision so the banked cache type matches the
-# real grid type: AbstractUnitRange{<:Integer} → `_UnitStep`, else `_Generic`;
-# an already-wrapped `_CachedRange` preserves its tag.
-@inline _cached_axis_type(::Type{<:AbstractRange}, ::Type{T}) where {T} = _CachedRange{T, T, _Generic}
-@inline _cached_axis_type(::Type{<:AbstractUnitRange}, ::Type{T}) where {T} = _CachedRange{T, T, _UnitStep}
-@inline _cached_axis_type(::Type{<:_CachedRange{S, Si, Tag}}, ::Type{T}) where {S, Si, Tag, T} = _CachedRange{T, T, Tag}
+# Map a user input grid type to the cache's wrapped axis type — mirrors `_to_float`
+# so the banked cache type matches the real grid: `Tinv = typeof(inv(oneunit(T)))`,
+# AbstractUnitRange → `_UnitStep` else `_Generic` (a wrapped `_CachedRange` keeps its
+# tag), Vector → `_CachedVector`, `:exclusive` → outer `_ExclusivePeriodicAxis`.
+@inline _cached_axis_type(::Type{<:AbstractRange}, ::Type{T}) where {T} = _CachedRange{T, typeof(inv(oneunit(T))), _Generic}
+@inline _cached_axis_type(::Type{<:AbstractUnitRange}, ::Type{T}) where {T} = _CachedRange{T, typeof(inv(oneunit(T))), _UnitStep}
+@inline _cached_axis_type(::Type{<:_CachedRange{S, Si, Tag}}, ::Type{T}) where {S, Si, Tag, T} = _CachedRange{T, typeof(inv(oneunit(T))), Tag}
 @inline _cached_axis_type(::Type{<:AbstractVector}, ::Type{T}) where {T} =
     _CachedVector{T, typeof(inv(oneunit(T)))}
 

--- a/src/linear/linear_kernels.jl
+++ b/src/linear/linear_kernels.jl
@@ -77,3 +77,16 @@ end
 @inline function _linear_kernel(::DerivOp{N}, yL::Tv, ::Tv, ::Tg, α) where {N, Tg, Tv}
     return 0 * yL * one(α)
 end
+
+# ========================================
+# Normalized cell coordinate: α = (q - L) / h
+# ========================================
+# Shared by 1D (`linear_oneshot.jl`) and ND (`linear_nd_eval.jl`); grid-type dispatched:
+#   - `inv_h` form: caller supplies the reciprocal (ND `_locate_cell`).
+#   - `_CachedRange`: pull cached `inv_h` via the accessor — a `_UnitStep` grid returns
+#     `one`, so LLVM folds the `×inv_h` away (α = q - L). No `_UnitStep` method needed.
+#   - plain `AbstractVector`: divide by the on-the-fly `R - L` (EvalValue can then DCE
+#     the separately-extracted `inv_h`, which only EvalDeriv1 kernels use).
+@inline _alpha_of(q::Real, L::Real, inv_h::Real) = (q - L) * inv_h
+@inline _alpha_of(q::Real, L::Real, R::Real, x::_CachedRange) = (q - L) * _get_inv_h(x)
+@inline _alpha_of(q::Real, L::Real, R::Real, ::AbstractVector) = (q - L) / float(R - L)

--- a/src/linear/nd/linear_nd_eval.jl
+++ b/src/linear/nd/linear_nd_eval.jl
@@ -108,15 +108,8 @@ end
     return false
 end
 
-# 3-arg form: caller supplies cached `inv_h` (persistent path).
-# 4-arg form: dispatch on grid type (oneshot path) — plain `AbstractVector`
-# uses direct division so EvalValue queries can DCE the separately-extracted
-# `inv_hs` (only needed by EvalDeriv1 kernel weights).
-@inline _alpha_of(q::Real, L::Real, inv_h::Real) = (q - L) * inv_h
-@inline _alpha_of(q::Real, L::Real, R::Real, x::_CachedRange) = (q - L) * x.inv_h
-# Unit-step (`_UnitStep` tag): inv_h ≡ 1, so α = q - L (skip the ×inv_h).
-@inline _alpha_of(q::Real, L::Real, R::Real, ::_CachedRange{T, Tinv, _UnitStep}) where {T, Tinv} = q - L
-@inline _alpha_of(q::Real, L::Real, R::Real, ::AbstractVector) = (q - L) / float(R - L)
+# `_alpha_of` (normalized cell coordinate, shared by 1D + ND) is defined in
+# linear_kernels.jl. The `_ExclusivePeriodicAxis` overload lives in periodic_axis.jl.
 
 # ========================================
 # Multilinear Interpolation Kernel

--- a/src/linear/nd/linear_nd_eval.jl
+++ b/src/linear/nd/linear_nd_eval.jl
@@ -114,6 +114,8 @@ end
 # `inv_hs` (only needed by EvalDeriv1 kernel weights).
 @inline _alpha_of(q::Real, L::Real, inv_h::Real) = (q - L) * inv_h
 @inline _alpha_of(q::Real, L::Real, R::Real, x::_CachedRange) = (q - L) * x.inv_h
+# Unit-step (`_UnitStep` tag): inv_h ≡ 1, so α = q - L (skip the ×inv_h).
+@inline _alpha_of(q::Real, L::Real, R::Real, ::_CachedRange{T, Tinv, _UnitStep}) where {T, Tinv} = q - L
 @inline _alpha_of(q::Real, L::Real, R::Real, ::AbstractVector) = (q - L) / float(R - L)
 
 # ========================================

--- a/test/test_unitstep_tag.jl
+++ b/test/test_unitstep_tag.jl
@@ -1,0 +1,81 @@
+# Coverage for the `_UnitStep` axis tag: which inputs earn it, the `Tinv`
+# reciprocal-type contract, the accessor fold invariant, and that persistent
+# interpolants (1D + ND) carry the intended tag — for both `_UnitStep` and
+# `_Generic`.
+
+@testitem "Axis tag — resolver assigns _UnitStep iff AbstractUnitRange" begin
+    using FastInterpolations:
+        _resolve_axis, _cache_axis, _to_float,
+        _CachedRange, _UnitStep, _Generic, _get_h, _get_inv_h, NoBC
+
+    tagof(x::_CachedRange) = typeof(x).parameters[3]
+
+    @testset "AbstractUnitRange → _UnitStep (one-shot and persistent agree)" begin
+        for g in (1:100, Base.OneTo(100))
+            @test _resolve_axis(g) isa _CachedRange{Float64, Float64, _UnitStep}
+            @test _cache_axis(g, NoBC(), Float64) isa _CachedRange{Float64, Float64, _UnitStep}
+        end
+    end
+
+    @testset "Non-unit-range (incl. step-1 StepRange) → _Generic" begin
+        # `1:1:100` is a StepRange, NOT an AbstractUnitRange — its unit step is a
+        # runtime field, not a type fact — so it correctly stays `_Generic`.
+        for g in (1:1:100, 1.0:100.0, 0.0:0.5:50.0, range(0.0, 1.0; length = 100))
+            @test _resolve_axis(g) isa _CachedRange{Float64, Float64, _Generic}
+            @test _cache_axis(g, NoBC(), Float64) isa _CachedRange{Float64, Float64, _Generic}
+        end
+    end
+
+    @testset "Tinv contract — reciprocal type, never the coordinate Int" begin
+        # `Tinv == typeof(inv(oneunit(T)))`: Float64 for Int, T for Float. A
+        # `_UnitStep` Int grid must NOT collapse to `_CachedRange{Int, Int}`.
+        cr_i = _to_float(1:4, Int)
+        @test cr_i isa _CachedRange{Int, Float64, _UnitStep}
+        @test cr_i.h === 1                    # coordinate spacing stays Int
+        @test cr_i.inv_h === 1.0              # reciprocal is Float64
+        cr32 = _to_float(1:4, Float32)
+        @test cr32 isa _CachedRange{Float32, Float32, _UnitStep}
+        @test cr32.inv_h === 1.0f0
+    end
+
+    @testset "Accessors fold to one(Tinv) on _UnitStep; return field on _Generic" begin
+        u = _to_float(1:4, Float64)           # _UnitStep — h ≡ inv_h ≡ 1
+        @test _get_h(u) === 1.0 && _get_inv_h(u) === 1.0
+        @test _get_h(u, 1) === 1.0 && _get_inv_h(u, 1) === 1.0                  # 2-arg delegates
+        @test _get_h(u, 1, 0.0, 0.0) === 1.0 && _get_inv_h(u, 1, 0.0, 0.0) === 1.0  # 4-arg delegates
+        g = _to_float(0.0:0.5:5.0, Float64)   # _Generic — non-unit step
+        @test tagof(g) === _Generic
+        @test _get_h(g) === 0.5 && _get_inv_h(g) === 2.0
+    end
+end
+
+@testitem "Axis tag — survives into persistent interpolants (1D + ND)" begin
+    using FastInterpolations: _CachedRange, _UnitStep, _Generic
+    tagof(x::_CachedRange) = typeof(x).parameters[3]
+
+    y = collect(Float64, 1:60) .^ 2
+    data = [Float64(i + j) for i in 1:60, j in 1:60]
+
+    @testset "1D — UnitRange → _UnitStep, Float range → _Generic" begin
+        # grid field path differs by method: linear/quad/pchip `.x`, cubic `.cache.x`
+        @test tagof(linear_interp(1:60, y).x) === _UnitStep
+        @test tagof(linear_interp(1.0:60.0, y).x) === _Generic
+        @test tagof(cubic_interp(1:60, y).cache.x) === _UnitStep
+        @test tagof(cubic_interp(1.0:60.0, y).cache.x) === _Generic
+        @test tagof(quadratic_interp(1:60, y).x) === _UnitStep
+        @test tagof(pchip_interp(1:60, y).x) === _UnitStep
+    end
+
+    @testset "Constant keeps Tg=Int, _UnitStep, Float64 reciprocal" begin
+        c = constant_interp(1:4, Float32[1, 4, 9, 16])
+        @test c.x isa _CachedRange{Int, Float64, _UnitStep}
+    end
+
+    @testset "ND — per-axis tags are independent (mixed _UnitStep/_Generic)" begin
+        itp = linear_interp((1:60, 1.0:60.0), data)
+        @test tagof(itp.grids[1]) === _UnitStep
+        @test tagof(itp.grids[2]) === _Generic
+        itp2 = linear_interp((1:60, Base.OneTo(60)), data)
+        @test all(tagof.(itp2.grids) .=== _UnitStep)
+    end
+end


### PR DESCRIPTION
## Summary

`UnitRange`/`OneTo` grids (e.g.,image and index axes) have step ≡ 1 known at the **type** level. This PR carries that through as a `_UnitStep` axis tag so the compiler folds the per-query spacing multiplies (`×inv_h`/`×h`) out of persistent interpolation.

The payoff: **5–18% faster** on `UnitRange`/`OneTo` grids across linear, cubic, and Hermite — bit-identical and zero-alloc. `_Generic` grids and one-shot calls are unaffected.

## Changes

**`_UnitStep` axis tag** (`core/axis_types.jl`, `core/cached_range.jl`) — `_CachedRange{T,Tinv,Tag}` gains a generic `Tag`; `_to_float(::AbstractUnitRange)` stamps `_UnitStep`, every other range stays `_Generic`. Division-free, preserving the `Tinv = typeof(inv(oneunit(T)))` contract (`Float64` for `Int` grids).

**No-arg accessor fold** (`core/cached_range.jl`, `core/search.jl`, `linear/linear_kernels.jl`) — `_get_h(x)`/`_get_inv_h(x)` return the literal `one(Tinv)` for `_UnitStep`; the idx-shaped forms delegate. `_search_direct` and `_alpha_of` route through them, so the fold reaches every kernel that reads spacing via the accessor (linear, cubic, PCHIP/Cardinal/Akima, ND, integrate) — no per-method specialization.

**Cubic cache mirror** (`cubic/cubic_cache_pool.jl`) — `_cached_axis_type` mirrors `_to_float`'s tag + `Tinv`.

**Tests** (`test/test_unitstep_tag.jl`) — tag assignment, the `Tinv` contract, the accessor invariant, and persistent 1D/ND tag survival (`_UnitStep` and `_Generic`).

## Benchmark

Persistent interpolant, **scalar query in a loop** (one point at a time — the image-resize access pattern, not a batch call), `1:100` `UnitRange` grid vs. master. Apple Silicon (arm64), ns/query, 3-run average.

```julia
using FastInterpolations, BenchmarkTools

g  = 1:100                                  # UnitRange grid  → _UnitStep
y  = collect(Float64, 1:100) .^ 2
qs = collect(range(1.0, 98.5, length = 10_000))
itp = cubic_interp(g, y)                     # persistent: build once
@belapsed (for q in $qs; $itp(q); end)       # scalar eval, one query at a time
```

| method (1D persistent, scalar) | master | this PR | speedup |
|---|--:|--:|--:|
| linear | 1.23 | 1.07 | **1.16×** |
| cubic | 2.55 | 2.23 | **1.14×** |
| pchip / cardinal / akima | 2.67 | 2.30 | **1.16×** |

| ND (persistent, scalar tuple query) | master | this PR | speedup |
|---|--:|--:|--:|
| cubic 2D | 7.42 | 6.28 | **1.18×** |
| linear 2D | 3.27 | 3.10 | 1.06× |

Batch queries (`itp(qs)` / in-place `itp(out, qs)`, zero-alloc) hold the same gains for cubic/Hermite (~1.14–1.16×); linear's gain shrinks to ~1.06× there — its light kernel becomes throughput-bound in the vectorized inner loop, so the single folded `×inv_h` overlaps away.

No effect where the kernel never reads `inv_h` at eval time: **quadratic** (coefficients baked at build) and linear **`deriv1`** — both ≈1.0×. Cubic/Hermite track linear in 1D (they rebuild the polynomial from cached derivatives/slopes each query, folding several `×h`/`×inv_h`); the spread widens in ND, where the tensor collapse re-runs the heavier kernel per axis so the folds compound.

## Safety

- **Bit-identical** — `h ≡ inv_h ≡ 1` exactly, so `×1.0` / `muladd(_,1.0,_)` folding is an exact IEEE identity (cubic eval drops 20 → 18 FP ops; no `fmul`/`fmadd` for the folded terms).
- **Zero-alloc, type-stable** — the tag derives from `AbstractUnitRange` (compile-time), no runtime branch, no `Union`. `_Generic` grids unchanged.
