### PR TITLE
(perf): promote-then-compare for Int-grid comparisons

### DIFF
--- a/src/core/anchor_common.jl
+++ b/src/core/anchor_common.jl
@@ -35,8 +35,10 @@ independent for Dual grids.
 @inline function _oob_state(x::AbstractVector, xq::Real)
     lo, hi = _domain_bounds(x)
     xqp = _extract_primal(xq)
-    xqp < _extract_primal(lo) && return OOB_LEFT
-    xqp > _extract_primal(hi) && return OOB_RIGHT
+    # `_lt`/`_gt` promote-compare: dodge Base's exact mixed `<(Int, Float)` on an
+    # Int/Rational grid (no-op on a Float grid). See ordering helpers in search.jl.
+    _lt(xqp, _extract_primal(lo)) && return OOB_LEFT
+    _gt(xqp, _extract_primal(hi)) && return OOB_RIGHT
     return IN_DOMAIN
 end
 

--- a/src/core/search.jl
+++ b/src/core/search.jl
@@ -547,7 +547,7 @@ end
 
 
 # ----------------------------------------
-# Promote-then-compare ordering helpers (interval search only)
+# Promote-then-compare ordering helpers
 # ----------------------------------------
 # Promote both operands first so dispatch hits the homogeneous `<=(T, T)`, not
 # Base's *exact* mixed `<=(Int, Float)` (which round-trips through an Int reconvert,

--- a/src/core/search.jl
+++ b/src/core/search.jl
@@ -546,6 +546,27 @@ muladd to identity — no separate `_UnitStep` method needed.
 end
 
 
+# ----------------------------------------
+# Promote-then-compare ordering helpers (interval search only)
+# ----------------------------------------
+# Promote both operands first so dispatch hits the homogeneous `<=(T, T)`, not
+# Base's *exact* mixed `<=(Int, Float)` (which round-trips through an Int reconvert,
+# ~1.7x slower/compare; its >2^53 exactness is moot for float-representable grids).
+# Bit-identical to `a <= b` for Int/Float/Rational/Dual (a Dual's value-tie order is
+# preserved, unlike a primal strip), zero-overhead identity on a Float grid. Only the
+# `Bool` is produced — coordinates keep their `_promote_coord` type. `_ge`/`_gt`
+# delegate (Base-style `>=(x, y) = y <= x`) so call sites keep natural operand order.
+@inline function _le(a, b)
+    pa, pb = promote(a, b)
+    return pa <= pb
+end
+@inline function _lt(a, b)
+    pa, pb = promote(a, b)
+    return pa < pb
+end
+@inline _ge(a, b) = _le(b, a)
+@inline _gt(a, b) = _lt(b, a)
+
 """
     _search_binary(x::AbstractVector{T}, xq::Real) where {T<:Real}
 
@@ -561,9 +582,11 @@ compile to ARM64 `csel` / x86 `cmov` — fully branchless binary search body.
         # Endpoint guards via `first`/`last` (not `x[1]`/`x[end]`) so a wrapper's
         # `@inbounds` endpoint overrides are reused — CSE-shared with the domain
         # check instead of re-walking `inner`. Identity for raw `Vector`.
-        if xq <= first(x)
+        # Comparisons go through `_le` so an Int/Rational grid is promoted
+        # per-compare (no exact mixed `<=`); identity on a Float grid.
+        if _le(xq, first(x))
             idx = 1
-        elseif xq >= last(x)
+        elseif _ge(xq, last(x))
             idx = n - 1
         else
             lo, hi = 1, n
@@ -573,7 +596,7 @@ compile to ARM64 `csel` / x86 `cmov` — fully branchless binary search body.
             iters = 64 - leading_zeros((hi - lo - 1) % UInt64)
             for _ in 1:iters
                 mid = (lo + hi) >> 1
-                cond = x[mid] <= xq
+                cond = _le(x[mid], xq)
                 lo = ifelse(cond, mid, lo)
                 hi = ifelse(cond, hi, mid)
             end
@@ -617,17 +640,17 @@ No bounds checking (except initial clamp), no binary fallback.
         ix = _clamp(ix, 1, n - 1)
 
         # Direct hit - most common case for monotonic queries
-        if x[ix] <= xq < x[ix + 1]
+        if _le(x[ix], xq) && _lt(xq, x[ix + 1])
             return ix, x[ix], x[ix + 1]
         end
 
         # LinearSearch walk - NO bounds check, NO fallback
-        if xq < x[ix]
-            while x[ix] > xq
+        if _lt(xq, x[ix])
+            while _gt(x[ix], xq)
                 ix -= 1
             end
         else  # xq >= x[ix + 1]
-            while x[ix + 1] <= xq
+            while _le(x[ix + 1], xq)
                 ix += 1
             end
         end
@@ -668,7 +691,7 @@ Walk left up to MAX steps. Returns `(ix, found)`.
                 stmts, quote
                     ix <= 1 && return (ix, false)
                     ix -= 1
-                    @inbounds x[ix] <= xq && return (ix, true)
+                    @inbounds _le(x[ix], xq) && return (ix, true)
                 end
             )
         end
@@ -682,7 +705,7 @@ Walk left up to MAX steps. Returns `(ix, found)`.
             lo = max(1, ix - $MAX)
             @inbounds while ix > lo
                 ix -= 1
-                x[ix] <= xq && return (ix, true)
+                _le(x[ix], xq) && return (ix, true)
             end
             return (ix, false)
         end
@@ -702,7 +725,7 @@ Same @generated strategy as `_walk_left`.
                 stmts, quote
                     ix >= n - 1 && return (ix, false)
                     ix += 1
-                    @inbounds xq < x[ix + 1] && return (ix, true)
+                    @inbounds _lt(xq, x[ix + 1]) && return (ix, true)
                 end
             )
         end
@@ -715,7 +738,7 @@ Same @generated strategy as `_walk_left`.
             hi = min(n - 1, ix + $MAX)
             @inbounds while ix < hi
                 ix += 1
-                xq < x[ix + 1] && return (ix, true)
+                _lt(xq, x[ix + 1]) && return (ix, true)
             end
             return (ix, false)
         end
@@ -750,9 +773,9 @@ Optimal for monotonic query sequences.
         # Direct hit — most common for sorted/monotonic queries
         xL = x[ix]
         xR = x[ix + 1]
-        xL <= xq < xR && return ix, xL, xR  # no hint write (ix unchanged)
+        _le(xL, xq) && _lt(xq, xR) && return ix, xL, xR  # no hint write (ix unchanged)
 
-        if xq < xL
+        if _lt(xq, xL)
             # Walk left: xq < x[ix] guaranteed ⟹ after ix-=1,
             # x[ix+1] = old x[ix] > xq — right bound already satisfied.
             # Only need: x[ix] <= xq  (single comparison per step)

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -621,7 +621,9 @@ end
 @inline function _is_inbounds(x::AbstractVector, xq::Real)
     lo, hi = _domain_bounds(x)
     xqp = _extract_primal(xq)
-    return _extract_primal(lo) <= xqp <= _extract_primal(hi)
+    # `_le` promote-compare: dodge Base's exact mixed `<=(Int, Float)` on an
+    # Int/Rational grid (no-op on a Float grid). See ordering helpers in search.jl.
+    return _le(_extract_primal(lo), xqp) && _le(xqp, _extract_primal(hi))
 end
 
 # Clamp a query to the grid's physical span `[first(x), last(x)]`, never the
@@ -654,8 +656,11 @@ the OOB slow-path, so this form stays preferred even post-1.10-LTS.
 @inline function _is_all_inbounds(x::AbstractVector, queries::AbstractVector{<:Real})
     isempty(queries) && return true
     lo, hi = _domain_bounds(x)
-    return minimum(queries) >= _extract_primal(lo) &&
-        maximum(queries) <= _extract_primal(hi)
+    # `_ge`/`_le` promote-compare (see search.jl): dodge Base's exact mixed
+    # `>=(Float, Int)` on an Int/Rational grid. Amortized over the min/max scan
+    # (one compare per batch), but free on a Float grid.
+    return _ge(minimum(queries), _extract_primal(lo)) &&
+        _le(maximum(queries), _extract_primal(hi))
 end
 
 # ========================================

--- a/test/test_promote_compare.jl
+++ b/test/test_promote_compare.jl
@@ -1,0 +1,152 @@
+# Behavior-pinning tests for the interval-search ordering helpers
+# `_le` / `_lt` / `_ge` / `_gt` (src/core/search.jl).
+#
+# Contract being pinned:
+#   1. Each helper is BIT-IDENTICAL to its Base operator (`<=`/`<`/`>=`/`>`) for
+#      any operands representable in their common promoted type — i.e. every grid
+#      valid for interpolation. (The helpers only `promote`-then-compare to dodge
+#      Base's *exact* mixed `<=(Int,Float)`; they never change the result.)
+#   2. The `Dual` total order (value tie broken by the partial) is PRESERVED —
+#      a primal strip would change it, so this guards that regression.
+#   3. Helpers are type-stable `Bool` and allocation-free.
+#   4. End-to-end: interval search + one-shot `linear_interp` are identical across
+#      `Int` / `Rational` / `Float` grids, and AD through an `Int` grid is correct.
+
+@testitem "Promote-compare ordering helpers" begin
+    using FastInterpolations
+    using FastInterpolations: _le, _lt, _ge, _gt, _search_binary
+    using ForwardDiff: Dual, derivative
+
+    # ── 1. Equivalence to Base operators ─────────────────────────────────────
+    @testset "≡ Base, same + mixed types (within mantissa)" begin
+        # integer-valued points: represented exactly by every test type
+        ipts = (-7, -3, -1, 0, 1, 3, 7, 12)
+        typed = (
+            Int64.(ipts), Int32.(ipts), Float64.(ipts),
+            Float32.(ipts), Rational{Int}.(ipts),
+        )
+        for A in typed, B in typed, a in A, b in B
+            @test _le(a, b) === (a <= b)
+            @test _lt(a, b) === (a < b)
+            @test _ge(a, b) === (a >= b)
+            @test _gt(a, b) === (a > b)
+        end
+
+        # fractional Float query vs Int/Rational grid — the hot mixed case the
+        # helpers exist for — tested in BOTH operand orders.
+        grids = (Int64[0, 1, 2, 5, 10], Rational{Int}[0, 1, 2, 5, 10])
+        for G in grids, g in G, q in -1.0:0.25:11.0
+            @test _le(g, q) === (g <= q)
+            @test _le(q, g) === (q <= g)
+            @test _lt(g, q) === (g < q)
+            @test _lt(q, g) === (q < g)
+            @test _ge(g, q) === (g >= q)
+            @test _ge(q, g) === (q >= g)
+            @test _gt(g, q) === (g > q)
+            @test _gt(q, g) === (q > g)
+        end
+    end
+
+    @testset "same-type stays exact beyond 2^53" begin
+        # promote is identity for same-type operands → no float rounding, the
+        # full integer order is kept even past the Float64 mantissa.
+        big = 2^53
+        @test _le(big + 1, big + 2) === true
+        @test _le(big + 2, big + 1) === false
+        @test _lt(big, big) === false
+        @test _ge(big + 1, big) === true
+        @test _gt(typemax(Int64), typemax(Int64) - 1) === true
+        @test _le(typemin(Int64), typemax(Int64)) === true
+    end
+
+    # ── 2. Dual total order preserved (NOT a primal strip) ───────────────────
+    @testset "Dual value-tie ordering preserved" begin
+        d = Dual(5.0, 1.0)   # value 5.0, +partial ⇒ orders ABOVE 5.0 at the tie
+        # Pin against Base: a primal strip would make `_le(d, 5.0)` true while
+        # `d <= 5.0` is false — these asserts would then fail.
+        @test _le(d, 5.0) === (d <= 5.0)
+        @test _ge(d, 5.0) === (d >= 5.0)
+        @test _lt(5.0, d) === (5.0 < d)
+        @test _gt(d, 5.0) === (d > 5.0)
+        @test (d <= 5.0) === false          # document the tie-break direction
+        @test (d >= 5.0) === true
+        # non-tie cases follow value order
+        @test _le(d, 6.0) === true
+        @test _gt(d, 4.0) === true
+        # Dual×Dual, Dual×Int (mixed) all match Base
+        e = Dual(5.0, -2.0)
+        @test _le(d, e) === (d <= e)
+        @test _lt(e, d) === (e < d)
+        @test _le(d, 5) === (d <= 5)
+        @test _ge(5, d) === (5 >= d)
+        # helpers return a plain Bool — no Dual leaks out
+        @test _le(d, 6.0) isa Bool
+        @test _gt(d, e) isa Bool
+    end
+
+    # ── NaN semantics match Base (promote preserves them) ────────────────────
+    @testset "NaN matches Base" begin
+        for x in (1.0, -1.0, 0.0)
+            @test _le(NaN, x) === (NaN <= x)
+            @test _lt(x, NaN) === (x < NaN)
+            @test _ge(NaN, x) === (NaN >= x)
+            @test _gt(NaN, x) === (NaN > x)
+        end
+        @test _le(NaN, NaN) === false
+        @test _le(NaN, 5) === (NaN <= 5)     # mixed NaN/Int
+        @test _gt(5, NaN) === (5 > NaN)
+    end
+
+    # ── 3. Type stability + zero allocation ──────────────────────────────────
+    @testset "type-stable Bool, zero allocation" begin
+        @test @inferred(_le(1, 2.0)) isa Bool
+        @test @inferred(_lt(1.0, 2)) isa Bool
+        @test @inferred(_ge(Int32(1), 2.0)) isa Bool
+        @test @inferred(_gt(1 // 2, 0.5)) isa Bool
+        @test @inferred(_le(Dual(1.0, 1.0), 2)) isa Bool
+        bench() = _le(3, 5.5) & _lt(3, 5.5) & _ge(3, 5.5) & _gt(3, 5.5)
+        bench()  # warm up / compile
+        @test @allocated(bench()) == 0
+    end
+
+    # ── 4. End-to-end equivalence across grid eltypes ────────────────────────
+    @testset "interval search identical across grid eltypes" begin
+        ints = collect(0:20)                # Vector{Int}
+        flts = Float64.(ints)               # reference (Float grid)
+        rats = Rational{Int}.(ints)
+        qs = vcat(collect(range(-2.0, 22.0; length = 251)), 0.0, 10.0, 20.0)
+        for q in qs
+            ref = _search_binary(flts, q)[1]     # cell index on the float grid
+            @test _search_binary(ints, q)[1] == ref
+            @test _search_binary(rats, q)[1] == ref
+        end
+    end
+
+    @testset "one-shot linear_interp identical: Int vs Float grid" begin
+        yv = Float64[i^2 for i in 0:20]
+        ints = collect(0:20)
+        flts = Float64.(ints)
+        # scalar, in-domain + extrapolating policies
+        for q in range(-3.0, 23.0; length = 261)
+            for ex in (ExtendExtrap(), ClampExtrap())
+                @test linear_interp(ints, yv, q; extrap = ex) ==
+                    linear_interp(flts, yv, q; extrap = ex)
+            end
+        end
+        # NoExtrap (in-domain only) + batch
+        for q in range(0.0, 20.0; length = 151)
+            @test linear_interp(ints, yv, q) == linear_interp(flts, yv, q)
+        end
+        qb = collect(range(0.5, 19.5; length = 53))
+        @test linear_interp(ints, yv, qb) == linear_interp(flts, yv, qb)
+    end
+
+    @testset "AD derivative through an Int grid" begin
+        yv = Float64[i^2 for i in 0:10]    # slope on cell [k,k+1] is 2k+1
+        ints = collect(0:10)
+        for q0 in (0.5, 3.25, 7.9, 9.5)
+            d = derivative(q -> linear_interp(ints, yv, q; extrap = ExtendExtrap()), q0)
+            @test d ≈ 2 * floor(Int, q0) + 1
+        end
+    end
+end

--- a/test/test_promote_compare.jl
+++ b/test/test_promote_compare.jl
@@ -14,7 +14,8 @@
 
 @testitem "Promote-compare ordering helpers" begin
     using FastInterpolations
-    using FastInterpolations: _le, _lt, _ge, _gt, _search_binary
+    using FastInterpolations: _le, _lt, _ge, _gt, _search_binary,
+        _oob_state, _is_inbounds, _is_all_inbounds, OOB_LEFT, OOB_RIGHT, IN_DOMAIN
     using ForwardDiff: Dual, derivative
 
     # ── 1. Equivalence to Base operators ─────────────────────────────────────
@@ -148,5 +149,84 @@
             d = derivative(q -> linear_interp(ints, yv, q; extrap = ExtendExtrap()), q0)
             @test d ≈ 2 * floor(Int, q0) + 1
         end
+    end
+
+    # ── 5. Domain classification (`_oob_state` / `_is_inbounds`) ──────────────
+    # Same promote-compare fix, applied to OOB classification. Both strip the
+    # primal of query AND bounds first, so they classify by VALUE (partial-sign
+    # independent) — intentionally different from the search ordering helpers,
+    # which preserve the Dual total order.
+    @testset "classification ≡ across grid eltypes (Int/Float32/Rational/Dual)" begin
+        flt = Float64.(collect(0:10))            # reference grid, domain [0, 10]
+        ducks = (
+            collect(0:10),                        # Int
+            collect(0.0f0:1.0f0:10.0f0),          # Float32
+            Rational{Int}.(0:10),                 # Rational
+            [Dual(Float64(i), 1.0) for i in 0:10],  # Dual grid
+        )
+        qs = vcat(collect(range(-3.0, 13.0; length = 321)), 0.0, 10.0)  # incl endpoints
+        for g in ducks, q in qs
+            @test _oob_state(g, q) === _oob_state(flt, q)
+            @test _is_inbounds(g, q) === _is_inbounds(flt, q)
+        end
+        # Rational + Dual queries (duck query types) vs the float grid
+        gi = collect(0:10)
+        for q in (11 // 2, 21 // 2, -1 // 2, Dual(5.5, 1.0), Dual(-1.0, 1.0), Dual(11.0, 1.0))
+            @test _oob_state(gi, q) === _oob_state(flt, q)
+            @test _is_inbounds(gi, q) === _is_inbounds(flt, q)
+        end
+    end
+
+    @testset "classification: explicit values + boundaries" begin
+        g = collect(0:10)                        # Int grid, domain [0, 10]
+        @test _oob_state(g, -0.5) === OOB_LEFT
+        @test _oob_state(g, 10.5) === OOB_RIGHT
+        @test _oob_state(g, 5.5) === IN_DOMAIN
+        @test _oob_state(g, 0.0) === IN_DOMAIN   # exact endpoints are in-domain
+        @test _oob_state(g, 10.0) === IN_DOMAIN
+        @test _is_inbounds(g, 0.0) === true
+        @test _is_inbounds(g, 10.0) === true
+        @test _is_inbounds(g, prevfloat(0.0)) === false
+        @test _is_inbounds(g, nextfloat(10.0)) === false
+    end
+
+    @testset "classification: Dual is value-based (partial-independent)" begin
+        g = collect(0:10)
+        @test _oob_state(g, Dual(5.0, 1.0)) === IN_DOMAIN
+        @test _oob_state(g, Dual(0.0, -9.0)) === IN_DOMAIN   # boundary, any partial
+        @test _oob_state(g, Dual(10.0, 9.0)) === IN_DOMAIN
+        @test _oob_state(g, Dual(-0.5, 9.0)) === OOB_LEFT
+        @test _oob_state(g, Dual(10.5, -9.0)) === OOB_RIGHT
+        @test _is_inbounds(g, Dual(10.0, 5.0)) === true      # in by value
+        @test _is_inbounds(g, Dual(10.5, -5.0)) === false
+        # Dual grid (differentiate wrt knot positions): bounds primal-stripped too
+        dg = [Dual(Float64(i), 1.0) for i in 0:10]
+        @test _oob_state(dg, 5.5) === IN_DOMAIN
+        @test _oob_state(dg, -1.0) === OOB_LEFT
+        @test _is_inbounds(dg, 10.0) === true
+    end
+
+    @testset "_is_all_inbounds (batch) ≡ across grid eltypes" begin
+        flt = Float64.(collect(0:10))
+        ducks = (
+            collect(0:10), collect(0.0f0:1.0f0:10.0f0), Rational{Int}.(0:10),
+            [Dual(Float64(i), 1.0) for i in 0:10],
+        )
+        batches = (
+            [1.5, 5.0, 9.0],                    # all in
+            [-0.5, 5.0],                        # one OOB-left
+            [5.0, 10.5],                        # one OOB-right
+            [0.0, 10.0],                        # exact endpoints (in)
+            Float64[],                          # empty → true
+            [Dual(2.0, 1.0), Dual(8.0, 1.0)],   # Dual query batch
+        )
+        for g in ducks, b in batches
+            @test _is_all_inbounds(g, b) === _is_all_inbounds(flt, b)
+        end
+        gi = collect(0:10)
+        @test _is_all_inbounds(gi, [0.0, 10.0]) === true
+        @test _is_all_inbounds(gi, [0.0, nextfloat(10.0)]) === false
+        @test _is_all_inbounds(gi, [prevfloat(0.0), 5.0]) === false
+        @test _is_all_inbounds(gi, Float64[]) === true
     end
 end


### PR DESCRIPTION
## Summary

**Problem.** One-shot interpolation on an `Int` (or `Rational`) `Vector` grid ran ~3× slower than on `Float64` — not from cache-building, but because every binary-search comparison hit Base's *exact* mixed `<=(Int, Float)`.

**Change.** Compare via `promote`-first helpers (`_le`/`_lt`/`_ge`/`_gt`), applied to every hot Int-grid comparison: interval search and domain classification.

**Result.** Scalar `Int` one-shot **22.5 → 9.7 ns (2.3×)**, batch **1.7–2.5×**. Bit-identical for `Int`/`Float32`/`Rational`/`Dual` grids; float `Vector`, `Range`, and persistent paths untouched.

## Benchmark

ns, arm64, in-domain unless noted, vs `master`.

**Interval search (one-shot)**

| path | master | this PR | Δ |
|---|--:|--:|--:|
| scalar, `Vector{Int}` grid | 22.55 | 9.67 | **2.3×** |
| scalar, `Vector{Float64}` (ctrl) | 7.71 | 7.71 | ~0 |
| scalar, `Range` (ctrl) | 4.92 | 4.92 | ~0 |
| scalar, persistent `itp(xq)` (ctrl) | 7.55 | 7.55 | ~0 |
| batch `Vector{Int}`, nq=4 / 32 / 1000 (ns/q) | 28.40 / 8.63 / 2.88 | 14.24 / 3.48 / 1.68 | **2.0 / 2.5 / 1.7×** |
| batch `Vector{Float64}` (ctrl, ns/q) | 11.17 / 3.20 / 1.35 | 11.16 / 3.16 / 1.35 | ~0 |

**Domain classification (`Int` grid, per-query looped)**

| path | master | this PR | Float ctrl |
|---|--:|--:|--:|
| `_oob_state` | 1.86 | **0.89** | 0.89 |
| `_is_inbounds` | 1.24 | **0.90** | 0.90 |
| `_is_all_inbounds` (batch, nq=2; flat ~0.3 ns/call) | 4.58 | **4.25** | 4.25 |
| `linear_interp` Fill, OOB (surface) | 5.83 | **5.23** | 5.23 |

## Under the hood

**Why the exact compare is slow.** `<=(::Int64, ::Float64)` round-trips through an integer reconvert (`Float → Int` plus an integer compare) to stay correct past the float mantissa (`|n| > 2^53`). That is a 9-op dependent chain versus 2 ops for a plain float compare — ~1.7× the per-compare latency, paid ~log2(n)× per binary search. The exactness is wasted for any grid representable in float, i.e. every grid you can actually interpolate on.

**Why `promote` first fixes it.** `promote(a, b)` lifts both operands to their common type *before* dispatch, so the comparison lands on the homogeneous `<=(T, T)` and never the exact mixed method. This is exactly Julia's promotion-fallback comparison, so the result is bit-identical to `a <= b`. On a float grid `promote(F64, F64)` is identity, so `_le` compiles to the native `<=` (16 vs 16 asm lines) — zero overhead.

**`promote`, not a primal strip.** A `Dual`'s value-tie ordering (`Dual(5,1) <= 5.0 == false`) is preserved, so AD and `Dual` grids stay correct — a primal strip would flip it. `_ge`/`_gt` delegate Base-style (`>=(x, y) = y <= x`) so call sites keep natural operand order.

**It is runtime exactness, not "Int" per se.** The penalty hits any *runtime* integer/rational compared to float — `Rational <= Float` is even worse (164 asm / ~10 ns; the helper recovers it too). Compile-time constants are free: `π <= x` const-folds to a single `le_float`, and `Float32 <= Float64` is a lossless promote. So only the runtime exact-compare types pay.

**Applied sites.** Interval search: `_search_binary` (scalar) plus the LinearBinarySearch walkers (`_search_linear!`, `_walk_left`, `_walk_right`, `_search_linear_binary!`). Domain classification: `_oob_state` / `_is_inbounds` (scalar; primal-stripped first, so value-based / partial-sign independent for `Dual`) and `_is_all_inbounds` (batch). Untouched: the persistent path (grid is always `_CachedVector{Float64}`), `Range` (`_search_direct`), and `_check_domain` (already clamps via `min`/`max`).

## Safety

Bit-identical to `a <= b` for `Int` / `Float32` / `Float64` / `Rational` / `Dual` grids and `Dual` queries — the promote-fallback equals the exact compare for any value within the float mantissa, and the `Dual` value-tie order is preserved. Classification is identical across grid eltypes (value-based for `Dual`). AD derivative through an `Int` grid verified correct. Behavior pinned by `test/test_promote_compare.jl` (14k+ assertions); affected suites green.
