### PR TITLE
perf(search): InBounds endpoint contracts with a unit-step no-cap arm

### DIFF
--- a/docs/src/extrapolation.md
+++ b/docs/src/extrapolation.md
@@ -44,6 +44,12 @@ AbstractExtrap
 └── InBounds         # skip domain checks (advanced/internal)
 ```
 
+`InBounds` additionally accepts endpoint keywords that narrow the promised interval:
+`InBounds(last = :exclusive)` promises `first(x) ≤ xq < last(x)` and unlocks a leaner
+direct search on unit-step range grids (`1:n`, `Base.OneTo`, offset unit ranges). Like
+`Base.@inbounds`, violating the promise is undefined behavior — see the
+[`InBounds`](@ref) docstring for the full contract table.
+
 ## Examples
 
 ```@example extrap
@@ -192,6 +198,7 @@ vline!([x[1], x[end]], color=:gray, linestyle=:dot, alpha=0.5, label=nothing)
 | `WrapExtrap()` | Wraps coordinates (no smoothness) | Cyclic data (see [`PeriodicBC`](interpolation/cubic.md) for C² continuity) |
 | `FillExtrap(v)` | Returns constant `v` outside domain | Masking (`NaN`), zero-padding, sentinel values |
 | `InBounds()` | Skip domain checks | Pre-validated queries, batch inner loops |
+| `InBounds(last = :exclusive)` | Skip checks + promise `xq < last(x)` | Fastest unit-step range search for strictly-interior queries |
 
 ## See Also
 

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -24,7 +24,7 @@
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         xi::Tq,
-        ::InBounds,
+        e::InBounds,
         side::AbstractSide,
         op::AbstractEvalOp,
         searcher::S
@@ -41,7 +41,7 @@
     # Reached only in-domain (genuine InBounds; NoExtrap post-throw; Clamp/Fill/Extend after
     # their IN_DOMAIN check — ExtendExtrap is routed to Clamp above), so the lean InBounds
     # search is safe here. bit-identical to the standard search for an in-bounds query.
-    idx, idx_R, xL, xR = search_interval(searcher, x, xi, InBounds())
+    idx, idx_R, xL, xR = search_interval(searcher, x, xi, e)
     dL = xi - xL
     @inbounds return _constant_kernel(op, y[idx], y[idx_R], _get_h(x, idx, xL, xR), dL, side)
 end

--- a/src/core/eval_ops.jl
+++ b/src/core/eval_ops.jl
@@ -335,6 +335,7 @@ struct WrapExtrap <: AbstractExtrap end
 
 """
     InBounds <: AbstractExtrap
+    InBounds(; first = :inclusive, last = :inclusive)
 
 Caller guarantees all queries are within the interpolation domain.
 Skips domain validation for maximum performance.
@@ -343,13 +344,55 @@ Used internally by vector loops after batch `_check_domain` validation
 (NoExtrap → InBounds conversion), and available to advanced users who
 have pre-validated their query points.
 
+The endpoint keywords (each `:inclusive` or `:exclusive`) narrow the promised
+interval at the type level (`InBounds{First, Last}`):
+
+| extrap                                           | caller promises              |
+|:-------------------------------------------------|:-----------------------------|
+| `InBounds()`                                     | `first(x) ≤ xq ≤ last(x)`    |
+| `InBounds(last = :exclusive)`                    | `first(x) ≤ xq < last(x)`    |
+| `InBounds(first = :exclusive)`                   | `first(x) < xq ≤ last(x)`    |
+| `InBounds(first = :exclusive, last = :exclusive)`| `first(x) < xq < last(x)`    |
+
+Like `Base.@inbounds`, violating the promise is undefined for the optimized
+paths: the result may be a wrong cell, an out-of-bounds read, or a
+`BoundsError`. A stricter promise can only be exploited, never required —
+paths without a dedicated lean arm safely treat it as the closed contract.
+Currently `last = :exclusive` selects a no-top-cap direct search on unit-step
+range axes; `first` is accepted for API completeness and future use.
+
 # Example
 ```julia
 # Skip domain check when you know queries are in-domain
 linear_interp(x, y, xq; extrap=InBounds())
+
+# Queries generated in [first(x), last(x)) — never touch the right endpoint
+linear_interp(x, y, xq; extrap=InBounds(last = :exclusive))
 ```
 """
-struct InBounds <: AbstractExtrap end
+struct InBounds{First, Last} <: AbstractExtrap
+    function InBounds{First, Last}() where {First, Last}
+        First isa Symbol || error("InBounds type parameter First must be a Symbol")
+        Last isa Symbol || error("InBounds type parameter Last must be a Symbol")
+        First in (:inclusive, :exclusive) ||
+            error("InBounds type parameter First must be :inclusive or :exclusive")
+        Last in (:inclusive, :exclusive) ||
+            error("InBounds type parameter Last must be :inclusive or :exclusive")
+        return new{First, Last}()
+    end
+end
+
+# Keyword constructor with validation — mirrors `PeriodicBC(; endpoint=...)`. The
+# zero-arg `InBounds()` call constant-folds to the closed singleton, so the ~15
+# internal promotion sites (`_check_domain` returns, Clamp/Fill in-domain
+# delegations) stay zero-cost.
+function InBounds(; first::Symbol = :inclusive, last::Symbol = :inclusive)
+    first in (:inclusive, :exclusive) ||
+        throw(ArgumentError("first must be :inclusive or :exclusive, got :$first"))
+    last in (:inclusive, :exclusive) ||
+        throw(ArgumentError("last must be :inclusive or :exclusive, got :$last"))
+    return InBounds{first, last}()
+end
 
 # ========================================
 # Typed Side Selection Tags (Constant Interpolation)

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -752,8 +752,8 @@ end
 # 5-arg form unchanged. Any ND `_locate_cell` that threads its `extraps` into the search
 # picks this up; 5-arg callers are unaffected. `hint` is always a concrete `Ref{Int}` here
 # (the 6-arg `_search_all_intervals` is reached only from persistent `_locate_cell`).
-@inline function _search_axis_adaptive(q, grid::_CachedRange, ::AbstractSearchPolicy, hint::Base.RefValue{Int}, _mono, ::InBounds)
-    idx, xL, xR = _search_direct_inbounds(grid, q)
+@inline function _search_axis_adaptive(q, grid::_CachedRange, ::AbstractSearchPolicy, hint::Base.RefValue{Int}, _mono, e::InBounds)
+    idx, xL, xR = _search_direct_inbounds(grid, q, e)
     hint[] = idx
     return idx, idx + 1, xL, xR
 end
@@ -861,8 +861,8 @@ end
 # still writes the hint (symmetry). EVERY other `(q, grid, extrap)` — GridIdx queries,
 # vector grids, and periodic axes (always WrapExtrap, never InBounds; the `_ExclusivePeriodicAxis`
 # seam wrap in `search_interval` is untouched) — delegates to the 4-arg form verbatim.
-@inline function _search_axis_oneshot_hint(q::Real, grid::_CachedRange, search, hint::Base.RefValue{Int}, ::InBounds)
-    idx, xL, xR = _search_direct_inbounds(grid, q)
+@inline function _search_axis_oneshot_hint(q::Real, grid::_CachedRange, search, hint::Base.RefValue{Int}, e::InBounds)
+    idx, xL, xR = _search_direct_inbounds(grid, q, e)
     hint[] = idx
     return idx, idx + 1, xL, xR
 end
@@ -974,8 +974,8 @@ end
 # to the 4-arg `_search_axis_stencil`: crucially `_ExclusivePeriodicAxis` (always
 # WrapExtrap, never InBounds, and `<: AbstractVector` not `_CachedRange`) keeps its
 # `search_interval` seam wrap `(n, 1, …)` untouched, as do GridIdx and vector grids.
-@inline function _search_axis_stencil(grid::_CachedRange, q::Real, search, hint::Base.RefValue{Int}, ::InBounds)
-    idx, xL, xR = _search_direct_inbounds(grid, q)
+@inline function _search_axis_stencil(grid::_CachedRange, q::Real, search, hint::Base.RefValue{Int}, e::InBounds)
+    idx, xL, xR = _search_direct_inbounds(grid, q, e)
     hint[] = idx
     return idx, idx + 1, xL, xR
 end

--- a/src/core/search.jl
+++ b/src/core/search.jl
@@ -618,6 +618,40 @@ end
 @inline _search_direct_inbounds(x::_CachedRange{T, Tinv, _WidenedDomain}, xq::Real) where {T, Tinv} =
     _search_direct(x, xq)
 
+# ── Endpoint-aware (3-arg) family: `_search_direct_inbounds(x, xq, e::InBounds)` ──
+# Default (closed) contract → the 2-arg helper above verbatim: top-cell cap kept,
+# `_WidenedDomain` keeps its guarded fallback through the same 2-arg dispatch. Range
+# call sites that hold the actual `e::InBounds` thread it here so a stricter endpoint
+# contract can select a leaner arm; everything else is bit-identical to the 2-arg form.
+@inline _search_direct_inbounds(x::_CachedRange, xq::Real, ::InBounds) =
+    _search_direct_inbounds(x, xq)
+
+# `last = :exclusive` + unit-step: NO top-cell cap. The caller promises
+# `lo ≤ xq < last`, and the unit-step index arithmetic is exact (`xq − lo` is a
+# same-scale subtraction of a value < len and `+1` stays representable — the same
+# chain as the 2-arg method's bit-identity argument), so `trunc(·) ≤ len−1` is
+# guaranteed: the `min(·, len−1)` cap is provably dead, dropping the remaining `len`
+# load + `cmp/csel` ahead of the cell loads. A violated promise (`xq == last`)
+# indexes the phantom cell `len` — undefined, exactly like an `InBounds()` promise
+# violated below `lo`. Float-step ranges do NOT get a no-cap arm: their
+# `muladd(xq−lo, inv_h, 1)` can overshoot `len` by rounding even for a valid
+# strictly-interior query, so the cap doubles as a rounding guard there — they stay
+# on the closed delegate above. `_WidenedDomain` is not `<: _AbstractUnitStep`, so
+# its 1-ULP-wider acceptance bracket can never reach this arm.
+@inline function _search_direct_inbounds(
+        x::_CachedRange{T, Tinv, Tag}, xq::Real, ::InBounds{First, :exclusive}
+    ) where {T, Tinv, First, Tag <: _AbstractUnitStep}
+    if first(x) == one(T)
+        idx = unsafe_trunc(Int, _extract_primal(xq))
+        xL = T(idx)
+        return idx, xL, xL + one(T)
+    end
+    lo = first(x)
+    idx = unsafe_trunc(Int, _extract_primal(xq - lo + one(T)))
+    xL = lo + (idx - 1)
+    return idx, xL, xL + one(T)
+end
+
 
 # ----------------------------------------
 # Promote-then-compare ordering helpers
@@ -1000,15 +1034,20 @@ end
 # to the standard search for an in-bounds query and both writing the hint (symmetry with
 # `_search_direct!`; `NoHint` no-ops via `_write_hint!`):
 #   • normalized `_CachedRange` → `_search_direct_inbounds` (one-sided clamp; the lower
-#     `max(·,1)` is dead in-domain).
+#     `max(·,1)` is dead in-domain). The extrap instance is threaded through so an
+#     endpoint contract (`InBounds{_, :exclusive}` on a unit-step axis) selects the
+#     no-top-cap arm; the closed default is bit-identical to before.
 #   • non-uniform vector grid   → `_search_binary_inbounds` (drops the binary search's
-#     `first`/`last` boundary guards, which are always-false branches in-domain).
-# The genuine `::InBounds` eval cores pass `InBounds()` here. GridIdx and any non-InBounds
-# extrap (e.g. ExtendExtrap, which may be OOB and needs the two-sided clamp) delegate to the
-# standard 4-arg search. `_CachedRange` is the more-specific overload, so it wins over the
+#     `first`/`last` boundary guards, which are always-false branches in-domain; the
+#     binary loop needs no top-cell cap, so endpoint contracts have nothing to elide —
+#     the instance is intentionally NOT threaded).
+# The genuine `::InBounds` eval cores thread their received extrap here (promotion sites
+# pass the closed `InBounds()` they proved). GridIdx and any non-InBounds extrap (e.g.
+# ExtendExtrap, which may be OOB and needs the two-sided clamp) delegate to the standard
+# 4-arg search. `_CachedRange` is the more-specific overload, so it wins over the
 # `AbstractVector` one.
-@inline function search_interval(s::Searcher, x::_CachedRange, xq::Real, ::InBounds)
-    idx, xL, xR = _search_direct_inbounds(x, xq)
+@inline function search_interval(s::Searcher, x::_CachedRange, xq::Real, e::InBounds)
+    idx, xL, xR = _search_direct_inbounds(x, xq, e)
     _write_hint!(s.hint, idx)
     return idx, idx + 1, xL, xR
 end

--- a/src/cubic/cubic_eval.jl
+++ b/src/cubic/cubic_eval.jl
@@ -30,12 +30,12 @@
         y::AbstractVector{Tv},
         z::AbstractVector,
         xq::Tq,
-        ::InBounds,
+        e::InBounds,
         op::O,
         searcher::S
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq = _resolve_grididx(xq, x)
-    idx, idx_R, xL, xR = search_interval(searcher, x, xq, InBounds())
+    idx, idx_R, xL, xR = search_interval(searcher, x, xq, e)
     dL = xq - xL
     dR = xR - xq
     h = _get_h(x, idx)

--- a/src/hermite/hermite_eval.jl
+++ b/src/hermite/hermite_eval.jl
@@ -19,12 +19,12 @@
         y::AbstractVector{Tv},
         dy::AbstractVector,
         xq::Tq,
-        ::InBounds,
+        e::InBounds,
         op::O,
         searcher::S
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq = _resolve_grididx(xq, x)
-    idx, idx_R, xL, _ = search_interval(searcher, x, xq, InBounds())
+    idx, idx_R, xL, _ = search_interval(searcher, x, xq, e)
     dL = xq - xL
     h = _get_h(x, idx)
     inv_h = _get_inv_h(x, idx)
@@ -136,12 +136,12 @@ end
         y::AbstractVector{Tv},
         sm::AbstractSlopeMethod,
         xq::Tq,
-        ::InBounds,
+        e::InBounds,
         op::O,
         searcher::S
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq = _resolve_grididx(xq, x)
-    idx, idx_R, xL, _ = search_interval(searcher, x, xq, InBounds())
+    idx, idx_R, xL, _ = search_interval(searcher, x, xq, e)
     n = _data_length(x)
     dyL = _local_slope(sm, x, y, idx, n)
     dyR = _local_slope(sm, x, y, idx_R, n)

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -218,12 +218,12 @@ For ForwardDiff compatibility, `xq` can be a Dual type:
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         xq::Tq,
-        ::InBounds,
+        e::InBounds,
         op::O,
         searcher::S
     ) where {Tg, Tv, Tq, O <: AbstractEvalOp, S <: Searcher}
     xq = _resolve_grididx(xq, x)
-    idx, idx_R, xL, xR = search_interval(searcher, x, xq, InBounds())
+    idx, idx_R, xL, xR = search_interval(searcher, x, xq, e)
     # Independent computation of `α` and `inv_h`. The kernel uses only one
     # (EvalValue → α, `DerivOp(1)` → inv_h, `DerivOp(2)` → neither), so the
     # unused branch's fdiv is dead-code-eliminated by LLVM. `_alpha_of`

--- a/src/quadratic/quadratic_oneshot.jl
+++ b/src/quadratic/quadratic_oneshot.jl
@@ -30,12 +30,12 @@
         a::AbstractVector{Tc},
         d::AbstractVector{Tc},
         xq::Tq,
-        ::InBounds,
+        e::InBounds,
         op::AbstractEvalOp,
         searcher::S
     ) where {Tg, Tv, Tc, Tq, S <: Searcher}
     xq = _resolve_grididx(xq, x)
-    idx, _, xL, _ = search_interval(searcher, x, xq, InBounds())
+    idx, _, xL, _ = search_interval(searcher, x, xq, e)
     dt = xq - xL  # Can be Dual for AD
     @inbounds return _quadratic_kernel(op, a[idx], d[idx], y[idx], dt)
 end

--- a/test/test_inbounds_endpoints.jl
+++ b/test/test_inbounds_endpoints.jl
@@ -1,0 +1,170 @@
+# Endpoint-contract tests for the parameterized `InBounds{First, Last}` extrap.
+#
+# `InBounds(last = :exclusive)` promises `first(x) ≤ xq < last(x)`; unit-step range
+# axes then drop the direct search's top-cell cap (`min(·, len−1)` — see
+# `_search_direct_inbounds(x, xq, ::InBounds{First, :exclusive})`). Pinned here:
+#   1. constructor surface: defaults, kwarg forms, validation errors;
+#   2. closed `InBounds()` semantics are UNCHANGED (incl. `xq == last(x)`);
+#   3. exclusive-last is BIT-IDENTICAL (`===`) to closed for strictly-interior
+#      queries on unit-step grids — 1D scalar/batch across families, 2D
+#      persistent + one-shot, mixed per-axis contracts;
+#   4. GridIdx keeps its index short-circuit under an endpoint contract;
+#   5. float-step ranges have NO no-cap arm (their cap doubles as a rounding
+#      guard) — exclusive-last delegates to the capped closed search there, so
+#      it stays bit-identical even at `xq == last(x)`.
+# `xq == last(x)` under exclusive-last on a UNIT-STEP axis is a violated promise
+# (undefined, like `Base.@inbounds`) and is deliberately never exercised.
+
+@testitem "InBounds endpoint constructors and validation" begin
+    @test InBounds() isa InBounds{:inclusive, :inclusive}
+    @test InBounds(last = :exclusive) isa InBounds{:inclusive, :exclusive}
+    @test InBounds(first = :exclusive) isa InBounds{:exclusive, :inclusive}
+    @test InBounds(first = :exclusive, last = :exclusive) isa InBounds{:exclusive, :exclusive}
+
+    # Singleton identity — internal promotion sites compare `=== InBounds()`.
+    @test InBounds() === InBounds{:inclusive, :inclusive}()
+
+    @test_throws ArgumentError InBounds(first = :closed)
+    @test_throws ArgumentError InBounds(last = :open)
+    # Inner constructor rejects raw bad parameters (Symbol-typed and otherwise).
+    @test_throws ErrorException InBounds{:bad, :inclusive}()
+    @test_throws ErrorException InBounds{:inclusive, 1}()
+end
+
+@testitem "1D exclusive-last === closed on unit-step grids (all families)" begin
+    x1 = 1:16                     # _UnitStep with lo == 1 → index-space arm
+    x2 = 3:18                     # _UnitStep with offset lo
+    excl = InBounds(last = :exclusive)
+
+    # Strictly-interior queries incl. the sharpest no-cap edge prevfloat(last).
+    qs(x) = [
+        float(first(x)), first(x) + 0.25, 0.5 * (first(x) + last(x)),
+        last(x) - 1.5, prevfloat(float(last(x))),
+    ]
+
+    for x in (x1, x2)
+        y = [sin(0.4i) + 0.01i for i in 1:length(x)]
+        for f in (linear_interp, cubic_interp, quadratic_interp, constant_interp, pchip_interp)
+            itp_c = f(x, y; extrap = InBounds())
+            itp_e = f(x, y; extrap = excl)
+            for q in qs(x)
+                @test itp_e(q) === itp_c(q)
+            end
+            # Batch: `_check_domain` passes a user InBounds through untouched,
+            # so the per-element search sees the exclusive contract.
+            @test itp_e(qs(x)) == itp_c(qs(x))
+            # One-shot scalar form.
+            @test f(x, y, first(x) + 0.75; extrap = excl) ===
+                f(x, y, first(x) + 0.75; extrap = InBounds())
+        end
+    end
+end
+
+@testitem "closed InBounds endpoint behavior unchanged (=== NoExtrap incl. xq == last)" begin
+    x = 1:12
+    y = [sin(0.5i) for i in 1:12]
+    for f in (linear_interp, cubic_interp)
+        itp_ib = f(x, y; extrap = InBounds())
+        itp_ne = f(x, y)                       # NoExtrap reference
+        for q in (1.0, 4.3, 11.999, 12.0)      # incl. the closed right endpoint
+            @test itp_ib(q) === itp_ne(q)
+        end
+    end
+end
+
+@testitem "2D exclusive-last === closed (persistent + one-shot + batch + mixed axes)" begin
+    axx, axy = 1:7, 2:9
+    data = [sin(0.3i) + cos(0.2j) + 0.01i * j for i in 1:length(axx), j in 1:length(axy)]
+
+    closed = (InBounds(), InBounds())
+    excl = (InBounds(last = :exclusive), InBounds(last = :exclusive))
+    mixed = (InBounds(last = :exclusive), InBounds())
+
+    qs = ((1.0, 2.0), (1.25, 4.75), (3.4, 6.2), (6.999, 8.5), (prevfloat(7.0), prevfloat(9.0)))
+
+    @testset "persistent: linear + cubic" begin
+        for f in (linear_interp, cubic_interp)
+            itp_c = f((axx, axy), data; extrap = closed)
+            itp_e = f((axx, axy), data; extrap = excl)
+            for q in qs
+                @test itp_e(q) === itp_c(q)
+            end
+        end
+    end
+
+    @testset "mixed per-axis: exclusive x-axis, closed y-axis may touch its endpoint" begin
+        itp_c = linear_interp((axx, axy), data; extrap = closed)
+        itp_m = linear_interp((axx, axy), data; extrap = mixed)
+        for q in ((1.5, 9.0), (prevfloat(7.0), 9.0), (2.2, 5.5))
+            @test itp_m(q) === itp_c(q)
+        end
+    end
+
+    @testset "one-shot scalar (all families) + batch (linear!)" begin
+        for f in (linear_interp, cubic_interp, quadratic_interp, constant_interp)
+            for q in qs
+                @test f((axx, axy), data, q; extrap = excl) ===
+                    f((axx, axy), data, q; extrap = closed)
+            end
+        end
+        qxs = Float64[q[1] for q in qs]
+        qys = Float64[q[2] for q in qs]
+        o_e = similar(qxs)
+        o_c = similar(qxs)
+        linear_interp!(o_e, (axx, axy), data, (qxs, qys); extrap = excl)
+        linear_interp!(o_c, (axx, axy), data, (qxs, qys); extrap = closed)
+        @test o_e == o_c
+    end
+end
+
+@testitem "GridIdx keeps the index short-circuit under an exclusive contract" begin
+    using FastInterpolations: GridIdx
+
+    x = 1:10
+    y = collect(1.0:10.0)
+    itp_c = linear_interp(x, y; extrap = InBounds())
+    itp_e = linear_interp(x, y; extrap = InBounds(last = :exclusive))
+    # GridIdx is in-domain by construction and coordinate-free — the endpoint
+    # contract must not reroute it into the coordinate lean. Includes the last
+    # node: the short-circuit never runs the no-cap coordinate arithmetic.
+    for k in (1, 3, 10)
+        @test itp_e(GridIdx(k)) === itp_c(GridIdx(k))
+        @test itp_e(GridIdx(k)) === y[k]
+    end
+
+    axx, axy = 1:7, 2:9
+    data = [0.1i + 0.3j + 0.01i * j for i in 1:length(axx), j in 1:length(axy)]
+    excl = (InBounds(last = :exclusive), InBounds(last = :exclusive))
+    closed = (InBounds(), InBounds())
+    for q in ((GridIdx(2), GridIdx(3)), (GridIdx(7), GridIdx(8)))
+        @test linear_interp((axx, axy), data, q; extrap = excl) ===
+            linear_interp((axx, axy), data, q; extrap = closed)
+    end
+end
+
+@testitem "float-step ranges: exclusive-last delegates to the capped closed search" begin
+    x = range(0.0, 1.0; length = 17)           # float-step _CachedRange, NOT unit-step
+    y = sin.(x)
+    itp_c = linear_interp(x, y; extrap = InBounds())
+    itp_e = linear_interp(x, y; extrap = InBounds(last = :exclusive))
+    # Same (capped) code path ⇒ bit-identical for every in-domain query, INCLUDING
+    # xq == last(x). This pins the safety property that float-step ranges never get
+    # a no-cap arm: their muladd index arithmetic can overshoot len by rounding, so
+    # the cap is a rounding guard there, not just endpoint semantics.
+    for q in (0.0, 0.123, 0.5, prevfloat(1.0), 1.0)
+        @test itp_e(q) === itp_c(q)
+    end
+end
+
+@testitem "AD: Dual query under exclusive-last === closed (value + derivative)" begin
+    using ForwardDiff
+
+    x = 1:16
+    y = [sin(0.4i) for i in 1:16]
+    itp_c = cubic_interp(x, y; extrap = InBounds())
+    itp_e = cubic_interp(x, y; extrap = InBounds(last = :exclusive))
+    for q in (1.5, 7.25, prevfloat(16.0))
+        @test itp_e(q) === itp_c(q)
+        @test ForwardDiff.derivative(itp_e, q) === ForwardDiff.derivative(itp_c, q)
+    end
+end


### PR DESCRIPTION
## Summary

`InBounds` becomes `InBounds{First, Last}` with a validated kwarg constructor — the caller can now narrow the promised interval at the type level:

```julia
InBounds()   # Default: first(x) ≤ xq ≤ last(x)  
InBounds(first= :inclusvie, last = :inclusive)  # Same as Default

InBounds(last = :exclusive)      # first(x) ≤ xq < last(x) 
```

Under `last = :exclusive`, the unit-step direct search drops its top-cell cap `min(·, len−1)` — the last `len` load + `cmp/csel` ahead of the cell loads. Safe **only** there: unit-step index arithmetic is exact, so `trunc ≤ len−1` follows from the promise. Violating the promise is undefined, like `Base.@inbounds`.

**Opt-in; unit-step range grids only (`1:n`, `Base.OneTo`, offset `UnitRange`). Everything else is untouched and bit-identical** — float-step ranges keep the cap (it doubles as a rounding guard there; pinned by test), binary search has no cap to drop, `_WidenedDomain`/GridIdx/promotion sites unchanged.

## Benchmark

Same-process A/B (extrap instance is the only difference), looped-scalar public path, ns/query, M1, n=16:

| | `InBounds()` | `last = :exclusive` | speed-up |
|---|--:|--:|--:|
| 1D Float64 | 0.633 | 0.593 | **+6.8%** |
| 2D Float64 | 1.351 | 1.282 | **+5.4%** |
| 2D Gray{N0f8} | 2.315 | 2.261 | +2.4% |
| 2D RGB{N0f8} | 5.697 | 5.527 | +3.1% |
| 2D RGBA{N0f8} | 7.324 | 7.009 | +4.5% |

Codegen guards: closed arm keeps `smin`, exclusive arm has none; the kwarg ctor constant-folds (internal `InBounds()` promotion sites stay zero-cost); 0 alloc.

## Safety / Tests

- Received `e::InBounds` threaded through all range InBounds call sites (1D search, 3 ND arms, 6 family cores); domain-check promotions keep returning closed `InBounds()` (a check proves only `[first, last]`).
- Compat audit clean: no `typeof === InBounds` checks, no `::InBounds` fields, no printed-name tests; `=== InBounds()` singleton identity preserved.
- Bit-identity pinned on interior ULP edges (1D + 2D, `1:n` + offset grids), Dual queries, mixed per-axis contracts — `test_inbounds_endpoints.jl`; affected suites + Aqua/type-stability/allocation green.

## Follow-ups (not in this PR)

- Batch `NoExtrap` promotion → exclusive-last when the validator proves `qmax < last(x)`: hands this win to default-extrap users on unit-step grids.
- `first = :exclusive` accepted for API completeness; no consumer yet.