### PR TITLE
(perf): branchless clamp-compare for NoExtrap domain check

### DIFF
--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -524,15 +524,16 @@ _promote_coord(0.5f0, Float32)  # → 0.5f0 (Float32)
 @noinline _throw_domain_error(xi, x_min, x_max) =
     throw(DomainError(xi, "query point outside interpolation domain [$x_min, $x_max]"))
 
-# `_extract_primal(xi)` (query) as well as the bounds: at equal primals
-# ForwardDiff's `Dual <=> Real` tie-breaks on the partial sign, so a Dual query
-# exactly at the boundary would flip in/out of domain by its derivative direction
-# alone — same partial-independence rationale as `_is_all_inbounds`/`_oob_state`.
+# NoExtrap domain check. OOB iff the branchless `_clamp` (min/max) alters the query:
+# `_clamp(xip,lo,hi) != xip` is 1 compare + 1 branch vs `(xip<lo || xip>hi)`'s two
+# branches — a saving that compounds across axes in ND's `_validate_nd_domain`.
+# Compares the extracted primal, so a Dual query at the boundary classifies by value,
+# not partial sign (cf. `_is_all_inbounds`/`_oob_state`).
 "Scalar domain check for NoExtrap: throws DomainError if out of domain."
 @inline function _check_domain(x::AbstractVector, xi::Real, ::NoExtrap)
     xip = _extract_primal(xi)
     x_min, x_max = _extract_primal(first(x)), _extract_primal(last(x))
-    (xip < x_min || xip > x_max) && _throw_domain_error(xi, x_min, x_max)
+    (_clamp(xip, x_min, x_max) != xip) && _throw_domain_error(xi, x_min, x_max)
     return nothing
 end
 
@@ -540,7 +541,7 @@ end
 @inline function _check_domain(x::_CachedRange, xi::Real, ::NoExtrap)
     xip = _extract_primal(xi)
     lo, hi = _extract_primal(x.domain_lo), _extract_primal(x.domain_hi)
-    (xip < lo || xip > hi) && _throw_domain_error(xi, _extract_primal(x.lo), _extract_primal(x.hi))
+    (_clamp(xip, lo, hi) != xip) && _throw_domain_error(xi, _extract_primal(x.lo), _extract_primal(x.hi))
     return nothing
 end
 

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -533,13 +533,19 @@ _promote_coord(0.5f0, Float32)  # → 0.5f0 (Float32)
 # NoExtrap domain check. OOB iff the branchless `_clamp` (min/max) alters the query:
 # `_clamp(xip,lo,hi) != xip` is 1 compare + 1 branch vs `(xip<lo || xip>hi)`'s two
 # branches — a saving that compounds across axes in ND's `_validate_nd_domain`.
+# `min`/`max` promote, so the clamp result `c` carries the bound type; comparing
+# against `oftype(c, xip)` aligns the RHS to that type so the idiom stays a true
+# value test. Without it, a query whose `==` vs its float-promotion is non-reflexive
+# (`Irrational`: `Float64(π) != π`; inexact `Rational`) is spuriously flagged OOB.
+# On the Float64 hot path `oftype(c, xip)` is identity, so this is free.
 # Compares the extracted primal, so a Dual query at the boundary classifies by value,
 # not partial sign (cf. `_is_all_inbounds`/`_oob_state`).
 "Scalar domain check for NoExtrap: throws DomainError if out of domain."
 @inline function _check_domain(x::AbstractVector, xi::Real, ::NoExtrap)
     xip = _extract_primal(xi)
     x_min, x_max = _extract_primal(first(x)), _extract_primal(last(x))
-    (_clamp(xip, x_min, x_max) != xip) && _throw_domain_error(xi, x_min, x_max)
+    c = _clamp(xip, x_min, x_max)
+    (c != oftype(c, xip)) && _throw_domain_error(xi, x_min, x_max)
     return nothing
 end
 
@@ -547,7 +553,8 @@ end
 @inline function _check_domain(x::_CachedRange, xi::Real, ::NoExtrap)
     xip = _extract_primal(xi)
     lo, hi = _extract_primal(x.domain_lo), _extract_primal(x.domain_hi)
-    (_clamp(xip, lo, hi) != xip) && _throw_domain_error(xi, x)
+    c = _clamp(xip, lo, hi)
+    (c != oftype(c, xip)) && _throw_domain_error(xi, x)
     return nothing
 end
 

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -524,6 +524,12 @@ _promote_coord(0.5f0, Float32)  # → 0.5f0 (Float32)
 @noinline _throw_domain_error(xi, x_min, x_max) =
     throw(DomainError(xi, "query point outside interpolation domain [$x_min, $x_max]"))
 
+# _CachedRange overload: pull the physical endpoints (`lo`/`hi`, distinct from the
+# `domain_lo`/`domain_hi` the hot check clamps against) inside this @noinline cold path,
+# so the in-domain hot path never materializes them — guaranteed, not LLVM-sink-dependent.
+@noinline _throw_domain_error(xi, x::_CachedRange) =
+    _throw_domain_error(xi, _extract_primal(x.lo), _extract_primal(x.hi))
+
 # NoExtrap domain check. OOB iff the branchless `_clamp` (min/max) alters the query:
 # `_clamp(xip,lo,hi) != xip` is 1 compare + 1 branch vs `(xip<lo || xip>hi)`'s two
 # branches — a saving that compounds across axes in ND's `_validate_nd_domain`.
@@ -541,7 +547,7 @@ end
 @inline function _check_domain(x::_CachedRange, xi::Real, ::NoExtrap)
     xip = _extract_primal(xi)
     lo, hi = _extract_primal(x.domain_lo), _extract_primal(x.domain_hi)
-    (_clamp(xip, lo, hi) != xip) && _throw_domain_error(xi, _extract_primal(x.lo), _extract_primal(x.hi))
+    (_clamp(xip, lo, hi) != xip) && _throw_domain_error(xi, x)
     return nothing
 end
 

--- a/test/test_noextrap_domain_real_types.jl
+++ b/test/test_noextrap_domain_real_types.jl
@@ -1,0 +1,124 @@
+# ═══════════════════════════════════════════════════════════════════════════════
+# test_noextrap_domain_real_types.jl
+#
+# Regression pins for the NoExtrap scalar domain check across Real query types.
+#
+# The branchless idiom `_clamp(xip, lo, hi) != xip` (utils.jl `_check_domain`)
+# silently assumes the in-bounds clamp is a no-op under `==`. That holds only
+# when the query and the bounds share a type — `min`/`max` PROMOTE, so the clamp
+# result's type can differ from the original query, and `==` across that boundary
+# is NOT guaranteed reflexive:
+#   * `Irrational`  — `Float64(π) == π` is `false` (exact comparison). ALWAYS red.
+#   * `Rational`    — `Float64(1//3) == 1//3` is `false` when inexact. Red.
+#   * large `Int`   — `Float64(2^53+1) == 2^53+1` is `false`. Red (rare).
+# Floats / small Ints / Duals survive because their `==` promotes both operands
+# to a common type first.
+#
+# A correct in-domain query MUST NOT throw; a correct OOB query MUST throw. The
+# Irrational / inexact-Rational interior cases below are GREEN under the old
+# comparison check `(xip < lo) || (xip > hi)` and RED under the new clamp-compare.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@testitem "NoExtrap domain check — Real query subtypes" begin
+    using ForwardDiff: Dual
+
+    # Two grid representations exercise BOTH _check_domain methods:
+    #   range(...)   -> _CachedRange  (clamps against domain_lo/domain_hi)
+    #   collect(...) -> Vector        (clamps against first/last)
+    big_rng = range(0.0, 10.0, 11)       # interior room for π, ℯ, 1//3, ...
+    big_vec = collect(big_rng)
+    unit_rng = range(0.0, 1.0, 11)       # π, ℯ, 3.5 land OOB here
+
+    f(g) = sin.(collect(g))
+    mk(builder, g) = builder(g, f(g); extrap = NoExtrap())
+
+    # Returns true iff `itp(q)` does NOT raise a DomainError (clean Bool ⇒ a
+    # false-positive throw shows as a @test Fail, not an Error). A non-DomainError
+    # surfaces unchanged so genuine kernel failures are never masked.
+    nothrow(itp, q) = try
+        itp(q)
+        true
+    catch e
+        e isa DomainError ? false : rethrow()
+    end
+
+    # ── RED PINS: in-domain queries that the clamp-compare wrongly rejects ──
+    @testset "Irrational interior — must NOT throw (RED before fix)" begin
+        for g in (big_rng, big_vec)
+            itp = mk(cubic_interp, g)
+            @test nothrow(itp, π)      # 3.14159… ∈ [0,10]
+            @test nothrow(itp, ℯ)      # 2.71828… ∈ [0,10]
+        end
+    end
+
+    @testset "Rational interior — inexact must NOT throw (RED before fix)" begin
+        for g in (big_rng, big_vec)
+            itp = mk(cubic_interp, g)
+            @test nothrow(itp, 1 // 3)   # inexact in Float64 — RED
+            @test nothrow(itp, 7 // 3)   # inexact — RED
+            @test nothrow(itp, 7 // 2)   # 3.5 exact — already green
+        end
+    end
+
+    @testset "shared across methods (check lives in one place)" begin
+        for builder in (linear_interp, constant_interp, cubic_interp)
+            @test nothrow(mk(builder, big_rng), π)
+            @test nothrow(mk(builder, big_vec), 1 // 3)
+        end
+    end
+
+    # ── OOB of the same exotic types still throws (no false negatives) ──
+    @testset "Irrational / Rational OOB — must throw" begin
+        itp = mk(cubic_interp, unit_rng)
+        @test_throws DomainError itp(π)        # 3.14 > 1
+        @test_throws DomainError itp(ℯ)        # 2.71 > 1
+        @test_throws DomainError itp(7 // 2)   # 3.5 > 1
+        @test_throws DomainError itp(-1 // 3)  # < 0
+    end
+
+    # ── Regression coverage: types unaffected by the bug stay green ──
+    @testset "mixed-precision Float queries — stay green" begin
+        itp = mk(cubic_interp, big_rng)
+        @test nothrow(itp, 3.5f0)             # Float32 on Float64 grid
+        @test nothrow(itp, Float16(3.5))      # Float16
+        @test nothrow(itp, big"3.5")          # BigFloat
+        # Float64 query on a Float32 grid
+        g32 = Float32.(big_vec)
+        @test nothrow(cubic_interp(g32, f(g32); extrap = NoExtrap()), 3.5)
+        # OOB still throws
+        @test_throws DomainError mk(cubic_interp, unit_rng)(3.5f0)
+    end
+
+    @testset "Int query — stays green" begin
+        itp = mk(cubic_interp, big_rng)
+        @test nothrow(itp, 3)                 # interior
+        @test_throws DomainError mk(cubic_interp, unit_rng)(3)   # OOB
+    end
+
+    @testset "boundary-equal queries — inclusive, must NOT throw" begin
+        for g in (big_rng, big_vec)
+            itp = mk(cubic_interp, g)
+            lo, hi = first(g), last(g)
+            @test nothrow(itp, lo)       # exact lower endpoint (Float64)
+            @test nothrow(itp, hi)       # exact upper endpoint
+            @test nothrow(itp, 0 // 1)   # Rational == lo
+            @test nothrow(itp, 10 // 1)  # Rational == hi
+        end
+    end
+
+    @testset "Dual query — classify by primal, partial sign irrelevant" begin
+        itp = mk(cubic_interp, big_rng)
+        lo, hi = first(big_rng), last(big_rng)
+        # interior primal, either partial sign → in domain
+        @test nothrow(itp, Dual(3.5, +1.0))
+        @test nothrow(itp, Dual(3.5, -1.0))
+        # primal exactly at a boundary, either partial sign → in domain
+        @test nothrow(itp, Dual(lo, +1.0))
+        @test nothrow(itp, Dual(lo, -1.0))
+        @test nothrow(itp, Dual(hi, +1.0))
+        @test nothrow(itp, Dual(hi, -1.0))
+        # primal OOB → throws regardless of partial sign
+        @test_throws DomainError itp(Dual(lo - 0.1, +1.0))
+        @test_throws DomainError itp(Dual(hi + 0.1, -1.0))
+    end
+end


### PR DESCRIPTION
## Summary

The `NoExtrap` domain check is the only per-query overhead separating a bounds-checked eval from the `InBounds` floor. It went from `(q < lo || q > hi)` (two conditional branches) to `_clamp(q, lo, hi) != q` (branchless `min/max` + one compare + one branch).

`_check_domain` is shared by the 1D scalar path and ND's per-axis `_validate_nd_domain`, so the saving **compounds across the N axes**. Semantics are unchanged.

This **cuts the domain-check overhead (the `NoExtrap − InBounds` gap) by ~25–59% on range grids** — biggest in ND. Vector grids are search-bound, so the effect is negligible.

## Benchmark

ns/query, arm64, in-domain, median of best-of-9. `InBounds` = the no-check floor;
its rows are **byte-identical** master↔branch (the check is the only thing that changed).

| grid (op) | InBounds | NoExtrap: master → PR | speedup | check-overhead cut |
|---|--:|--:|--:|--:|
| 1D UnitStep | 0.94 | 1.08 → 1.05 | 1.03× | 25% |
| 1D StepRange | 1.00 | 1.24 → 1.13 | **1.09×** | 43% |
| 1D Vector | 9.26 | 10.45 → 10.40 | 1.00× | 4% |
| 2D UnitStep · value | 1.89 | 2.58 → 2.23 | **1.15×** | 50% |
| 2D UnitStep · grad | 1.56 | 2.16 → 1.87 | **1.16×** | 49% |
| 2D StepRange · value | 2.08 | 2.80 → 2.39 | **1.17×** | 57% |
| 2D StepRange · grad | 1.72 | 2.47 → 2.03 | **1.22×** | 59% |
| 3D UnitStep · value | 3.66 | 5.46 → 4.78 | **1.14×** | 38% |
| 3D UnitStep · grad | 3.28 | 4.85 → 4.40 | **1.10×** | 29% |

`check-overhead cut` = fraction of the `NoExtrap − InBounds` gap removed.

## Safety

- Semantics identical: compares the extracted primal (Dual-at-boundary safe), NaN/OOB
  still throws, error message keeps the physical endpoints. `InBounds`/batch paths untouched.
- Affected suites green (`linear`, `nd_linear`, `derivatives`, `inbounds_extrap`,
  `fillextrap_domain_boundary`); `@inferred` clean for `Float`/`Dual`, 1D + ND.
