### PR TITLE
(perf): share _CachedVector endpoint loads across domain check and search

### DIFF
--- a/src/core/cached_vector.jl
+++ b/src/core/cached_vector.jl
@@ -20,6 +20,12 @@ Base.length(c::_CachedVector) = length(c.inner)
 @inline Base.@propagate_inbounds Base.getindex(c::_CachedVector, i::Int) = c.inner[i]
 @inline Base.firstindex(::_CachedVector) = 1
 @inline Base.lastindex(c::_CachedVector) = length(c.inner)
+# Endpoint accessors: index `inner` directly under `@inbounds` — shared via CSE
+# with the domain check and `_search_binary`'s guard, bounds check dropped (n≥2
+# by ctor). `last` doesn't propagate `@inbounds`, so index explicitly
+# (`@inbounds last(c.inner)` would keep the check).
+@inline Base.first(c::_CachedVector) = @inbounds c.inner[1]
+@inline Base.last(c::_CachedVector) = @inbounds c.inner[end]
 Base.eltype(::Type{<:_CachedVector{T}}) where {T} = T
 Base.IndexStyle(::Type{<:_CachedVector}) = IndexLinear()
 

--- a/src/core/search.jl
+++ b/src/core/search.jl
@@ -558,9 +558,12 @@ compile to ARM64 `csel` / x86 `cmov` — fully branchless binary search body.
 @inline function _search_binary(x::AbstractVector{T}, xq::Real) where {T <: Real}
     n = length(x)
     @inbounds begin
-        if xq <= x[1]
+        # Endpoint guards via `first`/`last` (not `x[1]`/`x[end]`) so a wrapper's
+        # `@inbounds` endpoint overrides are reused — CSE-shared with the domain
+        # check instead of re-walking `inner`. Identity for raw `Vector`.
+        if xq <= first(x)
             idx = 1
-        elseif xq >= x[end]
+        elseif xq >= last(x)
             idx = n - 1
         else
             lo, hi = 1, n


### PR DESCRIPTION
## Summary

The persistent `Vector`-grid eval read its grid endpoints **twice** per query — the domain
check and the binary-search guard each loaded `inner[1]`/`inner[end]` independently, both
bounds-checked. This PR routes both through `_CachedVector`'s `first`/`last` so they share a
single `@inbounds` load (CSE). Biggest win: **Clamp eval, especially batch** (−0.87 ns/query).

## Key Design

- **`_CachedVector` `first`/`last` overrides** index `inner` directly under `@inbounds`
  (`first(c)=@inbounds c.inner[1]`, `last(c)=@inbounds c.inner[end]`).
- **`_search_binary`'s guard** uses `first(x)`/`last(x)` instead of `x[1]`/`x[end]`.
- The override carries its own `@inbounds`, so every generic caller (`_check_domain`,
  `_oob_state`, `_domain_bounds`, `_search_binary`) shares the load and drops the check
  transparently — no `@inbounds` at call sites.
- **Index `inner`, not new `lo`/`hi` struct fields.** Caching `lo`/`hi` pairs into one `ldp`
  (bigger NoExtrap win, −0.77) but lives at a *separate* address, so the search re-loads
  `inner` anyway (duplicate loads) and the +16 B/axis regresses ND (+0.3) and `_oob_state`
  paths. Indexing `inner` keeps it a clean sweep with no struct-size cost.
- `last` is indexed explicitly: `Base.last` doesn't propagate `@inbounds` (unlike `first`),
  so `@inbounds last(inner)` would silently keep the check.

## Benchmark

ns/query, arm64, in-domain, looped scalar (`S`) / batch in-place (`B`), vs `master`.
Bit-identical results; raw `Vector` and `Range` paths unaffected.

| path (Vector grid) | master | this PR | Δ |
|---|--:|--:|--:|
| InBounds (control) S / B | 9.23 / 24.23 | 9.23 / 24.24 | ~0 |
| NoExtrap · value / deriv | 10.38 / 9.88 | 10.26 / 9.78 | −0.13 / −0.09 |
| Clamp · value / deriv (S) | 9.73 / 9.96 | 9.28 / 9.75 | **−0.45 / −0.21** |
| Clamp · value / deriv (B) | 25.26 / 24.43 | 24.38 / 24.09 | **−0.87 / −0.33** |
| Fill · value / deriv | 10.51 / 9.95 | 10.50 / 10.06 | ~0 / +0.11 ⚠ |

Clamp benefits most (its hot path clamps every query). The lone outlier, **Fill deriv +0.11**
(~1%, uncommon), is a scheduling artifact — its codegen is *strictly leaner* than master
(fewer instructions, identical loads/branches), so there is no extra work.

## Safety

Bit-identical: `first`/`last` return the same endpoints, and the grid has ≥2 points by
construction so `@inbounds` is sound. Raw `Vector` (`first ≡ x[1]`) and `Range` (uses
`_search_direct`) unchanged. Affected suites green: `linear`, `nd_linear`, `axis_data_resolvers`.
