### PR TITLE
perf(nd): zero-alloc Int-grid scalar one-shot

### DIFF
--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -19,7 +19,7 @@ Zero-allocation scalar one-shot ND constant evaluation.
 Evaluates directly from grids + data without constructing a ConstantInterpolantND.
 """
 function _constant_interp_nd_oneshot(
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         query::Tuple{Vararg{Real, N}},
         bcs::NTuple{N, AbstractBC},
@@ -28,7 +28,7 @@ function _constant_interp_nd_oneshot(
         searches::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
         hints = nothing
-    ) where {Tg, Tv, N}
+    ) where {Tv, N}
     grids_eff = map(_resolve_axis, grids, bcs)
     _validate_nd_domain(grids_eff, query, extraps_val)
     oob_result = _try_fill_oob(query, grids_eff, extraps_val, ops, @inbounds first(data))
@@ -133,8 +133,11 @@ function constant_interp(
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
-    grids_typed, _, _ = _nd_promote_grids_raw(grids, data)
-    _validate_nd_grids(grids_typed, data)
+    # Scalar one-shot: raw grids — the kernel shapes each axis via
+    # `map(_resolve_axis, …)` and the selection follows `eltype(data)`, so no
+    # eager grid conversion is needed. (Batch keeps eager-convert; see the
+    # `linear_interp` scalar note on the amortisation tradeoff.)
+    _validate_nd_grids(grids, data)
 
     bcs = _resolve_bcs_nd(bc, Val(N))
     sides = _resolve_side_nd(side, Val(N))
@@ -143,7 +146,7 @@ function constant_interp(
 
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)
     return _constant_interp_nd_oneshot(
-        grids_typed, data, query, bcs, extraps_val, sides, searches, ops, hint
+        grids, data, query, bcs, extraps_val, sides, searches, ops, hint
     )
 end
 

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -133,10 +133,8 @@ function constant_interp(
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
-    # Scalar one-shot: raw grids — the kernel shapes each axis via
-    # `map(_resolve_axis, …)` and the selection follows `eltype(data)`, so no
-    # eager grid conversion is needed. (Batch keeps eager-convert; see the
-    # `linear_interp` scalar note on the amortisation tradeoff.)
+    # Scalar one-shot: raw grids (kernel resolves each axis; selection follows
+    # `eltype(data)`). Batch keeps eager-convert.
     _validate_nd_grids(grids, data)
 
     bcs = _resolve_bcs_nd(bc, Val(N))

--- a/src/core/cached_vector.jl
+++ b/src/core/cached_vector.jl
@@ -132,8 +132,7 @@ end
 #
 # Bottom line: `_cache_axis_pooled(pool, x, Tg)` *always* returns a wrapper
 # with eltype `Tg`. The fast paths (same-eltype Vector/Range/wrapped) are
-# zero-alloc; eltype mismatches incur a one-time conversion alloc (and warn
-# on raw `Vector{S}` per `_to_float`'s `_warn_type_conversion`).
+# zero-alloc; eltype mismatches incur a one-time conversion alloc.
 @inline _cache_axis_pooled(pool, x, ::Type{Tg}) where {Tg} =
     _cache_axis_pooled(pool, _to_float(x, Tg))
 

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1010,7 +1010,9 @@ Compute local cell parameters for all axes via `_get_h(grid, idx)` /
     # Promote `hs`/`inv_hs` to one common float `Tg`: `_eval_nd_*_cell` is `@generated`
     # and couples them as `NTuple{N, Tg}`, so heterogeneous/mixed-precision raw grids
     # need them unified. Bit-identical for the homogeneous Float/Dual callers.
-    Tg = float(_promote_grid_eltype(grids))
+    # (N=0 edge: `float(promote_type())` = `float(Union{})` throws; the ntuples are
+    # empty there, so this placeholder is never used.)
+    Tg = N == 0 ? Float64 : float(_promote_grid_eltype(grids))
     hs = ntuple(Val(N)) do d
         @inbounds convert(Tg, _get_h(grids[d], indices[d]))
     end

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1007,15 +1007,9 @@ Compute local cell parameters for all axes via `_get_h(grid, idx)` /
         indices::NTuple{N, Int},
         Ls::Tuple{Vararg{Real, N}},
     ) where {N}
-    # Promote `hs` AND `inv_hs` to one common float type `Tg` (= float(promote of
-    # the axis eltypes)). `_eval_nd_*_cell` is `@generated` and couples them as
-    # `NTuple{N, Tg}`, so a heterogeneous / mixed-precision raw grid (e.g.
-    # `Float32 × Float64`, or a Range that floats to Float64 beside a `Vector{Int}`)
-    # would have no matching method otherwise. This is a pre-promotion of the N
-    # spacing scalars (the `_le` promote-then-use idea), NOT a grid conversion: the
-    # grid stays raw and the search promote-compares it. Integer spacings are exact
-    # in Float64 so it is bit-identical, and it is a zero-cost identity for the
-    # homogeneous Float/Dual grids every existing caller passes.
+    # Promote `hs`/`inv_hs` to one common float `Tg`: `_eval_nd_*_cell` is `@generated`
+    # and couples them as `NTuple{N, Tg}`, so heterogeneous/mixed-precision raw grids
+    # need them unified. Bit-identical for the homogeneous Float/Dual callers.
     Tg = float(_promote_grid_eltype(grids))
     hs = ntuple(Val(N)) do d
         @inbounds convert(Tg, _get_h(grids[d], indices[d]))
@@ -1120,7 +1114,7 @@ Returns:
 
 Callers destructure only what they need:
 ```julia
-grids_typed, _, _, _ = _nd_promote_grids(grids, data)   # grid-only (constant/adjoint)
+grids_typed, _, _, _ = _nd_promote_grids(grids, data)   # grid-only (batch dispatch)
 grids_typed, Tg, Tv, Tz = _nd_promote_grids(grids, data) # full (oneshot/build)
 ```
 """
@@ -1148,7 +1142,7 @@ is no x·y arithmetic and the output contract follows `eltype(data)` directly.
 - `grids_typed`: each axis converted to share `Tg` (container heterogeneity
   preserved — Range stays Range, Vector stays Vector).
 
-Arithmetic methods keep `_nd_promote_grids` (Float-widened Tg, value-promoted Tv).
+Arithmetic batch/constructor paths keep `_nd_promote_grids` (Float-widened Tg, value-promoted Tv).
 """
 @inline function _nd_promote_grids_raw(
         grids::NTuple{N, AbstractVector},

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1007,8 +1007,12 @@ Compute local cell parameters for all axes via `_get_h(grid, idx)` /
         indices::NTuple{N, Int},
         Ls::Tuple{Vararg{Real, N}},
     ) where {N}
+    # `float(...)` so a raw Int axis yields a Float cell width: `_eval_nd_*_cell`
+    # (@generated on a Float `h`) has no Int method, and integer spacings are exact
+    # in Float64 so this is bit-identical. Identity (zero-cost) for the Float/Dual
+    # grids every existing caller passes.
     hs = ntuple(Val(N)) do d
-        @inbounds _get_h(grids[d], indices[d])
+        @inbounds float(_get_h(grids[d], indices[d]))
     end
     inv_hs = ntuple(Val(N)) do d
         @inbounds _get_inv_h(grids[d], indices[d])

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1007,15 +1007,21 @@ Compute local cell parameters for all axes via `_get_h(grid, idx)` /
         indices::NTuple{N, Int},
         Ls::Tuple{Vararg{Real, N}},
     ) where {N}
-    # `float(...)` so a raw Int axis yields a Float cell width: `_eval_nd_*_cell`
-    # (@generated on a Float `h`) has no Int method, and integer spacings are exact
-    # in Float64 so this is bit-identical. Identity (zero-cost) for the Float/Dual
-    # grids every existing caller passes.
+    # Promote `hs` AND `inv_hs` to one common float type `Tg` (= float(promote of
+    # the axis eltypes)). `_eval_nd_*_cell` is `@generated` and couples them as
+    # `NTuple{N, Tg}`, so a heterogeneous / mixed-precision raw grid (e.g.
+    # `Float32 × Float64`, or a Range that floats to Float64 beside a `Vector{Int}`)
+    # would have no matching method otherwise. This is a pre-promotion of the N
+    # spacing scalars (the `_le` promote-then-use idea), NOT a grid conversion: the
+    # grid stays raw and the search promote-compares it. Integer spacings are exact
+    # in Float64 so it is bit-identical, and it is a zero-cost identity for the
+    # homogeneous Float/Dual grids every existing caller passes.
+    Tg = float(_promote_grid_eltype(grids))
     hs = ntuple(Val(N)) do d
-        @inbounds float(_get_h(grids[d], indices[d]))
+        @inbounds convert(Tg, _get_h(grids[d], indices[d]))
     end
     inv_hs = ntuple(Val(N)) do d
-        @inbounds _get_inv_h(grids[d], indices[d])
+        @inbounds convert(Tg, _get_inv_h(grids[d], indices[d]))
     end
     dLs = ntuple(Val(N)) do d
         @inbounds q_evals[d] - Ls[d]

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -653,34 +653,11 @@ end
     # axes already returned raw above; `grids` may be raw/heterogeneous).
     Tg = float(_promote_grid_eltype(grids))
 
-    # Per-axis grid extension + bc resolution. `map` with `ntuple(identity, Val(N))`
-    # dispatches per-element with concrete (grid, bc) types → each closure call
-    # compiles to a specialization with concrete return type. A `do d …` with
-    # runtime indexing `bcs[d]` / `grids[d]` over a heterogeneous tuple would
-    # leave the return type as `Union{...}` → heap-boxed Refs (~2 KB/query).
-    # See MEMORY.md "ND Constructor Inferrability Pattern".
-    processed = map(ntuple(identity, Val(N)), grids, bcs) do d, grid_d, bc_d
-        bc_d isa PeriodicBC{:exclusive} || return (grid_d, bc_d)
-        period = _resolve_exclusive_period(grid_d, bc_d)
-        _validate_exclusive_period(grid_d, period)
-        x_end = first(grid_d) + Tg(period)
-        last(grid_d) < x_end ||
-            _throw_prepare_periodic_nd_endpoint(d, period, x_end, last(grid_d))
-        # Range axes use type-preserving `_to_float_adding_endpoint`; Vector axes
-        # delegate to the caller-supplied `extend_vector_grid` (vcat vs pool).
-        grid_ext = grid_d isa AbstractRange ?
-            _to_float_adding_endpoint(grid_d, Tg) :
-            extend_vector_grid(grid_d, x_end, Tg)
-        # Promote bc to `:extended` post-extension: the extended grid IS a
-        # closed-cycle layout (length n+1, last point at x[1]+period). The
-        # `:extended` symbol records this promotion so downstream solvers and
-        # cache builders can distinguish "user gave :exclusive, we extended"
-        # from "user gave :inclusive" while still routing through the
-        # `_is_periodic_seam_folded` trait. Without this, BC-aware solvers
-        # (e.g. cubic) would interpret `:exclusive` as "raw n-grid" and
-        # miscount the cycle.
-        return (grid_ext, _bc_after_extend(bc_d))
-    end
+    # Per-axis grid extension + bc resolution via a `::Type{Tg}` function barrier:
+    # `Tg` must reach the extension closure as a static parameter, not a captured
+    # type-valued local — Julia 1.10 boxes such a local, making the extended grid
+    # type abstract (→ alloc + @inferred failure on the periodic-exclusive ctor).
+    processed = _extend_periodic_nd_axes(grids, bcs, extend_vector_grid, Tg)
     grids_out = map(first, processed)
     bcs_out = map(last, processed)
 
@@ -697,6 +674,34 @@ end
     _extend_all_slices!(data_out, data, bcs, Val(N))
 
     return (grids_out, data_out, bcs_out)
+end
+
+# Per-axis exclusive-periodic extension, factored out so `Tg` reaches the closure
+# as a static `::Type` parameter (not a captured type-valued local). Julia 1.10
+# boxes such a local → the extended grid type goes abstract (alloc + @inferred
+# failure on the periodic-exclusive constructor); the barrier keeps it concrete.
+@inline function _extend_periodic_nd_axes(
+        grids::Tuple{Vararg{AbstractVector, N}},
+        bcs::Tuple{Vararg{AbstractBC, N}},
+        extend_vector_grid::F_ext,
+        ::Type{Tg},
+    ) where {N, F_ext, Tg}
+    return map(ntuple(identity, Val(N)), grids, bcs) do d, grid_d, bc_d
+        bc_d isa PeriodicBC{:exclusive} || return (grid_d, bc_d)
+        period = _resolve_exclusive_period(grid_d, bc_d)
+        _validate_exclusive_period(grid_d, period)
+        x_end = first(grid_d) + Tg(period)
+        last(grid_d) < x_end ||
+            _throw_prepare_periodic_nd_endpoint(d, period, x_end, last(grid_d))
+        # Range axes use type-preserving `_to_float_adding_endpoint`; Vector axes
+        # delegate to the caller-supplied `extend_vector_grid` (vcat vs pool).
+        grid_ext = grid_d isa AbstractRange ?
+            _to_float_adding_endpoint(grid_d, Tg) :
+            extend_vector_grid(grid_d, x_end, Tg)
+        # Promote bc to `:extended` post-extension so downstream solvers / cache
+        # builders route the closed cycle (records the exclusive→extended step).
+        return (grid_ext, _bc_after_extend(bc_d))
+    end
 end
 
 # Cold-path error body (kept out of the happy-path inlined code).

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -649,9 +649,8 @@ end
     # Fast path: purely inclusive → no extension needed.
     _has_any_bc(bcs, Val(N), PeriodicBC{:exclusive}) || return (grids, data, bcs)
 
-    # Common float grid type for the per-axis exclusive extension below. Only the
-    # exclusive-periodic path needs it (non-periodic axes returned raw above), and
-    # the extension homogenises those axes to `Tg` — `grids` may be raw/heterogeneous.
+    # Common float grid type for the exclusive-periodic extension below (non-periodic
+    # axes already returned raw above; `grids` may be raw/heterogeneous).
     Tg = float(_promote_grid_eltype(grids))
 
     # Per-axis grid extension + bc resolution. `map` with `ntuple(identity, Val(N))`

--- a/src/core/periodic.jl
+++ b/src/core/periodic.jl
@@ -634,12 +634,12 @@ end
 # pool reference is carried via a type parameter — concrete dispatch, no Box).
 # ────────────────────────────────────────────────────────
 @inline function _prepare_periodic_nd_impl(
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC},
         extend_vector_grid::F_ext,
         allocate_data::F_alloc,
-    ) where {Tg, Tv, N, F_ext, F_alloc}
+    ) where {Tv, N, F_ext, F_alloc}
     # Ultra-fast path: non-periodic call-sites collapse this to a no-op via
     # the `@generated` predicate (zero runtime cost on the hot non-periodic path).
     _has_any_bc(bcs, Val(N), PeriodicBC) || return (grids, data, bcs)
@@ -648,6 +648,11 @@ end
     _validate_periodic_slices_nd(data, bcs, Val(N))
     # Fast path: purely inclusive → no extension needed.
     _has_any_bc(bcs, Val(N), PeriodicBC{:exclusive}) || return (grids, data, bcs)
+
+    # Common float grid type for the per-axis exclusive extension below. Only the
+    # exclusive-periodic path needs it (non-periodic axes returned raw above), and
+    # the extension homogenises those axes to `Tg` — `grids` may be raw/heterogeneous.
+    Tg = float(_promote_grid_eltype(grids))
 
     # Per-axis grid extension + bc resolution. `map` with `ntuple(identity, Val(N))`
     # dispatches per-element with concrete (grid, bc) types → each closure call
@@ -724,10 +729,10 @@ via `acquire!`, so they must NOT escape the enclosing `@with_pool` scope.
 """
 @inline function _prepare_periodic_nd_pooled(
         pool::AbstractArrayPool,
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
-    ) where {Tg, Tv, N}
+    ) where {Tv, N}
     return _prepare_periodic_nd_impl(
         grids, data, bcs,
         _PoolGridExtender(pool),

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -57,8 +57,14 @@ the same broadcast applies — `T.(x)` dispatches to ForwardDiff's `convert`.
 """
 function _to_float(x::AbstractVector, ::Type{T}) where {T}
     _warn_type_conversion(T)
-    return T.(x)
+    return _to_float_nowarn(x, T)
 end
+
+# Conversion without the user-facing "pre-convert" warning, for cache/pool build
+# paths whose converted result is stored (the one-time build alloc is not the
+# per-call cost the warning is about; warm calls hit the cache zero-alloc).
+_to_float_nowarn(x::AbstractVector{T}, ::Type{T}) where {T} = x
+_to_float_nowarn(x::AbstractVector, ::Type{T}) where {T} = T.(x)
 
 @noinline function _warn_type_conversion(::Type{T}) where {T}
     @warn "Non-matching vector element type detected — allocating type conversion. " *

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -50,27 +50,10 @@ _to_float(x::AbstractVector{T}, ::Type{T}) where {T} = x
 """
     _to_float(x::AbstractVector, ::Type{T}) where {T}
 
-Convert a Vector to target type (element-wise broadcast).
-For standard numerics (Int→Float64, Float32→Float64), emits a one-time warning
-since this allocates a new vector. For duck types (e.g. `Dual{Int}→Dual{Float64}`),
-the same broadcast applies — `T.(x)` dispatches to ForwardDiff's `convert`.
+Convert a Vector to target type (element-wise broadcast). For duck types
+(e.g. `Dual{Int}→Dual{Float64}`), `T.(x)` dispatches to ForwardDiff's `convert`.
 """
-function _to_float(x::AbstractVector, ::Type{T}) where {T}
-    _warn_type_conversion(T)
-    return _to_float_nowarn(x, T)
-end
-
-# Conversion without the user-facing "pre-convert" warning, for cache/pool build
-# paths whose converted result is stored (the one-time build alloc is not the
-# per-call cost the warning is about; warm calls hit the cache zero-alloc).
-_to_float_nowarn(x::AbstractVector{T}, ::Type{T}) where {T} = x
-_to_float_nowarn(x::AbstractVector, ::Type{T}) where {T} = T.(x)
-
-@noinline function _warn_type_conversion(::Type{T}) where {T}
-    @warn "Non-matching vector element type detected — allocating type conversion. " *
-        "For zero-allocation, pre-convert your data: `x_typed = $T.(x)`" maxlog = 1
-    return nothing
-end
+_to_float(x::AbstractVector, ::Type{T}) where {T} = T.(x)
 
 # ========================================
 # Value Type Helpers (for Complex support)

--- a/src/cubic/cubic_cache_pool.jl
+++ b/src/cubic/cubic_cache_pool.jl
@@ -493,9 +493,10 @@ end
 end
 
 # Non-AbstractFloat Real input (Int, Rational): convert to float, build cache.
-# Only called on cache miss — subsequent hits are zero-alloc.
+# Only called on cache miss — subsequent hits are zero-alloc, so use the
+# non-warning conversion (the cached copy is not a per-call allocation).
 @inline function _build_cache(::Type{<:CacheEntry{T, L, R}}, x::AbstractVector, bc::BCPair{L, R}) where {T <: AbstractFloat, L <: PointBC, R <: PointBC}
-    return _build_derivative_bc_cache(_to_float(x, T), bc.left, bc.right)
+    return _build_derivative_bc_cache(_to_float_nowarn(x, T), bc.left, bc.right)
 end
 
 # Build cache for periodic BC entry. The `bc::PeriodicBC{E}` argument is required
@@ -506,9 +507,10 @@ end
     return _build_periodic_cache(x, bc)
 end
 
-# Non-AbstractFloat Real input: convert to float for periodic cache.
+# Non-AbstractFloat Real input: convert to float for periodic cache (cache-miss
+# only — converted copy is cached, so no per-call warning).
 @inline function _build_cache(::Type{<:PeriodicCacheEntry{T, X, E}}, x::AbstractVector, bc::PeriodicBC{E}) where {T <: AbstractFloat, X, E}
-    return _build_periodic_cache(_to_float(x, T), bc)
+    return _build_periodic_cache(_to_float_nowarn(x, T), bc)
 end
 
 # ---------------------------------------------------------------

--- a/src/cubic/cubic_cache_pool.jl
+++ b/src/cubic/cubic_cache_pool.jl
@@ -493,10 +493,9 @@ end
 end
 
 # Non-AbstractFloat Real input (Int, Rational): convert to float, build cache.
-# Only called on cache miss — subsequent hits are zero-alloc, so use the
-# non-warning conversion (the cached copy is not a per-call allocation).
+# Only called on cache miss — subsequent hits are zero-alloc.
 @inline function _build_cache(::Type{<:CacheEntry{T, L, R}}, x::AbstractVector, bc::BCPair{L, R}) where {T <: AbstractFloat, L <: PointBC, R <: PointBC}
-    return _build_derivative_bc_cache(_to_float_nowarn(x, T), bc.left, bc.right)
+    return _build_derivative_bc_cache(_to_float(x, T), bc.left, bc.right)
 end
 
 # Build cache for periodic BC entry. The `bc::PeriodicBC{E}` argument is required
@@ -507,10 +506,9 @@ end
     return _build_periodic_cache(x, bc)
 end
 
-# Non-AbstractFloat Real input: convert to float for periodic cache (cache-miss
-# only — converted copy is cached, so no per-call warning).
+# Non-AbstractFloat Real input: convert to float for periodic cache.
 @inline function _build_cache(::Type{<:PeriodicCacheEntry{T, X, E}}, x::AbstractVector, bc::PeriodicBC{E}) where {T <: AbstractFloat, X, E}
-    return _build_periodic_cache(_to_float_nowarn(x, T), bc)
+    return _build_periodic_cache(_to_float(x, T), bc)
 end
 
 # ---------------------------------------------------------------

--- a/src/cubic/nd/cubic_nd_build.jl
+++ b/src/cubic/nd/cubic_nd_build.jl
@@ -413,8 +413,7 @@ end
     # in the data (it is added by _prepare_periodic_nd/_prepare_periodic_nd_pooled after
     # this validation).  Checking data[1] ≈ data[end] on unextended exclusive data would
     # produce false positives for perfectly valid periodic inputs.
-    # `grids` may be raw/heterogeneous-eltype (scalar one-shot passes them unconverted);
-    # the periodic tolerance uses the float-promoted grid type either way.
+    # `grids` may be raw/heterogeneous (scalar one-shot); use the float-promoted type.
     if bcs[D] isa PeriodicBC{:inclusive} && periodic_check(bcs[D])
         _check_periodic_data_noalloc!(data, Val(D), float(_promote_grid_eltype(grids)))
     end
@@ -453,8 +452,7 @@ end
     return nothing
 end
 
-# `grids` may be heterogeneous-eltype (raw scalar one-shot): each dimension is
-# differentiated independently via `grids[D]`, so no single grid `Tg` is needed.
+# Raw/heterogeneous grids: each dimension differentiates independently via `grids[D]`.
 @inline _build_nd_partials_dim!(
     partials::AbstractArray{Tv, NP1},
     grids::NTuple{N, AbstractVector},

--- a/src/cubic/nd/cubic_nd_build.jl
+++ b/src/cubic/nd/cubic_nd_build.jl
@@ -396,25 +396,27 @@ end
 end
 
 @inline _validate_nd_bcs!(
-    grids::NTuple{N, AbstractVector{Tg}},
+    grids::NTuple{N, AbstractVector},
     bcs::NTuple{N, AbstractBC},
     data::AbstractArray{Tv, N},
     ::Val{N}
-) where {Tv, Tg, N} = _validate_nd_bcs!(grids, bcs, data, Val(1), Val(N))
+) where {Tv, N} = _validate_nd_bcs!(grids, bcs, data, Val(1), Val(N))
 
 @inline function _validate_nd_bcs!(
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::NTuple{N, AbstractVector},
         bcs::NTuple{N, AbstractBC},
         data::AbstractArray{Tv, N},
         ::Val{D},
         ::Val{N}
-    ) where {Tv, Tg, D, N}
+    ) where {Tv, D, N}
     # Only validate inclusive PeriodicBC: for exclusive, the endpoint is not yet present
     # in the data (it is added by _prepare_periodic_nd/_prepare_periodic_nd_pooled after
     # this validation).  Checking data[1] ≈ data[end] on unextended exclusive data would
     # produce false positives for perfectly valid periodic inputs.
+    # `grids` may be raw/heterogeneous-eltype (scalar one-shot passes them unconverted);
+    # the periodic tolerance uses the float-promoted grid type either way.
     if bcs[D] isa PeriodicBC{:inclusive} && periodic_check(bcs[D])
-        _check_periodic_data_noalloc!(data, Val(D), Tg)
+        _check_periodic_data_noalloc!(data, Val(D), float(_promote_grid_eltype(grids)))
     end
     polyfit_deg = get_polyfit_degree(bcs[D])
     if polyfit_deg > 0 && length(grids[D]) < polyfit_deg + 1

--- a/src/cubic/nd/cubic_nd_build.jl
+++ b/src/cubic/nd/cubic_nd_build.jl
@@ -367,18 +367,18 @@ end
 
 @inline _validate_nd_partials_dims!(
     partials::AbstractArray,
-    grids::NTuple{N, AbstractVector{Tg}},
+    grids::NTuple{N, AbstractVector},
     data::AbstractArray{Tv, N},
     ::Val{N}
-) where {Tv, Tg, N} = _validate_nd_partials_dims!(partials, grids, data, Val(1), Val(N))
+) where {Tv, N} = _validate_nd_partials_dims!(partials, grids, data, Val(1), Val(N))
 
 @inline function _validate_nd_partials_dims!(
         partials::AbstractArray,
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         ::Val{D},
         ::Val{N}
-    ) where {Tv, Tg, D, N}
+    ) where {Tv, D, N}
     size(partials, D + 1) == size(data, D) || throw(
         DimensionMismatch(
             "partials dim $(D + 1) must match data dim $D"
@@ -453,20 +453,22 @@ end
     return nothing
 end
 
+# `grids` may be heterogeneous-eltype (raw scalar one-shot): each dimension is
+# differentiated independently via `grids[D]`, so no single grid `Tg` is needed.
 @inline _build_nd_partials_dim!(
     partials::AbstractArray{Tv, NP1},
-    grids::NTuple{N, AbstractVector{Tg}},
+    grids::NTuple{N, AbstractVector},
     bcs::NTuple{N, AbstractBC},
     ::Val{N}
-) where {Tv, Tg, N, NP1} = _build_nd_partials_dim!(partials, grids, bcs, Val(1), Val(N))
+) where {Tv, N, NP1} = _build_nd_partials_dim!(partials, grids, bcs, Val(1), Val(N))
 
 @inline function _build_nd_partials_dim!(
         partials::AbstractArray{Tv, NP1},
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::NTuple{N, AbstractVector},
         bcs::NTuple{N, AbstractBC},
         ::Val{D},
         ::Val{N}
-    ) where {Tv, Tg, D, N, NP1}
+    ) where {Tv, D, N, NP1}
     bit_d = 1 << (D - 1)
     @inbounds for p_src in 1:bit_d
         p_dst = p_src + bit_d
@@ -532,10 +534,10 @@ For d = 1 to N:
 """
 function _compute_nd_partials!(
         partials::AbstractArray{Tz, NP1},
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
-    ) where {Tz, Tv, Tg, N, NP1}
+    ) where {Tz, Tv, N, NP1}
     # Validate dimensions (fast, no allocation)
     @boundscheck begin
         NP1 == N + 1 || throw(DimensionMismatch("partials must have N+1 dimensions"))

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -36,14 +36,9 @@ function cubic_interp(
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
-    # Scalar one-shot: raw grids. The per-axis cubic cache (`_get_cubic_cache`)
-    # memoises by grid object id, so a stable raw grid hits the cache after the
-    # first build — the eager `Tg.(x)` copy gave a fresh id every call, defeating
-    # the memo (and adding a heap alloc). The OnTheFly path runs raw; PreCompute
-    # converts internally (its cell-eval needs Float spacing). Output types come
-    # from op-shape inference (`_promote_eltype`): the witness ops float Int via
-    # `inv(h)`/`dL/h`, so a *raw* `Tg` is correct — no manual `float()`/`_value_type`.
-    # (Batch keeps eager-convert; see the linear_interp scalar note.)
+    # Scalar one-shot: raw grids — a stable grid id lets `_get_cubic_cache` memoise
+    # (a per-call `Tg.(x)` copy would miss every time + alloc). Output types from
+    # op-shape inference (`inv(h)`/`dL/h` float Int). Batch keeps eager-convert.
     Tg = _promote_grid_eltype(grids)
     Tv_p = _promote_eltype(_coeff_op, Tg, Tv)
     _validate_nd_grids(grids, data)
@@ -125,11 +120,8 @@ Zero-allocation after warmup (pool reuse).
         ops::NTuple{N, AbstractEvalOp},
         hints = nothing
     ) where {Tv, N}
-    # Raw grids (no eager `Tg.(x)` copy): `_compute_nd_partials!` differentiates each
-    # axis independently (its per-axis spline cache memoises by id → zero-alloc warm
-    # on Int), and the shared `_compute_all_local_params` promotes the cell width so
-    # `_eval_nd_cell` takes a raw/heterogeneous axis. `Tg` (op-form, raw) only types
-    # the pooled partials buffer — `_coeff_op`'s `inv(h)` floats Int internally.
+    # Raw grids: per-axis partials + `_compute_all_local_params` (promotes the cell
+    # width) accept a raw/heterogeneous axis. `Tg` only types the pooled buffer.
     Tg = _promote_grid_eltype(grids)
     # 0. NoExtrap domain check must precede FillExtrap short-circuit
     _validate_nd_domain(grids, query, extraps_val)

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -125,12 +125,12 @@ Zero-allocation after warmup (pool reuse).
         ops::NTuple{N, AbstractEvalOp},
         hints = nothing
     ) where {Tv, N}
-    # PreCompute cell-eval needs Float spacing (`hs = xR - xL`): a raw Int axis
-    # would give Int `hs`, which `_eval_nd_cell` (@generated on a Float `h`) has no
-    # method for. The OnTheFly path memoises raw grids per-axis; PreCompute (opt-in)
-    # converts up front instead, so this path keeps its baseline behaviour.
-    Tg = float(_promote_grid_eltype(grids))
-    grids = _convert_grids_typed(grids, Tg)
+    # Raw grids (no eager `Tg.(x)` copy): `_compute_nd_partials!` differentiates each
+    # axis independently (its per-axis spline cache memoises by id → zero-alloc warm
+    # on Int), and the shared `_compute_all_local_params` promotes the cell width so
+    # `_eval_nd_cell` takes a raw/heterogeneous axis. `Tg` (op-form, raw) only types
+    # the pooled partials buffer — `_coeff_op`'s `inv(h)` floats Int internally.
+    Tg = _promote_grid_eltype(grids)
     # 0. NoExtrap domain check must precede FillExtrap short-circuit
     _validate_nd_domain(grids, query, extraps_val)
     oob_result = _try_fill_oob(query, grids, extraps_val, ops, @inbounds first(data))

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -36,16 +36,24 @@ function cubic_interp(
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
-    # Type promotion + validation (same as constructor path)
-    grids_typed, Tg, Tv_p, _ = _nd_promote_grids(grids, data)
-    _validate_nd_grids(grids_typed, data)
+    # Scalar one-shot: raw grids. The per-axis cubic cache (`_get_cubic_cache`)
+    # memoises by grid object id, so a stable raw grid hits the cache after the
+    # first build — the eager `Tg.(x)` copy gave a fresh id every call, defeating
+    # the memo (and adding a heap alloc). The OnTheFly path runs raw; PreCompute
+    # converts internally (its cell-eval needs Float spacing). Output types come
+    # from op-shape inference (`_promote_eltype`): the witness ops float Int via
+    # `inv(h)`/`dL/h`, so a *raw* `Tg` is correct — no manual `float()`/`_value_type`.
+    # (Batch keeps eager-convert; see the linear_interp scalar note.)
+    Tg = _promote_grid_eltype(grids)
+    Tv_p = _promote_eltype(_coeff_op, Tg, Tv)
+    _validate_nd_grids(grids, data)
     Tr = _promote_eltype(_interp_op, Tg, Tv, promote_type(typeof.(query)...))
 
     bcs = _resolve_bcs_nd(bc, Val(N))
     searches = _resolve_search_nd(search, Val(N), query)  # NTuple{N,Real} <: Tuple → BinarySearch/axis
 
     # Validate BC requirements (once, before dispatch).
-    _validate_nd_bcs!(grids_typed, bcs, data, Val(N))
+    _validate_nd_bcs!(grids, bcs, data, Val(N))
 
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv_p)
     ops = _resolve_deriv_nd(deriv, Val(N))
@@ -54,9 +62,9 @@ function cubic_interp(
     coeffs_resolved = _resolve_coeffs_nd_oneshot(coeffs, query, ntuple(_ -> CubicInterp(), Val(N)))
     if coeffs_resolved isa OnTheFly
         methods = map(CubicInterp, bcs)
-        return _interp_nd_oneshot_onthefly(grids_typed, data, query, methods, extraps_val, searches, ops, hint)::Tr
+        return _interp_nd_oneshot_onthefly(grids, data, query, methods, extraps_val, searches, ops, hint)::Tr
     end
-    return _cubic_interp_nd_oneshot(grids_typed, data, query, bcs, extraps_val, searches, ops, hint)::Tr
+    return _cubic_interp_nd_oneshot(grids, data, query, bcs, extraps_val, searches, ops, hint)::Tr
 end
 
 """
@@ -108,7 +116,7 @@ Zero-allocation after warmup (pool reuse).
 (e.g., `(NoExtrap(), ClampExtrap())`), computed via `_resolve_extrap_nd` in the API layer.
 """
 @with_pool pool function _cubic_interp_nd_oneshot(
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         query::Tuple{Vararg{Real, N}},
         bcs::NTuple{N, AbstractBC},
@@ -116,7 +124,13 @@ Zero-allocation after warmup (pool reuse).
         searches::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
         hints = nothing
-    ) where {Tg, Tv, N}
+    ) where {Tv, N}
+    # PreCompute cell-eval needs Float spacing (`hs = xR - xL`): a raw Int axis
+    # would give Int `hs`, which `_eval_nd_cell` (@generated on a Float `h`) has no
+    # method for. The OnTheFly path memoises raw grids per-axis; PreCompute (opt-in)
+    # converts up front instead, so this path keeps its baseline behaviour.
+    Tg = float(_promote_grid_eltype(grids))
+    grids = _convert_grids_typed(grids, Tg)
     # 0. NoExtrap domain check must precede FillExtrap short-circuit
     _validate_nd_domain(grids, query, extraps_val)
     oob_result = _try_fill_oob(query, grids, extraps_val, ops, @inbounds first(data))

--- a/src/hermite/nd/hermite_nd_build.jl
+++ b/src/hermite/nd/hermite_nd_build.jl
@@ -313,11 +313,14 @@ end
 # through `_eval_nd_cell` and returns a scalar.
 @inline function _pack_and_extend_nodal_derivs_pooled(
         pool::AbstractArrayPool,
-        grids::Tuple{Vararg{AbstractVector{Tg}, N}},
+        grids::Tuple{Vararg{AbstractVector, N}},
         data::AbstractArray{Tv, N},
         partials::HermitePartials{N, Tv, K},
         bcs::Tuple{Vararg{AbstractBC, N}},
-    ) where {Tg, Tv, N, K}
+    ) where {Tv, N, K}
+    # `Tg` only feeds the `:exclusive` virtual-endpoint extension below (the common
+    # non-periodic path leaves each axis untouched); raw grids may be Int/heterogeneous.
+    Tg = _promote_grid_eltype(grids)
     extended = ntuple(d -> bcs[d] isa PeriodicBC{:exclusive}, Val(N))
     n_orig = size(data)
     n_ext = ntuple(d -> extended[d] ? n_orig[d] + 1 : n_orig[d], Val(N))

--- a/src/hermite/nd/hermite_nd_build.jl
+++ b/src/hermite/nd/hermite_nd_build.jl
@@ -331,13 +331,11 @@ end
     _fill_packed_src_region!(buf, (data, partials.partials...))
     _wrap_all_axes_all_slots!(buf, extended, Val(N))
 
-    # `map` (not `ntuple` over `bcs[d]`) so each axis dispatches concretely
-    # without boxing the Union — see the heap twin.
-    grids_ext = map(grids, bcs) do grid_d, bc_d
-        bc_d isa PeriodicBC{:exclusive} ?
-            _extend_grid_one_axis_pooled(pool, grid_d, bc_d, Tg) :
-            grid_d
-    end
+    # Per-axis grid extension via a `::Type{Tg}` function barrier: `Tg` must reach
+    # the closure as a static parameter, not a captured type-valued local — Julia
+    # 1.10 boxes such a local, making the extended grid abstract (256 B/call on the
+    # exclusive one-shot). Mirrors `_extend_periodic_nd_axes` (cubic/quad twin).
+    grids_ext = _extend_hermite_nd_grids_pooled(pool, grids, bcs, Tg)
 
     bcs_post = map(bcs, grids_ext) do bc_d, grid_ext_d
         bc_eff = _bc_after_extend(bc_d)
@@ -347,6 +345,25 @@ end
     end
 
     return grids_ext, buf, bcs_post
+end
+
+# Per-axis exclusive-periodic grid extension, factored out so `Tg` reaches the
+# closure as a static `::Type` parameter (not a captured type-valued local) —
+# Julia 1.10 boxes such a local → abstract extended grid → 256 B/call on the
+# exclusive one-shot. `map` (not `ntuple` over `bcs[d]`) keeps each axis's
+# dispatch concrete without boxing the per-axis Union. Mirrors the cubic/quad
+# twin `_extend_periodic_nd_axes`.
+@inline function _extend_hermite_nd_grids_pooled(
+        pool::AbstractArrayPool,
+        grids::Tuple{Vararg{AbstractVector, N}},
+        bcs::Tuple{Vararg{AbstractBC, N}},
+        ::Type{Tg},
+    ) where {N, Tg}
+    return map(grids, bcs) do grid_d, bc_d
+        bc_d isa PeriodicBC{:exclusive} ?
+            _extend_grid_one_axis_pooled(pool, grid_d, bc_d, Tg) :
+            grid_d
+    end
 end
 
 # Pool-based per-axis grid extension. Range case preserves Range type

--- a/src/hermite/nd/hermite_nd_build.jl
+++ b/src/hermite/nd/hermite_nd_build.jl
@@ -318,8 +318,8 @@ end
         partials::HermitePartials{N, Tv, K},
         bcs::Tuple{Vararg{AbstractBC, N}},
     ) where {Tv, N, K}
-    # `Tg` only feeds the `:exclusive` virtual-endpoint extension below (the common
-    # non-periodic path leaves each axis untouched); raw grids may be Int/heterogeneous.
+    # `Tg` only feeds the `:exclusive` virtual-endpoint extension below; raw grids
+    # may be Int/heterogeneous.
     Tg = _promote_grid_eltype(grids)
     extended = ntuple(d -> bcs[d] isa PeriodicBC{:exclusive}, Val(N))
     n_orig = size(data)

--- a/src/hermite/nd/hermite_nd_oneshot.jl
+++ b/src/hermite/nd/hermite_nd_oneshot.jl
@@ -112,7 +112,8 @@ end
     K == (1 << N) - 1 || _throw_partials_not_full_mixed(N, K)
 
     # Raw grids: the pack + cell-eval float the cell width, so no eager `Tg.(x)` copy.
-    Tv_promoted = _promote_eltype(_coeff_op, _promote_grid_eltype(grids), eltype(data))
+    Tg = _promote_grid_eltype(grids)
+    Tv_promoted = _promote_eltype(_coeff_op, Tg, eltype(data))
     Tv = promote_type(Tv_promoted, Tv_part)
     data_typed = _coerce_data_eltype(data, Tv, Val(N))
     partials_typed = _coerce_partials_eltype(partials, Tv, Val(N))

--- a/src/hermite/nd/hermite_nd_oneshot.jl
+++ b/src/hermite/nd/hermite_nd_oneshot.jl
@@ -111,9 +111,7 @@ end
     ) where {N, Tv_part, K}
     K == (1 << N) - 1 || _throw_partials_not_full_mixed(N, K)
 
-    # Raw grids: the pack + cell-eval accept them (the eval floats the cell width),
-    # so no eager `Tg.(x)` copy. `Tv_promoted` (data eltype at grid precision) is
-    # type-only via op-shape inference — `_coeff_op`'s `inv(h)` floats a raw Int grid.
+    # Raw grids: the pack + cell-eval float the cell width, so no eager `Tg.(x)` copy.
     Tv_promoted = _promote_eltype(_coeff_op, _promote_grid_eltype(grids), eltype(data))
     Tv = promote_type(Tv_promoted, Tv_part)
     data_typed = _coerce_data_eltype(data, Tv, Val(N))

--- a/src/hermite/nd/hermite_nd_oneshot.jl
+++ b/src/hermite/nd/hermite_nd_oneshot.jl
@@ -61,7 +61,7 @@ function hermite_interp(
         search::Union{AbstractSearchPolicy, NTuple{N, AbstractSearchPolicy}} = AutoSearch(),
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing,
     ) where {Tv, N, Tv_part}
-    _, Tg, _, _ = _nd_promote_grids(grids, data)
+    Tg = _promote_grid_eltype(grids)
     Tq = _query_eltype(queries)
     Tr = _promote_eltype(_interp_op, Tg, promote_type(Tv, Tv_part), Tq)
     output = Vector{Tr}(undef, _query_length(queries))
@@ -111,12 +111,15 @@ end
     ) where {N, Tv_part, K}
     K == (1 << N) - 1 || _throw_partials_not_full_mixed(N, K)
 
-    grids_typed, _, Tv_promoted, _ = _nd_promote_grids(grids, data)
+    # Raw grids: the pack + cell-eval accept them (the eval floats the cell width),
+    # so no eager `Tg.(x)` copy. `Tv_promoted` (data eltype at grid precision) is
+    # type-only via op-shape inference — `_coeff_op`'s `inv(h)` floats a raw Int grid.
+    Tv_promoted = _promote_eltype(_coeff_op, _promote_grid_eltype(grids), eltype(data))
     Tv = promote_type(Tv_promoted, Tv_part)
     data_typed = _coerce_data_eltype(data, Tv, Val(N))
     partials_typed = _coerce_partials_eltype(partials, Tv, Val(N))
 
-    _validate_nd_grids(grids_typed, data_typed)
+    _validate_nd_grids(grids, data_typed)
 
     bcs = _resolve_bcs_nd(bc, Val(N))
     searches = _resolve_search_nd(search, Val(N))
@@ -128,7 +131,7 @@ end
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)
     ops = _resolve_deriv_nd(deriv, Val(N))
 
-    return grids_typed, data_typed, partials_typed, bcs, extraps_val, searches, ops
+    return grids, data_typed, partials_typed, bcs, extraps_val, searches, ops
 end
 
 # ========================================
@@ -138,7 +141,7 @@ end
 # validate domain → fill-OOB short circuit → pool-pack + extend → shared
 # search + eval → scalar.
 @with_pool pool function _hermite_interp_nd_oneshot(
-        grids::Tuple{Vararg{AbstractVector{Tg}, N}},
+        grids::Tuple{Vararg{AbstractVector, N}},
         data::AbstractArray{Tv, N},
         partials::HermitePartials{N, Tv, K},
         query::Tuple{Vararg{Real, N}},
@@ -147,7 +150,7 @@ end
         searches::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}},
-    ) where {Tg, Tv, N, K}
+    ) where {Tv, N, K}
     _validate_nd_domain(grids, query, extraps_val)
     oob_result = _try_fill_oob(query, grids, extraps_val, ops, @inbounds first(data))
     oob_result !== nothing && return oob_result
@@ -175,7 +178,7 @@ end
 # happens ONCE; then a tight per-query eval loop writes into `output`.
 @with_pool pool function _hermite_interp_nd_oneshot_batch!(
         output::AbstractVector,
-        grids::Tuple{Vararg{AbstractVector{Tg}, N}},
+        grids::Tuple{Vararg{AbstractVector, N}},
         data::AbstractArray{Tv, N},
         partials::HermitePartials{N, Tv, K},
         queries,
@@ -184,7 +187,7 @@ end
         ops::NTuple{N, AbstractEvalOp},
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}},
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}},
-    ) where {Tg, Tv, N, K}
+    ) where {Tv, N, K}
     policies, hints = _resolve_oneshot_search_nd(search, queries, hint, Val(N))
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))

--- a/src/hetero/hetero_oneshot.jl
+++ b/src/hetero/hetero_oneshot.jl
@@ -148,11 +148,8 @@ end
     # O(boundary-size) check once per batch instead of once per query.
     extraps_eff = map(_resolve_extrap, extraps_val, bcs, grids_eff)
     q_eval = _handle_all_extraps(query, grids_eff, extraps_eff)
-    # Tr promotes data eltype with grid + query eltypes → Dual-safe pool buffers for AD.
-    # Grid eltype included: when grid is Dual, 1D oneshot returns Dual-typed results
-    # that must fit into _collapse_dims intermediate buffers. `_promote_eltype` floats
-    # Int internally, so a *raw* grid type is correct (and Dual-preserving) — no manual
-    # `float()`; raw grids may be Int/heterogeneous (the cubic scalar one-shot passes them).
+    # Tr promotes data with grid + query eltypes → Dual-safe pool buffers for AD.
+    # Raw grids may be Int/heterogeneous; `_promote_eltype` floats Int internally.
     Tg = _promote_grid_eltype(grids)
     Tr = _promote_eltype(Tv, Tg, typeof.(q_eval)...)
 

--- a/src/hetero/hetero_oneshot.jl
+++ b/src/hetero/hetero_oneshot.jl
@@ -124,7 +124,7 @@ end
 # Periodic BC is handled internally by each _oneshot_eval_1d call.
 
 @inline @with_pool pool function _interp_nd_oneshot_onthefly(
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         query::Tuple{Vararg{Real, N}},
         methods::Tuple{Vararg{AbstractInterpMethod, N}},
@@ -132,7 +132,7 @@ end
         searches::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
         hints = nothing,
-    ) where {Tg, Tv, N}
+    ) where {Tv, N}
     _validate_nd_domain(grids, query, extraps_val)
     oob_result = _try_fill_oob(query, grids, extraps_val, ops, @inbounds first(data))
     oob_result !== nothing && return oob_result
@@ -150,7 +150,10 @@ end
     q_eval = _handle_all_extraps(query, grids_eff, extraps_eff)
     # Tr promotes data eltype with grid + query eltypes → Dual-safe pool buffers for AD.
     # Grid eltype included: when grid is Dual, 1D oneshot returns Dual-typed results
-    # that must fit into _collapse_dims intermediate buffers.
+    # that must fit into _collapse_dims intermediate buffers. `_promote_eltype` floats
+    # Int internally, so a *raw* grid type is correct (and Dual-preserving) — no manual
+    # `float()`; raw grids may be Int/heterogeneous (the cubic scalar one-shot passes them).
+    Tg = _promote_grid_eltype(grids)
     Tr = _promote_eltype(Tv, Tg, typeof.(q_eval)...)
 
     # GridIdx safety gate: same reason as the persistent path — a GridIdx on a

--- a/src/linear/nd/linear_nd_eval.jl
+++ b/src/linear/nd/linear_nd_eval.jl
@@ -139,7 +139,7 @@ seam-aware stencils from `_search_all_intervals_stencil`.
 @generated function _multilinear_sum(
         data::AbstractArray{Tv, N},
         stencils::NTuple{N, _IdxStencil{2}},
-        inv_hs::NTuple{N},
+        inv_hs::Tuple{Vararg{Real, N}},   # heterogeneous-tolerant (raw mixed-precision grids); each axis used independently
         αs::Tuple{Vararg{Real, N}},
         ops::NTuple{N, AbstractEvalOp},
         ::Val{N}

--- a/src/linear/nd/linear_nd_oneshot.jl
+++ b/src/linear/nd/linear_nd_oneshot.jl
@@ -131,10 +131,12 @@ function linear_interp(
     # Scalar one-shot: search/evaluate the RAW grids. The kernel's own
     # `map(_resolve_axis, …)` shapes each axis (Range→`_CachedRange`, Vector→
     # passthrough) and the search promote-compares, so no axis needs an eager
-    # `Tg.(x)` heap copy (mirrors 1D one-shot). Only the type `Tg` is needed,
-    # for the `::Tr` boxing guard. (Batch keeps eager-convert — it amortises the
-    # conversion over all queries, where per-query promote-compare costs more.)
-    Tg = float(_promote_grid_eltype(grids))
+    # `Tg.(x)` heap copy (mirrors 1D one-shot). `Tr` (the `::Tr` boxing guard)
+    # comes from op-shape inference: `_interp_op`'s `dL/h` floats Int internally,
+    # so a *raw* grid type is correct — no manual `float()`. (Batch keeps eager-
+    # convert — it amortises the conversion over all queries, where per-query
+    # promote-compare costs more.)
+    Tg = _promote_grid_eltype(grids)
     _validate_nd_grids(grids, data)
     Tr = _promote_eltype(_interp_op, Tg, Tv, promote_type(typeof.(query)...))
 

--- a/src/linear/nd/linear_nd_oneshot.jl
+++ b/src/linear/nd/linear_nd_oneshot.jl
@@ -25,7 +25,7 @@ original `data`. Expect ~1× parity with persistent ND interpolant for periodic
 exclusive (was ~365× pre-refactor due to per-query N-dim data copy).
 """
 function _linear_interp_nd_oneshot(
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         query::Tuple{Vararg{Real, N}},
         bcs::NTuple{N, AbstractBC},
@@ -33,7 +33,7 @@ function _linear_interp_nd_oneshot(
         searches::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
         hints = nothing
-    ) where {Tg, Tv, N}
+    ) where {Tv, N}
     # Per-axis BC-aware axis resolution: `:exclusive` axes (Vector or Range) →
     # `_ExclusivePeriodicAxis` carrying the precomputed virtual endpoint and
     # period; non-periodic → passthrough or cached float form. After this,
@@ -128,8 +128,14 @@ function linear_interp(
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
-    grids_typed, Tg, _, _ = _nd_promote_grids(grids, data)
-    _validate_nd_grids(grids_typed, data)
+    # Scalar one-shot: search/evaluate the RAW grids. The kernel's own
+    # `map(_resolve_axis, …)` shapes each axis (Range→`_CachedRange`, Vector→
+    # passthrough) and the search promote-compares, so no axis needs an eager
+    # `Tg.(x)` heap copy (mirrors 1D one-shot). Only the type `Tg` is needed,
+    # for the `::Tr` boxing guard. (Batch keeps eager-convert — it amortises the
+    # conversion over all queries, where per-query promote-compare costs more.)
+    Tg = float(_promote_grid_eltype(grids))
+    _validate_nd_grids(grids, data)
     Tr = _promote_eltype(_interp_op, Tg, Tv, promote_type(typeof.(query)...))
 
     searches = _resolve_search_nd(search, Val(N), query)  # scalar: type-based (no monotonicity check)
@@ -137,7 +143,7 @@ function linear_interp(
     bcs = _resolve_bcs_nd(bc, Val(N))
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)
     ops = _resolve_deriv_nd(deriv, Val(N))
-    return _linear_interp_nd_oneshot(grids_typed, data, query, bcs, extraps_val, searches, ops, hint)::Tr
+    return _linear_interp_nd_oneshot(grids, data, query, bcs, extraps_val, searches, ops, hint)::Tr
 end
 
 """

--- a/src/linear/nd/linear_nd_oneshot.jl
+++ b/src/linear/nd/linear_nd_oneshot.jl
@@ -22,7 +22,7 @@ exclusive periodic axes. Per-axis bc is projected into typed `WrapExtrap` via
 `_resolve_extrap` (validation + materialization); BC-aware `Searcher` returns `(idx_L=n, idx_R=1)`
 at periodic seam cells so the kernel reads wrapped corners directly from the
 original `data`. Expect ~1× parity with persistent ND interpolant for periodic
-exclusive (was ~365× pre-refactor due to per-query N-dim data copy).
+exclusive (no per-query N-dim data copy).
 """
 function _linear_interp_nd_oneshot(
         grids::NTuple{N, AbstractVector},
@@ -128,14 +128,9 @@ function linear_interp(
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
-    # Scalar one-shot: search/evaluate the RAW grids. The kernel's own
-    # `map(_resolve_axis, …)` shapes each axis (Range→`_CachedRange`, Vector→
-    # passthrough) and the search promote-compares, so no axis needs an eager
-    # `Tg.(x)` heap copy (mirrors 1D one-shot). `Tr` (the `::Tr` boxing guard)
-    # comes from op-shape inference: `_interp_op`'s `dL/h` floats Int internally,
-    # so a *raw* grid type is correct — no manual `float()`. (Batch keeps eager-
-    # convert — it amortises the conversion over all queries, where per-query
-    # promote-compare costs more.)
+    # Scalar one-shot: raw grids — the kernel's `map(_resolve_axis, …)` shapes each
+    # axis and the search promote-compares, so no eager `Tg.(x)` copy. `Tr` from
+    # op-shape inference (`dL/h` floats Int). Batch keeps eager-convert (amortised).
     Tg = _promote_grid_eltype(grids)
     _validate_nd_grids(grids, data)
     Tr = _promote_eltype(_interp_op, Tg, Tv, promote_type(typeof.(query)...))

--- a/src/quadratic/nd/quadratic_nd_build.jl
+++ b/src/quadratic/nd/quadratic_nd_build.jl
@@ -253,8 +253,7 @@ end
 # Generic ND Partial Derivative Computation (Quadratic)
 # ========================================
 
-# `grids` may be heterogeneous-eltype (raw scalar one-shot): each dimension is
-# differentiated independently via `grids[D]`, so no single grid `Tg` is needed.
+# Raw/heterogeneous grids: each dimension differentiates independently via `grids[D]`.
 @inline _build_nd_partials_dim_quadratic!(
     partials::AbstractArray{Tv, NP1},
     grids::NTuple{N, AbstractVector},

--- a/src/quadratic/nd/quadratic_nd_build.jl
+++ b/src/quadratic/nd/quadratic_nd_build.jl
@@ -253,21 +253,23 @@ end
 # Generic ND Partial Derivative Computation (Quadratic)
 # ========================================
 
+# `grids` may be heterogeneous-eltype (raw scalar one-shot): each dimension is
+# differentiated independently via `grids[D]`, so no single grid `Tg` is needed.
 @inline _build_nd_partials_dim_quadratic!(
     partials::AbstractArray{Tv, NP1},
-    grids::NTuple{N, AbstractVector{Tg}},
+    grids::NTuple{N, AbstractVector},
     bcs::NTuple{N, AbstractBC},
     ::Val{N}
-) where {Tv, Tg, N, NP1} =
+) where {Tv, N, NP1} =
     _build_nd_partials_dim_quadratic!(partials, grids, bcs, Val(1), Val(N))
 
 @inline function _build_nd_partials_dim_quadratic!(
         partials::AbstractArray{Tv, NP1},
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::NTuple{N, AbstractVector},
         bcs::NTuple{N, AbstractBC},
         ::Val{D},
         ::Val{N}
-    ) where {Tv, Tg, D, N, NP1}
+    ) where {Tv, D, N, NP1}
     bit_d = 1 << (D - 1)
     @inbounds for p_src in 1:bit_d
         p_dst = p_src + bit_d
@@ -292,10 +294,10 @@ recurrence for 1D differentiation instead of Thomas tridiagonal.
 """
 function _compute_nd_partials_quadratic!(
         partials::AbstractArray{Tz, NP1},
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
-    ) where {Tz, Tv, Tg, N, NP1}
+    ) where {Tz, Tv, N, NP1}
     # Validate dimensions
     @boundscheck begin
         NP1 == N + 1 || throw(DimensionMismatch("partials must have N+1 dimensions"))

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -21,7 +21,7 @@ Computes 2^N partial derivatives in a pool buffer and evaluates at a single poin
 Zero-allocation after warmup (pool reuse).
 """
 @with_pool pool function _quadratic_interp_nd_oneshot(
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         query::Tuple{Vararg{Real, N}},
         bcs::NTuple{N, AbstractBC},
@@ -29,7 +29,7 @@ Zero-allocation after warmup (pool reuse).
         searches::NTuple{N, AbstractSearchPolicy},
         ops::NTuple{N, AbstractEvalOp},
         hints = nothing
-    ) where {Tg, Tv, N}
+    ) where {Tv, N}
     # 0. NoExtrap domain check must precede FillExtrap short-circuit
     _validate_nd_domain(grids, query, extraps_val)
     oob_result = _try_fill_oob(query, grids, extraps_val, ops, @inbounds first(data))
@@ -42,6 +42,8 @@ Zero-allocation after warmup (pool reuse).
 
     # 2. Pool-allocate partials array (THE KEY: pool instead of heap)
     # Tz widens Tv with Tg: when grid is Dual, derivatives = data × inv_h → Dual-typed.
+    # `Tg` from op-shape inference floats a raw Int grid; `_coeff_op`'s `inv(h)` does it.
+    Tg = _promote_grid_eltype(grids)
     Tz = _promote_eltype(_coeff_op, Tg, Tv)
     n_partials = 1 << N
     partials = acquire!(pool, Tz, (n_partials, size(data)...))
@@ -158,8 +160,13 @@ function quadratic_interp(
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
-    grids_typed, Tg, _, _ = _nd_promote_grids(grids, data)
-    _validate_nd_grids(grids_typed, data)
+    # Scalar one-shot: raw grids. Both the PreCompute kernel (wraps each axis via
+    # `_cache_axis_pooled` internally) and the OnTheFly kernel accept raw grids, and
+    # `_compute_all_local_params` floats the cell width so the PreCompute cell-eval
+    # takes a raw Int axis — no eager `Tg.(x)` copy. Output type via op-shape
+    # inference. (Batch keeps eager-convert; see the linear_interp scalar note.)
+    Tg = _promote_grid_eltype(grids)
+    _validate_nd_grids(grids, data)
     Tr = _promote_eltype(_interp_op, Tg, Tv, promote_type(typeof.(query)...))
 
     bcs = _resolve_bcs_nd(bc, Val(N))
@@ -174,10 +181,10 @@ function quadratic_interp(
     if coeffs_resolved isa OnTheFly
         sample = @inbounds first(data)
         methods = map(bc_i -> QuadraticInterp(_to_quadratic_bc(bc_i, sample)), bcs)
-        return _interp_nd_oneshot_onthefly(grids_typed, data, query, methods, extraps_val, searches, ops, hint)::Tr
+        return _interp_nd_oneshot_onthefly(grids, data, query, methods, extraps_val, searches, ops, hint)::Tr
     end
     return _quadratic_interp_nd_oneshot(
-        grids_typed, data, query, bcs, extraps_val, searches, ops, hint
+        grids, data, query, bcs, extraps_val, searches, ops, hint
     )::Tr
 end
 

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -41,8 +41,7 @@ Zero-allocation after warmup (pool reuse).
     grids_c = map(g -> _cache_axis_pooled(pool, g), grids)
 
     # 2. Pool-allocate partials array (THE KEY: pool instead of heap)
-    # Tz widens Tv with Tg: when grid is Dual, derivatives = data × inv_h → Dual-typed.
-    # `Tg` from op-shape inference floats a raw Int grid; `_coeff_op`'s `inv(h)` does it.
+    # Tz widens Tv with Tg (Dual grid → Dual derivs). `Tg` raw; `_coeff_op` floats Int.
     Tg = _promote_grid_eltype(grids)
     Tz = _promote_eltype(_coeff_op, Tg, Tv)
     n_partials = 1 << N
@@ -160,11 +159,8 @@ function quadratic_interp(
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
-    # Scalar one-shot: raw grids. Both the PreCompute kernel (wraps each axis via
-    # `_cache_axis_pooled` internally) and the OnTheFly kernel accept raw grids, and
-    # `_compute_all_local_params` floats the cell width so the PreCompute cell-eval
-    # takes a raw Int axis — no eager `Tg.(x)` copy. Output type via op-shape
-    # inference. (Batch keeps eager-convert; see the linear_interp scalar note.)
+    # Scalar one-shot: raw grids — both PreCompute and OnTheFly accept them
+    # (`_compute_all_local_params` floats the cell width). Batch keeps eager-convert.
     Tg = _promote_grid_eltype(grids)
     _validate_nd_grids(grids, data)
     Tr = _promote_eltype(_interp_op, Tg, Tv, promote_type(typeof.(query)...))

--- a/test/test_axis_data_resolvers.jl
+++ b/test/test_axis_data_resolvers.jl
@@ -481,8 +481,7 @@ end
     bc_inc = PeriodicBC(endpoint = :inclusive)
     bc_excl = PeriodicBC(endpoint = :exclusive, period = 4.0)
 
-    # Suppress the `_warn_type_conversion` one-shot warning that
-    # `_to_float(::AbstractVector, Tg)` emits when broadcasting.
+    # Float32 grid promotes to Float64 via `_to_float` broadcasting.
     x32 = Float32[0.0, 1.0, 2.0, 3.0]
 
     @testset "Vector{Float32} + Tg=Float64 promotes via _to_float" begin
@@ -696,8 +695,8 @@ end
         r_int = 0:1:3                                  # Int range
         r_f64 = 0.0:1.0:3.0                            # Float64 range
 
-        # Suppress repeated warning emission by warmup.
-        _cache_axis_pooled(pool, x32, Float64)         # warms _warn_type_conversion
+        # Warm up compilation/pool before the allocation assertions below.
+        _cache_axis_pooled(pool, x32, Float64)
         cv_promoted = _cache_axis_pooled(pool, x32, Float64)
         cr_int_promoted = _cache_axis_pooled(pool, r_int, Float32)
         cr_f64_demoted = _cache_axis_pooled(pool, r_f64, Float32)

--- a/test/test_cubic_oneshot_no_spurious_warning.jl
+++ b/test/test_cubic_oneshot_no_spurious_warning.jl
@@ -1,7 +1,8 @@
-# The warm Int-Vector-grid cubic one-shot is zero-alloc, yet currently emits a
-# `@warn "...allocating type conversion..."` from the internal pooled cubic rebuild
-# on the windowed Int view — wrongly telling users to pre-convert for zero-alloc.
-# `maxlog=1` makes in-process log capture order-dependent, so assert in a fresh process.
+# The grid type-conversion warning was removed as obsolete (one-shot Int grids are
+# zero-alloc via the cache; persistent construction allocates a grid copy regardless,
+# so "pre-convert for zero-allocation" never applied). Guard against re-introducing a
+# spurious per-call warning on the warm Int-grid cubic one-shot — asserted in a fresh
+# process since a `maxlog`-throttled warning would be order-dependent in-process.
 
 @testitem "Cubic Int-grid one-shot — no spurious 'allocating conversion' warning" begin
     code = """

--- a/test/test_cubic_oneshot_no_spurious_warning.jl
+++ b/test/test_cubic_oneshot_no_spurious_warning.jl
@@ -1,0 +1,21 @@
+# The warm Int-Vector-grid cubic one-shot is zero-alloc, yet currently emits a
+# `@warn "...allocating type conversion..."` from the internal pooled cubic rebuild
+# on the windowed Int view — wrongly telling users to pre-convert for zero-alloc.
+# `maxlog=1` makes in-process log capture order-dependent, so assert in a fresh process.
+
+@testitem "Cubic Int-grid one-shot — no spurious 'allocating conversion' warning" begin
+    code = """
+    using FastInterpolations
+    x = [0, 1, 2, 3, 4, 5, 6, 7]; y = [0, 1, 2, 3, 4, 5]
+    data = [sin(1.0a) + cos(1.0b) for a in x, b in y]
+    q = (3.4, 2.6)
+    for _ in 1:3
+        cubic_interp((x, y), data, q)
+    end
+    """
+    err = IOBuffer()
+    cmd = `$(Base.julia_cmd()) --project=$(Base.active_project()) --startup-file=no --color=no -e $code`
+    run(pipeline(cmd; stdout = devnull, stderr = err))
+    log = String(take!(err))
+    @test !occursin("allocating type conversion", log)
+end

--- a/test/test_hermite_nd_partials.jl
+++ b/test/test_hermite_nd_partials.jl
@@ -519,6 +519,9 @@
         # Bulk-loop measurements amortize single-call setup noise.
         # 1000-iter bulk / 1000 must be exactly 0.
         @test _measure_nobc(1000) == 0
+        # Periodic-EXCLUSIVE extends the grid; the extension routes `Tg` through a
+        # `::Type{Tg}` function barrier (`_extend_hermite_nd_grids_pooled`) so it
+        # stays zero-alloc on 1.10 too — a captured type-valued `Tg` boxes ~256 B/call.
         @test _measure_excl(1000) == 0
         @test _measure_inc(1000) == 0
         # Single-call batch & persistent eval (already inside function barrier).

--- a/test/test_nd_noextrap_oob.jl
+++ b/test/test_nd_noextrap_oob.jl
@@ -217,7 +217,7 @@
             println(string("OK:", typeof(e)))
         end
         """
-        result = readchomp(`julia --startup-file=no --project=$project_dir -e $batch_script`)
+        result = readchomp(`$(Base.julia_cmd()) --startup-file=no --project=$project_dir -e $batch_script`)
         @test endswith(result, "OK:DomainError")
 
         # Scalar oneshot path
@@ -232,7 +232,7 @@
             println(string("OK:", typeof(e)))
         end
         """
-        result2 = readchomp(`julia --startup-file=no --project=$project_dir -e $scalar_script`)
+        result2 = readchomp(`$(Base.julia_cmd()) --startup-file=no --project=$project_dir -e $scalar_script`)
         @test endswith(result2, "OK:DomainError")
 
         # Interpolant scalar path (the gap found in code review)
@@ -248,7 +248,7 @@
             println(string("OK:", typeof(e)))
         end
         """
-        result3 = readchomp(`julia --startup-file=no --project=$project_dir -e $itp_scalar_script`)
+        result3 = readchomp(`$(Base.julia_cmd()) --startup-file=no --project=$project_dir -e $itp_scalar_script`)
         @test endswith(result3, "OK:DomainError")
 
         # AoS query path
@@ -265,7 +265,7 @@
             println(string("OK:", typeof(e)))
         end
         """
-        result4 = readchomp(`julia --startup-file=no --project=$project_dir -e $aos_script`)
+        result4 = readchomp(`$(Base.julia_cmd()) --startup-file=no --project=$project_dir -e $aos_script`)
         @test endswith(result4, "OK:DomainError")
     end
 

--- a/test/test_nd_oneshot_mixed_precision_grids.jl
+++ b/test/test_nd_oneshot_mixed_precision_grids.jl
@@ -1,0 +1,59 @@
+# ND scalar one-shot on mixed-precision / heterogeneous-eltype grids.
+#
+# After the raw-grid migration every method must still evaluate on axis tuples
+# whose eltypes differ (e.g. `Float32 × Float64`) and under AD-wrt-grid (a Dual
+# axis beside a Float axis). Linear's `_multilinear_sum` constrains `inv_hs` to a
+# homogeneous tuple, so genuinely-mixed-float grids throw `MethodError` until that
+# signature is relaxed. Cubic/quadratic/hermite promote spacings via
+# `_compute_all_local_params`, and constant is a selection kernel — all handled.
+
+@testitem "ND one-shot mixed-precision grids — value matches all-Float64" begin
+    fq(a, b) = 2.0a + 3.0b - 0.5a * b + 1.0
+    q = (1.5, 2.5)
+    # Genuinely mixed-eltype axes: a Float32 axis keeps a Float32 `inv_h` that
+    # cannot collapse to the other axis' Float64 (unlike Int, whose `inv_h` floats).
+    mixes = [
+        ("Int × Float64", [0, 1, 2, 3, 4], Float64.(0:3)),          # control (both inv_h Float64)
+        ("Float32 × Float64", Float32.(0:4), Float64.(0:3)),
+        ("Float64 × Float32", Float64.(0:4), Float32.(0:3)),
+        ("Int × Float32", [0, 1, 2, 3, 4], Float32.(0:3)),
+        ("Float64Range × IntVec", 0.0:4.0, [0, 1, 2, 3]),           # control (both inv_h Float64)
+    ]
+    for (name, gx, gy) in mixes
+        xc = collect(gx)
+        yc = collect(gy)
+        data = [fq(a, b) for a in xc, b in yc]
+        ref_lin = linear_interp((Float64.(xc), Float64.(yc)), data, q)
+        ref_con = constant_interp((Float64.(xc), Float64.(yc)), data, q)
+        @testset "linear $name" begin
+            @test linear_interp((gx, gy), data, q) ≈ ref_lin rtol = 1.0e-5
+        end
+        @testset "constant $name" begin
+            @test constant_interp((gx, gy), data, q) === ref_con
+        end
+    end
+end
+
+@testitem "Linear ND one-shot — AD wrt grid nodes (mixed Dual/Float axis)" begin
+    using ForwardDiff
+    x = [0.0, 1, 2, 3, 4]
+    y = [0.0, 1, 2, 3]
+    q = (1.5, 2.5)
+    data = [2.0a + 3.0b - 0.5a * b for a in x, b in y]   # bilinear → linear is exact
+    # Central-difference reference for ∂value/∂(x-nodes); the all-Float64 path works today.
+    fd = map(eachindex(x)) do i
+        xp = copy(x)
+        xm = copy(x)
+        xp[i] += 1.0e-6
+        xm[i] -= 1.0e-6
+        (linear_interp((xp, y), data, q) - linear_interp((xm, y), data, q)) / 2.0e-6
+    end
+    @testset "∂/∂x-nodes (x Dual, y Float64)" begin
+        g = ForwardDiff.gradient(xx -> linear_interp((xx, y), data, q), x)
+        @test g ≈ fd atol = 1.0e-6
+    end
+    @testset "homogeneous control: ∂/∂[x; y] (both axes Dual)" begin
+        g = ForwardDiff.gradient(p -> linear_interp((p[1:5], p[6:9]), data, q), [x; y])
+        @test all(isfinite, g)
+    end
+end

--- a/test/test_nd_oneshot_mixed_precision_grids.jl
+++ b/test/test_nd_oneshot_mixed_precision_grids.jl
@@ -57,3 +57,41 @@ end
         @test all(isfinite, g)
     end
 end
+
+@testitem "Cubic/Quadratic/Hermite ND one-shot — AD wrt grid nodes" begin
+    using ForwardDiff
+    using FastInterpolations: HermitePartials
+    x = [0.0, 1, 2, 3, 4, 5]
+    y = [0.0, 1, 2, 3, 4]
+    q = (3.4, 2.6)
+    # Central-difference reference for ∂value/∂(x-nodes); the all-Float64 path works today.
+    fdx(f) = map(eachindex(x)) do i
+        xp = copy(x)
+        xm = copy(x)
+        xp[i] += 1.0e-6
+        xm[i] -= 1.0e-6
+        (f((xp, y)) - f((xm, y))) / 2.0e-6
+    end
+    data = [sin(0.7a) + cos(0.5b) for a in x, b in y]
+    @testset "cubic ∂/∂x-nodes finite & matches FD" begin
+        g = ForwardDiff.gradient(xx -> cubic_interp((xx, y), data, q), x)
+        @test all(isfinite, g)
+        @test g ≈ fdx(gg -> cubic_interp(gg, data, q)) atol = 1.0e-3
+    end
+    @testset "quadratic ∂/∂x-nodes finite & matches FD" begin
+        g = ForwardDiff.gradient(xx -> quadratic_interp((xx, y), data, q), x)
+        @test all(isfinite, g)
+        @test g ≈ fdx(gg -> quadratic_interp(gg, data, q)) atol = 1.0e-3
+    end
+    @testset "hermite ∂/∂x-nodes finite & matches FD" begin
+        p = HermitePartials(
+            (1, 0) => [cos(1.0a) * cos(1.0b) for a in x, b in y],
+            (0, 1) => [-sin(1.0a) * sin(1.0b) for a in x, b in y],
+            (1, 1) => [-cos(1.0a) * sin(1.0b) for a in x, b in y],
+        )
+        dH = [sin(1.0a) * cos(1.0b) for a in x, b in y]
+        g = ForwardDiff.gradient(xx -> hermite_interp((xx, y), dH, p, q), x)
+        @test all(isfinite, g)
+        @test g ≈ fdx(gg -> hermite_interp(gg, dH, p, q)) atol = 1.0e-3
+    end
+end

--- a/test/test_nd_raw_grid_oneshot.jl
+++ b/test/test_nd_raw_grid_oneshot.jl
@@ -313,3 +313,78 @@ end
         @test g ≈ gf atol = 1.0e-10
     end
 end
+
+# ============================================================================
+# Hermite ND one-shot — raw Int grid (user-supplied nodal partials)
+# ============================================================================
+#
+# Hermite ND one-shot packs the user partials into a pool buffer and evaluates
+# via the shared `_compute_all_local_params` (now floats the cell width) +
+# `_eval_nd_cell`. Passing raw grids (no eager `Tg.(x)` copy) makes the warm
+# scalar one-shot on an Int Vector grid zero-alloc. Batch keeps pool packing.
+
+@testitem "Hermite ND one-shot raw-grid (no eager convert)" setup = [AllocConstants] begin
+    using FastInterpolations: HermitePartials
+    using ForwardDiff
+
+    _hp(x, y) = HermitePartials(
+        (1, 0) => [cos(1.0 * a) * cos(1.0 * b) for a in x, b in y],
+        (0, 1) => [-sin(1.0 * a) * sin(1.0 * b) for a in x, b in y],
+        (1, 1) => [-cos(1.0 * a) * sin(1.0 * b) for a in x, b in y],
+    )
+    _hdata(x, y) = [sin(1.0 * a) * cos(1.0 * b) for a in x, b in y]
+
+    function _alloc_hermite_nd_int_2d()
+        x = [0, 1, 2, 3, 4, 5]
+        y = [0, 1, 2, 3, 4]
+        data = _hdata(x, y)
+        p = _hp(x, y)
+        q = (3.4, 2.6)
+        for _ in 1:3
+            hermite_interp((x, y), data, p, q)
+        end
+        @allocated hermite_interp((x, y), data, p, q)
+    end
+
+    @testset "warm zero-alloc scalar one-shot on Int Vector grid" begin
+        @test _alloc_hermite_nd_int_2d() <= ND_ALLOC_THRESHOLD
+    end
+
+    # ---- bit-identical: raw Int grid === Float64 grid ----
+    @testset "Int Vector grid === Float64 grid" begin
+        x = [0, 1, 2, 3, 4, 5]
+        y = [0, 1, 2, 3, 4]
+        data = _hdata(x, y)
+        p = _hp(x, y)
+        xf = Float64.(x)
+        yf = Float64.(y)
+        for q in [(3.4, 2.6), (0.3, 0.7), (4.9, 3.1)]
+            @test hermite_interp((x, y), data, p, q) === hermite_interp((xf, yf), data, p, q)
+        end
+    end
+
+    # ---- one-shot === persistent interpolant ----
+    @testset "one-shot === persistent hermite interpolant" begin
+        x = [0, 1, 2, 3, 4, 5]
+        y = [0, 1, 2, 3, 4]
+        data = _hdata(x, y)
+        p = _hp(x, y)
+        itp = hermite_interp((x, y), data, p)
+        for q in [(3.4, 2.6), (0.3, 0.7), (4.9, 3.1)]
+            @test hermite_interp((x, y), data, p, q) === itp(q)
+        end
+    end
+
+    # ---- type stability + ForwardDiff through the query ----
+    @testset "type-stable + ForwardDiff on Int grid" begin
+        x = [0, 1, 2, 3, 4, 5]
+        y = [0, 1, 2, 3, 4]
+        data = _hdata(x, y)
+        p = _hp(x, y)
+        q = (3.4, 2.6)
+        @test (@inferred hermite_interp((x, y), data, p, q)) isa Float64
+        g = ForwardDiff.gradient(pp -> hermite_interp((x, y), data, p, (pp[1], pp[2])), [3.4, 2.6])
+        gf = ForwardDiff.gradient(pp -> hermite_interp((Float64.(x), Float64.(y)), data, p, (pp[1], pp[2])), [3.4, 2.6])
+        @test g ≈ gf atol = 1.0e-10
+    end
+end

--- a/test/test_nd_raw_grid_oneshot.jl
+++ b/test/test_nd_raw_grid_oneshot.jl
@@ -133,3 +133,99 @@
         end
     end
 end
+
+# ============================================================================
+# Cubic ND one-shot — raw Int grid hits the (Float) per-axis cache after warmup
+# ============================================================================
+#
+# Cubic ND builds per-axis spline caches via `_get_cubic_cache`, which memoises
+# by grid object id. The eager `_nd_promote_grids` built a fresh `Tg.(x)` Vector
+# every call (new id → permanent cache miss + the conversion alloc). Passing the
+# RAW grid (stable id) lets the cache hit, so warm scalar one-shot on an Int grid
+# is zero-alloc — matching 1D cubic. (Batch keeps eager-convert; see linear note.)
+
+@testitem "Cubic ND one-shot raw-grid (warm cache hit, no eager convert)" setup = [AllocConstants] begin
+    using ForwardDiff
+
+    # ---- warm zero-alloc on Int Vector grids (default OnTheFly + PreCompute) ----
+    # Function barrier: build grid once, warm the per-axis cache, then @allocated.
+    function _alloc_cubic_nd_int_otf_2d()
+        x = [0, 1, 2, 3, 4, 5, 6, 7]
+        y = [0, 1, 2, 3, 4, 5]
+        data = [sin(1.0 * a) + cos(1.0 * b) for a in x, b in y]
+        q = (3.4, 2.6)
+        for _ in 1:3
+            cubic_interp((x, y), data, q)
+        end
+        @allocated cubic_interp((x, y), data, q)
+    end
+    # NB: only the default OnTheFly path is zero-alloc on raw Int grids. PreCompute
+    # (opt-in) converts grids internally (its cell-eval needs Float spacing), so it
+    # is intentionally NOT zero-alloc on Int grids — no alloc test for it here.
+    function _alloc_cubic_nd_int_otf_3d()
+        x = [0, 1, 2, 3, 4, 5]
+        y = [0, 1, 2, 3, 4]
+        z = [0, 1, 2, 3, 4, 5, 6]
+        data = [a + 0.5b + 0.25c for a in x, b in y, c in z]
+        q = (2.4, 1.6, 3.8)
+        for _ in 1:3
+            cubic_interp((x, y, z), data, q)
+        end
+        @allocated cubic_interp((x, y, z), data, q)
+    end
+
+    @testset "warm zero-alloc scalar one-shot on Int Vector grids (OnTheFly)" begin
+        @test _alloc_cubic_nd_int_otf_2d() <= ND_ALLOC_THRESHOLD
+        @test _alloc_cubic_nd_int_otf_3d() <= ND_ALLOC_THRESHOLD
+    end
+
+    # ---- bit-identical: raw Int grid === Float64 grid (value) ----
+    @testset "Int Vector grid === Float64 grid" begin
+        x = [0, 1, 2, 3, 4, 5, 6, 7]
+        y = [0, 1, 2, 3, 4, 5]
+        data = [sin(1.0 * a) + cos(1.0 * b) for a in x, b in y]
+        xf = Float64.(x)
+        yf = Float64.(y)
+        for q in [(3.4, 2.6), (0.3, 0.7), (6.9, 4.1)]
+            @test cubic_interp((x, y), data, q) === cubic_interp((xf, yf), data, q)
+            @test cubic_interp((x, y), data, q; coeffs = PreCompute()) ===
+                cubic_interp((xf, yf), data, q; coeffs = PreCompute())
+        end
+    end
+
+    # ---- one-shot ≈ persistent interpolant ----
+    # NB: `≈` not `===` — the default scalar one-shot is OnTheFly (sequential
+    # collapse) while the persistent interpolant is PreCompute (full tensor
+    # partials); the two algorithms agree to ~1 ULP, not bit-for-bit.
+    @testset "one-shot ≈ persistent CubicInterpolantND" begin
+        x = [0, 1, 2, 3, 4, 5, 6, 7]
+        y = [0, 1, 2, 3, 4, 5]
+        data = [sin(1.0 * a) + cos(1.0 * b) for a in x, b in y]
+        itp = cubic_interp((x, y), data)
+        for q in [(3.4, 2.6), (0.3, 0.7), (6.9, 4.1)]
+            @test cubic_interp((x, y), data, q) ≈ itp(q)
+        end
+    end
+
+    # ---- type stability (::Tr) on raw / heterogeneous axes ----
+    @testset "type-stable (::Tr) on raw / heterogeneous axes" begin
+        x = [0, 1, 2, 3, 4, 5, 6, 7]
+        yi = [0, 1, 2, 3, 4, 5]
+        yf = Float64.(yi)
+        data = [sin(1.0 * a) + cos(1.0 * b) for a in x, b in yi]
+        q = (3.4, 2.6)
+        @test (@inferred cubic_interp((x, yi), data, q)) isa Float64
+        @test (@inferred cubic_interp((x, yf), data, q)) isa Float64   # heterogeneous
+    end
+
+    # ---- ForwardDiff through the ND query on an Int Vector grid ----
+    @testset "ForwardDiff through ND query on Int Vector grid" begin
+        x = [0, 1, 2, 3, 4, 5, 6, 7]
+        y = [0, 1, 2, 3, 4, 5]
+        data = [1.0 * a^2 + 2.0 * b for a in x, b in y]
+        p = [3.4, 2.6]
+        g = ForwardDiff.gradient(pp -> cubic_interp((x, y), data, (pp[1], pp[2])), p)
+        gf = ForwardDiff.gradient(pp -> cubic_interp((Float64.(x), Float64.(y)), data, (pp[1], pp[2])), p)
+        @test g ≈ gf atol = 1.0e-10
+    end
+end

--- a/test/test_nd_raw_grid_oneshot.jl
+++ b/test/test_nd_raw_grid_oneshot.jl
@@ -1,0 +1,135 @@
+# ============================================================================
+# ND one-shot raw-grid evaluation (no eager grid conversion)
+# ============================================================================
+#
+# Linear/Constant ND one-shot search & evaluate the RAW grid tuple (via the
+# kernel's own `map(_resolve_axis, grids, bcs)` + promote-compare search),
+# instead of eagerly materialising `Tg.(x)` for every non-`Tg` Vector axis.
+#
+# Contract:
+#   - Int / Float64 Vector axes: zero heap alloc on the scalar one-shot,
+#     bit-identical to the Float64-grid / persistent-interpolant result.
+#   - Heterogeneous axes (e.g. Int × Float64) stay type-stable (::Tr guard).
+#   - ForwardDiff through the query is unchanged.
+#   - Float32 Vector axes: within a few ULP of the Float64 reference.
+
+@testitem "ND one-shot raw-grid eval (no eager grid conversion)" setup = [AllocConstants] begin
+    using ForwardDiff
+
+    # ---- zero-alloc scalar one-shot on Int Vector grids (the migration) ----
+    # Function barriers: setup + warmup + @allocated inside one function to
+    # avoid @testset-scope boxing artifacts (mirrors test_nd_constant.jl).
+    function _alloc_linear_int_vec_2d()
+        x = [0, 1, 2, 3, 4]      # Int Vector axis — was `Float64.(x)` per call
+        y = [0, 1, 2, 3]
+        data = [2.0 * xi + 3.0 * yj for xi in x, yj in y]
+        q = (1.5, 2.5)
+        linear_interp((x, y), data, q)
+        linear_interp((x, y), data, q)
+        @allocated linear_interp((x, y), data, q)
+    end
+    function _alloc_constant_int_vec_2d()
+        x = [0, 1, 2, 3, 4]
+        y = [0, 1, 2, 3]
+        data = [2.0 * xi + 3.0 * yj for xi in x, yj in y]
+        q = (1.5, 2.5)
+        constant_interp((x, y), data, q)
+        constant_interp((x, y), data, q)
+        @allocated constant_interp((x, y), data, q)
+    end
+    function _alloc_linear_int_vec_3d()
+        x = [0, 1, 2, 3]
+        y = [0, 1, 2]
+        z = [0, 1, 2, 3, 4]
+        data = [xi + yj + zk for xi in x, yj in y, zk in z]
+        q = (1.5, 1.5, 2.5)
+        linear_interp((x, y, z), data, q)
+        linear_interp((x, y, z), data, q)
+        @allocated linear_interp((x, y, z), data, q)
+    end
+
+    @testset "zero-alloc scalar one-shot on Int Vector grids" begin
+        @test _alloc_linear_int_vec_2d() <= ND_ALLOC_THRESHOLD
+        @test _alloc_constant_int_vec_2d() <= ND_ALLOC_THRESHOLD
+        @test _alloc_linear_int_vec_3d() <= ND_ALLOC_THRESHOLD
+    end
+
+    # ---- bit-identical: raw Int grid eval === Float64 grid eval ----
+    @testset "bit-identical: Int Vector grid === Float64 grid" begin
+        x = [0, 1, 2, 3, 4]
+        y = [0, 1, 2, 3]
+        data = [2.0 * xi + 3.0 * yj - 0.5 * xi * yj for xi in x, yj in y]
+        xf = Float64.(x)
+        yf = Float64.(y)
+        for q in [(1.5, 2.5), (0.3, 0.7), (3.9, 0.1), (2.0, 3.0)]
+            @test linear_interp((x, y), data, q) === linear_interp((xf, yf), data, q)
+            @test constant_interp((x, y), data, q) === constant_interp((xf, yf), data, q)
+        end
+    end
+
+    # ---- one-shot === persistent interpolant (eager-convert path, unchanged) ----
+    @testset "one-shot === persistent interpolant" begin
+        x = [0, 1, 2, 3, 4]
+        y = [0, 1, 2, 3]
+        data = [sin(1.0 * xi) + cos(1.0 * yj) for xi in x, yj in y]
+        itp_lin = linear_interp((x, y), data)
+        itp_con = constant_interp((x, y), data)
+        for q in [(1.5, 2.5), (0.3, 0.7), (3.9, 0.1)]
+            @test linear_interp((x, y), data, q) === itp_lin(q)
+            @test constant_interp((x, y), data, q) === itp_con(q)
+        end
+    end
+
+    # ---- type-stable (::Tr boxing guard holds on raw / heterogeneous axes) ----
+    @testset "type-stable (no boxing) on raw / heterogeneous axes" begin
+        x_int = [0, 1, 2, 3, 4]
+        y_int = [0, 1, 2, 3]
+        y_f64 = Float64.(y_int)
+        data = [2.0 * xi + 3.0 * yj for xi in x_int, yj in y_int]
+        data_int = [2 * xi + 3 * yj for xi in x_int, yj in y_int]   # Int data → Tr=Float64
+        q = (1.5, 2.5)
+        @test (@inferred linear_interp((x_int, y_int), data, q)) isa Float64
+        @test (@inferred linear_interp((x_int, y_f64), data, q)) isa Float64   # heterogeneous
+        @test (@inferred linear_interp((x_int, y_int), data_int, q)) isa Float64  # Int data
+        @test (@inferred constant_interp((x_int, y_int), data, q)) isa Float64
+    end
+
+    # ---- heterogeneous (Int × Float64) axes: value correct ----
+    @testset "heterogeneous (Int × Float64) axes value" begin
+        x = [0, 1, 2, 3, 4]          # Int
+        y = [0.0, 0.5, 1.0, 1.5]     # Float64
+        f(xi, yj) = 2.0 * xi + 3.0 * yj + 1.0
+        data = [f(xi, yj) for xi in x, yj in y]
+        for q in [(1.5, 0.75), (3.2, 1.1)]
+            @test linear_interp((x, y), data, q) ≈ f(q[1], q[2]) atol = 1.0e-12
+        end
+    end
+
+    # ---- ForwardDiff through the ND query on an Int Vector grid ----
+    @testset "ForwardDiff through ND query on Int Vector grid" begin
+        x = [0, 1, 2, 3, 4]
+        y = [0, 1, 2, 3]
+        a, b, c = 2.0, 3.0, -0.5
+        data = [a * xi + b * yj + c * xi * yj for xi in x, yj in y]
+        # Within a single cell the bilinear surface has analytic partials
+        # ∂/∂x = a + c·y, ∂/∂y = b + c·x.
+        p = [1.5, 2.5]
+        g = ForwardDiff.gradient(pp -> linear_interp((x, y), data, (pp[1], pp[2])), p)
+        @test g[1] ≈ a + c * p[2] atol = 1.0e-10
+        @test g[2] ≈ b + c * p[1] atol = 1.0e-10
+    end
+
+    # ---- Float32 Vector axis: within a few ULP of the Float64 reference ----
+    @testset "Float32 Vector axis ≈ Float64 reference (relaxed bar)" begin
+        xf = Float32[0, 1, 2, 3, 4]
+        yf = Float32[0, 1, 2, 3]
+        x64 = Float64.(xf)
+        y64 = Float64.(yf)
+        data = [2.0 * xi + 3.0 * yj for xi in xf, yj in yf]
+        for q in [(1.5, 2.5), (0.3, 0.7)]
+            ref = linear_interp((x64, y64), data, q)
+            got = linear_interp((xf, yf), data, q)
+            @test got ≈ ref rtol = 1.0e-6
+        end
+    end
+end

--- a/test/test_nd_raw_grid_oneshot.jl
+++ b/test/test_nd_raw_grid_oneshot.jl
@@ -388,3 +388,60 @@ end
         @test g ≈ gf atol = 1.0e-10
     end
 end
+
+# ============================================================================
+# RED PHASE — heterogeneous / mixed-eltype grids on the build methods.
+# ============================================================================
+#
+# The eager-convert path unified every axis to a single `Tg`, hiding a homogeneity
+# assumption. The raw-grid migration exposes it: quad's build chain
+# (`_compute_nd_partials_quadratic!{Tg}`) wants one grid eltype, and `_eval_nd_cell`
+# couples `hs`/`inv_hs` as `NTuple{N, Tg}`. So a heterogeneous-eltype grid
+# (`Int × Float64`), a mixed-precision grid (`Float32 × Float64`), or a
+# Range×Vector mix (a Range floats to Float64 while a Vector{Int} stays Int) breaks
+# — even though the all-Float64 grid evaluates fine. These worked before the
+# migration; pinned RED to drive the heterogeneous-grid fix. The earlier testsets
+# only exercised homogeneous Int grids and missed this.
+
+@testitem "ND build-method one-shot — heterogeneous/mixed grids (RED)" setup = [AllocConstants] begin
+    using FastInterpolations: HermitePartials
+
+    fq(a, b) = sin(0.3 * a) + cos(0.2 * b)
+
+    quad_mixes = [
+        ("Int × Float64", [0, 1, 2, 3, 4, 5], Float64.(0:4)),
+        ("Float32 × Float64", Float32.(0:5), Float64.(0:4)),
+        ("Int × Float32", [0, 1, 2, 3, 4, 5], Float32.(0:4)),
+        ("IntRange × IntVec", 0:5, [0, 1, 2, 3, 4]),
+        ("Float64Range × IntVec", 0.0:5.0, [0, 1, 2, 3, 4]),
+    ]
+    for (name, gx, gy) in quad_mixes
+        @testset "quadratic $name === all-Float64" begin
+            data = [fq(a, b) for a in collect(gx), b in collect(gy)]
+            ref = quadratic_interp((Float64.(collect(gx)), Float64.(collect(gy))), data, (3.4, 2.6))
+            @test quadratic_interp((gx, gy), data, (3.4, 2.6)) ≈ ref rtol = 1.0e-6
+        end
+    end
+
+    hp(x, y) = HermitePartials(
+        (1, 0) => [cos(1.0 * a) * cos(1.0 * b) for a in x, b in y],
+        (0, 1) => [-sin(1.0 * a) * sin(1.0 * b) for a in x, b in y],
+        (1, 1) => [-cos(1.0 * a) * sin(1.0 * b) for a in x, b in y],
+    )
+    hdata(x, y) = [sin(1.0 * a) * cos(1.0 * b) for a in x, b in y]
+    herm_mixes = [
+        ("Float32 × Float64", Float32.(0:5), Float64.(0:4)),
+        ("Int × Float32", [0, 1, 2, 3, 4, 5], Float32.(0:4)),
+        ("IntRange × IntVec", 0:5, [0, 1, 2, 3, 4]),
+    ]
+    for (name, gx, gy) in herm_mixes
+        @testset "hermite $name === all-Float64" begin
+            xc = collect(gx)
+            yc = collect(gy)
+            data = hdata(xc, yc)
+            p = hp(xc, yc)
+            ref = hermite_interp((Float64.(xc), Float64.(yc)), data, p, (3.4, 2.6))
+            @test hermite_interp((gx, gy), data, p, (3.4, 2.6)) ≈ ref rtol = 1.0e-6
+        end
+    end
+end

--- a/test/test_nd_raw_grid_oneshot.jl
+++ b/test/test_nd_raw_grid_oneshot.jl
@@ -229,3 +229,87 @@ end
         @test g ≈ gf atol = 1.0e-10
     end
 end
+
+# ============================================================================
+# Quadratic ND one-shot — raw Int grid, default PreCompute path
+# ============================================================================
+#
+# Quad `AutoCoeffs` defaults to PreCompute (for bit-exact AD-rule matching), so the
+# DEFAULT scalar path is the PreCompute cell-eval. Passing raw grids + floating the
+# cell width in `_compute_all_local_params` makes the default warm scalar one-shot
+# on an Int Vector grid zero-alloc (the kernel wraps axes via `_cache_axis_pooled`
+# into pool buffers, so the Int grid needs no `Tg.(x)` copy). Batch keeps eager-convert.
+
+@testitem "Quadratic ND one-shot raw-grid (default PreCompute, no eager convert)" setup = [AllocConstants] begin
+    using ForwardDiff
+
+    function _alloc_quad_nd_int_2d()
+        x = [0, 1, 2, 3, 4, 5, 6]
+        y = [0, 1, 2, 3, 4]
+        data = [sin(1.0 * a) + cos(1.0 * b) for a in x, b in y]
+        q = (3.4, 2.6)
+        for _ in 1:3
+            quadratic_interp((x, y), data, q)
+        end
+        @allocated quadratic_interp((x, y), data, q)
+    end
+    function _alloc_quad_nd_int_3d()
+        x = [0, 1, 2, 3, 4]
+        y = [0, 1, 2, 3]
+        z = [0, 1, 2, 3, 4, 5]
+        data = [a + 0.5b + 0.25c for a in x, b in y, c in z]
+        q = (2.4, 1.6, 3.8)
+        for _ in 1:3
+            quadratic_interp((x, y, z), data, q)
+        end
+        @allocated quadratic_interp((x, y, z), data, q)
+    end
+
+    @testset "warm zero-alloc scalar one-shot on Int Vector grids (default PreCompute)" begin
+        @test _alloc_quad_nd_int_2d() <= ND_ALLOC_THRESHOLD
+        @test _alloc_quad_nd_int_3d() <= ND_ALLOC_THRESHOLD
+    end
+
+    # ---- bit-identical: raw Int grid === Float64 grid (default PreCompute) ----
+    @testset "Int Vector grid === Float64 grid" begin
+        x = [0, 1, 2, 3, 4, 5, 6]
+        y = [0, 1, 2, 3, 4]
+        data = [sin(1.0 * a) + cos(1.0 * b) for a in x, b in y]
+        xf = Float64.(x)
+        yf = Float64.(y)
+        for q in [(3.4, 2.6), (0.3, 0.7), (5.9, 3.1)]
+            @test quadratic_interp((x, y), data, q) === quadratic_interp((xf, yf), data, q)
+        end
+    end
+
+    # ---- one-shot === persistent QuadraticInterpolantND (both PreCompute) ----
+    @testset "one-shot === persistent QuadraticInterpolantND" begin
+        x = [0, 1, 2, 3, 4, 5, 6]
+        y = [0, 1, 2, 3, 4]
+        data = [sin(1.0 * a) + cos(1.0 * b) for a in x, b in y]
+        itp = quadratic_interp((x, y), data)
+        for q in [(3.4, 2.6), (0.3, 0.7), (5.9, 3.1)]
+            @test quadratic_interp((x, y), data, q) === itp(q)
+        end
+    end
+
+    # ---- type stability (::Tr) ----
+    @testset "type-stable (::Tr) on Int grid" begin
+        x = [0, 1, 2, 3, 4, 5, 6]
+        y = [0, 1, 2, 3, 4]
+        data = [sin(1.0 * a) + cos(1.0 * b) for a in x, b in y]
+        q = (3.4, 2.6)
+        @test (@inferred quadratic_interp((x, y), data, q)) isa Float64
+    end
+
+    # ---- ForwardDiff through the ND query on an Int Vector grid ----
+    @testset "ForwardDiff through ND query on Int Vector grid" begin
+        x = [0, 1, 2, 3, 4, 5, 6]
+        y = [0, 1, 2, 3, 4]
+        data = [1.0 * a^2 + 2.0 * b for a in x, b in y]
+        p = [3.4, 2.6]
+        g = ForwardDiff.gradient(pp -> quadratic_interp((x, y), data, (pp[1], pp[2])), p)
+        gf = ForwardDiff.gradient(pp -> quadratic_interp((Float64.(x), Float64.(y)), data, (pp[1], pp[2])), p)
+        @test g ≈ gf atol = 1.0e-10
+    end
+end

--- a/test/test_nd_raw_grid_oneshot.jl
+++ b/test/test_nd_raw_grid_oneshot.jl
@@ -20,7 +20,7 @@
     # Function barriers: setup + warmup + @allocated inside one function to
     # avoid @testset-scope boxing artifacts (mirrors test_nd_constant.jl).
     function _alloc_linear_int_vec_2d()
-        x = [0, 1, 2, 3, 4]      # Int Vector axis — was `Float64.(x)` per call
+        x = [0, 1, 2, 3, 4]      # Int Vector axis
         y = [0, 1, 2, 3]
         data = [2.0 * xi + 3.0 * yj for xi in x, yj in y]
         q = (1.5, 2.5)
@@ -401,20 +401,14 @@ end
 end
 
 # ============================================================================
-# RED PHASE — heterogeneous / mixed-eltype grids on the build methods.
+# Heterogeneous / mixed-eltype grids on the build methods.
 # ============================================================================
 #
-# The eager-convert path unified every axis to a single `Tg`, hiding a homogeneity
-# assumption. The raw-grid migration exposes it: quad's build chain
-# (`_compute_nd_partials_quadratic!{Tg}`) wants one grid eltype, and `_eval_nd_cell`
-# couples `hs`/`inv_hs` as `NTuple{N, Tg}`. So a heterogeneous-eltype grid
-# (`Int × Float64`), a mixed-precision grid (`Float32 × Float64`), or a
-# Range×Vector mix (a Range floats to Float64 while a Vector{Int} stays Int) breaks
-# — even though the all-Float64 grid evaluates fine. These worked before the
-# migration; pinned RED to drive the heterogeneous-grid fix. The earlier testsets
-# only exercised homogeneous Int grids and missed this.
+# Raw grids expose a homogeneity assumption: `_eval_nd_cell` couples `hs`/`inv_hs`
+# as `NTuple{N, Tg}`, so mixed grids (Int×Float64, Float32×Float64, Range×Vector)
+# must promote spacings to one `Tg` (via `_compute_all_local_params`).
 
-@testitem "ND build-method one-shot — heterogeneous/mixed grids (RED)" setup = [AllocConstants] begin
+@testitem "ND build-method one-shot — heterogeneous/mixed grids" setup = [AllocConstants] begin
     using FastInterpolations: HermitePartials
 
     fq(a, b) = sin(0.3 * a) + cos(0.2 * b)

--- a/test/test_nd_raw_grid_oneshot.jl
+++ b/test/test_nd_raw_grid_oneshot.jl
@@ -159,9 +159,19 @@ end
         end
         @allocated cubic_interp((x, y), data, q)
     end
-    # NB: only the default OnTheFly path is zero-alloc on raw Int grids. PreCompute
-    # (opt-in) converts grids internally (its cell-eval needs Float spacing), so it
-    # is intentionally NOT zero-alloc on Int grids — no alloc test for it here.
+    # PreCompute (the practically-used cubic strategy) is now also raw: each axis's
+    # spline cache memoises by id and the cell width is promoted, so warm Int-grid
+    # one-shot is zero-alloc here too — no internal `Tg.(x)` convert.
+    function _alloc_cubic_nd_int_pre_2d()
+        x = [0, 1, 2, 3, 4, 5, 6, 7]
+        y = [0, 1, 2, 3, 4, 5]
+        data = [sin(1.0 * a) + cos(1.0 * b) for a in x, b in y]
+        q = (3.4, 2.6)
+        for _ in 1:3
+            cubic_interp((x, y), data, q; coeffs = PreCompute())
+        end
+        @allocated cubic_interp((x, y), data, q; coeffs = PreCompute())
+    end
     function _alloc_cubic_nd_int_otf_3d()
         x = [0, 1, 2, 3, 4, 5]
         y = [0, 1, 2, 3, 4]
@@ -174,9 +184,10 @@ end
         @allocated cubic_interp((x, y, z), data, q)
     end
 
-    @testset "warm zero-alloc scalar one-shot on Int Vector grids (OnTheFly)" begin
+    @testset "warm zero-alloc scalar one-shot on Int Vector grids" begin
         @test _alloc_cubic_nd_int_otf_2d() <= ND_ALLOC_THRESHOLD
         @test _alloc_cubic_nd_int_otf_3d() <= ND_ALLOC_THRESHOLD
+        @test _alloc_cubic_nd_int_pre_2d() <= ND_ALLOC_THRESHOLD   # PreCompute now raw
     end
 
     # ---- bit-identical: raw Int grid === Float64 grid (value) ----
@@ -420,6 +431,18 @@ end
             data = [fq(a, b) for a in collect(gx), b in collect(gy)]
             ref = quadratic_interp((Float64.(collect(gx)), Float64.(collect(gy))), data, (3.4, 2.6))
             @test quadratic_interp((gx, gy), data, (3.4, 2.6)) ≈ ref rtol = 1.0e-6
+        end
+    end
+
+    # Cubic: both the OnTheFly default and the (now-raw) PreCompute strategy.
+    for (name, gx, gy) in quad_mixes
+        @testset "cubic $name === all-Float64" begin
+            data = [fq(a, b) for a in collect(gx), b in collect(gy)]
+            gxf = Float64.(collect(gx))
+            gyf = Float64.(collect(gy))
+            @test cubic_interp((gx, gy), data, (3.4, 2.6)) ≈ cubic_interp((gxf, gyf), data, (3.4, 2.6)) rtol = 1.0e-6
+            @test cubic_interp((gx, gy), data, (3.4, 2.6); coeffs = PreCompute()) ≈
+                cubic_interp((gxf, gyf), data, (3.4, 2.6); coeffs = PreCompute()) rtol = 1.0e-6
         end
     end
 


### PR DESCRIPTION
## Summary

ND scalar one-shot now searches and evaluates the user's grid tuple **directly**, instead of eagerly materialising a `Tg.(x)` float copy of every non-`Tg` axis. Warm scalar one-shot on an `Int` `Vector` grid drops to **zero allocation** (the per-call copy is gone; Cubic also regains its per-axis cache hit).
Batch keeps eager-convert, which amortises the conversion over all queries.

The migration makes heterogeneous / mixed-precision grids first-class — and surfaced one method that wasn't: `linear_interp` ND one-shot threw `MethodError` on `Float32 × Float64` / `Int × Float32` and on AD-wrt-grid, the only method whose kernel still required a homogeneous spacing tuple. 

This PR fixes that, removes a now-misleading warning, and tidies the migration's comments and tests.

## Changes

**Raw-grid scalar one-shot** (`{linear,constant,cubic,quadratic,hermite}/nd/*_oneshot.jl`, `core/nd_utils.jl`) — drop the eager per-axis `Tg.(x)` copy; the kernels shape each axis themselves and the search promote-compares. `_compute_all_local_params` promotes the per-axis spacings so the `@generated` cell-eval accepts a raw / heterogeneous grid. Warm Int-grid one-shot is zero-alloc.

**Fix linear ND heterogeneous grids** (`linear/nd/linear_nd_eval.jl`) — `_multilinear_sum` constrained `inv_hs::NTuple{N}` (homogeneous); relaxed to `Tuple{Vararg{Real, N}}`, matching the `αs` argument beside it. The `@generated` body already uses each axis independently, so this is a signature relaxation only. Pinned by `test_nd_oneshot_mixed_precision_grids.jl` (mixed-precision values + AD-wrt-grid; the bug reproduces as `MethodError` on the parent commit).

**Remove the obsolete type-conversion warning** (`core/utils.jl`, `cubic/cubic_cache_pool.jl`) — `_warn_type_conversion` advised "pre-convert your data for zero-allocation", but that no longer holds: one-shot Int grids are already zero-alloc (raw grids + cached spline/axis), and persistent construction allocates a stored grid copy regardless of eltype (720 B Float64 vs 816 B Int — never zero). Dropped entirely; no behaviour change beyond log output.

**Tests + docs** — pinned cubic/quad/hermite AD-wrt-grid one-shot (worked but only linear was covered); trimmed the migration's verbose/duplicated rationale comments (−40 lines, comment-only); fixed stale docstrings.

## Benchmark

Apple Silicon (arm64), scalar one-shot, 2D grid `16×12` (3D `10×8×9`), single interior query; `@belapsed` min · `@allocated` warm. `master` = eager `Tg.(x)` convert · **this PR** = raw grid.

**Float64 grid (primary path) — unchanged**

| case | master | this PR |
|---|--:|--:|
| `linear_interp` 2D | 12.9 ns · 0 B | 12.7 ns · 0 B |
| `constant_interp` 2D | 13.1 ns · 0 B | 13.1 ns · 0 B |
| `cubic_interp` 2D | 1388 ns · 0 B | 1396 ns · 0 B |
| `quadratic_interp` 2D | 2250 ns · 0 B | 2250 ns · 0 B |
| `cubic_interp` 3D | 6600 ns · 0 B | 6625 ns · 0 B |

The eager convert is already a no-op for a Float64 grid, so the primary path runs the same code —
times within run-to-run noise, 0 allocation on both.

**Int `Vector` grid — per-call conversion copy eliminated**

| case | master | this PR |
|---|--:|--:|
| `linear_interp` 2D | 47.3 ns · **352 B** | **14.8 ns · 0 B** |
| `constant_interp` 2D | 15.4 ns · 0 B | 15.3 ns · 0 B |
| `cubic_interp` 2D | 1450 ns · **352 B** | 1470 ns · **0 B** |
| `quadratic_interp` 2D | 2280 ns · **352 B** | 2340 ns · **0 B** |
| `cubic_interp` 3D | 6830 ns · **400 B** | 7010 ns · **0 B** |

The per-call `Float64.(x)` copy of every Int axis is gone → **zero allocation**. For `linear` (cheap eval) the copy dominated → **3.2× faster**; for `cubic`/`quadratic` the spline/partials work dominates, so wall-time is unchanged (±3%) while allocation drops to zero. `constant` was already copy-free (it keeps the raw eltype).

## Safety

- **Bit-identical** for homogeneous Float/Dual grids — the linear relaxation doesn't touch codegen, the warning removal only changes log output. Verified `===` on Int-vs-Float64 grids and on cubic Int-grid cache values (max diff 0.0).
- **Zero-alloc** warm one-shot on Int grids across all five methods.
- **AD through query and grid nodes** verified (ForwardDiff) for linear/cubic/quad/hermite.
- Adversarially verified across 38 cases (Rational / Float16 / BigFloat, 3D/4D mixed, AD-wrt-grid, periodic-heterogeneous).

## Deferred (follow-up)

In scope for this theme, but split out to keep the diff focused:

- **Batch signature symmetry** — the cubic/quadratic *batch* inner functions still take `NTuple{N, AbstractVector{Tg}}` while hermite's batch is already raw. Safe today (the batch API eager-converts before dispatch), but worth aligning to raw for a uniform method matrix.
- **Persistent-eval zero-alloc guard** — `_compute_all_local_params` is shared with the persistent interpolant eval; a warm `@allocated == 0` test on that path would pin the contract (only the one-shot path is guarded today).
