### PR TITLE
(perf): restore `ClampExtrap` OOB short-circuit

### DIFF
--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -675,6 +675,10 @@ end
 #                       The leading `0 * val` preserves NaN/Inf at the boundary
 #                       sample (IEEE: `0 * NaN = NaN`); `zero(xq) * zero(val)`
 #                       carries the query carrier (Dual, etc.) into the result.
+# These arithmetic forms are LOAD-BEARING — do NOT fold them to `oftype`/`convert` to drop the
+# `+ 0.0`: the trailing add also normalizes signed zero (`-0.0 → +0.0`) and keeps Unitful
+# dimension-correctness (`oftype(zero(val)+zero(xq), val)` throws on `Quantity` + plain query).
+# Guarded by test/test_extrap_carrier_guards.jl.
 # Named _promote_extrap_val (not _promote_extrap) to avoid collision with the struct
 # promoter in eval_ops.jl which promotes FillExtrap fill_value at construction time.
 @inline _promote_extrap_val(val::Number, xq::Number) = val + zero(xq) * zero(val)

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -249,25 +249,11 @@ end
     return _linear_eval_at_point(x, y, xq, InBounds(), op, searcher)
 end
 
-# ClampExtrap VALUE: branchless coordinate clamp — an OOB query freezes at the boundary
-# node, so the kernel there IS the boundary value (no chain-rule factor needed). Replaces the
-# `_oob_state` classify + branches with one `min/max` clamp. Derivatives stay on the
-# `_ClampOrFill` path below (faster `_oob_state` short-circuit; ∂ = 0 outside the domain).
-@inline function _linear_eval_at_point(
-        x::AbstractVector{Tg},
-        y::AbstractVector{Tv},
-        xq::Tq,
-        ::ClampExtrap,
-        op::EvalValue,
-        searcher::S
-    ) where {Tg, Tv, Tq, S <: Searcher}
-    xqc = _clamp(_resolve_grididx(xq, x), first(x), last(x))
-    idx, idx_R, xL, xR = search_interval(searcher, x, xqc)
-    α = _alpha_of(xqc, xL, xR, x)
-    @inbounds return _linear_kernel(op, y[idx], y[idx_R], _get_inv_h(x, idx), α)
-end
-
-# FillExtrap (all ops) + ClampExtrap DERIV: boundary check → extrap value or delegate.
+# ClampExtrap / FillExtrap (all ops): boundary check → extrap value or delegate.
+# An OOB query under flat extrapolation freezes at the boundary node, so the result IS the
+# boundary sample (value) or zero (derivative) — short-circuit, skipping search + kernel. The
+# saving scales with the OOB fraction (each OOB query is ~half a full eval), so this dominates
+# an always-clamp-then-evaluate path on extrapolation-heavy batches.
 @inline function _linear_eval_at_point(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},

--- a/test/test_extrap_carrier_guards.jl
+++ b/test/test_extrap_carrier_guards.jl
@@ -1,0 +1,50 @@
+# Guards for the OOB flat-extrapolation carrier idiom (ClampExtrap/FillExtrap).
+#
+# `_promote_extrap_val` (`val + zero(xq)*zero(val)`) and `_promote_extrap_zero` (`0*val + …`)
+# in src/core/utils.jl look like they carry a pointless `+ 0.0`, but those arithmetic forms are
+# LOAD-BEARING: the trailing add normalizes signed zero (`-0.0 → +0.0`) and keeps Unitful
+# dimension-correctness, while `0*val` propagates NaN/Inf. Folding them to `oftype`/`convert`
+# (to drop the `+0.0`) silently regresses these. These guards fail loudly if that happens.
+
+@testitem "OOB flat-extrap carrier idiom — load-bearing guards" begin
+    using FastInterpolations: _promote_extrap_val, _promote_extrap_zero
+    using ForwardDiff
+
+    @testset "signed-zero normalization — value path" begin
+        # `val + zero(xq)*zero(val)` flushes -0.0 → +0.0; an oftype/convert fold would keep -0.0.
+        @test !signbit(_promote_extrap_val(-0.0, 1.0))
+        @test !signbit(_promote_extrap_val(-0.0f0, 1.0f0))
+        # end-to-end: ClampExtrap returning a -0.0 boundary sample
+        itp = linear_interp([0.0, 1.0, 2.0], [-0.0, 1.0, 2.0]; extrap = ClampExtrap())
+        @test !signbit(itp(-5.0))                       # OOB-left → y[1] = -0.0 → +0.0
+        # FillExtrap with a -0.0 fill value
+        itpf = linear_interp([0.0, 1.0, 2.0], [1.0, 2.0, 3.0]; extrap = FillExtrap(-0.0))
+        @test !signbit(itpf(-5.0))
+    end
+
+    @testset "signed-zero normalization — deriv path" begin
+        # `0*val` of a negative sample is -0.0; the trailing `+ zero*zero` normalizes to +0.0.
+        @test iszero(_promote_extrap_zero(-3.5, 1.0))
+        @test !signbit(_promote_extrap_zero(-3.5, 1.0))
+    end
+
+    @testset "NaN/Inf propagation — deriv path keeps `0*val`" begin
+        # 0*NaN = NaN, 0*Inf = NaN: a non-finite boundary sample must surface, not a clean 0.
+        @test isnan(_promote_extrap_zero(NaN, 1.0))
+        @test isnan(_promote_extrap_zero(Inf, 1.0))
+        @test isnan(_promote_extrap_val(NaN, 1.0))
+        @test isinf(_promote_extrap_val(Inf, 1.0))
+        # end-to-end via the native derivative API (routes through _promote_extrap_zero)
+        itpn = linear_interp([0.0, 1.0, 2.0], [NaN, 1.0, 2.0]; extrap = ClampExtrap())
+        @test isnan(itpn(-5.0; deriv = DerivOp(1)))     # OOB-left, NaN boundary → NaN derivative
+    end
+
+    @testset "AD carrier — OOB value-path derivative is zero, value correct, type stable" begin
+        itp = linear_interp([0.0, 1.0, 2.0], [10.0, 20.0, 30.0]; extrap = ClampExtrap())
+        @test ForwardDiff.derivative(itp, -5.0) == 0.0  # clamp is flat outside the domain
+        @test ForwardDiff.derivative(itp, 7.0) == 0.0
+        @test itp(-5.0) == 10.0
+        @test itp(7.0) == 30.0
+        @test (@inferred itp(-5.0)) isa Float64
+    end
+end


### PR DESCRIPTION
## Summary

The previous clamp PR (#159) made the 1D `ClampExtrap` **value** path branchless: it clamps the query coordinate and then always runs the full search + kernel. But for a 1D `ClampExtrap` query the OOB result **is** the boundary sample — the old `_oob_state` short-circuit returned it directly, skipping search + kernel. Removing that made every OOB query pay a full evaluation, so cost went **flat against the OOB fraction** instead of decreasing with it.

That regressed extrapolation-heavy batches (issue #70). This PR deletes the dedicated branchless method so `ClampExtrap` value falls back to the unified `_ClampOrFill` short-circuit — the same path `FillExtrap` and `ClampExtrap` derivatives already use.

- **OOB-scaling restored** — cost drops as the OOB fraction rises (each OOB query is ~half a full eval), instead of master's flat line.
- **In-domain hot path unchanged** — in-bounds queries delegate to the same `InBounds` kernel; 0% OOB is identical to master.
- **Recovers issue #70** — 29% OOB batch `1138 → 1042` ns/query; up to `1138 → 918` (1.24×) at 50% OOB.

## Changes

**Delete the branchless `ClampExtrap` value method** (`linear/linear_oneshot.jl`) — the `::ClampExtrap, op::EvalValue` method added by #159 is removed; `ClampExtrap` value now dispatches to the generic `_ClampOrFill` `_oob_state` short-circuit, unifying value + derivative on one path. #159's genuine wins are untouched: the `_clamp_to_grid` adjoint (the real Float win), the ND per-axis coordinate clamp, and the Int index clamps all stay.

> ND is **not** affected. A 1D OOB query freezes the whole result at the boundary (short-circuitable), but one OOB axis in ND only clamps *that axis's coordinate* — the other axes still interpolate, so there is no full-result short-circuit and the branchless coordinate clamp is correct (measured fast + flat across OOB ratios).

**Harden the OOB carrier idiom** (`core/utils.jl`, `test/test_extrap_carrier_guards.jl`) — `_promote_extrap_val`/`_promote_extrap_zero`'s `+ zero(xq)*zero(val)` / `0*val` look like a pointless `+ 0.0` but are **load-bearing**: the trailing add normalizes signed zero (`-0.0 → +0.0`), `0*val` propagates `NaN/Inf`, and the form keeps Unitful dimension-correctness (`oftype(zero(val)+zero(xq), val)` throws on a `Quantity` value + plain query). A comment marks this, and new guards pin all three contracts so a future "fold the `+ 0.0`" refactor fails loudly instead of silently regressing.

## Benchmark

Apple Silicon (arm64), batch `linear_interp!`, range grid `N=100`, `Q=1000`, ns/query (min). `ExtendExtrap` control is unchanged (~935) across every version.

| OOB% | master (branchless) | **this PR** |
|---|--:|--:|
| 0 | 1071 | **1067** |
| 10 | 1138 | 1146 |
| 20 | 1138 | **1096** |
| 30 | 1138 | **1033** |
| 40 | 1138 | **978** |
| 50 | 1138 | **918** |

master is flat at `1138` from 10% on (OOB-scaling lost); this PR slopes back down. Equal at 0–10%, increasingly faster from 20% — issue #70's workload sits at ~29% OOB.

## Safety

- **In-domain unchanged** — delegates to the same `InBounds` kernel (cached `inv_h`); 0% OOB matches master.
- **Bit-identical values**, and Float32 `ClampExtrap` is **ULP-restored** (master's branchless `min/max` had drifted it by 1 ULP).
- **Derivative + `FillExtrap` paths unchanged** — both already short-circuited via `_oob_state`; value now joins them.
- **Carrier guards** — `test_extrap_carrier_guards.jl` pins the signed-zero, NaN/Inf, and AD-zero-derivative contracts on the OOB path.
