### PR TITLE
(feat): `store` (zero-copy) through the unified `interp` API + quadratic parity

### DIFF
--- a/src/core/store_policy.jl
+++ b/src/core/store_policy.jl
@@ -21,10 +21,10 @@
     StorePolicy(; copy=true, copy_grid=copy, copy_values=copy)
 
 Storage policy passed via the `store=` keyword to the persistent interpolant
-constructors — `linear_interp`, `constant_interp`, `cubic_interp`, `akima_interp`,
-`pchip_interp`, `cardinal_interp`, `hermite_interp`, and `interp`. Controls whether
-the grid and value arrays are **copied** (owned, immutable — the default) or
-**aliased** (referenced, zero-copy).
+constructors — `linear_interp`, `constant_interp`, `quadratic_interp`, `cubic_interp`,
+`akima_interp`, `pchip_interp`, `cardinal_interp`, `hermite_interp`, and `interp`.
+Controls whether the grid and value arrays are **copied** (owned, immutable — the
+default) or **aliased** (referenced, zero-copy).
 
 `copy` is the master switch; `copy_grid` / `copy_values` override per component.
 
@@ -32,8 +32,8 @@ the grid and value arrays are **copied** (owned, immutable — the default) or
 
 `copy=false` is best-effort — it aliases what each method can and copies the rest:
 - **Full** grid + value/data reference: `linear` / `constant` (1D + ND, including
-  `view`s), `akima` / `pchip` / `cardinal` / `hermite` (1D), and `interp` / cubic
-  ND **OnTheFly**.
+  `view`s), `quadratic` / `akima` / `pchip` / `cardinal` / `hermite` (1D), and
+  `interp` / cubic ND **OnTheFly**.
 - **Value-only** (grid stays owned, in the spline cache): `cubic` 1D.
 - **PreCompute ND** (`cubic` ND, `interp(...; coeffs=PreCompute())`) builds a derived
   partials array and keeps no raw data, so reference cannot be honored — it **warns
@@ -53,9 +53,9 @@ linear_interp(x, y; store = StorePolicy(copy_values = false))# alias values, cop
     - **grid** mutation always goes silently stale — spacing caches (`h`/`inv_h`),
       and any spline/slope coefficients, are snapshotted at construction.
     - **value** mutation is read live by `linear`/`constant`, but goes silently
-      stale for coefficient-building methods (`cubic`/`akima`/`pchip`/`cardinal`/
-      `hermite`), whose slopes / second-derivatives are derived from the values at
-      construction.
+      stale for coefficient-building methods (`quadratic`/`cubic`/`akima`/`pchip`/
+      `cardinal`/`hermite`), whose slopes / second-derivatives are derived from the
+      values at construction.
 
     The rule: a stored array that feeds a build-time derived cache cannot be
     mutated without silently invalidating results.

--- a/src/hetero/hetero_interpolant.jl
+++ b/src/hetero/hetero_interpolant.jl
@@ -380,7 +380,7 @@ end
 # ========================================
 
 """
-    interp(grids, data; method, coeffs=PreCompute(), extrap=NoExtrap(), search=AutoSearch())
+    interp(grids, data; method, coeffs=AutoCoeffs(), extrap=NoExtrap(), search=AutoSearch(), store=StorePolicy())
 
 Unified N-dimensional interpolation constructor with per-axis method specification.
 
@@ -404,6 +404,9 @@ Automatically dispatches to the optimal implementation:
   - `OnTheFly()`: Build 1D per query (zero build cost, O(n) eval)
 - `extrap=NoExtrap()`: Extrapolation mode(s) — single or per-axis tuple
 - `search=AutoSearch()`: Search policy(ies) — single or per-axis tuple
+- `store=StorePolicy()`: Grid/data storage policy. `StorePolicy(copy=false)` aliases
+  the caller's arrays (zero-copy) on the **OnTheFly** path; **PreCompute** retains
+  only derived partials, so it warns once and copies. See [`StorePolicy`](@ref).
 
 # Examples
 ```julia

--- a/src/hetero/interp_1d.jl
+++ b/src/hetero/interp_1d.jl
@@ -73,9 +73,9 @@ Build a 1D interpolant. Equivalent to calling the dedicated 1D constructor for
 `method` directly (e.g. `method=CubicInterp()` → `cubic_interp(x, y)`), with the
 method's boundary condition / side / tension forwarded.
 
-`store` is forwarded to the dedicated constructor, so `StorePolicy(copy=false)`
-builds a copy-free (reference) interpolant for every supported method — see the
-[`StorePolicy`](@ref) docstring for per-method aliasing detail.
+`store` is forwarded to the dedicated constructor; `StorePolicy(copy=false)`
+aliases the caller's arrays where the method supports it (the extent is
+method-dependent) — see the [`StorePolicy`](@ref) docstring for per-method detail.
 
 ```julia
 itp = interp(x, y; method = CubicInterp())              # === cubic_interp(x, y)

--- a/src/hetero/interp_1d.jl
+++ b/src/hetero/interp_1d.jl
@@ -67,16 +67,21 @@ _interp1d_route(m::AbstractInterpMethod) = _throw_unsupported_1d_method(m)
 # ----------------------------------------------------------------------------
 
 """
-    interp(x::AbstractVector, y::AbstractVector; method, extrap=NoExtrap(), search=AutoSearch())
+    interp(x::AbstractVector, y::AbstractVector; method, extrap=NoExtrap(), search=AutoSearch(), store=StorePolicy())
 
 Build a 1D interpolant. Equivalent to calling the dedicated 1D constructor for
 `method` directly (e.g. `method=CubicInterp()` → `cubic_interp(x, y)`), with the
 method's boundary condition / side / tension forwarded.
 
+`store` is forwarded to the dedicated constructor, so `StorePolicy(copy=false)`
+builds a copy-free (reference) interpolant for every supported method — see the
+[`StorePolicy`](@ref) docstring for per-method aliasing detail.
+
 ```julia
 itp = interp(x, y; method = CubicInterp())              # === cubic_interp(x, y)
 itp = interp(x, y; method = LinearInterp(bc = PeriodicBC()))
 itp = interp(x, y; method = CardinalInterp(tension = 0.5))
+itp = interp(x, y; method = PchipInterp(), store = StorePolicy(copy = false))  # zero-copy
 ```
 """
 @inline function interp(
@@ -85,9 +90,10 @@ itp = interp(x, y; method = CardinalInterp(tension = 0.5))
         method::AbstractInterpMethod,
         extrap::AbstractExtrap = NoExtrap(),
         search::AbstractSearchPolicy = AutoSearch(),
+        store::StorePolicy = StorePolicy(),
     )
     fn, _, opts = _interp1d_route(method)
-    return fn(x, y; opts..., extrap = extrap, search = search)
+    return fn(x, y; opts..., extrap = extrap, search = search, store = store)
 end
 
 """

--- a/src/quadratic/quadratic_interpolant.jl
+++ b/src/quadratic/quadratic_interpolant.jl
@@ -124,7 +124,8 @@ end
         y::AbstractVector{TY};
         bc::QuadraticBC = Left(QuadraticFit()),
         extrap::AbstractExtrap = NoExtrap(),
-        search::AbstractSearchPolicy = AutoSearch()
+        search::AbstractSearchPolicy = AutoSearch(),
+        store::StorePolicy = StorePolicy()
     ) where {TX, TY}
     Tg = _promote_grid_float(TX, TY)
     Tv = _value_type(TY, Tg)
@@ -146,5 +147,5 @@ end
 
     # 3-arg form: promote FillExtrap value type to Tv (no-op for other extraps).
     extrap_p = _resolve_extrap(extrap, x_eff, Tv)
-    return QuadraticInterpolant(x_eff, y, a, d, extrap_p, search, bc_p)
+    return QuadraticInterpolant(x_eff, y, a, d, extrap_p, search, bc_p; store = store)
 end

--- a/src/quadratic/quadratic_interpolant.jl
+++ b/src/quadratic/quadratic_interpolant.jl
@@ -63,7 +63,7 @@ end
 # ========================================
 
 """
-    quadratic_interp(x, y; bc=Left(QuadraticFit()), extrap=NoExtrap(), search=AutoSearch()) -> QuadraticInterpolant
+    quadratic_interp(x, y; bc=Left(QuadraticFit()), extrap=NoExtrap(), search=AutoSearch(), store=StorePolicy()) -> QuadraticInterpolant
 
 Create a callable interpolant for broadcast fusion and reuse.
 
@@ -73,6 +73,7 @@ Create a callable interpolant for broadcast fusion and reuse.
 - `bc`: Boundary condition (Left, Right, MinCurvFit, or Left/Right with QuadraticFit)
 - `extrap::AbstractExtrap`: `NoExtrap()` (default), `ClampExtrap()`, `ExtendExtrap()`, or `WrapExtrap()`
 - `search::AbstractSearchPolicy`: Default search policy (default: `AutoSearch()`)
+- `store::StorePolicy`: Copy (default) or alias the grid/values; see [`StorePolicy`](@ref)
 
 # Returns
 `QuadraticInterpolant` object for scalar/broadcast evaluation.
@@ -131,8 +132,8 @@ end
     Tv = _value_type(TY, Tg)
     # Caching wrap (zero-copy of buffer): Range → `_CachedRange{Tg}`,
     # Vector → `_CachedVector{Tg, Tinv}` aliasing user buffer. Mirrors
-    # Linear/Constant — outer is reference-only, inner constructor takes
-    # ownership via `_convert_copy(x, Tg)` / `_convert_copy(y, Tv)`.
+    # Linear/Constant — outer is reference-only; the inner constructor copies
+    # (default) or aliases per `store` via `_own_or_ref_{axis,values}`.
     x_eff = _cache_axis(x, NoBC(), Tg)
     bc_p = _normalize_bc(bc, first(y))
 

--- a/src/quadratic/quadratic_types.jl
+++ b/src/quadratic/quadratic_types.jl
@@ -70,18 +70,20 @@ struct QuadraticInterpolant{Tg, Tv, X <: AbstractVector{Tg}, Y <: AbstractVector
 
     # Inner: `_cache_axis` (insurance, passes the polynomial `bc::QuadraticBC`
     # through — these are not `PeriodicBC` so it just caches h/inv_h) then
-    # `_convert_copy` for ownership. `a`/`d` come freshly-allocated from the
-    # outer ctor's solver.
+    # `_own_or_ref_{axis,values}` for ownership (copy by default, alias under
+    # `StorePolicy(copy=false)`). `a`/`d` always come freshly-allocated from the
+    # outer ctor's solver, so they are never aliased.
     function QuadraticInterpolant(
             x::AbstractVector, y::AbstractVector,
-            a::Vector{Tc}, d::Vector{Tc}, ev::E, search::P, bc::BC
+            a::Vector{Tc}, d::Vector{Tc}, ev::E, search::P, bc::BC;
+            store::StorePolicy = StorePolicy()
         ) where {Tc, E <: AbstractExtrap, P <: AbstractSearchPolicy, BC <: QuadraticBC}
         length(x) == length(y) || _throw_length_mismatch(length(x), length(y))
         length(x) >= 2 || _throw_grid_too_small(length(x))
         Tg = _promote_grid_float(eltype(x), eltype(y))
         Tv = _value_type(eltype(y), Tg)
-        xc = _convert_copy(_cache_axis(x, bc, Tg), Tg)
-        yc = _convert_copy(y, Tv)
+        xc = _own_or_ref_axis(_cache_axis(x, bc, Tg), Tg, store)
+        yc = _own_or_ref_values(y, Tv, store)
         return new{Tg, Tv, typeof(xc), typeof(yc), E, P, BC, Tc}(xc, yc, a, d, ev, search, bc)
     end
 end

--- a/test/test_store_policy.jl
+++ b/test/test_store_policy.jl
@@ -137,6 +137,59 @@ end
     end
 end
 
+@testitem "Store Policy - quadratic 1D reference" begin
+    # Quadratic was added to StorePolicy alongside the other 1D methods so the
+    # unified `interp(x, y; method=QuadraticInterp())` can build copy-free too.
+    x = collect(range(0.0, 1.0, 60))
+    y = @. sin(2π * x) + 0.2 * x
+    qs = range(0.05, 0.95, 31)
+
+    ic = quadratic_interp(x, y)
+    ir = quadratic_interp(x, y; store = StorePolicy(copy = false))
+    @test ir.y === y                       # value aliased
+    @test ir.x.inner === x                 # grid inner aliased (Vector grid, copy_grid=false)
+    @test ic.y !== y
+    @test ic.x.inner !== x                  # default owns a private grid copy
+    @test typeof(ic) === typeof(ir)
+    @test all(ic(q) ≈ ir(q) for q in qs)
+    @test all(ic(q; deriv = DerivOp(1)) ≈ ir(q; deriv = DerivOp(1)) for q in qs)
+
+    build_ref(xx, yy) = quadratic_interp(xx, yy; store = StorePolicy(copy = false))
+    @test (@inferred build_ref(x, y)) isa QuadraticInterpolant
+    build_ref(x, y)
+    @test (@allocated build_ref(x, y)) < (@allocated quadratic_interp(x, y))
+
+    # parametric y::Y → can alias a view
+    yv = @view y[:]
+    irv = quadratic_interp(x, yv; store = StorePolicy(copy = false))
+    @test irv.y === yv && irv.y isa SubArray
+    @test all(irv(q) ≈ ic(q) for q in qs)
+end
+
+@testitem "Store Policy - unified 1D interp(x, y; method, store)" begin
+    using FastInterpolations: LinearInterp, ConstantInterp, QuadraticInterp,
+        CubicInterp, PchipInterp, CardinalInterp, AkimaInterp
+
+    x = collect(range(0.0, 1.0, 50))
+    y = @. cos(3x) + 0.1 * x
+    qs = range(0.05, 0.95, 25)
+    ref = StorePolicy(copy = false)
+
+    # Every 1D method routed by the unified API must thread `store` through to its
+    # dedicated constructor and alias the user's value vector (zero-copy).
+    for m in (
+            LinearInterp(), ConstantInterp(), QuadraticInterp(), CubicInterp(),
+            PchipInterp(), CardinalInterp(), AkimaInterp(),
+        )
+        ic = interp(x, y; method = m)
+        ir = interp(x, y; method = m, store = ref)
+        @test ir.y === y                    # value aliased through the unified API
+        @test ic.y !== y                    # default still owns a private copy
+        @test typeof(ic) === typeof(ir)
+        @test all(ic(q) ≈ ir(q) for q in qs)
+    end
+end
+
 @testitem "Store Policy - ND reference" begin
     using FastInterpolations: CubicInterp, LinearInterp
 


### PR DESCRIPTION
## Summary

`StorePolicy(copy=false)` — opt-in zero-copy persistent storage (#165) — now works through the unified `interp(...)` API. The 1D bare-vector form `interp(x, y; method=…)` previously rejected `store`, and `quadratic_interp` had no `store` support at all
(the only 1D method missing it). 

Both are fixed, so **every 1D method builds copy-free through the unified API**. The ND form — including **heterogeneous** per-axis methods — already honored `store` on the OnTheFly path (data aliased; PreCompute warns-once + copies); this PR rounds out the matrix and documents it.

The 1D router is zero-cost: forwarding `store` emits the same code as calling the dedicated constructor by hand (verified — `@btime`/`@allocated` identical, bit-identical eval).

## Now possible

```julia
# 1D unified API — copy-free for any method (was blocked before)
itp = interp(x, y; method = PchipInterp(),     store = StorePolicy(copy = false))
itp = interp(x, y; method = QuadraticInterp(),  store = StorePolicy(copy = false))  # quadratic: new

# quadratic dedicated ctor too (the only 1D method previously without store)
itp = quadratic_interp(x, y; store = StorePolicy(copy = false))   # itp.y === y, itp.x.inner === x

# ND / heterogeneous (already supported; OnTheFly aliases data, PreCompute warns+copies)
itp = interp((x, y), data;
             method = (CubicInterp(), LinearInterp()),
             coeffs = OnTheFly(), store = StorePolicy(copy = false))   # itp.data === data
```

## Changes

- **Unified 1D `interp`** (`hetero/interp_1d.jl`): add `store`, forward it through the per-method router.
- **Quadratic** (`quadratic/quadratic_{interpolant,types}.jl`): thread `store` into the outer + inner ctor; grid/value via `_own_or_ref_{axis,values}` (was unconditional `_convert_copy`). Default `StorePolicy()` is bit-identical to before.
- **Docs** (`core/store_policy.jl` + ND `interp` docstring): list quadratic in the support tiers; document `store` on ND `interp`.
- **Tests** (`test/test_store_policy.jl`): quadratic 1D ref (alias + alloc-saved + view + deriv); unified 1D `interp(x, y; method, store)` across all 7 methods.
