### PR TITLE
(ci): Machine-aware benchmark comparison

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -98,6 +98,18 @@ jobs:
       - name: Install dependencies
         run: julia --project=benchmark -e 'using Pkg; Pkg.instantiate()'
 
+      # Machine key of THIS runner (e.g. "znver3|4c"). The fleet mixes CPUs, so
+      # we only ever min-merge / compare against the same machine. Dependency-free
+      # and fast (~1s, no project). Used below to pick the matching prev-best slice
+      # from the PR comment blob, and carried into the comment for a change note.
+      - name: Fingerprint runner
+        id: fingerprint
+        run: |
+          MK=$(julia -e 'include("benchmark/bench_machine.jl"); print(machine_key())')
+          echo "$MK" > machine_key.txt
+          echo "machine_key=$MK" >> "$GITHUB_OUTPUT"
+          echo "Runner machine key: $MK"
+
       # Resolve the PR this run should attach to (empty for plain master pushes).
       # On a pull_request re-run the original event context is preserved, so the
       # PR head SHA is stable across re-runs — that is what powers the min-merge.
@@ -152,15 +164,18 @@ jobs:
             > baseline_data.js 2>/dev/null || true
 
       # Read prior best times from the existing PR comment so re-running the same
-      # commit only lowers measured times (min-merge) and clears CI-noise flags.
-      # Fully best-effort: any missing comment / missing blob / SHA mismatch /
-      # parse error leaves prev_best.json absent -> a normal full fresh run.
+      # commit on the SAME machine only lowers measured times (min-merge) and
+      # clears CI-noise flags. The blob is machine-keyed (v2): we pick this
+      # runner's slice; a different/absent machine -> fresh full run for it.
+      # Fully best-effort: any missing comment / SHA mismatch / v1 blob / parse
+      # error leaves prev_best.json absent -> a normal full fresh run.
       - name: Read previous benchmark comment
         if: steps.ctx.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
           CUR_SHA: ${{ steps.ctx.outputs.pr_sha }}
+          MK: ${{ steps.fingerprint.outputs.machine_key }}
         run: |
           set +e
           BODY=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
@@ -171,15 +186,24 @@ jobs:
             echo "No prior benchmark data blob found -> full fresh run"
             exit 0
           fi
+          # Carry the whole blob forward so the comment step can rebuild it while
+          # preserving other machines' floors.
+          printf '%s' "$BLOB" > prev_blob.json
           BLOB_SHA=$(printf '%s' "$BLOB" | jq -r '.sha // ""' 2>/dev/null)
           if [ "$BLOB_SHA" != "$CUR_SHA" ]; then
             echo "Comment SHA ($BLOB_SHA) != current ($CUR_SHA) -> reset (full fresh run)"
+            rm -f prev_blob.json   # different commit: don't carry stale machines forward
             exit 0
           fi
-          printf '%s' "$BLOB" | jq -e '.benches' > prev_best.json 2>/dev/null \
-            && echo "Loaded prev-best ($(jq length prev_best.json) benches) for SHA $CUR_SHA" \
-            || { echo "Blob parse failed -> full fresh run"; rm -f prev_best.json; }
-          printf '%s' "$BLOB" | jq -r '.flagged // [] | join(",")' > flagged_names.txt 2>/dev/null || true
+          # v2 machine-keyed blob: select this runner's slice. A v1 blob (no
+          # .machines) or an unseen machine yields no floor -> fresh full run.
+          if printf '%s' "$BLOB" | jq -e --arg mk "$MK" '.machines[$mk].benches' > prev_best.json 2>/dev/null; then
+            echo "Loaded prev-best floor for machine $MK ($(jq length prev_best.json) benches) on SHA $CUR_SHA"
+            printf '%s' "$BLOB" | jq -r --arg mk "$MK" '.machines[$mk].flagged // [] | join(",")' > flagged_names.txt 2>/dev/null || true
+          else
+            echo "No prior entry for machine $MK on SHA $CUR_SHA -> fresh full run for this machine"
+            rm -f prev_best.json
+          fi
 
       - name: Run benchmarks
         run: |
@@ -238,8 +262,11 @@ jobs:
             benchmark_flat.json
             regression_report.json
             hardware.json
+            machine_key.txt
+            prev_blob.json
             pr_number
             pr_head_sha
+          if-no-files-found: ignore
 
       # Publish the master data point to gh-pages, keyed by commit SHA:
       #   - re-running a commit REPLACES its entry with the per-benchmark min

--- a/.github/workflows/BenchmarkComment.yml
+++ b/.github/workflows/BenchmarkComment.yml
@@ -45,22 +45,47 @@ jobs:
         run: |
           PR_SHORT="${PR_SHA:0:8}"
 
-          # Hidden machine-readable blob: prior best times + flagged names for
-          # this SHA. The next re-run of the same commit reads it back to
-          # min-merge (see Benchmark.yml "Read previous benchmark comment").
-          BENCH_DATA=""
+          MK=$( [ -f machine_key.txt ] && cat machine_key.txt || echo "unknown" )
+          CPU=$( [ -f hardware.json ] && cat hardware.json || echo '{}' )
+
+          # Machine whose numbers the previous comment displayed (for a change
+          # note), read from the v2 blob we carried forward. Only meaningful on
+          # the same commit — the read step drops the blob on a SHA change.
+          PREV_SHOWN=""
+          if [ -s prev_blob.json ] && jq -e '.v==2' prev_blob.json >/dev/null 2>&1; then
+            PREV_SHOWN=$(jq -r '.shown // ""' prev_blob.json)
+          fi
+
+          # CPU of master's most-recent commit — the baseline the ratios stand
+          # next to. When it differs from this runner the comparison is cross-CPU
+          # and unreliable; "unknown" means that master point had no fingerprint.
+          # (Compare the string directly, not .baseline_same — jq's `// true`
+          # would turn a genuine `false` into `true` and silence the warning.)
+          BASE_MACHINE=""
           if [ -f regression_report.json ]; then
-            BENCH_DATA=$(jq -c --arg sha "$PR_SHA" '{
-              sha: $sha,
-              benches: [.benchmarks[] | {name, value}],
-              flagged: [.benchmarks[] | select(.was_flagged == true) | .name]
-            }' regression_report.json)
+            BASE_MACHINE=$(jq -r '.machine.baseline // ""' regression_report.json)
+          fi
+
+          # This run's slice: the current machine's (min-merged) numbers + flags.
+          CUR=""
+          if [ -f regression_report.json ]; then
+            CUR=$(jq -c '{benches: [.benchmarks[] | {name, value}], flagged: [.benchmarks[] | select(.was_flagged == true) | .name]}' regression_report.json)
           elif [ -f benchmark_flat.json ]; then
-            BENCH_DATA=$(jq -c --arg sha "$PR_SHA" '{
-              sha: $sha,
-              benches: [.[] | {name, value}],
-              flagged: []
-            }' benchmark_flat.json)
+            CUR=$(jq -c '{benches: [.[] | {name, value}], flagged: []}' benchmark_flat.json)
+          fi
+
+          # Hidden machine-readable blob (v2): best times keyed BY MACHINE. The
+          # next re-run reads back this machine's slice to min-merge; other
+          # machines' floors are preserved so a fleet flip never discards them.
+          BENCH_DATA=""
+          if [ -n "$CUR" ]; then
+            BASE='{"v":2,"machines":{}}'
+            if [ -s prev_blob.json ] && jq -e '.v==2' prev_blob.json >/dev/null 2>&1; then
+              BASE=$(cat prev_blob.json)
+            fi
+            BENCH_DATA=$(printf '%s' "$BASE" | jq -c \
+              --arg mk "$MK" --arg sha "$PR_SHA" --argjson cur "$CUR" --argjson cpu "$CPU" \
+              '.v = 2 | .sha = $sha | .shown = $mk | .machines[$mk] = ($cur + {cpu: $cpu})')
           fi
 
           {
@@ -70,6 +95,29 @@ jobs:
             fi
             echo "# FastInterpolations.jl Benchmarks"
             echo ""
+
+            # PRIMARY warning: the regression baseline (master's latest commit)
+            # was measured on a different CPU than this PR — a cross-CPU ratio is
+            # unreliable. Fires on a real mismatch AND on an unfingerprinted
+            # ("unknown") master point.
+            if [ -n "$BASE_MACHINE" ] && [ "$BASE_MACHINE" != "$MK" ]; then
+              echo "> ## :rotating_light: Regression baseline is a different CPU"
+              echo "> "
+              echo "> | | CPU |"
+              echo "> |---|---|"
+              echo "> | **This PR run** | \`$MK\` |"
+              echo "> | **Master baseline (latest commit)** | \`$BASE_MACHINE\` |"
+              echo "> "
+              echo "> The **Previous / Imm. Ratio / Grad. Ratio** columns compare against master history, but master's most recent commit was benchmarked on a **different CPU** — so a naive comparison is cross-CPU and unreliable. The ratios below use only same-\`$MK\` history and are blank if master has none on this CPU yet."
+              echo ""
+            fi
+
+            # Secondary (nice-to-have): the previous COMMENT's numbers were from a
+            # different CPU than this run. Compact one-liner.
+            if [ -n "$PREV_SHOWN" ] && [ "$PREV_SHOWN" != "$MK" ]; then
+              echo "> :information_source: The previous comment's numbers were measured on \`$PREV_SHOWN\`; this run is \`$MK\`. Each CPU keeps its own min-merge floor."
+              echo ""
+            fi
 
             if [ -f regression_report.json ]; then
               # ── Rich report from regression verification ──
@@ -133,7 +181,7 @@ jobs:
 
             if [ -f hardware.json ]; then
               echo ""
-              echo "> Runner: \`$(jq -r '.cpu_name' hardware.json)\` — $(jq -r '.model' hardware.json) ($(jq -r '.ncores' hardware.json) cores). A faster runner can make times look artificially low."
+              echo "> Runner: \`$MK\` — $(jq -r '.model' hardware.json), julia $(jq -r '.julia' hardware.json). Times are min-merged and compared only against this same machine's history."
             fi
 
             echo ""

--- a/benchmark/bench_machine.jl
+++ b/benchmark/bench_machine.jl
@@ -1,0 +1,34 @@
+# Shared machine-identity helper for the benchmark pipeline.
+#
+# GitHub-hosted runners are drawn at random from a mixed CPU fleet, so a run can
+# land on a noticeably faster/slower box than a previous one. To compare only
+# like-with-like we tag every measurement with a machine key and never merge or
+# compare across keys. This file is intentionally **dependency-free** (only
+# `Sys.*`) so it can be `include`d by the benchmark scripts and also invoked
+# standalone from a fast CI shell step:
+#
+#     julia -e 'include("benchmark/bench_machine.jl"); print(machine_key())'
+
+function hardware_fingerprint()
+    ci = Sys.cpu_info()
+    return Dict{String, Any}(
+        "cpu_name" => Sys.CPU_NAME,          # LLVM uarch target (skylake, znver3, ...)
+        "arch" => String(Sys.ARCH),
+        "model" => isempty(ci) ? "" : ci[1].model,
+        "speed_mhz" => isempty(ci) ? 0 : ci[1].speed,
+        "ncores" => length(ci),
+        "cpu_threads" => Sys.CPU_THREADS,
+        "julia" => string(VERSION),
+    )
+end
+
+# Canonical, JSON/filesystem-safe machine identity, e.g. "znver3|4c".
+#
+# Keyed on the LLVM microarchitecture (which determines the native code Julia
+# emits, so same-key runs are genuinely comparable) plus the core count (runner
+# tier). Deliberately excludes `speed_mhz` — on Linux it reflects the live
+# turbo/thermal frequency and drifts within a single box, which would shatter
+# one machine into phantom "machines". Also excludes the Julia version (Phase 1
+# choice): a version bump is a legitimate step-change that should stay visible on
+# the trend rather than fragment the floor.
+machine_key(hw = hardware_fingerprint()) = string(hw["cpu_name"], "|", hw["ncores"], "c")

--- a/benchmark/ci_benchmark.jl
+++ b/benchmark/ci_benchmark.jl
@@ -38,29 +38,18 @@ const EVALS_MED = 50        # ~500ns-2μs benchmarks (50 evals still < 1% timer 
 const EVALS_SLOW = 10       # ~30-100μs benchmarks
 
 # ══════════════════════════════════════════════════════════════════════════════
-# Hardware fingerprint (diagnostic only)
+# Hardware fingerprint
 # ══════════════════════════════════════════════════════════════════════════════
 #
 # GitHub's shared runner fleet mixes CPU generations, so a run can land on a
-# noticeably faster box. We record a per-run fingerprint so an anomalously fast
-# point on the dashboard can be traced to its hardware. This is annotation only
-# — it does NOT gate the min-merge.
+# noticeably faster/slower box than the last. We record a per-run fingerprint and
+# derive a machine key from it (see bench_machine.jl); the key gates the
+# min-merge and the master store so we only ever compare like-with-like.
 
-function hardware_fingerprint()
-    ci = Sys.cpu_info()
-    return Dict{String, Any}(
-        "cpu_name" => Sys.CPU_NAME,          # LLVM uarch target (skylake, znver3, ...)
-        "arch" => String(Sys.ARCH),
-        "model" => isempty(ci) ? "" : ci[1].model,
-        "speed_mhz" => isempty(ci) ? 0 : ci[1].speed,
-        "ncores" => length(ci),
-        "cpu_threads" => Sys.CPU_THREADS,
-        "julia" => string(VERSION),
-    )
-end
+include(joinpath(@__DIR__, "bench_machine.jl"))
 
 let hw = hardware_fingerprint()
-    println("Runner hardware: $(hw["cpu_name"]) | $(hw["model"]) | $(hw["ncores"]) cores | julia $(hw["julia"])")
+    println("Runner hardware: $(hw["cpu_name"]) | $(hw["model"]) | $(hw["ncores"]) cores | julia $(hw["julia"]) | key=$(machine_key(hw))")
     open("hardware.json", "w") do io
         JSON.print(io, hw)
     end
@@ -583,9 +572,9 @@ if !IS_FILTERED && (!isempty(MASTER_SHA) || _HAS_BASELINE || _HAS_PREVBEST)
 
     if !isempty(MASTER_SHA)
         # ── Master store mode ──────────────────────────────────────────────
-        # prev_best = same-commit floor (re-run only lowers the stored point);
-        # latest/window_avg = the *previous* master, for regression detection.
-        prev_best, latest, window_avg = load_master_baseline(BASELINE_PATH, MASTER_SHA)
+        # prev_best = same-(commit,machine) floor (re-run only lowers the point);
+        # latest/window_avg = the *previous* master on THIS machine, for detection.
+        prev_best, latest, window_avg = load_master_baseline(BASELINE_PATH, MASTER_SHA, machine_key())
         if !isempty(prev_best)
             println("Loaded $(length(prev_best)) same-commit prior value(s) for SHA $(MASTER_SHA[1:min(8, lastindex(MASTER_SHA))]) (floor)")
         end
@@ -627,7 +616,7 @@ if !IS_FILTERED && (!isempty(MASTER_SHA) || _HAS_BASELINE || _HAS_PREVBEST)
         confirmed = FlaggedBench[]
 
         if _HAS_BASELINE
-            latest, window_avg = load_baseline(BASELINE_PATH)
+            latest, window_avg = load_baseline(BASELINE_PATH, machine_key())
             flagged = detect_regressions(effective, latest, window_avg)
 
             if !isempty(flagged)
@@ -662,8 +651,16 @@ if !IS_FILTERED && (!isempty(MASTER_SHA) || _HAS_BASELINE || _HAS_PREVBEST)
             println("No baseline available — applied prev-best min-merge, skipped regression comparison")
         end
 
-        write_regression_report("regression_report.json", effective, latest, window_avg, flagged, confirmed)
-        println("Wrote regression_report.json")
+        # Record which CPU this run measured on vs the CPU of master's most-recent
+        # commit (the natural baseline) so the comment can warn on a cross-CPU
+        # comparison — the more dangerous mismatch than a mere runner change.
+        cur_machine = machine_key()
+        base_machine = _HAS_BASELINE ? latest_master_machine(BASELINE_PATH) : ""
+        write_regression_report(
+            "regression_report.json", effective, latest, window_avg, flagged, confirmed,
+            cur_machine, base_machine,
+        )
+        println("Wrote regression_report.json (runner=$cur_machine, master-baseline=$(isempty(base_machine) ? "none" : base_machine))")
     end   # master-store vs PR mode
 end
 

--- a/benchmark/dedup_history.jl
+++ b/benchmark/dedup_history.jl
@@ -2,18 +2,22 @@
     dedup_history.jl <data.js> [<out.js>]
 
 One-time (idempotent) cleanup of the gh-pages benchmark history: collapse every
-group of entries that share a commit id into a single entry holding the
-per-benchmark **minimum** across that commit's runs, keeping the earliest date
-and commit metadata. Entries are re-sorted chronologically.
+group of entries that share a **(commit id, machine)** into a single entry
+holding the per-benchmark **minimum** across that group's runs, keeping the
+earliest date and commit metadata. Points are then re-split by machine into the
+canonical suite (primary machine) + per-machine secondary suites and re-sorted
+chronologically.
 
-This de-noises the graph (each commit becomes one point at its best measurement)
-and removes the duplicate points left by past re-runs of the stock benchmark
-action. Running it again is a no-op once the history is already unique.
+This de-noises the graph (each commit becomes one point per machine at its best
+measurement) and removes duplicate points left by past re-runs. Grouping is
+per-machine so a commit measured on two different boxes stays two points —
+collapsing across machines would mix incomparable timings.
 
 Intended to be run locally against a fresh `gh-pages` checkout; the resulting
 `data.js` is then pushed deliberately (this script never pushes).
 
     out defaults to overwriting the input path.
+    BENCH_PRIMARY_MACHINE (optional) pins the canonical series; else most-common.
 """
 
 include(joinpath(@__DIR__, "gh_pages_data.jl"))
@@ -23,30 +27,31 @@ const DATA_PATH = ARGS[1]
 const OUT_PATH = length(ARGS) >= 2 ? ARGS[2] : ARGS[1]
 
 data = parse_data_js(DATA_PATH)
-entries_all = get(data, "entries", Dict{String, Any}())
-suite_entries = get(entries_all, SUITE, Any[])
+all_entries = collect_suite_entries(data)
 
-if isempty(suite_entries)
-    println("No entries for suite '$SUITE' — nothing to do")
+if isempty(all_entries)
+    println("No FastInterpolations entries — nothing to do")
     exit(0)
 end
 
-# Group by commit id (dupes from past re-runs land in the same group).
-by_id = Dict{String, Vector{Any}}()
-for e in suite_entries
-    push!(get!(by_id, commit_id(e), Any[]), e)
+# Group by (commit id, machine): dupes from past re-runs of the SAME box land in
+# the same group; different boxes stay separate.
+by_key = Dict{Tuple{String, String}, Vector{Any}}()
+for e in all_entries
+    push!(get!(by_key, (commit_id(e), entry_machine_key(e)), Any[]), e)
 end
 
-collapsed = [collapse_entries(group) for group in values(by_id)]
-sort!(collapsed, by = _date)
+collapsed = [collapse_entries(group) for group in values(by_key)]
 
-entries_all[SUITE] = collapsed
-data["entries"] = entries_all
+primary = primary_machine(collapsed, get(ENV, "BENCH_PRIMARY_MACHINE", ""))
+suites = split_by_machine(collapsed, primary)
+apply_suite_split!(data, suites)
+data["lastUpdate"] = round(Int, maximum(_date, collapsed))
 
 write_data_js(OUT_PATH, data)
 
-n_dupe_commits = count(>(1) ∘ length, values(by_id))
+n_dupe = count(>(1) ∘ length, values(by_key))
 println(
-    "Deduped '$SUITE': $(length(suite_entries)) entries → $(length(collapsed)) unique commits " *
-        "($(n_dupe_commits) commit(s) had duplicates)"
+    "Deduped: $(length(all_entries)) entries → $(length(collapsed)) unique (commit,machine) points " *
+        "($(n_dupe) had duplicates); $(length(suites)) machine series (primary=$primary)"
 )

--- a/benchmark/gh_pages_data.jl
+++ b/benchmark/gh_pages_data.jl
@@ -14,6 +14,8 @@ Schema (per suite):
 
 using JSON
 
+include(joinpath(@__DIR__, "bench_machine.jl"))   # machine_key / hardware_fingerprint
+
 const SUITE = "FastInterpolations.jl Benchmarks"
 
 """
@@ -81,6 +83,139 @@ function collapse_entries(entries)
         end
     end
     return collapsed
+end
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Machine-aware keying
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# The runner fleet mixes CPUs, so a bare per-commit line jitters as consecutive
+# commits land on different boxes and a same-commit re-run on a faster box would
+# wrongly `min` away a real number. We key every point by machine and never merge
+# or compare across keys.
+
+"""
+    entry_machine_key(entry) -> String
+
+Machine key of a stored point, from its `cpu` fingerprint. Legacy / fingerprint-
+less points (or malformed ones) key as `"unknown"` so they form their own series
+rather than contaminating a real machine's.
+"""
+function entry_machine_key(entry)
+    haskey(entry, "cpu") || return "unknown"
+    hw = entry["cpu"]
+    (haskey(hw, "cpu_name") && haskey(hw, "ncores")) || return "unknown"
+    return machine_key(hw)
+end
+
+"""
+    store_measurement(all_entries, sha, key, new_benches, cpu, fallback_commit, fallback_date)
+        -> (updated_entries, merged_entry)
+
+Merge this run's measurement into `all_entries`, keyed by **(commit, machine)**:
+
+- Entries sharing this `sha` **and** `key` are collapsed with `new_benches` to the
+  per-benchmark minimum (a same-box re-run only ever lowers the point).
+- Every other entry — different commit **or** different machine — is left
+  untouched (forward-only; no cross-machine `min`).
+- On a re-run the earliest date + original commit metadata are kept; a first-time
+  (commit, machine) uses `fallback_commit` / `fallback_date`.
+"""
+function store_measurement(all_entries, sha, key, new_benches, cpu, fallback_commit, fallback_date)
+    same = [e for e in all_entries if commit_id(e) == sha && entry_machine_key(e) == key]
+    others = [e for e in all_entries if !(commit_id(e) == sha && entry_machine_key(e) == key)]
+
+    merged_benches = merge_benches(vcat(same, [Dict{String, Any}("benches" => new_benches)]))
+
+    if !isempty(same)
+        i_earliest = argmin([_date(e) for e in same])
+        date = same[i_earliest]["date"]
+        commit = same[i_earliest]["commit"]
+    else
+        date = fallback_date
+        commit = fallback_commit
+    end
+
+    merged_entry = Dict{String, Any}("commit" => commit, "date" => date, "benches" => merged_benches, "cpu" => cpu)
+    return (vcat(others, [merged_entry]), merged_entry)
+end
+
+"""
+    primary_machine(all_entries, override) -> String
+
+The machine whose series is shown as the canonical trend line. `override`
+(`BENCH_PRIMARY_MACHINE`) wins when non-empty — this is the knob a future
+self-hosted "official" runner sets. Otherwise the most-common key across the
+history is used (ties broken lexicographically for determinism).
+"""
+function primary_machine(all_entries, override)
+    isempty(override) || return override
+    isempty(all_entries) && return "unknown"
+    counts = Dict{String, Int}()
+    for e in all_entries
+        k = entry_machine_key(e)
+        counts[k] = get(counts, k, 0) + 1
+    end
+    best, bestn = "unknown", -1
+    for k in sort(collect(keys(counts)))   # deterministic tie-break
+        if counts[k] > bestn
+            best, bestn = k, counts[k]
+        end
+    end
+    return best
+end
+
+"""
+    split_by_machine(all_entries, primary_key) -> Dict{suite_name => Vector{entry}}
+
+Presentation transform: the primary machine's points go under the canonical
+`SUITE` (the main, first chart), every other machine under `"SUITE (<key>)"`
+(secondary charts). Each series is sorted by date. Storage stays lossless — this
+only decides which suite name each point renders under.
+"""
+function split_by_machine(all_entries, primary_key)
+    suites = Dict{String, Any}()
+    for e in all_entries
+        k = entry_machine_key(e)
+        name = k == primary_key ? SUITE : "$SUITE ($k)"
+        push!(get!(suites, name, Any[]), e)
+    end
+    for es in values(suites)
+        sort!(es, by = _date)
+    end
+    return suites
+end
+
+"""
+    collect_suite_entries(data) -> Vector
+
+Gather every FastInterpolations point across the canonical suite and any
+per-machine secondary suites into one flat list (for re-keying / re-splitting).
+"""
+function collect_suite_entries(data)
+    entries_all = get(data, "entries", Dict{String, Any}())
+    out = Any[]
+    for (name, es) in entries_all
+        (name == SUITE || startswith(name, "$SUITE (")) && append!(out, es)
+    end
+    return out
+end
+
+"""
+    apply_suite_split!(data, suites)
+
+Replace all FastInterpolations suites in `data` with the machine-split `suites`
+(canonical + secondaries), leaving unrelated suites untouched.
+"""
+function apply_suite_split!(data, suites)
+    entries_all = get!(data, "entries", Dict{String, Any}())
+    for name in collect(keys(entries_all))
+        (name == SUITE || startswith(name, "$SUITE (")) && delete!(entries_all, name)
+    end
+    for (name, es) in suites
+        entries_all[name] = es
+    end
+    return data
 end
 
 """

--- a/benchmark/regression_check.jl
+++ b/benchmark/regression_check.jl
@@ -29,9 +29,10 @@ const SUITE_NAME = "FastInterpolations.jl Benchmarks"
 """
     read_suite_entries(data_js_path) -> Vector
 
-Parse a gh-pages `data.js` and return the chronological entry array for this
-package's benchmark suite (each entry: `Dict` with "commit", "date",
-"benches"). Returns an empty vector on missing / empty / unparseable input.
+Parse a gh-pages `data.js` and return every entry for this package across the
+canonical suite AND any per-machine secondary suites (`"<suite> (<key>)"`),
+flattened. Callers filter by machine key. Returns an empty vector on missing /
+empty / unparseable input.
 """
 function read_suite_entries(data_js_path::String)
     (isfile(data_js_path) && filesize(data_js_path) > 0) || return Any[]
@@ -45,10 +46,54 @@ function read_suite_entries(data_js_path::String)
     data = JSON.parse(json_str)
     entries_dict = get(data, "entries", Dict())
     isempty(entries_dict) && return Any[]
-    return get(entries_dict, SUITE_NAME, get(entries_dict, first(keys(entries_dict)), Any[]))
+
+    out = Any[]
+    for (name, es) in entries_dict
+        (name == SUITE_NAME || startswith(name, "$SUITE_NAME (")) && append!(out, es)
+    end
+    # Fallback for a foreign single-suite file whose name we don't recognise.
+    isempty(out) && return get(entries_dict, first(keys(entries_dict)), Any[])
+    return out
 end
 
 _commit_id(entry) = get(get(entry, "commit", Dict{String, Any}()), "id", "")
+
+_entry_date(entry) = Float64(entry["date"])
+
+# Machine key of a stored point — mirror of gh_pages_data.jl's entry_machine_key
+# (machine_key comes from bench_machine.jl, in scope via ci_benchmark.jl).
+function _entry_machine_key(entry)
+    haskey(entry, "cpu") || return "unknown"
+    hw = entry["cpu"]
+    (haskey(hw, "cpu_name") && haskey(hw, "ncores")) || return "unknown"
+    return machine_key(hw)
+end
+
+# One machine's series, chronologically. Baselines are computed within a single
+# machine so a slower/faster box never confounds the regression comparison.
+function _same_machine(entries, key::AbstractString)
+    filtered = [e for e in entries if _entry_machine_key(e) == key]
+    sort!(filtered, by = _entry_date)
+    return filtered
+end
+
+"""
+    latest_master_machine(data_js_path) -> String
+
+Machine key of the most-recent master commit's point overall (any machine) — the
+natural immediate baseline the PR's ratios stand next to. `"unknown"` when that
+point carries no fingerprint (older history); `""` when there is no history. Used
+to warn when a PR ran on a different CPU than the baseline it is compared against.
+"""
+function latest_master_machine(data_js_path::String)
+    entries = try
+        read_suite_entries(data_js_path)
+    catch
+        return ""
+    end
+    isempty(entries) && return ""
+    return _entry_machine_key(argmax(_entry_date, entries))
+end
 
 _benches_to_dict(benches) = Dict{String, Float64}(b["name"] => Float64(b["value"]) for b in benches)
 
@@ -79,16 +124,18 @@ function _window_average(entries)
 end
 
 """
-    load_baseline(data_js_path) -> (latest, window_avg)
+    load_baseline(data_js_path, key) -> (latest, window_avg)
 
-Parse gh-pages `data.js` and extract two baselines (PR mode):
-- `latest`: Dict{String,Float64} from the most recent push
-- `window_avg`: Dict{String,Float64} averaged over WINDOW_W commits around LOOKBACK_M ago
+Parse gh-pages `data.js` and extract two baselines (PR mode) from the `key`
+machine's series only, so a PR is never compared against a point measured on a
+different box:
+- `latest`: Dict{String,Float64} from the most recent same-machine push
+- `window_avg`: averaged over WINDOW_W same-machine commits around LOOKBACK_M ago
 """
-function load_baseline(data_js_path::String)
+function load_baseline(data_js_path::String, key::AbstractString)
     empty_result = (Dict{String, Float64}(), Dict{String, Float64}())
     entries = try
-        read_suite_entries(data_js_path)
+        _same_machine(read_suite_entries(data_js_path), key)
     catch
         return empty_result
     end
@@ -99,20 +146,22 @@ function load_baseline(data_js_path::String)
 end
 
 """
-    load_master_baseline(data_js_path, current_sha) -> (prev_best, latest, window_avg)
+    load_master_baseline(data_js_path, current_sha, key) -> (prev_best, latest, window_avg)
 
-Master-store variant. Splits the history relative to `current_sha`:
-- `prev_best`: per-benchmark min across ALL existing entries for `current_sha`
-  (robust to pre-existing duplicate points) — the cross-run floor that makes a
-  re-run of the same master commit only lower the stored value.
-- `latest` / `window_avg`: baselines from entries of *other* commits (the true
-  previous master state), so regression detection never compares a commit to
-  its own earlier run.
+Master-store variant, restricted to the `key` machine's series. Splits that
+history relative to `current_sha`:
+- `prev_best`: per-benchmark min across existing entries for `current_sha` **on
+  this machine** — the same-box cross-run floor that makes a re-run only lower
+  the stored value.
+- `latest` / `window_avg`: baselines from *other* commits on the same machine,
+  so regression detection never compares a commit to its own earlier run nor to
+  a different box. Empty (⇒ comparison skipped) the first time this machine
+  appears.
 """
-function load_master_baseline(data_js_path::String, current_sha::AbstractString)
+function load_master_baseline(data_js_path::String, current_sha::AbstractString, key::AbstractString)
     empty_result = (Dict{String, Float64}(), Dict{String, Float64}(), Dict{String, Float64}())
     entries = try
-        read_suite_entries(data_js_path)
+        _same_machine(read_suite_entries(data_js_path), key)
     catch
         return empty_result
     end
@@ -316,6 +365,8 @@ function write_regression_report(
         window_avg::Dict{String, Float64},
         initially_flagged::Vector{FlaggedBench},
         confirmed::Vector{FlaggedBench},
+        current_machine::AbstractString = "",
+        baseline_machine::AbstractString = "",
     )
     flagged_names = Set(fb.full_name for fb in initially_flagged)
     confirmed_names = Set(fb.full_name for fb in confirmed)
@@ -367,6 +418,14 @@ function write_regression_report(
             "total" => length(benchmarks),
             "initially_flagged" => length(initially_flagged),
             "confirmed_regressions" => length(confirmed),
+        ),
+        # Machine provenance for the comment's cross-CPU warning: `current` is the
+        # runner this PR measured on; `baseline` is the CPU of master's most-recent
+        # commit (the natural comparison baseline; "unknown" if unfingerprinted).
+        "machine" => Dict{String, Any}(
+            "current" => current_machine,
+            "baseline" => baseline_machine,
+            "baseline_same" => baseline_machine == current_machine,
         ),
         "benchmarks" => benchmarks,
     )

--- a/benchmark/regression_check.jl
+++ b/benchmark/regression_check.jl
@@ -92,7 +92,15 @@ function latest_master_machine(data_js_path::String)
         return ""
     end
     isempty(entries) && return ""
-    return _entry_machine_key(argmax(_entry_date, entries))
+    # The same commit re-benchmarked on two CPUs yields two entries sharing the
+    # commit date, so the max-date point can tie. Resolve deterministically:
+    # prefer a fingerprinted CPU over "unknown", then lexicographically — the
+    # baseline machine (and the cross-CPU warning) must not flip on identical
+    # history from Dict/suite iteration order.
+    dmax = maximum(_entry_date, entries)
+    keys_at_max = sort!(unique([_entry_machine_key(e) for e in entries if _entry_date(e) == dmax]))
+    known = filter(!=("unknown"), keys_at_max)
+    return isempty(known) ? "unknown" : first(known)
 end
 
 _benches_to_dict(benches) = Dict{String, Float64}(b["name"] => Float64(b["value"]) for b in benches)

--- a/benchmark/update_gh_pages_data.jl
+++ b/benchmark/update_gh_pages_data.jl
@@ -1,25 +1,29 @@
 """
     update_gh_pages_data.jl <existing_data.js> <master_benches.json> <out_data.js>
 
-CI store step. Merges the current master commit's benches into `data.js`,
-keyed by commit SHA:
+CI store step. Merges the current master commit's benches into `data.js`, keyed
+by **(commit SHA, machine)**:
 
-- If the commit already has one or more entries (e.g. a re-run), they are
-  collapsed with the new measurement to the per-benchmark **minimum** and
-  replaced by a single entry — so re-running a commit only *lowers* its stored
-  point instead of appending a noisy duplicate.
-- Otherwise a new entry is appended.
+- If this (commit, machine) already has one or more entries (a same-box re-run),
+  they are collapsed with the new measurement to the per-benchmark **minimum**
+  and replaced by a single entry — a re-run only *lowers* its stored point.
+- A different machine on the same commit becomes a **separate** entry; we never
+  `min` across machines (the fleet mixes CPUs, so that would mask real numbers).
+- **Forward-only**: entries for other commits/machines are left untouched.
 
-**Forward-only**: entries for *other* commits are left untouched. Bulk cleanup
-of pre-existing duplicates is a separate, deliberate step (`dedup_history.jl`).
+For display, points are split by machine across suite names: the primary
+machine's series is the canonical suite (the main chart), every other machine a
+secondary `"<suite> (<key>)"`. Storage stays lossless; the split only decides the
+suite name each point renders under.
 
 Environment:
-    BENCH_SHA          (required) commit id used as the merge key
-    BENCH_COMMIT_META  (optional) path to a JSON file with commit metadata for a
-                       brand-new entry: {id,message,timestamp,url,author,
-                       committer,date_ms}. Built by the workflow via `gh api`
-                       (avoids injecting multi-line commit messages through env).
-    BENCH_DATE_MS      (fallback) entry date in ms when no meta file is given.
+    BENCH_SHA              (required) commit id used as the merge key
+    BENCH_HARDWARE         (required) path to hardware.json — keys the point by machine
+    BENCH_PRIMARY_MACHINE  (optional) machine key to pin as the canonical series;
+                           defaults to the most-common key in the history
+    BENCH_COMMIT_META      (optional) JSON metadata for a brand-new entry:
+                           {id,message,timestamp,url,author,committer,date_ms}
+    BENCH_DATE_MS          (fallback) entry date in ms when no meta file is given
 """
 
 include(joinpath(@__DIR__, "gh_pages_data.jl"))
@@ -32,76 +36,57 @@ const OUT_PATH = ARGS[3]
 const SHA = get(ENV, "BENCH_SHA", "")
 isempty(SHA) && error("BENCH_SHA is required")
 
+# Hardware fingerprint is REQUIRED — it keys the point onto a machine series.
+# Without it we cannot place the measurement on the right line, so fail loudly
+# rather than store a mis-keyed point.
+const HW_PATH = get(ENV, "BENCH_HARDWARE", "")
+(!isempty(HW_PATH) && isfile(HW_PATH)) ||
+    error("BENCH_HARDWARE must point to an existing hardware.json (required to key the point by machine)")
+const CPU = JSON.parsefile(HW_PATH)
+const CURRENT_KEY = machine_key(CPU)
+
 data = parse_data_js(DATA_PATH)
-entries_all = get!(data, "entries", Dict{String, Any}())
-suite_entries = get(entries_all, SUITE, Any[])
+all_entries = collect_suite_entries(data)
 
 new_benches = JSON.parsefile(NEW_BENCHES_PATH)  # [{name,value,unit,extra}]
 
-same = [e for e in suite_entries if commit_id(e) == SHA]
-others = [e for e in suite_entries if commit_id(e) != SHA]
+# Fallback commit metadata / date for a first-time (commit, machine) point.
+meta_path = get(ENV, "BENCH_COMMIT_META", "")
+if !isempty(meta_path) && isfile(meta_path)
+    m = JSON.parsefile(meta_path)
+    author = get(m, "author", Dict{String, Any}("name" => "", "email" => ""))
+    fallback_commit = Dict{String, Any}(
+        "id" => get(m, "id", SHA),
+        "message" => get(m, "message", ""),
+        "timestamp" => get(m, "timestamp", ""),
+        "url" => get(m, "url", ""),
+        "author" => author,
+        "committer" => get(m, "committer", author),
+    )
+    fallback_date = round(Int, Float64(get(m, "date_ms", parse(Float64, get(ENV, "BENCH_DATE_MS", "0")))))
+else
+    fallback_commit = Dict{String, Any}("id" => SHA)
+    fallback_date = parse(Int, get(ENV, "BENCH_DATE_MS", "0"))
+end
 
-# Per-benchmark min over existing same-SHA entries ∪ this run's benches.
-new_entry_wrapper = Dict{String, Any}("benches" => new_benches)
-merged_benches = merge_benches(vcat(same, [new_entry_wrapper]))
+updated, merged_entry = store_measurement(all_entries, SHA, CURRENT_KEY, new_benches, CPU, fallback_commit, fallback_date)
 
-if isempty(merged_benches)
+if isempty(merged_entry["benches"])
     @warn "No benches to store — writing data.js unchanged"
-    write_data_js(OUT_PATH, data)
+    write_data_js(OUT_PATH, data)   # `data` not yet mutated (split happens below)
     exit(0)
 end
 
-# Date + commit metadata: keep the commit's original (earliest) identity on a
-# re-run; synthesize for a first-time commit from the meta file (or env).
-if !isempty(same)
-    i_earliest = argmin([_date(e) for e in same])
-    entry_date = same[i_earliest]["date"]
-    commit = same[i_earliest]["commit"]
-else
-    meta_path = get(ENV, "BENCH_COMMIT_META", "")
-    if !isempty(meta_path) && isfile(meta_path)
-        m = JSON.parsefile(meta_path)
-        author = get(m, "author", Dict{String, Any}("name" => "", "email" => ""))
-        commit = Dict{String, Any}(
-            "id" => get(m, "id", SHA),
-            "message" => get(m, "message", ""),
-            "timestamp" => get(m, "timestamp", ""),
-            "url" => get(m, "url", ""),
-            "author" => author,
-            "committer" => get(m, "committer", author),
-        )
-        entry_date = round(Int, Float64(get(m, "date_ms", parse(Float64, get(ENV, "BENCH_DATE_MS", "0")))))
-    else
-        commit = Dict{String, Any}("id" => SHA)
-        entry_date = parse(Int, get(ENV, "BENCH_DATE_MS", "0"))
-    end
-end
-
-merged_entry = Dict{String, Any}("commit" => commit, "date" => entry_date, "benches" => merged_benches)
-
-# Diagnostic hardware fingerprint of the run that produced this point (annotation
-# only — the graph tooltip / our tooling can flag anomalously-fast hardware).
-hw_path = get(ENV, "BENCH_HARDWARE", "")
-if !isempty(hw_path) && isfile(hw_path)
-    merged_entry["cpu"] = JSON.parsefile(hw_path)
-else
-    # Carry a prior fingerprint forward on a re-run with no fresh one.
-    for e in same
-        if haskey(e, "cpu")
-            merged_entry["cpu"] = e["cpu"]
-            break
-        end
-    end
-end
-
-new_suite = vcat(others, [merged_entry])
-sort!(new_suite, by = _date)
-entries_all[SUITE] = new_suite
-data["lastUpdate"] = round(Int, maximum(_date, new_suite))
+primary = primary_machine(updated, get(ENV, "BENCH_PRIMARY_MACHINE", ""))
+suites = split_by_machine(updated, primary)
+apply_suite_split!(data, suites)
+data["lastUpdate"] = round(Int, maximum(_date, updated))
 
 write_data_js(OUT_PATH, data)
+
+n_collapsed = count(e -> commit_id(e) == SHA && entry_machine_key(e) == CURRENT_KEY, all_entries)
 println(
-    "Stored SHA $(SHA[1:min(8, lastindex(SHA))]): $(length(merged_benches)) benches; " *
-        "collapsed $(length(same)) prior same-commit entr$(length(same) == 1 ? "y" : "ies"); " *
-        "suite now $(length(new_suite)) entries"
+    "Stored SHA $(SHA[1:min(8, lastindex(SHA))]) on machine $CURRENT_KEY (primary=$primary): " *
+        "$(length(merged_entry["benches"])) benches; collapsed $n_collapsed prior same-(commit,machine) " *
+        "entr$(n_collapsed == 1 ? "y" : "ies"); history now $(length(updated)) points across $(length(suites)) machine series"
 )


### PR DESCRIPTION
## Summary 
GitHub-hosted runners are drawn from a **mixed CPU fleet**, so a benchmark run can land on a faster/slower box than the last. Today the pipeline `min`-merges and compares across those boxes, which masks real numbers — a fast-machine re-run makes a slower machine's regression disappear (seen on #175).

This makes the whole pipeline **key everything by machine** (`cpu_name|ncores`) and only ever compare like-with-like.

## What changes

- **gh-pages store** keys points by `(commit, machine)`: a same-box re-run min-merges; a different box gets its own entry. The trend graph shows one primary machine's line + per-machine secondaries.
- **PR comment blob** is now per-machine: re-runs min-merge against *this* CPU's floor, other CPUs' floors are preserved.
- **Regression baseline** is filtered to the same machine, so a PR is never compared against a point measured on a different CPU (skips gracefully when this CPU has no history yet).
- **New 🚨 warning** in the comment when master's latest-commit CPU differs from this run's (including an unfingerprinted `unknown` point) — the cross-CPU comparison that produces false regressions.

No package `src/` is touched — benchmark tooling + workflows only.

## Note for the reviewer

`BenchmarkComment.yml` is a `workflow_run` workflow, which GitHub **always runs from the default branch**. So the new comment only appears **after this is merged to master** — it can't be previewed from the PR branch. (The comment format was verified by rendering the exact workflow script locally.)

## Phase 1 of 3

- **Phase 2 (later):** benchmark master + head in the same job → machine-independent ratio (removes the cross-CPU comparison entirely).
- **Phase 3 (later):** a self-hosted runner pinned as the primary series → clean official trend line.
