### PR TITLE
perf(search): faster NoExtrap batches on unit-step grids

### DIFF
--- a/src/core/eval_ops.jl
+++ b/src/core/eval_ops.jl
@@ -394,6 +394,15 @@ function InBounds(; first::Symbol = :inclusive, last::Symbol = :inclusive)
     return InBounds{first, last}()
 end
 
+# Kwarg-form show (`GridIdx`/`DerivOp` precedent): round-trips as `InBounds()` /
+# `InBounds(last = :exclusive)` instead of raw type parameters.
+function Base.show(io::IO, ::InBounds{First, Last}) where {First, Last}
+    parts = String[]
+    First === :inclusive || push!(parts, "first = :$First")
+    Last === :inclusive || push!(parts, "last = :$Last")
+    return print(io, "InBounds(", join(parts, ", "), ")")
+end
+
 # ========================================
 # Typed Side Selection Tags (Constant Interpolation)
 # ========================================

--- a/src/core/query_protocol.jl
+++ b/src/core/query_protocol.jl
@@ -148,13 +148,46 @@ end
 # `InBounds()` for that axis, else the original extrap; empty batch → `extraps` unchanged. The
 # `<:Real` bound is load-bearing: batch `_check_domain` is only defined for `AbstractVector{<:Real}`,
 # so a non-Real / duck-typed SoA batch falls to the generic method below (validate, no promotion).
+#
+# Exclusive-last promotions are DEMOTED to closed here (`_check_axis_batch_closed`):
+# unions nested in a tuple type don't union-split, so per-axis exclusive would send an
+# abstract extrap tuple into the batch locate loop (measured ~10× on 2D SoA). The
+# strict upgrade happens tuple-level on the all-NoExtrap lane below.
 @inline function _validate_nd_domain(
         grids::NTuple{N, AbstractVector},
         queries::Tuple{AbstractVector{<:Real}, Vararg{AbstractVector{<:Real}}},
         extraps::Tuple{Vararg{AbstractExtrap, N}}
     ) where {N}
     isempty(first(queries)) && return extraps
-    return map(_check_domain, grids, queries, extraps)
+    return map(_check_axis_batch_closed, grids, queries, extraps)
+end
+
+# Per-axis SoA check with concrete return shapes: validation/throw from the batch
+# `_check_domain` verbatim; only the exclusive upgrade collapses back to closed.
+@inline _check_axis_batch_closed(g, q, e::AbstractExtrap) = _check_domain(g, q, e)
+@inline function _check_axis_batch_closed(g, q, e::NoExtrap)
+    _check_domain(g, q, e)      # throws on OOB; promotion result intentionally discarded
+    return InBounds()
+end
+@inline function _check_axis_batch_closed(g, q, e::Union{ClampExtrap, FillExtrap, WrapExtrap})
+    r = _check_domain(g, q, e)
+    return r isa InBounds ? InBounds() : e
+end
+
+# All-unit-step, all-NoExtrap SoA lane: per-axis 3-outcome checks (validate/throw),
+# then ALL-OR-NOTHING — every axis exclusive → all-exclusive tuple, else all-closed.
+# The transient per-axis unions are consumed by one tuple type test and never reach
+# the locate loop; mixed-grid / mixed-extrap tuples take the demoting generic lane.
+@inline function _validate_nd_domain(
+        grids::NTuple{N, _CachedRange{<:Any, <:Any, <:_AbstractUnitStep}},
+        queries::Tuple{AbstractVector{<:Real}, Vararg{AbstractVector{<:Real}}},
+        extraps::NTuple{N, NoExtrap}
+    ) where {N}
+    isempty(first(queries)) && return extraps
+    effs = map(_check_domain, grids, queries, extraps)
+    return effs isa NTuple{N, InBounds{:inclusive, :exclusive}} ?
+        ntuple(_ -> InBounds(last = :exclusive), Val(N)) :
+        ntuple(_ -> InBounds(), Val(N))
 end
 
 # Generic (AoS, etc.): per-query per-axis NoExtrap check (min/max promotion deferred), so return

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -633,14 +633,16 @@ end
 # Unit-step axis: fused 3-outcome check — throw (OOB), `InBounds(last = :exclusive)`
 # (`maximum < last` proven → the batch loop rides the no-cap search), else closed.
 # Generic axes keep the closed-only method above (no Union; nothing to win there).
+# Extrema classify on primals: a Dual max whose VALUE == `last` must not tie-break
+# on its partial into a false exclusive promotion (→ no-cap OOB read).
 # Only the throws are `@boundscheck`-elidable; the promotion is build-mode independent.
 @inline function _check_domain(
         x::_CachedRange{T, Tinv, Tag}, xi::AbstractVector{<:Real}, ::NoExtrap
     ) where {T, Tinv, Tag <: _AbstractUnitStep}
     isempty(xi) && return InBounds()
     lo, hi = _domain_bounds(x)
-    @boundscheck _ge(minimum(xi), _extract_primal(lo)) || _throw_batch_oob(x, xi)
-    mx = maximum(xi)
+    @boundscheck _ge(_extract_primal(minimum(xi)), _extract_primal(lo)) || _throw_batch_oob(x, xi)
+    mx = _extract_primal(maximum(xi))
     hip = _extract_primal(hi)
     @boundscheck _le(mx, hip) || _throw_batch_oob(x, xi)
     return _lt(mx, hip) ? InBounds(last = :exclusive) : InBounds()
@@ -667,15 +669,15 @@ end
 end
 
 # Unit-step twin: original extrap (any OOB) / exclusive-last (strictly below `last`)
-# / closed (touches `last`).
+# / closed (touches `last`). Primal extrema — see the NoExtrap twin.
 @inline function _check_domain(
         x::_CachedRange{T, Tinv, Tag}, xi::AbstractVector{<:Real},
         e::Union{ClampExtrap, FillExtrap, WrapExtrap}
     ) where {T, Tinv, Tag <: _AbstractUnitStep}
     isempty(xi) && return InBounds()
     lo, hi = _domain_bounds(x)
-    _ge(minimum(xi), _extract_primal(lo)) || return e
-    mx = maximum(xi)
+    _ge(_extract_primal(minimum(xi)), _extract_primal(lo)) || return e
+    mx = _extract_primal(maximum(xi))
     hip = _extract_primal(hi)
     _le(mx, hip) || return e
     return _lt(mx, hip) ? InBounds(last = :exclusive) : InBounds()

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -737,9 +737,11 @@ the OOB slow-path, so this form stays preferred even post-1.10-LTS.
     lo, hi = _domain_bounds(x)
     # `_ge`/`_le` promote-compare (see search.jl): dodge Base's exact mixed
     # `>=(Float, Int)` on an Int/Rational grid. Amortized over the min/max scan
-    # (one compare per batch), but free on a Float grid.
-    return _ge(minimum(queries), _extract_primal(lo)) &&
-        _le(maximum(queries), _extract_primal(hi))
+    # (one compare per batch), but free on a Float grid. Extrema classify on
+    # primals: a Dual query whose VALUE == a bound must not tie-break on its
+    # partial sign into a false OOB verdict (identity on the Float64 hot path).
+    return _ge(_extract_primal(minimum(queries)), _extract_primal(lo)) &&
+        _le(_extract_primal(maximum(queries)), _extract_primal(hi))
 end
 
 # ========================================

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -630,6 +630,22 @@ exact endpoints, not the widened bracket.
     return InBounds()
 end
 
+# Unit-step axis: fused 3-outcome check — throw (OOB), `InBounds(last = :exclusive)`
+# (`maximum < last` proven → the batch loop rides the no-cap search), else closed.
+# Generic axes keep the closed-only method above (no Union; nothing to win there).
+# Only the throws are `@boundscheck`-elidable; the promotion is build-mode independent.
+@inline function _check_domain(
+        x::_CachedRange{T, Tinv, Tag}, xi::AbstractVector{<:Real}, ::NoExtrap
+    ) where {T, Tinv, Tag <: _AbstractUnitStep}
+    isempty(xi) && return InBounds()
+    lo, hi = _domain_bounds(x)
+    @boundscheck _ge(minimum(xi), _extract_primal(lo)) || _throw_batch_oob(x, xi)
+    mx = maximum(xi)
+    hip = _extract_primal(hi)
+    @boundscheck _le(mx, hip) || _throw_batch_oob(x, xi)
+    return _lt(mx, hip) ? InBounds(last = :exclusive) : InBounds()
+end
+
 @noinline function _throw_batch_oob(x::AbstractVector, xi::AbstractVector{<:Real})
     qmin, qmax = minimum(xi), maximum(xi)
     x_min = _extract_primal(first(x))
@@ -648,6 +664,21 @@ end
         e::Union{ClampExtrap, FillExtrap, WrapExtrap}
     )
     return _is_all_inbounds(x, xi) ? InBounds() : e
+end
+
+# Unit-step twin: original extrap (any OOB) / exclusive-last (strictly below `last`)
+# / closed (touches `last`).
+@inline function _check_domain(
+        x::_CachedRange{T, Tinv, Tag}, xi::AbstractVector{<:Real},
+        e::Union{ClampExtrap, FillExtrap, WrapExtrap}
+    ) where {T, Tinv, Tag <: _AbstractUnitStep}
+    isempty(xi) && return InBounds()
+    lo, hi = _domain_bounds(x)
+    _ge(minimum(xi), _extract_primal(lo)) || return e
+    mx = maximum(xi)
+    hip = _extract_primal(hi)
+    _le(mx, hip) || return e
+    return _lt(mx, hip) ? InBounds(last = :exclusive) : InBounds()
 end
 
 # Safe domain bounds — single axis-dispatched source of truth for every in-domain

--- a/test/test_inbounds_endpoints.jl
+++ b/test/test_inbounds_endpoints.jl
@@ -106,6 +106,29 @@ end
     @test J ≈ [1.0 0.0; 0.0 1.0]
 end
 
+@testitem "generic batch domain check classifies Dual extrema on primals (no spurious throw)" begin
+    using FastInterpolations: _is_all_inbounds, _check_domain
+    using ForwardDiff
+    Dual = ForwardDiff.Dual
+
+    # `_is_all_inbounds` (the non-unit-step batch classifier) must not tie-break a Dual
+    # query whose VALUE == last(x) on its partial sign: a +partial there compares
+    # "greater" and would falsely reject a valid boundary batch (spurious DomainError).
+    for g in (range(0.0, 1.0; length = 11), collect(0.0:0.1:1.0))   # float-step range + vector
+        cr = linear_interp((g, g), zeros(length(g), length(g))).grids[1]
+        xi = [Dual{:t}(0.2, 1.0), Dual{:t}(1.0, 1.0)]              # max value == last, +partial
+        @test _is_all_inbounds(cr, xi)                              # in-domain on primal
+        @test _check_domain(cr, xi, NoExtrap()) === InBounds()      # no spurious throw
+    end
+
+    # end-to-end on a float-step grid (routes through `_is_all_inbounds`, not the
+    # unit-step method): jacobian over a batch touching last(x) must not throw.
+    gf = range(0.0, 1.0; length = 11)
+    itpf = linear_interp(gf, collect(0.0:0.1:1.0))                 # y == x ⇒ slope 1
+    J = ForwardDiff.jacobian(q -> itpf(q), [0.35, 1.0])
+    @test J[1, 1] ≈ 1.0 && J[2, 2] ≈ 1.0                          # endpoint query differentiates fine
+end
+
 @testitem "batch NoExtrap end-to-end rides the promoted contract, bit-identical" begin
     x = 1:16
     y = [sin(0.4i) for i in 1:16]

--- a/test/test_inbounds_endpoints.jl
+++ b/test/test_inbounds_endpoints.jl
@@ -29,6 +29,81 @@
     # Inner constructor rejects raw bad parameters (Symbol-typed and otherwise).
     @test_throws ErrorException InBounds{:bad, :inclusive}()
     @test_throws ErrorException InBounds{:inclusive, 1}()
+
+    # Compact kwarg-form show (round-trips as constructor calls; GridIdx/DerivOp precedent).
+    @test repr(InBounds()) == "InBounds()"
+    @test repr(InBounds(last = :exclusive)) == "InBounds(last = :exclusive)"
+    @test repr(InBounds(first = :exclusive)) == "InBounds(first = :exclusive)"
+    @test repr(InBounds(first = :exclusive, last = :exclusive)) ==
+        "InBounds(first = :exclusive, last = :exclusive)"
+end
+
+@testitem "batch domain check promotes to exclusive-last on unit-step axes (proven)" begin
+    using FastInterpolations: _check_domain
+
+    # `_CachedRange` instances via the resolved ND grids (same extraction as the
+    # perf probes) — one per tag family.
+    cr(g) = linear_interp((g, g), zeros(length(g), length(g))).grids[1]
+    g_us = cr(1:16)                            # _UnitStep
+    g_ot = cr(Base.OneTo(16))                  # _OneTo (<: _AbstractUnitStep)
+    g_fs = cr(range(0.0, 1.0; length = 17))    # float-step → generic method (gate)
+
+    @testset "NoExtrap batch: strict → exclusive, touch-hi → closed, OOB → throw" begin
+        @test _check_domain(g_us, [2.0, 5.5, prevfloat(16.0)], NoExtrap()) ===
+            InBounds(last = :exclusive)
+        @test _check_domain(g_ot, [1.0, 15.5], NoExtrap()) === InBounds(last = :exclusive)
+        @test _check_domain(g_us, [2.0, 16.0], NoExtrap()) === InBounds()   # touches last
+        @test _check_domain(g_us, Float64[], NoExtrap()) === InBounds()     # empty → closed
+        @test_throws DomainError _check_domain(g_us, [0.5, 5.0], NoExtrap())
+        @test_throws DomainError _check_domain(g_us, [2.0, 16.5], NoExtrap())
+    end
+
+    @testset "float-step axis keeps the closed-only promotion (gate)" begin
+        @test _check_domain(g_fs, [0.1, 0.9], NoExtrap()) === InBounds()
+        @test _check_domain(g_fs, [0.1, 0.9], ClampExtrap()) === InBounds()
+        # Inference pin: the literal-false strict claim must constant-fold, keeping
+        # the non-unit-step promotion CONCRETE closed (no Union).
+        @test Base.promote_op(_check_domain, typeof(g_fs), Vector{Float64}, NoExtrap) ==
+            InBounds{:inclusive, :inclusive}
+    end
+
+    @testset "Clamp/Fill/Wrap batch: strict → exclusive, touch-hi → closed, OOB → original" begin
+        @test _check_domain(g_us, [2.0, 15.0], ClampExtrap()) === InBounds(last = :exclusive)
+        @test _check_domain(g_us, [2.0, 16.0], ClampExtrap()) === InBounds()
+        @test _check_domain(g_us, [0.0, 5.0], ClampExtrap()) === ClampExtrap()
+        @test _check_domain(g_us, [2.0, 15.0], FillExtrap(0.0)) === InBounds(last = :exclusive)
+        @test _check_domain(g_us, [2.0, 17.0], FillExtrap(0.0)) === FillExtrap(0.0)
+        @test _check_domain(g_us, [2.0, 15.0], WrapExtrap()) === InBounds(last = :exclusive)
+    end
+end
+
+@testitem "batch NoExtrap end-to-end rides the promoted contract, bit-identical" begin
+    x = 1:16
+    y = [sin(0.4i) for i in 1:16]
+    qs = [1.0, 2.25, 7.5, 15.999, prevfloat(16.0)]      # strictly interior batch
+    qs_hi = [2.0, 9.5, 16.0]                            # touches the right endpoint
+
+    for f in (linear_interp, cubic_interp, quadratic_interp, constant_interp, pchip_interp)
+        itp_ne = f(x, y)                                        # NoExtrap default
+        itp_ib = f(x, y; extrap = InBounds())
+        itp_ex = f(x, y; extrap = InBounds(last = :exclusive))
+        @test itp_ne(qs) == itp_ex(qs)      # promoted batch == explicit exclusive
+        @test itp_ne(qs) == itp_ib(qs)      # and still bit-identical to closed
+        @test itp_ne(qs_hi) == itp_ib(qs_hi)                    # closed fallback at last
+        @test itp_ne(qs_hi)[end] === itp_ib(qs_hi)[end]
+    end
+
+    # ND SoA per-axis: x-axis strictly interior (promotes), y-axis touches its
+    # last (stays closed) — the mixed per-axis tuple must stay bit-identical.
+    axx, axy = 1:7, 2:9
+    data = [0.1i + 0.3j + 0.01i * j for i in 1:7, j in 1:8]
+    qx = [1.5, 3.25, 6.9]
+    qy = [2.5, 9.0, 8.5]
+    out_ne = similar(qx)
+    out_ib = similar(qx)
+    linear_interp!(out_ne, (axx, axy), data, (qx, qy))
+    linear_interp!(out_ib, (axx, axy), data, (qx, qy); extrap = (InBounds(), InBounds()))
+    @test out_ne == out_ib
 end
 
 @testitem "1D exclusive-last === closed on unit-step grids (all families)" begin

--- a/test/test_inbounds_endpoints.jl
+++ b/test/test_inbounds_endpoints.jl
@@ -77,6 +77,35 @@ end
     end
 end
 
+@testitem "Dual-query batch touching last must NOT promote to exclusive (no-cap OOB guard)" begin
+    using FastInterpolations: _check_domain
+    using ForwardDiff
+    Dual = ForwardDiff.Dual
+
+    # `Dual(16,-1) < 16.0 === true` (partial tie-break at equal primals). A Dual batch
+    # whose max VALUE == last(x) must classify on primal, else it falsely promotes to
+    # exclusive and the no-cap search reads y[len+1] OOB.
+    cr(g) = linear_interp((g, g), zeros(length(g), length(g))).grids[1]
+    g = cr(1:16)
+
+    # max value == 16 == last(x), partial < 0 (the tie-break trap)
+    xi_touch = [Dual{:t}(2.0, 0.3), Dual{:t}(8.0, 0.1), Dual{:t}(16.0, -1.0)]
+    @test _check_domain(g, xi_touch, NoExtrap()) === InBounds()            # NOT exclusive
+    @test _check_domain(g, xi_touch, ClampExtrap()) === InBounds()
+
+    # strictly-interior Dual batch (max primal < last) still promotes
+    xi_interior = [Dual{:t}(2.0, 1.0), Dual{:t}(15.0, -1.0)]
+    @test _check_domain(g, xi_interior, NoExtrap()) === InBounds(last = :exclusive)
+
+    # end-to-end: gradient through a Dual batch touching last(x) must not OOB
+    x = 1:16
+    y = collect(1.0:16.0)
+    itp = linear_interp(x, y)
+    qs = [3.0, 16.0]                                    # includes the exact endpoint
+    J = ForwardDiff.jacobian(q -> itp(q), qs)          # batch value+partials, no OOB read
+    @test J ≈ [1.0 0.0; 0.0 1.0]
+end
+
 @testitem "batch NoExtrap end-to-end rides the promoted contract, bit-identical" begin
     x = 1:16
     y = [sin(0.4i) for i in 1:16]


### PR DESCRIPTION
## Summary

Follow-up to #178: the batch domain check now proves the exclusive-last contract itself, so **default `NoExtrap` batches** on unit-step grids ride the no-cap search — no `InBounds` knowledge required. Same-`NoExtrap` speed-up vs master: 1D +2–6%, 2D wide carriers +3%.

How it works:

- The validation scan already computes `maximum(xi)`; one extra compare picks throw / `InBounds(last=:exclusive)` (`max < last`) / closed. The promoted contract is *proven*, not promised — no new UB.
- Dedicated `_CachedRange{…,<:_AbstractUnitStep}` methods only; generic axes stay byte-identical to master (no Union where no no-cap arm exists).
- ND SoA rides an all-unit-step all-NoExtrap lane with an all-or-nothing tuple upgrade. Per-axis promotion is off by design: tuple-nested Unions don't union-split (measured ~10× on 2D SoA); mixed tuples take the generic lane.

## Benchmark — master vs this branch, **same default `NoExtrap`** (M1, K=1024, ns/query)

| default `NoExtrap` batch | master | This PR | speed-up |
|---|--:|--:|--:|
| 1D Float64 | 0.854 | 0.804 | **+6.2%** |
| 1D RGB{N0f8} | 2.744 | 2.640 | +3.9% |
| 2D SoA Float64 | 2.328 | 2.342 | ~0% (noise) |
| 2D SoA RGB{N0f8} | 6.046 | 5.851 | +3.3% |
| _drift anchor: float-step 1D_ | 1.103 | 1.099 | +0.4% |

Every 1D carrier and every 2D wide carrier wins; 2D Float64/Gray sit at the noise floor
