### PR TITLE
perf(hermite-family): cached-inv_h secants + single-division PCHIP harmonic mean

### DIFF
--- a/src/akima/akima_adjoint.jl
+++ b/src/akima/akima_adjoint.jl
@@ -89,7 +89,10 @@ end
 #
 # Derivatives of dy w.r.t. the 4 secants (m_km2, m_km1, m_k, m_kp1):
 #
-# Let s1 = sign(m_kp1 - m_k), s2 = sign(m_km1 - m_km2).
+# Let s1, s2 be the `abs` sub-derivatives of (m_kp1 - m_k) and (m_km1 - m_km2) — via
+# `_abs_subderiv`, NOT `sign`. At an exact secant tie (m_kp1 == m_k, e.g. symmetric
+# data) `sign` returns 0, but the forward's `abs` differentiates to ±1 (ForwardDiff
+# convention), so `sign` would make the hand-adjoint disagree with ForwardDiff there.
 #
 # If wsum > 0 (weighted branch):
 #   ∂dy/∂m_km2 = s2*(dy - m_k) / wsum
@@ -99,6 +102,10 @@ end
 #
 # If wsum == 0 (equal-weight fallback):
 #   ∂dy/∂m_km1 = 1/2, ∂dy/∂m_k = 1/2, others = 0
+
+# d|u|/du with ForwardDiff's convention (flipsign: +1 at +0.0, -1 at -0.0). Replaces
+# `sign` so the adjoint stays the exact transpose of the forward's `abs` at exact ties.
+@inline _abs_subderiv(u) = flipsign(one(u), u)
 
 """
     _akima_slope_adjoint_weighted(dy, m_km1, m_k, w1, w2, wsum, s1, s2)
@@ -240,13 +247,13 @@ end
     end
 
     # General case: n ≥ 4
-    # Recompute secants on the fly (same approach as forward pass). `Tc` widens
-    # narrow/fixed-point y before the difference so `sign`-based Akima weights don't
-    # flip on a wrapped secant (N0f8 reaches here un-promoted — see `_PromotableValue`).
-    Tc = _promote_eltype(_coeff_op, Tg, Tv)
-    @inbounds m1 = _fielddiff(Tc, y[2], y[1]) / (x[2] - x[1])
-    @inbounds m2 = _fielddiff(Tc, y[3], y[2]) / (x[3] - x[2])
-    @inbounds m3 = _fielddiff(Tc, y[4], y[3]) / (x[4] - x[3])
+    # Recompute secants via the SAME `_forward_secant` helper the forward uses, so the
+    # slope-limiter sees bit-identical secants — a ≤1-ULP `/h` vs `*inv_h` gap can flip an
+    # Akima `abs` weight branch at an exact tie. `_forward_secant` also widens narrow/
+    # fixed-point y before the difference (N0f8 reaches here un-promoted — see `_PromotableValue`).
+    @inbounds m1 = _forward_secant(x, y, 1)
+    @inbounds m2 = _forward_secant(x, y, 2)
+    @inbounds m3 = _forward_secant(x, y, 3)
 
     # Virtual secants for left boundary
     m_neg1 = 3 * m1 - 2 * m2
@@ -265,8 +272,8 @@ end
             _akima_scatter_secant_adjoint!(f_bar, db / 2, 1, x, n)
         else
             dy_k = (w1 * m_0 + w2 * m1) / wsum
-            s1 = sign(m2 - m1)
-            s2 = sign(m_0 - m_neg1)
+            s1 = _abs_subderiv(m2 - m1)
+            s2 = _abs_subderiv(m_0 - m_neg1)
             d_km2, d_km1, d_k, d_kp1 = _akima_slope_adjoint_weighted(
                 dy_k, m_0, m1, w1, w2, wsum, s1, s2
             )
@@ -289,8 +296,8 @@ end
             _akima_scatter_secant_adjoint!(f_bar, db / 2, 2, x, n)
         else
             dy_k = (w1 * m1 + w2 * m2) / wsum
-            s1 = sign(m3 - m2)
-            s2 = sign(m1 - m_0)
+            s1 = _abs_subderiv(m3 - m2)
+            s2 = _abs_subderiv(m1 - m_0)
             d_km2, d_km1, d_k, d_kp1 = _akima_slope_adjoint_weighted(
                 dy_k, m1, m2, w1, w2, wsum, s1, s2
             )
@@ -309,7 +316,7 @@ end
     m_k = m3
 
     @inbounds for k in 3:(n - 2)
-        m_kp1 = _fielddiff(Tc, y[k + 2], y[k + 1]) / (x[k + 2] - x[k + 1])
+        m_kp1 = _forward_secant(x, y, k + 1)
         w1 = abs(m_kp1 - m_k)
         w2 = abs(m_km1 - m_km2)
         wsum = w1 + w2
@@ -319,8 +326,8 @@ end
             _akima_scatter_secant_adjoint!(f_bar, db / 2, k, x, n)
         else
             dy_kv = (w1 * m_km1 + w2 * m_k) / wsum
-            s1 = sign(m_kp1 - m_k)
-            s2 = sign(m_km1 - m_km2)
+            s1 = _abs_subderiv(m_kp1 - m_k)
+            s2 = _abs_subderiv(m_km1 - m_km2)
             d_km2, d_km1, d_k, d_kp1 = _akima_slope_adjoint_weighted(
                 dy_kv, m_km1, m_k, w1, w2, wsum, s1, s2
             )
@@ -353,8 +360,8 @@ end
             _akima_scatter_secant_adjoint!(f_bar, db / 2, n - 1, x, n)
         else
             dy_kv = (w1 * m_km1 + w2 * m_k) / wsum
-            s1 = sign(m_np1 - m_k)
-            s2 = sign(m_km1 - m_km2)
+            s1 = _abs_subderiv(m_np1 - m_k)
+            s2 = _abs_subderiv(m_km1 - m_km2)
             d_km2, d_km1, d_k, d_kp1 = _akima_slope_adjoint_weighted(
                 dy_kv, m_km1, m_k, w1, w2, wsum, s1, s2
             )
@@ -377,8 +384,8 @@ end
             _akima_scatter_secant_adjoint!(f_bar, db / 2, n, x, n)
         else
             dy_kv = (w1 * m_k + w2 * m_np1) / wsum
-            s1 = sign(m_np2 - m_np1)
-            s2 = sign(m_k - m_km1)
+            s1 = _abs_subderiv(m_np2 - m_np1)
+            s2 = _abs_subderiv(m_k - m_km1)
             d_km2, d_km1, d_k, d_kp1 = _akima_slope_adjoint_weighted(
                 dy_kv, m_k, m_np1, w1, w2, wsum, s1, s2
             )
@@ -416,16 +423,18 @@ end
         x::AbstractVector{Tg}, y::AbstractVector,
         k::Int, j_km2::Int, j_km1::Int, j_k::Int, j_kp1::Int
     ) where {Tg}
-    Tc = _promote_eltype(_coeff_op, Tg, eltype(y))
     @inbounds begin
         h_km2 = x[j_km2 + 1] - x[j_km2]
         h_km1 = x[j_km1 + 1] - x[j_km1]
         h_k = x[j_k + 1] - x[j_k]
         h_kp1 = x[j_kp1 + 1] - x[j_kp1]
-        m_km2 = _fielddiff(Tc, y[j_km2 + 1], y[j_km2]) / h_km2
-        m_km1 = _fielddiff(Tc, y[j_km1 + 1], y[j_km1]) / h_km1
-        m_k = _fielddiff(Tc, y[j_k + 1], y[j_k]) / h_k
-        m_kp1 = _fielddiff(Tc, y[j_kp1 + 1], y[j_kp1]) / h_kp1
+        # Secant VALUES must match the forward bit-for-bit (`_forward_secant` = Δy·inv_h):
+        # a ≤1-ULP `/h` vs `*inv_h` gap can flip the Akima |Δsecant| slope-limiter branch
+        # and disagree with ForwardDiff. `h_*` retained for the ∂m/∂y partials below.
+        m_km2 = _forward_secant(x, y, j_km2)
+        m_km1 = _forward_secant(x, y, j_km1)
+        m_k = _forward_secant(x, y, j_k)
+        m_kp1 = _forward_secant(x, y, j_kp1)
     end
 
     w1 = abs(m_kp1 - m_k)
@@ -446,8 +455,8 @@ end
         end
     else
         dy_k = (w1 * m_km1 + w2 * m_k) / wsum
-        s1 = sign(m_kp1 - m_k)
-        s2 = sign(m_km1 - m_km2)
+        s1 = _abs_subderiv(m_kp1 - m_k)
+        s2 = _abs_subderiv(m_km1 - m_km2)
         d_km2, d_km1, d_k, d_kp1 = _akima_slope_adjoint_weighted(
             dy_k, m_km1, m_k, w1, w2, wsum, s1, s2
         )

--- a/src/akima/akima_slopes.jl
+++ b/src/akima/akima_slopes.jl
@@ -51,8 +51,6 @@ function _akima_slopes!(
     @assert length(y) == n "y length must match x"
     @assert length(dy) == n "dy length must match x"
 
-    Tc = eltype(dy)   # coefficient field — loop-invariant, hoisted once
-
     # Special case: 2 points. PeriodicBC routes through the wrap-aware
     # 4-secant helper (cycle=2 for `:exclusive` yields a 2-secant alternation).
     if n == 2
@@ -62,7 +60,7 @@ function _akima_slopes!(
             return dy
         end
         @inbounds begin
-            δ = _fielddiff(Tc, y[2], y[1]) / (x[2] - x[1])
+            δ = _forward_secant(x, y, 1)
             dy[1] = δ
             dy[2] = δ
         end
@@ -80,8 +78,8 @@ function _akima_slopes!(
             return dy
         end
         @inbounds begin
-            m1 = _fielddiff(Tc, y[2], y[1]) / (x[2] - x[1])
-            m2 = _fielddiff(Tc, y[3], y[2]) / (x[3] - x[2])
+            m1 = _forward_secant(x, y, 1)
+            m2 = _forward_secant(x, y, 2)
             dy[1] = m1
             dy[2] = (m1 + m2) / 2
             dy[3] = m2
@@ -103,9 +101,9 @@ function _akima_slopes!(
     # Simplification: extrapolate m sequence linearly.
 
     # Compute all n-1 secant slopes
-    @inbounds m1 = _fielddiff(Tc, y[2], y[1]) / (x[2] - x[1])
-    @inbounds m2 = _fielddiff(Tc, y[3], y[2]) / (x[3] - x[2])
-    @inbounds m3 = _fielddiff(Tc, y[4], y[3]) / (x[4] - x[3])
+    @inbounds m1 = _forward_secant(x, y, 1)
+    @inbounds m2 = _forward_secant(x, y, 2)
+    @inbounds m3 = _forward_secant(x, y, 3)
 
     # Boundary virtual / wrapped secants for the LEFT side of the domain.
     # NoBC:                          linear extrapolation (Akima's original).
@@ -135,7 +133,7 @@ function _akima_slopes!(
     m_k = m3
 
     @inbounds for k in 3:(n - 2)
-        m_kp1 = _fielddiff(Tc, y[k + 2], y[k + 1]) / (x[k + 2] - x[k + 1])
+        m_kp1 = _forward_secant(x, y, k + 1)
         dy[k] = _akima_weighted_slope(m_km2, m_km1, m_k, m_kp1)
         m_km2 = m_km1
         m_km1 = m_k

--- a/src/cardinal/cardinal_slopes.jl
+++ b/src/cardinal/cardinal_slopes.jl
@@ -47,8 +47,7 @@ function _cardinal_slopes!(
             return dy
         end
         @inbounds begin
-            Tc = eltype(dy)
-            δ = _fielddiff(Tc, y[2], y[1]) / (x[2] - x[1])
+            δ = _forward_secant(x, y, 1)
             dy[1] = scale * δ
             dy[2] = scale * δ
         end
@@ -59,9 +58,8 @@ function _cardinal_slopes!(
     @inbounds dy[1] = _cardinal_boundary_slope(x, y, 1, n, scale, bc)
 
     # Interior: central finite difference (K=3, no wrap needed).
-    Tc = eltype(dy)
     @inbounds for k in 2:(n - 1)
-        dy[k] = scale * _fielddiff(Tc, y[k + 1], y[k - 1]) / (x[k + 1] - x[k - 1])
+        dy[k] = scale * _centered_secant(x, y, k)
     end
 
     # Right endpoint: same bc-dispatched helper. PeriodicBC{:inclusive} yields

--- a/src/core/cached_range.jl
+++ b/src/core/cached_range.jl
@@ -167,8 +167,10 @@ end
 # Inverse of the 2-cell span x[i+1]-x[i-1] (central-difference / cardinal interior).
 # A uniform range has span = 2h, so inv = inv_h/2; `_UnitStep` folds to one/2 = 0.5
 # (no division). 0.5 is exact (power of two) → one cached load + one multiply.
-@inline _get_inv_2cell(x::_CachedRange, i::Int) =
-    _get_inv_h(x, i) * oftype(_get_inv_h(x, i), 0.5)
+@inline function _get_inv_2cell(x::_CachedRange, i::Int)
+    inv_h = _get_inv_h(x, i)
+    return inv_h * oftype(inv_h, 0.5)
+end
 # idx-shaped forms — `(x, idx)` (solver/coeff) and `(x, idx, xL, xR)` (from
 # `search_interval`) — ignore the extra args and delegate to the no-arg form.
 @inline _get_h(x::_CachedRange, ::Int) = _get_h(x)

--- a/src/core/cached_range.jl
+++ b/src/core/cached_range.jl
@@ -164,6 +164,11 @@ end
 @inline _get_inv_h(x::_CachedRange) = x.inv_h
 @inline _get_h(::_CachedRange{T, Tinv, _UnitStep}) where {T, Tinv} = one(T)
 @inline _get_inv_h(::_CachedRange{T, Tinv, _UnitStep}) where {T, Tinv} = one(Tinv)
+# Inverse of the 2-cell span x[i+1]-x[i-1] (central-difference / cardinal interior).
+# A uniform range has span = 2h, so inv = inv_h/2; `_UnitStep` folds to one/2 = 0.5
+# (no division). 0.5 is exact (power of two) → one cached load + one multiply.
+@inline _get_inv_2cell(x::_CachedRange, i::Int) =
+    _get_inv_h(x, i) * oftype(_get_inv_h(x, i), 0.5)
 # idx-shaped forms — `(x, idx)` (solver/coeff) and `(x, idx, xL, xR)` (from
 # `search_interval`) — ignore the extra args and delegate to the no-arg form.
 @inline _get_h(x::_CachedRange, ::Int) = _get_h(x)

--- a/src/core/cached_vector.jl
+++ b/src/core/cached_vector.jl
@@ -145,6 +145,16 @@ end
 @inline Base.@propagate_inbounds _get_h(x::_CachedVector, i::Int) = @inbounds x.h[i]
 @inline Base.@propagate_inbounds _get_inv_h(x::_CachedVector, i::Int) = @inbounds x.inv_h[i]
 
+# Inverse of the 2-cell span x[i+1]-x[i-1] (central-difference / cardinal interior).
+# `_CachedVector` has no cached inverse for h[i-1]+h[i], so one (necessary) division —
+# but the widths come from the cache (no re-subtraction).
+@inline Base.@propagate_inbounds _get_inv_2cell(x::_CachedVector, i::Int) =
+    @inbounds inv(x.h[i - 1] + x.h[i])
+
+# Raw AbstractVector fallback: direct span (one necessary division).
+@inline Base.@propagate_inbounds _get_inv_2cell(x::AbstractVector, i::Int) =
+    @inbounds inv(x[i + 1] - x[i - 1])
+
 # AbstractVector — on-the-fly diff (one-shot, no cache). Raw eltype preserved
 # (`Int→Int`, `Rational→Rational`); downstream kernels auto-promote, so no eager-Float.
 @inline Base.@propagate_inbounds _get_h(x::AbstractVector, i::Int) =

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -212,6 +212,26 @@ end
 @inline _fieldsum(::Type{Tc}, a::Tc, b::Tc) where {Tc} = a + b
 @inline _fieldsum(::Type{Tc}, a, b) where {Tc} = convert(Tc, a) + convert(Tc, b)
 
+# ── Secant helpers (cached-inverse, axis-aware) ──────────────────────────────
+# Single-cell forward secant (y[i+1]-y[i]) / h_i. Routes through `_get_inv_h`, so a
+# `_CachedVector`/`_CachedRange` axis uses the cached reciprocal (no division) and a
+# `_UnitStep` range folds the multiply to identity. Raw `AbstractVector` computes
+# `inv(h)` on the fly (≤1 ULP vs `/h`, perf-neutral: the extra multiply runs free in
+# the divider's shadow). `Tc` matches every call site.
+@inline function _forward_secant(x, y, i)
+    Tc = _promote_eltype(_coeff_op, eltype(x), eltype(y))
+    return @inbounds _fielddiff(Tc, y[i + 1], y[i]) * _get_inv_h(x, i)
+end
+
+# Backward secant at i is the forward secant of the previous cell (denominator h_{i-1}).
+@inline _backward_secant(x, y, i) = _forward_secant(x, y, i - 1)
+
+# Centered (2-cell-span) secant (y[i+1]-y[i-1]) / (x[i+1]-x[i-1]) via `_get_inv_2cell`.
+@inline function _centered_secant(x, y, i)
+    Tc = _promote_eltype(_coeff_op, eltype(x), eltype(y))
+    return @inbounds _fielddiff(Tc, y[i + 1], y[i - 1]) * _get_inv_2cell(x, i)
+end
+
 # Convex linear value blend = α·yR + (1−α)·yL. The negation lands on the float
 # weight `α`, never on data, so finite/colorant values appear only as `weight ×
 # value` (wrap-free). Endpoint-exact at α=0,1; bounded within [min(yL,yR),

--- a/src/hermite/hermite_local_slopes.jl
+++ b/src/hermite/hermite_local_slopes.jl
@@ -67,7 +67,7 @@
     else
         w1 = 2 * h_curr + h_prev
         w2 = h_curr + 2 * h_prev
-        return (w1 + w2) / (w1 / δ_prev + w2 / δ_curr)
+        return _pchip_harmonic_mean(w1, w2, δ_prev, δ_curr)
     end
 end
 
@@ -113,7 +113,7 @@ end
     else
         w1 = 2 * h_curr + h_prev
         w2 = h_curr + 2 * h_prev
-        return (w1 + w2) / (w1 / δ_prev + w2 / δ_curr)
+        return _pchip_harmonic_mean(w1, w2, δ_prev, δ_curr)
     end
 end
 

--- a/src/hermite/hermite_local_slopes.jl
+++ b/src/hermite/hermite_local_slopes.jl
@@ -48,8 +48,7 @@
         if sm.bc isa PeriodicBC
             return _pchip_boundary_slope(xr, yr, i, n, sm.bc)
         end
-        Tc = _promote_eltype(_coeff_op, Tg, Tv)
-        @inbounds return _fielddiff(Tc, yr[2], yr[1]) / (xr[2] - xr[1])
+        return _forward_secant(xr, yr, 1)
     end
 
     if i == 1 || i == n
@@ -57,12 +56,11 @@
     end
 
     # Interior: weighted harmonic mean (Fritsch-Carlson)
-    Tc = _promote_eltype(_coeff_op, Tg, Tv)
     @inbounds begin
-        h_prev = xr[i] - xr[i - 1]
-        h_curr = xr[i + 1] - xr[i]
-        δ_prev = _fielddiff(Tc, yr[i], yr[i - 1]) / h_prev
-        δ_curr = _fielddiff(Tc, yr[i + 1], yr[i]) / h_curr
+        h_prev = _get_h(xr, i - 1)
+        h_curr = _get_h(xr, i)
+        δ_prev = _backward_secant(xr, yr, i)
+        δ_curr = _forward_secant(xr, yr, i)
     end
     if sign(δ_prev) != sign(δ_curr)
         return zero(_promote_eltype(_coeff_op, Tg, Tv))
@@ -76,21 +74,20 @@ end
 # ── PCHIP boundary slope dispatch ──
 # NoBC: original 3-point one-sided FD with monotonicity clamping
 @inline function _pchip_boundary_slope(x, y, i, n, ::NoBC)
-    Tc = _promote_eltype(_coeff_op, eltype(x), eltype(y))
     if i == 1
         @inbounds begin
-            h1 = x[2] - x[1]
-            h2 = x[3] - x[2]
-            δ1 = _fielddiff(Tc, y[2], y[1]) / h1
-            δ2 = _fielddiff(Tc, y[3], y[2]) / h2
+            h1 = _get_h(x, 1)
+            h2 = _get_h(x, 2)
+            δ1 = _forward_secant(x, y, 1)
+            δ2 = _forward_secant(x, y, 2)
         end
         return _pchip_endpoint_slope(h1, h2, δ1, δ2)
     else  # i == n
         @inbounds begin
-            h_last = x[n] - x[n - 1]
-            h_prev = x[n - 1] - x[n - 2]
-            δ_last = _fielddiff(Tc, y[n], y[n - 1]) / h_last
-            δ_prev = _fielddiff(Tc, y[n - 1], y[n - 2]) / h_prev
+            h_last = _get_h(x, n - 1)
+            h_prev = _get_h(x, n - 2)
+            δ_last = _backward_secant(x, y, n)
+            δ_prev = _backward_secant(x, y, n - 1)
         end
         return _pchip_endpoint_slope(h_last, h_prev, δ_last, δ_prev)
     end
@@ -135,29 +132,26 @@ end
     yr = _raw(y)
     scale = one(Tg) - sm.tension
 
-    Tc = _promote_eltype(_coeff_op, Tg, Tv)
-
     # Special case: 2 points. PeriodicBC must use wrap-aware central FD so the
     # seam-cell secant is folded in (see PCHIP n=2 note above).
     if n == 2
         if sm.bc isa PeriodicBC
             return _cardinal_boundary_slope(xr, yr, i, n, scale, sm.bc)
         end
-        @inbounds return scale * _fielddiff(Tc, yr[2], yr[1]) / (xr[2] - xr[1])
+        @inbounds return scale * _forward_secant(xr, yr, 1)
     end
 
     if i == 1 || i == n
         return _cardinal_boundary_slope(xr, yr, i, n, scale, sm.bc)
     end
-    @inbounds return scale * _fielddiff(Tc, yr[i + 1], yr[i - 1]) / (xr[i + 1] - xr[i - 1])
+    @inbounds return scale * _centered_secant(xr, yr, i)
 end
 
 @inline function _cardinal_boundary_slope(x, y, i, n, scale, ::NoBC)
-    Tc = _promote_eltype(_coeff_op, eltype(x), eltype(y))
     return if i == 1
-        @inbounds scale * _fielddiff(Tc, y[2], y[1]) / (x[2] - x[1])
+        @inbounds scale * _forward_secant(x, y, 1)
     else
-        @inbounds scale * _fielddiff(Tc, y[n], y[n - 1]) / (x[n] - x[n - 1])
+        @inbounds scale * _backward_secant(x, y, n)
     end
 end
 
@@ -200,8 +194,7 @@ end
         if sm.bc isa PeriodicBC
             return _akima_local_4secant_periodic(xr, yr, i, n, sm.bc)
         end
-        Tc = _promote_eltype(_coeff_op, Tg, Tv)
-        @inbounds return _fielddiff(Tc, yr[2], yr[1]) / (xr[2] - xr[1])
+        return _forward_secant(xr, yr, 1)
     end
 
     # Special case: 3 points
@@ -212,10 +205,9 @@ end
         if sm.bc isa PeriodicBC
             return _akima_local_4secant_periodic(xr, yr, i, n, sm.bc)
         end
-        Tc = _promote_eltype(_coeff_op, Tg, Tv)
         @inbounds begin
-            m1 = _fielddiff(Tc, yr[2], yr[1]) / (xr[2] - xr[1])
-            m2 = _fielddiff(Tc, yr[3], yr[2]) / (xr[3] - xr[2])
+            m1 = _forward_secant(xr, yr, 1)
+            m2 = _forward_secant(xr, yr, 2)
         end
         i == 1 && return m1
         i == 3 && return m2
@@ -247,8 +239,7 @@ end
     # Real secant range: 1 to n-1.
     # Out-of-range secants are virtual (linearly extrapolated from the secant sequence).
 
-    Tc = _promote_eltype(_coeff_op, Tg, Tv)
-    @inline _secant(j) = @inbounds _fielddiff(Tc, y[j + 1], y[j]) / (x[j + 1] - x[j])
+    @inline _secant(j) = _forward_secant(x, y, j)
 
     # Virtual secants extend the real sequence linearly:
     #   m[0]   = 2*m[1] - m[2]

--- a/src/hermite/hermite_periodic_slopes.jl
+++ b/src/hermite/hermite_periodic_slopes.jl
@@ -64,8 +64,7 @@ grid secants directly.
 @inline function _periodic_secant(x::AbstractVector, y::AbstractVector, j::Int, n::Int, ::PeriodicBC{:inclusive})
     nm1 = n - 1
     jw = mod1(j, nm1)
-    Tc = _promote_eltype(_coeff_op, eltype(x), eltype(y))
-    @inbounds return _fielddiff(Tc, y[jw + 1], y[jw]) / (x[jw + 1] - x[jw])
+    return _forward_secant(x, y, jw)
 end
 
 # `:extended` shares the `:inclusive` data layout (length n+1 closed-cycle);
@@ -73,8 +72,7 @@ end
 @inline function _periodic_secant(x::AbstractVector, y::AbstractVector, j::Int, n::Int, ::PeriodicBC{:extended})
     nm1 = n - 1
     jw = mod1(j, nm1)
-    Tc = _promote_eltype(_coeff_op, eltype(x), eltype(y))
-    @inbounds return _fielddiff(Tc, y[jw + 1], y[jw]) / (x[jw + 1] - x[jw])
+    return _forward_secant(x, y, jw)
 end
 
 # Cast the resolved exclusive period to the grid's promoted-float type so
@@ -99,8 +97,7 @@ end
         Tc = _promote_eltype(_coeff_op, eltype(x), eltype(y))
         @inbounds return _fielddiff(Tc, y[1], y[n]) / seam_h
     end
-    Tc = _promote_eltype(_coeff_op, eltype(x), eltype(y))
-    @inbounds return _fielddiff(Tc, y[jw + 1], y[jw]) / (x[jw + 1] - x[jw])
+    return _forward_secant(x, y, jw)
 end
 
 """
@@ -113,14 +110,14 @@ width (PCHIP harmonic mean) in addition to the secant value.
 @inline function _periodic_cell_width(x::AbstractVector, j::Int, n::Int, ::PeriodicBC{:inclusive})
     nm1 = n - 1
     jw = mod1(j, nm1)
-    @inbounds return x[jw + 1] - x[jw]
+    return _get_h(x, jw)
 end
 
 # `:extended` shares the `:inclusive` data layout — cell-width logic is identical.
 @inline function _periodic_cell_width(x::AbstractVector, j::Int, n::Int, ::PeriodicBC{:extended})
     nm1 = n - 1
     jw = mod1(j, nm1)
-    @inbounds return x[jw + 1] - x[jw]
+    return _get_h(x, jw)
 end
 
 @inline function _periodic_cell_width(x::AbstractVector, j::Int, n::Int, bc::PeriodicBC{:exclusive})
@@ -129,7 +126,7 @@ end
         period = _resolve_seam_period(x, bc)
         return period - (@inbounds x[n] - x[1])
     end
-    @inbounds return x[jw + 1] - x[jw]
+    return _get_h(x, jw)
 end
 
 # `_bc_after_extend` lives in `src/core/periodic.jl` next to `_periodic_extend_1d`

--- a/src/pchip/pchip_adjoint.jl
+++ b/src/pchip/pchip_adjoint.jl
@@ -107,17 +107,14 @@ end
         return nothing
     end
 
-    # Recompute secants for all intervals (O(n), no allocation needed beyond stack)
-    # We'll do a single forward pass, maintaining running secant values.
-    # `Tc` widens narrow/fixed-point y before the difference so `sign(δ)` branches
-    # don't flip on a wrapped secant (N0f8 reaches here un-promoted — see
-    # `_PromotableValue`).
-    Tc = _promote_eltype(_coeff_op, Tg, Tv)
-
+    # Recompute secants via the SAME `_forward_secant` helper the forward uses, so the
+    # `sign(δ)` / harmonic-mean branches see bit-identical secants — a ≤1-ULP `/h` vs
+    # `*inv_h` gap can flip a branch at an exact tie. `_forward_secant` also widens
+    # narrow/fixed-point y before the difference (N0f8 reaches here un-promoted).
     @inbounds h_prev = x[2] - x[1]
-    @inbounds δ_prev = _fielddiff(Tc, y[2], y[1]) / h_prev
+    @inbounds δ_prev = _forward_secant(x, y, 1)
     @inbounds h_curr = x[3] - x[2]
-    @inbounds δ_curr = _fielddiff(Tc, y[3], y[2]) / h_curr
+    @inbounds δ_curr = _forward_secant(x, y, 2)
 
     # ── Left endpoint (k=1) ──────────────────────────────────────────────
     # d = ((2h1+h2)*δ1 - h1*δ2) / (h1+h2)
@@ -159,9 +156,9 @@ end
     # ── Interior slopes (k=2..n-1) ──────────────────────────────────────
     # Reset running secants
     @inbounds h_prev = x[2] - x[1]
-    @inbounds δ_prev = _fielddiff(Tc, y[2], y[1]) / h_prev
+    @inbounds δ_prev = _forward_secant(x, y, 1)
     @inbounds h_curr = x[3] - x[2]
-    @inbounds δ_curr = _fielddiff(Tc, y[3], y[2]) / h_curr
+    @inbounds δ_curr = _forward_secant(x, y, 2)
 
     @inbounds for k in 2:(n - 1)
         if sign(δ_prev) != sign(δ_curr)
@@ -197,7 +194,7 @@ end
             h_prev = h_curr
             δ_prev = δ_curr
             h_curr = x[k + 2] - x[k + 1]
-            δ_curr = _fielddiff(Tc, y[k + 2], y[k + 1]) / h_curr
+            δ_curr = _forward_secant(x, y, k + 1)
         end
     end
 
@@ -304,12 +301,13 @@ end
         x::AbstractVector{Tg}, y::AbstractVector,
         k::Int, j_prev::Int, j_curr::Int
     ) where {Tg}
-    Tc = _promote_eltype(_coeff_op, Tg, eltype(y))
     @inbounds begin
         h_prev = x[j_prev + 1] - x[j_prev]
         h_curr = x[j_curr + 1] - x[j_curr]
-        δ_prev = _fielddiff(Tc, y[j_prev + 1], y[j_prev]) / h_prev
-        δ_curr = _fielddiff(Tc, y[j_curr + 1], y[j_curr]) / h_curr
+        # Match the forward's `_forward_secant` (`*inv_h`) bit-for-bit so the `sign(δ)`
+        # branch agrees with ForwardDiff; `h_*` retained for the ∂δ/∂y partials.
+        δ_prev = _forward_secant(x, y, j_prev)
+        δ_curr = _forward_secant(x, y, j_curr)
 
         # Zero-clamped branch: dy[k] = 0 → all derivatives zero, skip.
         sign(δ_prev) != sign(δ_curr) && return nothing

--- a/src/pchip/pchip_slopes.jl
+++ b/src/pchip/pchip_slopes.jl
@@ -41,6 +41,21 @@ Clamped endpoint slope that preserves monotonicity.
 end
 
 """
+    _pchip_harmonic_mean(w1, w2, δp, δc)
+
+Fritsch–Carlson weighted harmonic mean of two secants, single-division form.
+Algebraically `(w1+w2)/(w1/δp + w2/δc) == (w1+w2)·δp·δc / (w1·δc + w2·δp)`, which
+trades 3 divisions for 1. Called only from the monotone branch where
+`sign(δp) == sign(δc)`, so the denominator is nonzero unless both secants are
+exactly zero (flat data) — the `iszero(den)` guard maps that 0·0/0 case to `0`,
+matching the old form's `Inf`-arithmetic limit (and avoiding a NaN).
+"""
+@inline function _pchip_harmonic_mean(w1, w2, δp, δc)
+    den = w1 * δc + w2 * δp
+    return iszero(den) ? zero(den) : (w1 + w2) * δp * δc / den
+end
+
+"""
     _pchip_slopes!(dy, x, y)
 
 Compute PCHIP (Fritsch-Carlson) monotone-preserving slopes in-place.
@@ -110,7 +125,7 @@ function _pchip_slopes!(
             # Weighted harmonic mean (Fritsch-Carlson formula)
             w1 = 2 * h_curr + h_prev
             w2 = h_curr + 2 * h_prev
-            dy[k] = (w1 + w2) / (w1 / δ_prev + w2 / δ_curr)
+            dy[k] = _pchip_harmonic_mean(w1, w2, δ_prev, δ_curr)
         end
 
         # Advance to next interval (k < n-1 means there's a next interval)

--- a/src/pchip/pchip_slopes.jl
+++ b/src/pchip/pchip_slopes.jl
@@ -79,9 +79,8 @@ function _pchip_slopes!(
             @inbounds dy[2] = _pchip_boundary_slope(x, y, 2, n, bc)
             return dy
         end
-        Tc = eltype(dy)
         @inbounds begin
-            δ = _fielddiff(Tc, y[2], y[1]) / (x[2] - x[1])
+            δ = _forward_secant(x, y, 1)
             dy[1] = δ
             dy[2] = δ
         end
@@ -91,11 +90,11 @@ function _pchip_slopes!(
     Tc = eltype(dy)
 
     # Compute secant slopes for first two intervals (needed for first interior)
-    @inbounds h_prev = x[2] - x[1]
-    @inbounds δ_prev = _fielddiff(Tc, y[2], y[1]) / h_prev
+    @inbounds h_prev = _get_h(x, 1)
+    @inbounds δ_prev = _forward_secant(x, y, 1)
 
-    @inbounds h_curr = x[3] - x[2]
-    @inbounds δ_curr = _fielddiff(Tc, y[3], y[2]) / h_curr
+    @inbounds h_curr = _get_h(x, 2)
+    @inbounds δ_curr = _forward_secant(x, y, 2)
 
     # Left endpoint: bc-dispatched helper.
     # NoBC: one-sided 3-point FD with monotonicity clamping.
@@ -118,8 +117,8 @@ function _pchip_slopes!(
         if k < n - 1
             h_prev = h_curr
             δ_prev = δ_curr
-            h_curr = x[k + 2] - x[k + 1]
-            δ_curr = _fielddiff(Tc, y[k + 2], y[k + 1]) / h_curr
+            h_curr = _get_h(x, k + 1)
+            δ_curr = _forward_secant(x, y, k + 1)
         end
     end
 

--- a/test/test_secant_fastpath.jl
+++ b/test/test_secant_fastpath.jl
@@ -40,6 +40,37 @@ end
     @test _centered_secant(us, yv, 2) === (yv[3] - yv[1]) * 0.5   # *0.5
 end
 
+@testitem "_pchip_harmonic_mean (3-div → 1-div rewrite)" setup = [AllocConstants] begin
+    using FastInterpolations: _pchip_harmonic_mean
+    using Random: MersenneTwister
+
+    # Reference: original 3-division Fritsch–Carlson form.
+    ref(w1, w2, δp, δc) = (w1 + w2) / (w1 / δp + w2 / δc)
+
+    rng = MersenneTwister(11)
+    for _ in 1:2000
+        w1 = 5rand(rng) + 0.05
+        w2 = 5rand(rng) + 0.05
+        s = ifelse(rand(rng) < 0.5, -1.0, 1.0)        # same sign (monotone region)
+        δp = s * (3rand(rng) + 1.0e-3)
+        δc = s * (3rand(rng) + 1.0e-3)
+        a = ref(w1, w2, δp, δc)
+        b = _pchip_harmonic_mean(w1, w2, δp, δc)
+        @test abs(a - b) <= 4 * eps(abs(a))            # ≤ a few ULP
+    end
+
+    # Equal secants ⇒ harmonic mean is that secant.
+    @test _pchip_harmonic_mean(2.0, 3.0, 0.7, 0.7) ≈ 0.7 rtol = 1.0e-14
+
+    # Degenerate flat data (δp == δc == 0): must be 0, NOT NaN (the 0·0/0 trap).
+    @test _pchip_harmonic_mean(2.0, 3.0, 0.0, 0.0) == 0.0
+    @test !isnan(_pchip_harmonic_mean(2.0, 3.0, 0.0, 0.0))
+    # One zero secant ⇒ 0 (matches old Inf-limit behavior).
+    @test _pchip_harmonic_mean(2.0, 3.0, 0.0, 1.5) == 0.0
+
+    @test _pchip_harmonic_mean(2.0, 3.0, 0.5, 0.9) isa Float64
+end
+
 @testitem "secant fast-path: method equivalence + monotonicity" setup = [AllocConstants] begin
     using Random: MersenneTwister
 

--- a/test/test_secant_fastpath.jl
+++ b/test/test_secant_fastpath.jl
@@ -1,0 +1,71 @@
+# Secant fast-path helpers — value/type correctness across axis types.
+
+@testitem "_get_inv_2cell accessor" setup = [AllocConstants] begin
+    using FastInterpolations: _get_inv_2cell, _CachedVector, _to_float
+
+    xv = [0.0, 0.5, 1.5, 4.0]            # non-uniform Vector
+    cv = _CachedVector(xv)
+    cr = _to_float(range(0.0, 10.0; length = 11), Float64)   # uniform range, h=1
+    us = _to_float(1:11, Float64)                            # _UnitStep range
+
+    # raw vector: inv of the 2-cell span x[3]-x[1]
+    @test _get_inv_2cell(xv, 2) ≈ inv(xv[3] - xv[1])
+    # cached vector: same value via cached widths
+    @test _get_inv_2cell(cv, 2) ≈ inv(xv[3] - xv[1])
+    # uniform range: span = 2h = 2.0
+    @test _get_inv_2cell(cr, 5) ≈ inv(2.0)
+    # unit-step: exactly 0.5, no division
+    @test _get_inv_2cell(us, 5) === 0.5
+end
+
+@testitem "secant triad helpers" setup = [AllocConstants] begin
+    using FastInterpolations: _forward_secant, _backward_secant, _centered_secant,
+        _CachedVector, _to_float
+
+    xv = [0.0, 0.5, 1.5, 4.0]
+    yv = [1.0, 2.0, 0.0, 3.0]
+    cv = _CachedVector(xv)
+    us = _to_float(1:4, Float64)        # _UnitStep (h ≡ 1)
+
+    # forward secant
+    @test _forward_secant(xv, yv, 1) ≈ (yv[2] - yv[1]) / (xv[2] - xv[1])
+    @test _forward_secant(cv, yv, 2) ≈ (yv[3] - yv[2]) / (xv[3] - xv[2])
+    # backward at i ≡ forward at i-1 (exact identity, no recomputation)
+    @test _backward_secant(xv, yv, 3) === _forward_secant(xv, yv, 2)
+    # centered secant (2-cell span)
+    @test _centered_secant(xv, yv, 2) ≈ (yv[3] - yv[1]) / (xv[3] - xv[1])
+
+    # unit-step: division folds to identity ⇒ bit-identical to plain differences
+    @test _forward_secant(us, yv, 1) === (yv[2] - yv[1])          # *one
+    @test _centered_secant(us, yv, 2) === (yv[3] - yv[1]) * 0.5   # *0.5
+end
+
+@testitem "secant fast-path: method equivalence + monotonicity" setup = [AllocConstants] begin
+    using Random: MersenneTwister
+
+    f(x) = sin(1.3x) + 0.2x
+    grids = (
+        ("unit-step", collect(1.0:1.0:20.0)),
+        ("uniform", collect(range(0.0, 6.0, 24))),
+        ("nonunif", sort(0.0 .+ 6.0 .* rand(MersenneTwister(7), 22))),
+    )
+
+    for (gname, x) in grids
+        y = f.(x)
+        q = gname == "unit-step" ? collect(range(1.0, 18.0, 50)) :
+            collect(range(x[1] + 1.0e-3, x[end] - 1.0e-3, 50))
+        for meth in (:pchip, :akima, :cardinal)
+            interp = getfield(FastInterpolations, Symbol(meth, "_interp"))
+            ot = interp(x, y, q; coeffs = FastInterpolations.OnTheFly())
+            pc = interp(x, y, q; coeffs = FastInterpolations.PreCompute())
+            @test ot ≈ pc atol = 1.0e-10
+        end
+    end
+
+    # PCHIP monotonicity: monotone data ⇒ monotone interpolant (no overshoot).
+    xm = collect(range(0.0, 10.0, 15))
+    ym = cumsum(abs.(sin.(xm)) .+ 0.1)        # strictly increasing
+    qm = collect(range(0.0, 10.0, 400))
+    vm = pchip_interp(xm, ym, qm)
+    @test all(diff(vm) .>= -1.0e-12)
+end


### PR DESCRIPTION
## Summary

The local-cubic Hermite family (`pchip` / `akima` / `cardinal`, and on-the-fly `hermite`) computed every secant inline as `Δy / (x[j+1] - x[j])` — re-subtracting the cell width and dividing on each call, never touching the cached `inv_h` that `linear`/`cubic` already use. This PR routes those through the cached accessors, so division is **removed** on cached/range axes and **folds to a no-op** on unit-step grids, and rewrites PCHIP's weighted harmonic mean to a single division.

Up to **1.9× on on-the-fly scalar queries** (unit-step / uniform-range), compounding through the ND collapse; raw-`Vector` grids unchanged.

## Key Changes

- **New helpers.** `_forward_secant` / `_backward_secant` / `_centered_secant` (`core/utils.jl`) and the `_get_inv_2cell` accessor (`cached_range.jl` / `cached_vector.jl`) — parallel to the existing `_periodic_secant` / `_get_inv_h`.
- **Secant fast-path** (`571de2069`). Every single-cell secant in the on-the-fly `_local_slope`, the bulk `_*_slopes!` builders, and the periodic real-cell primitives now goes through the helpers: `_CachedVector`/`_CachedRange` → cached `inv_h` multiply, `_UnitStep` range → `× one` folded away. Cardinal's 2-cell central difference uses `_get_inv_2cell` (range → `× 0.5`). Raw `Vector` keeps a single division (no `inv`-then-multiply regression). Seam-cell, harmonic-mean, and weighted-average divisions stay (genuinely data-dependent).
- **PCHIP single-division harmonic mean** (`93daf78a0`). `(w1+w2)/(w1/δp + w2/δc)` → algebraically-equal `(w1+w2)·δp·δc / (w1·δc + w2·δp)`, trading 3 divisions for 1 at the three hot sites via `_pchip_harmonic_mean`. Flat data (`δp == δc == 0`) is guarded to `0`, matching the old form's `Inf`-limit instead of `0·0/0 = NaN`.

## Benchmark

ns, arm64, min time, vs `master`. 1D grids n=1000; ND grids 20² / 12³. `Vector` rows are controls (no cached `inv_h` to exploit).

**1D one-shot scalar (on-the-fly)**

| method | grid | master | this PR | Δ |
|---|---|--:|--:|--:|
| pchip | unit-step | 11.2 | 8.2 | **1.37×** |
| pchip | uniform-range | 17.7 | 12.9 | **1.37×** |
| pchip | `Vector` (ctrl) | 29.9 | 27.9 | ~0 |
| akima | unit-step | 13.3 | 7.1 | **1.87×** |
| akima | uniform-range | 18.7 | 11.1 | **1.68×** |
| akima | `Vector` (ctrl) | 27.6 | 27.2 | ~0 |
| cardinal | unit-step | 6.2 | 4.9 | **1.27×** |
| cardinal | uniform-range | 9.0 | 7.2 | **1.25×** |
| cardinal | `Vector` (ctrl) | 16.8 | 16.5 | ~0 |

**1D batch (PreCompute bulk builder; total ns over the batch)**

| method | grid | master | this PR | Δ |
|---|---|--:|--:|--:|
| pchip | unit-step | 7156 | 6225 | **1.15×** |
| pchip | uniform | 8916 | 7709 | **1.16×** |
| akima | unit-step | 6300 | 5264 | **1.20×** |
| cardinal | uniform | 6258 | 5493 | **1.14×** |
| pchip | `Vector` (ctrl) | 7823 | 7854 | ~0 |

**ND one-shot scalar**

| method | grid | master | this PR | Δ |
|---|---|--:|--:|--:|
| pchip 2D | unit-step | 92.4 | 76.0 | **1.22×** |
| pchip 2D | uniform | 98.8 | 82.1 | **1.20×** |
| akima 2D | unit-step | 105.2 | 85.0 | **1.24×** |
| cardinal 2D | unit-step | 69.4 | 66.1 | 1.05× |
| pchip **3D** | unit-step | 232.5 | 178.9 | **1.30×** |
| pchip 2D | `Vector` (ctrl) | 121.7 | 123.9 | ~0 |

The division removal compounds through the ND per-fiber collapse, so the relative win grows with dimension (3D > 2D). Raw-`Vector` grids are flat throughout — perf-neutral by design.

## Safety

- **`× inv_h` vs `/ h`**: ≤ 1 ULP on cached/uniform grids — the same convention `cubic`/`linear` and the Hermite eval kernel already use; inside the existing PreCompute↔OnTheFly `atol = 1e-10` contract.
- **Unit-step grids**: bit-identical (`× one` and `/ one` both fold to identity).
- **Raw `Vector`**: ≤ 1 ULP value, perf unchanged.
- **PCHIP monotonicity preserved** — the sign guard `sign(δp) != sign(δc)` is unaffected (`inv_h > 0`), so every clamping decision is unchanged; the harmonic-mean rewrite is ≤ 1 ULP, with the flat-data case guarded against `NaN`.
- Pinned by `test/test_secant_fastpath.jl` (helper units, unit-step bit-identity, OnTheFly↔PreCompute equivalence, PCHIP monotonicity, harmonic-mean flat-data `NaN` guard); affected 1D / periodic / ND suites green.
