### PR TITLE
perf(search): optimal interval search for _CachedRange with _UnitStep/_OneTo

### DIFF
--- a/src/core/axis_types.jl
+++ b/src/core/axis_types.jl
@@ -43,16 +43,18 @@ normalized to `_CachedRange` via `_to_float` at public API boundaries.
 """
 # Grid tag (3rd type param): a type-level marker for grid properties, kept open so
 # future kinds (log-spaced, reversed, …) — and `_CachedVector` — can reuse
-# `_AbstractAxisTag`. `_UnitStep` (step ≡ 1, statically known) lets
-# `_get_h`/`_get_inv_h`/`_search_direct`/`_alpha_of` skip the ×inv_h/×h multiplies;
-# `_WidenedDomain` lets `_domain_bounds` read the widened x86_64 bracket instead of
-# `lo`/`hi`. Every other call site dispatches on `::_CachedRange{T,Tinv}`
-# (= `…{T,Tinv,Tag} where Tag`), which matches all tags.
+# `_AbstractAxisTag`. The `_AbstractUnitStep` family (mirrors Base's AbstractUnitRange)
+# pins step ≡ 1, folding ×h/×inv_h through the accessors; `_OneTo` additionally pins
+# `lo ≡ 1` (`first` returns a literal → `lo == 1` tests constant-fold). `_WidenedDomain`
+# lets `_domain_bounds` read the widened x86_64 bracket instead of `lo`/`hi`. Every
+# other call site dispatches on `::_CachedRange{T,Tinv}`, which matches all tags.
 abstract type _AbstractAxisTag end
-struct _Generic <: _AbstractAxisTag end    # default: step is a runtime field
-struct _UnitStep <: _AbstractAxisTag end   # step ≡ 1 (from an AbstractUnitRange grid)
+struct _Generic <: _AbstractAxisTag end       # default: step is a runtime field
+abstract type _AbstractUnitStep <: _AbstractAxisTag end
+struct _UnitStep <: _AbstractUnitStep end     # step ≡ 1 (from an AbstractUnitRange grid)
+struct _OneTo <: _AbstractUnitStep end        # step ≡ 1 AND lo ≡ 1 (from a Base.OneTo grid)
 # Widened 1-ULP domain bracket (x86_64 TwicePrecision reconstruction cushion);
-# mutually exclusive with `_UnitStep`.
+# mutually exclusive with the unit-step family.
 struct _WidenedDomain <: _AbstractAxisTag end
 
 struct _CachedRange{T, Tinv, Tag <: _AbstractAxisTag} <: AbstractRange{T}

--- a/src/core/cached_range.jl
+++ b/src/core/cached_range.jl
@@ -30,7 +30,7 @@ function Base.getindex(r::_CachedRange, i::Int)
     @boundscheck checkbounds(r, i)
     i == 1 && return r.lo
     i == r.len && return r.hi
-    return muladd(i - 1, r.h, r.lo)
+    return muladd(i - 1, _get_h(r), r.lo)   # accessor: unit-step family folds the ×h
 end
 
 # Range slicing — return a new _CachedRange instead of falling back to a generic

--- a/src/core/cached_range.jl
+++ b/src/core/cached_range.jl
@@ -21,6 +21,9 @@ _CachedRange(x::AbstractRange{T}) where {T} = _to_float(x, T)
 Base.length(r::_CachedRange) = r.len
 Base.size(r::_CachedRange) = (r.len,)
 Base.first(r::_CachedRange) = r.lo
+# `_OneTo`: lo ≡ 1 is a type invariant — the literal return lets `lo == 1` tests
+# (e.g. the index-space search arm) constant-fold, like the `_get_h` ≡ one() fold.
+Base.first(r::_CachedRange{T, Tinv, _OneTo}) where {T, Tinv} = one(T)
 Base.last(r::_CachedRange) = r.hi
 Base.step(r::_CachedRange) = r.h
 function Base.getindex(r::_CachedRange, i::Int)
@@ -45,12 +48,17 @@ end
 # sub-range of a `_WidenedDomain` grid stays widened — its endpoints are `muladd`
 # reconstructions too, so they keep the ±1-ULP cushion (a boundary-touching slice
 # recovers the original `prevfloat(lo)`/`nextfloat(hi)`).
+# Exception: `_OneTo` demotes to `_UnitStep` (`i_lo` is runtime, so the type-level
+# `lo ≡ 1` invariant can't survive a slice) — same folds; a 1-based slice still hits
+# the search's `lo == 1` arm.
+@inline _slice_tag(tag::_AbstractAxisTag) = tag
+@inline _slice_tag(::_OneTo) = _UnitStep()
 @inline function Base.getindex(r::_CachedRange{T, Tinv, Tag}, idx::AbstractUnitRange{<:Integer}) where {T, Tinv, Tag}
     @boundscheck checkbounds(r, idx)
     new_len = length(idx)
     # Empty slice: return a length-0 _CachedRange anchored at r.lo (callers that
     # would dereference this hit the same checkbounds wall they would on r itself).
-    new_len == 0 && return _cached_range(Tag(), r.lo, r.lo, r.h, r.inv_h, 0)
+    new_len == 0 && return _cached_range(_slice_tag(Tag()), r.lo, r.lo, r.h, r.inv_h, 0)
     i_lo = Int(first(idx))
     i_hi = Int(last(idx))
     # Reuse cached endpoints when the slice touches them — preserves the exact-bit
@@ -58,7 +66,7 @@ end
     # any downstream Tg-precision comparison stable.
     new_lo = i_lo == 1 ? r.lo : muladd(i_lo - 1, r.h, r.lo)
     new_hi = i_hi == r.len ? r.hi : muladd(i_hi - 1, r.h, r.lo)
-    return _cached_range(Tag(), new_lo, new_hi, r.h, r.inv_h, new_len)
+    return _cached_range(_slice_tag(Tag()), new_lo, new_hi, r.h, r.inv_h, new_len)
 end
 
 # `view` follows `getindex` semantics for ranges — both return a fresh range, no
@@ -85,7 +93,7 @@ function _to_float(x::AbstractRange, ::Type{T}) where {T}
     return _cached_range(_Generic(), T(first(x)), T(last(x)), h, inv_h, length(x))
 end
 
-# Unit-step fast-path: `AbstractUnitRange` (`UnitRange`/`Base.OneTo`) has step ≡ 1 by
+# Unit-step fast-path: `AbstractUnitRange` (`UnitRange` etc.) has step ≡ 1 by
 # type, so the grid is built from literal constants (`h = one(T)`, `inv_h = one(Tinv)`)
 # with no runtime division — `inv` is only in the compile-time type
 # `Tinv = typeof(inv(oneunit(T)))` (Float64 for `T=Int`, `T` for Float, per the
@@ -93,6 +101,15 @@ end
 @inline function _to_float(x::AbstractUnitRange, ::Type{T}) where {T}
     Tinv = typeof(inv(oneunit(T)))
     return _cached_range(_UnitStep(), T(first(x)), T(last(x)), one(T), one(Tinv), length(x))
+end
+
+# `Base.OneTo`: 1-based by type → `_OneTo` tag (index-space search; `first` folds).
+# `1:n` deliberately keeps `_UnitStep` — a runtime `first(x) == 1` tag promotion would
+# make the interpolant type value-dependent (2^N Union in ND); the search's predicted
+# `lo == 1` arm covers that case instead.
+@inline function _to_float(x::Base.OneTo, ::Type{T}) where {T}
+    Tinv = typeof(inv(oneunit(T)))
+    return _cached_range(_OneTo(), one(T), T(last(x)), one(T), one(Tinv), length(x))
 end
 
 # x86_64: TwicePrecision first()/last() ~9ns each on Intel — bypass via plain-T muladd.
@@ -164,8 +181,8 @@ end
 # downstream `×h`/`×inv_h` to identity.
 @inline _get_h(x::_CachedRange) = x.h
 @inline _get_inv_h(x::_CachedRange) = x.inv_h
-@inline _get_h(::_CachedRange{T, Tinv, _UnitStep}) where {T, Tinv} = one(T)
-@inline _get_inv_h(::_CachedRange{T, Tinv, _UnitStep}) where {T, Tinv} = one(Tinv)
+@inline _get_h(::_CachedRange{T, Tinv, Tag}) where {T, Tinv, Tag <: _AbstractUnitStep} = one(T)
+@inline _get_inv_h(::_CachedRange{T, Tinv, Tag}) where {T, Tinv, Tag <: _AbstractUnitStep} = one(Tinv)
 # Inverse of the 2-cell span x[i+1]-x[i-1] (central-difference / cardinal interior).
 # A uniform range has span = 2h, so inv = inv_h/2; `_UnitStep` folds to one/2 = 0.5
 # (no division). 0.5 is exact (power of two) → one cached load + one multiply.

--- a/src/core/search.jl
+++ b/src/core/search.jl
@@ -531,18 +531,36 @@ end
 `_CachedRange` specialization: geometry fields are plain `T`, `inv_h` is `Tinv`
 (equals `T` for Float grids, `Float64` for `T = Int`) — no TwicePrecision arithmetic.
 Uses precomputed `inv_h` (multiply instead of divide) for the index calculation.
-Pulls `h`/`inv_h` through the accessors so a `_UnitStep` grid (which returns the
-literal `one`) lets LLVM fold the `×inv_h` index muladd and the `×h` left-edge
-muladd to identity — no separate `_UnitStep` method needed.
+Pulls `h`/`inv_h` through the accessors; the unit-step family takes its own
+index-space method below.
 """
 @inline function _search_direct(x::_CachedRange{T, Tinv}, xq::Real) where {T, Tinv}
     # Primal-based index: see _search_direct(::AbstractRange, ...) comment.
     inv_h = _get_inv_h(x)
     h = _get_h(x)
-    idx = _clamp(unsafe_trunc(Int, _extract_primal(muladd(xq - x.lo, inv_h, 1))), 1, x.len - 1)
-    xL = muladd(idx - 1, h, x.lo)
+    lo = first(x)
+    idx = _clamp(unsafe_trunc(Int, _extract_primal(muladd(xq - lo, inv_h, 1))), 1, length(x) - 1)
+    xL = muladd(idx - 1, h, lo)
     xR = xL + h
     return idx, xL, xR
+end
+
+# Unit-step family twin of the `_search_direct_inbounds` method below, keeping the
+# TWO-sided clamp: OOB queries legitimately reach the guarded search (ExtendExtrap
+# pins the boundary cell through it). Bit-identical for ALL xq — in-domain by the
+# exactness argument below; OOB because both forms clamp to the same boundary cell.
+@inline function _search_direct(
+        x::_CachedRange{T, Tinv, Tag}, xq::Real
+    ) where {T, Tinv, Tag <: _AbstractUnitStep}
+    if first(x) == one(T)
+        idx = _clamp(unsafe_trunc(Int, _extract_primal(xq)), 1, length(x) - 1)
+        xL = T(idx)
+        return idx, xL, xL + one(T)
+    end
+    lo = first(x)
+    idx = _clamp(unsafe_trunc(Int, _extract_primal(xq - lo + one(T))), 1, length(x) - 1)
+    xL = lo + (idx - 1)
+    return idx, xL, xL + one(T)
 end
 
 """
@@ -558,8 +576,9 @@ in-bounds `xq`. Unit-step grids take the `<:_AbstractUnitStep` method below.
 @inline function _search_direct_inbounds(x::_CachedRange{T, Tinv}, xq::Real) where {T, Tinv}
     inv_h = _get_inv_h(x)
     h = _get_h(x)
-    idx = min(unsafe_trunc(Int, _extract_primal(muladd(xq - x.lo, inv_h, 1))), x.len - 1)
-    xL = muladd(idx - 1, h, x.lo)
+    lo = first(x)
+    idx = min(unsafe_trunc(Int, _extract_primal(muladd(xq - lo, inv_h, 1))), length(x) - 1)
+    xL = muladd(idx - 1, h, lo)
     xR = xL + h
     return idx, xL, xR
 end
@@ -571,17 +590,20 @@ end
 # `first(x)` folds the test for `_OneTo` (literal `one(T)` by type); `_UnitStep` reads
 # the field — a loop-invariant, perfectly-predicted branch. The else-arm is the generic
 # body with `h ≡ inv_h ≡ 1` pre-folded; it assumes nothing about `lo` (offset AND
-# fractional-lo `UnitRange{Float64}` land there).
+# fractional-lo `UnitRange{Float64}` land there). `T(idx) ≡ sitofp(idx−1)+lo` needs
+# `idx` representable in `T` — always true for Float64; a Float32 axis past 2^24
+# cannot represent its own nodes and is outside the bit-identity contract.
 @inline function _search_direct_inbounds(
         x::_CachedRange{T, Tinv, Tag}, xq::Real
     ) where {T, Tinv, Tag <: _AbstractUnitStep}
     if first(x) == one(T)
-        idx = min(unsafe_trunc(Int, _extract_primal(xq)), x.len - 1)
+        idx = min(unsafe_trunc(Int, _extract_primal(xq)), length(x) - 1)
         xL = T(idx)
         return idx, xL, xL + one(T)
     end
-    idx = min(unsafe_trunc(Int, _extract_primal(xq - x.lo + one(T))), x.len - 1)
-    xL = x.lo + (idx - 1)
+    lo = first(x)
+    idx = min(unsafe_trunc(Int, _extract_primal(xq - lo + one(T))), length(x) - 1)
+    xL = lo + (idx - 1)
     return idx, xL, xL + one(T)
 end
 
@@ -590,7 +612,7 @@ end
 # `[domain_lo, lo)` sits BELOW the first grid point, so `muladd(xq - lo, inv_h, 1) < 1` — the lower
 # `max(·, 1)` half of the clamp is NOT dead here (unlike the exact tags, where `lo == domain_lo` ⇒
 # in-domain ⇒ `idx ≥ 1`). Keep the two-sided clamp by falling back to the guarded `_search_direct`,
-# which stays bit-identical to it. (The search's cell arithmetic uses grid `x.lo` by convention —
+# which stays bit-identical to it. (The search's cell arithmetic uses the grid lo (`first(x)`) by convention —
 # `domain_lo/hi` are read by `_domain_bounds` for the domain check only; using `domain_lo` as the
 # coordinate reference here would shift every interior cell by the cushion on zero-crossing ranges.)
 @inline _search_direct_inbounds(x::_CachedRange{T, Tinv, _WidenedDomain}, xq::Real) where {T, Tinv} =

--- a/src/core/search.jl
+++ b/src/core/search.jl
@@ -553,7 +553,7 @@ end
 `xq ≥ lo` ⇒ `idx ≥ 1` and the lower `max(·, 1)` half of `_clamp(idx, 1, len-1)` is
 provably dead — only the top-cell cap `min(·, len-1)` remains. `xL`/`xR` are computed
 identically, so the returned interval is **bit-identical** to `_search_direct` for any
-in-bounds `xq`. A `_UnitStep` axis folds the `×inv_h`/`×h` to identity.
+in-bounds `xq`. Unit-step grids take the `<:_AbstractUnitStep` method below.
 """
 @inline function _search_direct_inbounds(x::_CachedRange{T, Tinv}, xq::Real) where {T, Tinv}
     inv_h = _get_inv_h(x)
@@ -562,6 +562,27 @@ in-bounds `xq`. A `_UnitStep` axis folds the `×inv_h`/`×h` to identity.
     xL = muladd(idx - 1, h, x.lo)
     xR = xL + h
     return idx, xL, xR
+end
+
+# Unit-step family: 1-based grids take the index-space arm, dropping the whole
+# `(xq−lo)+1 → trunc → sitofp(idx−1)+lo` float chain ahead of the cell loads.
+# Bit-identical: in-domain `xq ≥ 1` makes `xq − 1` exact (Sterbenz / integral multiple
+# of ulp), so `trunc((xq−lo)+1) ≡ trunc(xq)` and `sitofp(idx−1)+lo ≡ T(idx)`.
+# `first(x)` folds the test for `_OneTo` (literal `one(T)` by type); `_UnitStep` reads
+# the field — a loop-invariant, perfectly-predicted branch. The else-arm is the generic
+# body with `h ≡ inv_h ≡ 1` pre-folded; it assumes nothing about `lo` (offset AND
+# fractional-lo `UnitRange{Float64}` land there).
+@inline function _search_direct_inbounds(
+        x::_CachedRange{T, Tinv, Tag}, xq::Real
+    ) where {T, Tinv, Tag <: _AbstractUnitStep}
+    if first(x) == one(T)
+        idx = min(unsafe_trunc(Int, _extract_primal(xq)), x.len - 1)
+        xL = T(idx)
+        return idx, xL, xL + one(T)
+    end
+    idx = min(unsafe_trunc(Int, _extract_primal(xq - x.lo + one(T))), x.len - 1)
+    xL = x.lo + (idx - 1)
+    return idx, xL, xL + one(T)
 end
 
 # `_WidenedDomain` exception: the accepted domain `[domain_lo, domain_hi]` is 1 ULP wider than the

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -652,13 +652,13 @@ end
 
 # Safe domain bounds — single axis-dispatched source of truth for every in-domain
 # test (`_is_all_inbounds`, `_is_inbounds`, `_oob_state`), so they never disagree
-# at a boundary query. Plain `AbstractVector` → exact `first/last`; exact-domain
-# `_CachedRange` (`_Generic`/`_UnitStep`) → `lo/hi` (sharing the load with the
-# search that follows); only a `_WidenedDomain` range → its `domain_lo/hi`, ≈1 ULP
-# wider than the stored `lo/hi` on the x86_64 fast path, keeping a query at the
-# true endpoint in-domain instead of falsely OOB.
+# at a boundary query. Exact-domain axes → `first/last` (field reads on
+# `_CachedRange`; `_OneTo` folds its lower bound to the literal `one(T)`); only a
+# `_WidenedDomain` range → its `domain_lo/hi`, ≈1 ULP wider than the stored
+# `lo/hi` on the x86_64 fast path, keeping a query at the true endpoint in-domain
+# instead of falsely OOB.
 @inline _domain_bounds(x::AbstractVector) = (first(x), last(x))
-@inline _domain_bounds(x::_CachedRange) = (x.lo, x.hi)                # _Generic / _UnitStep: exact
+@inline _domain_bounds(x::_CachedRange) = (first(x), last(x))
 @inline _domain_bounds(x::_CachedRange{T, Tinv, _WidenedDomain}) where {T, Tinv} =
     (x.domain_lo, x.domain_hi)                                        # widened bracket
 

--- a/test/test_unitstep_inbounds_locate.jl
+++ b/test/test_unitstep_inbounds_locate.jl
@@ -845,3 +845,67 @@ end
         @test hib[2][] == hne[2][] != 0
     end
 end
+
+@testitem "UnitStep lean search — ULP-edge sweep bit-identical (lo==1 and lo≠1)" begin
+    # Characterization sweep for the `_UnitStep` lean search arithmetic: every
+    # interior node ±1 ULP + exact nodes + half-cells + endpoints. Two independent
+    # references (the scalar NoExtrap path promotes to InBounds since the lean-search
+    # work, so it is NOT independent at the search stage):
+    #   1. unit level — `_search_direct_inbounds === _search_direct` for in-domain
+    #      queries is the documented contract of the lean search (one-sided clamp);
+    #   2. end-to-end — ClampExtrap does not promote, so its in-domain eval runs the
+    #      guarded generic search; `inb(q) === clamped(q)` pins idx/α/kernel to the ULP.
+    using FastInterpolations: InBounds, ClampExtrap, _to_float, _search_direct, _search_direct_inbounds
+
+    function ulp_probes(ax)
+        lo, hi = Float64(first(ax)), Float64(last(ax))
+        ps = Float64[lo, hi]
+        for k in first(ax):last(ax)
+            fk = Float64(k)
+            fk > lo && push!(ps, prevfloat(fk))
+            push!(ps, fk)
+            fk < hi && push!(ps, nextfloat(fk))
+            fk + 0.5 < hi && push!(ps, fk + 0.5)
+        end
+        return ps
+    end
+
+    @testset "unit: lean search === guarded search (1D grids: lo 1, lo 5, OneTo)" begin
+        for ax in (1:9, 5:13, Base.OneTo(9))
+            itp = linear_interp(ax, sin.(0.4 .* (1:length(ax))); extrap = InBounds())
+            cr = itp.x
+            for q in ulp_probes(ax)
+                @test _search_direct_inbounds(cr, q) === _search_direct(cr, q)
+            end
+        end
+    end
+
+    @testset "OneTo grids: end-to-end === the equivalent 1:n UnitRange interpolant" begin
+        axx, axy = Base.OneTo(8), Base.OneTo(12)
+        data = [cos(0.3i) * sin(0.2j) + 0.01i * j for i in 1:8, j in 1:12]
+        i_ot = linear_interp((axx, axy), data; extrap = (InBounds(), InBounds()))
+        i_ur = linear_interp((1:8, 1:12), data; extrap = (InBounds(), InBounds()))
+        for qx in ulp_probes(axx), qy in ulp_probes(axy)
+            @test i_ot((qx, qy)) === i_ur((qx, qy))
+        end
+    end
+
+    @testset "Int-T UnitStep grid: Int and Float queries hit the lo==1 arm safely" begin
+        # `constant_interp(1:n, …)` keeps Tg=Int, so the index-space arm sees
+        # `unsafe_trunc(Int, ::Int)` for an Int query — pin both query eltypes.
+        cri = _to_float(1:6, Int)
+        for q in (1, 3, 6, 1.0, 2.5, prevfloat(4.0), 6.0)
+            @test _search_direct_inbounds(cri, q) === _search_direct(cri, q)
+        end
+    end
+
+    @testset "end-to-end 2D: InBounds === ClampExtrap (generic search) on mixed-lo grids" begin
+        axx, axy = 1:8, 5:12
+        data = [cos(0.3i) * sin(0.2j) + 0.01i * j for i in 1:length(axx), j in 1:length(axy)]
+        inb = linear_interp((axx, axy), data; extrap = (InBounds(), InBounds()))
+        clp = linear_interp((axx, axy), data; extrap = (ClampExtrap(), ClampExtrap()))
+        for qx in ulp_probes(axx), qy in ulp_probes(axy)
+            @test inb((qx, qy)) === clp((qx, qy))
+        end
+    end
+end

--- a/test/test_unitstep_inbounds_locate.jl
+++ b/test/test_unitstep_inbounds_locate.jl
@@ -855,7 +855,8 @@ end
     #      queries is the documented contract of the lean search (one-sided clamp);
     #   2. end-to-end — ClampExtrap does not promote, so its in-domain eval runs the
     #      guarded generic search; `inb(q) === clamped(q)` pins idx/α/kernel to the ULP.
-    using FastInterpolations: InBounds, ClampExtrap, _to_float, _search_direct, _search_direct_inbounds
+    using FastInterpolations: InBounds, ClampExtrap, _to_float, _search_direct,
+        _search_direct_inbounds, _domain_bounds
 
     function ulp_probes(ax)
         lo, hi = Float64(first(ax)), Float64(last(ax))
@@ -897,6 +898,41 @@ end
         for q in (1, 3, 6, 1.0, 2.5, prevfloat(4.0), 6.0)
             @test _search_direct_inbounds(cri, q) === _search_direct(cri, q)
         end
+    end
+
+    @testset "guarded _search_direct family arm === value-space reference (incl. OOB)" begin
+        # Independent reference: the pre-family value-space body with the two-sided
+        # clamp (raw fields carry the same 1.0 the accessors fold to). OOB probes pin
+        # the ExtendExtrap contract: both forms must clamp to the same boundary cell.
+        function ref_direct(x, q)
+            idx = clamp(unsafe_trunc(Int, muladd(q - x.lo, x.inv_h, 1)), 1, x.len - 1)
+            xL = muladd(idx - 1, x.h, x.lo)
+            return idx, xL, xL + x.h
+        end
+        for ax in (1:9, 5:13, Base.OneTo(9))
+            cr = _to_float(ax, Float64)
+            oob = [first(ax) - 2.7, first(ax) - 1.0e9, last(ax) + 0.3, last(ax) + 1.0e9]
+            for q in vcat(ulp_probes(ax), oob)
+                @test _search_direct(cr, q) === ref_direct(cr, q)
+            end
+        end
+    end
+
+    @testset "getindex accessor routing — family node values unchanged" begin
+        for ax in (1:9, 5:13, Base.OneTo(9))
+            cr = _to_float(ax, Float64)
+            @test all(cr[i] === Float64(ax[i]) for i in eachindex(ax))
+        end
+        frac = _to_float(UnitRange(1.5, 4.5), Float64)   # fractional-lo unit step
+        @test all(frac[i] === 1.5 + (i - 1) for i in 1:4)
+    end
+
+    @testset "_domain_bounds _OneTo literal, NoExtrap boundary behavior unchanged" begin
+        @test _domain_bounds(_to_float(Base.OneTo(9), Float64)) === (1.0, 9.0)
+        itp = linear_interp(Base.OneTo(9), collect(1.0:9.0))
+        @test itp(1.0) === 1.0 && itp(9.0) === 9.0
+        @test_throws DomainError itp(prevfloat(1.0))
+        @test_throws DomainError itp(nextfloat(9.0))
     end
 
     @testset "end-to-end 2D: InBounds === ClampExtrap (generic search) on mixed-lo grids" begin

--- a/test/test_unitstep_tag.jl
+++ b/test/test_unitstep_tag.jl
@@ -1,21 +1,25 @@
-# Coverage for the `_UnitStep` axis tag: which inputs earn it, the `Tinv`
+# Coverage for the `_UnitStep`/`_OneTo` axis tags: which inputs earn them, the `Tinv`
 # reciprocal-type contract, the accessor fold invariant, and that persistent
-# interpolants (1D + ND) carry the intended tag. A unit range earns `_UnitStep`;
-# a Float range is non-unit-step (`_Generic` on aarch64, `_WidenedDomain` on the
-# x86_64 TwicePrecision fast path), so its assertions check `!== _UnitStep`.
+# interpolants (1D + ND) carry the intended tag. A unit range earns `_UnitStep`,
+# `Base.OneTo` earns `_OneTo` (statically 1-based); a Float range is non-unit-step
+# (`_Generic` on aarch64, `_WidenedDomain` on the x86_64 TwicePrecision fast path),
+# so its assertions check `!== _UnitStep`.
 
-@testitem "Axis tag — resolver assigns _UnitStep iff AbstractUnitRange" begin
+@testitem "Axis tag — resolver assigns _UnitStep/_OneTo iff AbstractUnitRange/OneTo" begin
     using FastInterpolations:
         _resolve_axis, _cache_axis, _to_float,
-        _CachedRange, _UnitStep, _Generic, _get_h, _get_inv_h, NoBC
+        _CachedRange, _UnitStep, _OneTo, _Generic, _get_h, _get_inv_h, NoBC
 
     tagof(x::_CachedRange) = typeof(x).parameters[3]
 
-    @testset "AbstractUnitRange → _UnitStep (one-shot and persistent agree)" begin
-        for g in (1:100, Base.OneTo(100))
-            @test _resolve_axis(g) isa _CachedRange{Float64, Float64, _UnitStep}
-            @test _cache_axis(g, NoBC(), Float64) isa _CachedRange{Float64, Float64, _UnitStep}
-        end
+    @testset "UnitRange → _UnitStep, Base.OneTo → _OneTo (one-shot and persistent agree)" begin
+        @test _resolve_axis(1:100) isa _CachedRange{Float64, Float64, _UnitStep}
+        @test _cache_axis(1:100, NoBC(), Float64) isa _CachedRange{Float64, Float64, _UnitStep}
+        @test _resolve_axis(Base.OneTo(100)) isa _CachedRange{Float64, Float64, _OneTo}
+        @test _cache_axis(Base.OneTo(100), NoBC(), Float64) isa _CachedRange{Float64, Float64, _OneTo}
+        # `_OneTo` carries the same geometry as the equivalent `1:n` `_UnitStep` axis.
+        @test _resolve_axis(Base.OneTo(100)).lo === 1.0
+        @test collect(_resolve_axis(Base.OneTo(100))) == collect(_resolve_axis(1:100))
     end
 
     @testset "Non-unit-range (incl. step-1 StepRange) → not _UnitStep" begin
@@ -43,7 +47,9 @@
         @test cr32.inv_h === 1.0f0
     end
 
-    @testset "Accessors fold to one(Tinv) on _UnitStep, return the field otherwise" begin
+    @testset "Accessors fold to one(Tinv) on _UnitStep/_OneTo, return the field otherwise" begin
+        o = _to_float(Base.OneTo(4), Float64) # _OneTo — same folds as _UnitStep
+        @test _get_h(o) === 1.0 && _get_inv_h(o) === 1.0
         u = _to_float(1:4, Float64)           # _UnitStep — h ≡ inv_h ≡ 1
         @test _get_h(u) === 1.0 && _get_inv_h(u) === 1.0
         @test _get_h(u, 1) === 1.0 && _get_inv_h(u, 1) === 1.0                  # 2-arg delegates
@@ -57,7 +63,7 @@
 end
 
 @testitem "Axis tag — survives into persistent interpolants (1D + ND)" begin
-    using FastInterpolations: _CachedRange, _UnitStep, _Generic
+    using FastInterpolations: _CachedRange, _UnitStep, _OneTo, _Generic
     tagof(x::_CachedRange) = typeof(x).parameters[3]
 
     y = collect(Float64, 1:60) .^ 2
@@ -86,6 +92,47 @@ end
         @test tagof(itp.grids[1]) === _UnitStep
         @test tagof(itp.grids[2]) !== _UnitStep        # Float axis: _Generic / _WidenedDomain (x86)
         itp2 = linear_interp((1:60, Base.OneTo(60)), data)
-        @test all(tagof.(itp2.grids) .=== _UnitStep)
+        @test tagof(itp2.grids[1]) === _UnitStep
+        @test tagof(itp2.grids[2]) === _OneTo
+    end
+end
+
+@testitem "_OneTo tag — slice demotes to _UnitStep, axes() construction, eltype convert" begin
+    using FastInterpolations: _to_float, _CachedRange, _AbstractUnitStep, _UnitStep, _OneTo
+    tagof(x::_CachedRange) = typeof(x).parameters[3]
+
+    o = _to_float(Base.OneTo(8), Float64)
+
+    @testset "unit-step tag family + first() fold literal" begin
+        @test _UnitStep <: _AbstractUnitStep
+        @test _OneTo <: _AbstractUnitStep
+        @test first(o) === 1.0                          # literal one(T), not the field
+        @test first(_to_float(Base.OneTo(8), Float32)) === 1.0f0
+    end
+
+    @testset "slice demotes (lo≡1 invariant would be a lie on sub-ranges)" begin
+        s = o[2:5]
+        @test tagof(s) === _UnitStep           # never _OneTo, even when 1-based:
+        @test s.lo === 2.0 && s.hi === 5.0 && length(s) == 4
+        s1 = o[1:5]                            # a 1-based slice demotes too (type can't
+        @test tagof(s1) === _UnitStep          # depend on the runtime slice start)
+        @test s1.lo === 1.0
+        @test tagof(view(o, 3:6)) === _UnitStep
+        e = o[2:1]                             # empty slice
+        @test tagof(e) === _UnitStep && length(e) == 0
+    end
+
+    @testset "eltype convert preserves _OneTo (lo ≡ 1 survives T conversion)" begin
+        o32 = _to_float(o, Float32)
+        @test o32 isa _CachedRange{Float32, Float32, _OneTo}
+        @test o32.lo === 1.0f0
+    end
+
+    @testset "axes(data) construction — the idiomatic image route gets _OneTo" begin
+        data = [0.1i + 0.3j for i in 1:8, j in 1:6]
+        itp = linear_interp(axes(data), data)
+        @test tagof(itp.grids[1]) === _OneTo
+        @test tagof(itp.grids[2]) === _OneTo
+        @test itp((3.5, 2.25)) === linear_interp((1:8, 1:6), data)((3.5, 2.25))
     end
 end


### PR DESCRIPTION
## Summary

**Scope: `UnitRange` / `Base.OneTo` grids only — every other grid type is untouched (1.00× controls below).**

A unit-step axis already folds `×h`/`×inv_h` (step ≡ 1 in the type), but `lo` is a runtime field, so the search still pays a float chain `(xq−lo)+1 → trunc → sitofp(idx−1)+lo` sitting ahead of every cell load — measured to be the *entire* remaining public-vs-hand-written gap. This PR adds an **index-space arm** (`trunc(xq)`, `xL = T(idx)`), provably **bit-identical** for 1-based grids (in-domain `xq ≥ 1` makes `xq − 1` exact), selected by `first(x) == one(T)`:

- `_UnitStep` (`1:n`): loop-invariant, perfectly-predicted runtime branch — free on Float64, ~0.1–0.2 ns of code-size cost on wide colorant carriers.
- **new `_OneTo` tag** (`Base.OneTo`, i.e. `linear_interp(axes(A), A)`): `Base.first` returns the literal `one(T)`, the test constant-folds, and the search compiles **branch-free** — recovering that wide-carrier margin (RGB 5.70 → 5.48–5.60).

## Benchmark

master (`895a5635d`) vs PR, looped scalar, ns/query, 16²/16³ grids, M1. Drift anchors: trivial-loop control **0.112 / 0.112**, 4 of 6 Interpolations.jl-primitive anchors **bit-identical**.

| 2D · `InBounds` | master | PR | speedup |
|---|--:|--:|--:|
| Float64 · `1:n` / `axes(A)` | 1.75 | 1.34 | **1.30×** |
| RGB{N0f8} · `1:n` | 6.90 | 5.70 | 1.21× |
| — float range `range(1.0, n, n)` | 1.92 | 1.92 | 1.00× (control) |
| — vector grid | 4.98 | 5.00 | 1.00× (control) |

Across the full matrix ({Float64, Gray, RGB, RGBA} × {`InBounds`, `NoExtrap`, `Clamp`}): **1.11–1.30×**. The outlier is 3D `Gray{N0f8}` `InBounds`: 8.52 → 5.75 (**1.48×**) — the 3-axis locate chain was causing register spills against the 8-corner blend — which flips FI vs the IP primitive there from −29% behind to **+13% ahead**. FI `InBounds` now beats the IP primitive **1.37–1.54×** on every 2D carrier.