### PR TITLE
feat(api): splatted scalar-query args for ND vector calculus

### DIFF
--- a/docs/src/extrapolation.md
+++ b/docs/src/extrapolation.md
@@ -15,9 +15,10 @@ linear_interp(x, y, xq; extrap=Extrap(:extend))
 cubic_interp(x, y, xq; extrap=ClampExtrap())
 linear_interp(x, y, xq; extrap=ExtendExtrap())
 
-# Interpolant: extrap is fixed at creation
+# Interpolant: stored extrap is fixed at creation; a per-call `InBounds()` skips the domain check
 itp = cubic_interp(x, y; extrap=Extrap(:extend))
-itp(xq)  # uses ExtendExtrap
+itp(xq)                      # uses ExtendExtrap
+itp(xq; extrap=InBounds())   # in-domain fast-path (query must be in-domain)
 ```
 
 !!! tip "Factory Functions"

--- a/src/constant/nd/constant_nd_eval.jl
+++ b/src/constant/nd/constant_nd_eval.jl
@@ -12,6 +12,7 @@
 @inline function (itp::ConstantInterpolantND{Tg, Tv, N})(
         query::Tuple{Vararg{Real, N}};
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
+        extrap::Union{Nothing, AbstractExtrap, Tuple} = nothing,
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
@@ -20,7 +21,8 @@
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
     mono = _scalar_mono(hint, Val(N))
-    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono)
+    extraps = _resolve_extrap_overrides(itp, extrap)
+    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono, extraps)
 end
 
 # In-place + allocating batch use the inherited `AbstractInterpolantND`

--- a/src/constant/nd/constant_nd_eval.jl
+++ b/src/constant/nd/constant_nd_eval.jl
@@ -16,13 +16,7 @@
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
-    resolved = map(_resolve_grididx, query, itp.grids)
-    ops = _resolve_deriv_nd(deriv, Val(N))
-    policies = _resolve_search_nd(search, Val(N))
-    hints = _ensure_hint_nd(hint, Val(N))
-    mono = _scalar_mono(hint, Val(N))
-    extraps = _resolve_extrap_overrides(itp, extrap)
-    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono, extraps)
+    return _eval_nd_scalar_query(itp, query, deriv, extrap, search, hint)
 end
 
 # In-place + allocating batch use the inherited `AbstractInterpolantND`

--- a/src/core/eval_ops.jl
+++ b/src/core/eval_ops.jl
@@ -368,6 +368,12 @@ linear_interp(x, y, xq; extrap=InBounds())
 
 # Queries generated in [first(x), last(x)) — never touch the right endpoint
 linear_interp(x, y, xq; extrap=InBounds(last = :exclusive))
+
+# On a built interpolant, `InBounds` is the only per-call `extrap` override: it
+# opts a query into the fast path without rebuilding (any other mode errors —
+# the stored extrapolation contract is not swappable per call).
+itp = linear_interp(x, y; extrap=ClampExtrap())
+itp(xq; extrap=InBounds())   # opt into the in-domain fast path
 ```
 """
 struct InBounds{First, Last} <: AbstractExtrap

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -30,13 +30,19 @@
 # it never changes OOB behavior, since the caller guarantees no OOB query). `nothing`
 # (the omitted default) keeps the stored contract. Any other extrapolation mode would
 # silently change OOB semantics, so it errors. The callables annotate the kwarg
-# `Union{Nothing, AbstractExtrap[, Tuple]}`, so genuine junk (`extrap=5`) is cut at
-# the call boundary (`TypeError`) — only a valid-but-disallowed mode reaches this
-# friendly throw. Dispatch on the override type folds away at specialization (spec §3.1/§3.5).
+# `Union{Nothing, AbstractExtrap[, Tuple]}`, so scalar junk (`extrap=5`) is cut at
+# the call boundary (`TypeError`) — only a valid-but-disallowed mode reaches the
+# friendly throw. Dispatch on the override type folds away at specialization.
 @inline _resolve_extrap_override(stored, ::Nothing) = stored
 @inline _resolve_extrap_override(_stored, over::InBounds) = over
 @noinline _resolve_extrap_override(stored, over::AbstractExtrap) =
     _throw_extrap_not_overridable(stored, over)
+# Per-axis tuple elements reuse this resolver (via the `map` below). The tuple kwarg
+# annotation cannot check element types, so a junk element (e.g. `(5, nothing)`) is
+# cut here as a `TypeError` — matching the scalar boundary rather than surfacing an
+# internal `MethodError`.
+@noinline _resolve_extrap_override(_stored, over) =
+    throw(TypeError(:extrap, "per-axis override tuple element", Union{Nothing, AbstractExtrap}, over))
 
 @noinline _throw_extrap_not_overridable(stored, over) = throw(
     ArgumentError(
@@ -52,9 +58,8 @@
 #   InBounds → broadcast to every axis (fast-path on all axes)
 #   Tuple    → per-axis, each element `nothing` (keep stored) or `InBounds`
 #             (a disallowed element / single non-InBounds mode routes to the throw)
-# The itp-level entry dispatches on the interpolant so the Hetero guard (a more
-# specific method) can reject an override there; tensor-product ND resolves
-# against its stored `extraps`.
+# The itp-level entry resolves against the interpolant's stored per-axis `extraps`;
+# every `AbstractInterpolantND` (tensor-product and Hetero alike) shares this method.
 @inline _resolve_extrap_overrides(itp::AbstractInterpolantND, over) = _resolve_extrap_overrides(itp.extraps, over)
 @inline _resolve_extrap_overrides(stored::NTuple{N, AbstractExtrap}, ::Nothing) where {N} = stored
 @inline _resolve_extrap_overrides(stored::NTuple{N, AbstractExtrap}, over::InBounds) where {N} =
@@ -294,8 +299,8 @@ function (itp::AbstractInterpolantND{Tg, Tv, N})(
     _query_validate(queries)
     # `extrap` (nothing → stored; InBounds → fast-path; else errors) resolved per-axis
     # BEFORE domain validation — an InBounds axis then skips the O(n) domain scan.
-    # Dispatches on `itp`, so HeteroND (which shares this batch callable) rejects a
-    # non-nothing override here instead of silently half-supporting it (§3.4).
+    # HeteroND shares this batch callable and is fully supported: it is an
+    # `AbstractInterpolantND`, so the same resolver threads the override.
     extraps0 = _resolve_extrap_overrides(itp, extrap)
     # Validate + batch-level InBounds promotion: throws on OOB NoExtrap and returns per-axis
     # `InBounds()` for SoA queries all in-bounds on an axis (AoS/generic stays original).

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -24,6 +24,52 @@
 @inline _itp_extrap(itp::AbstractInterpolant1D) = itp.extrap
 @inline _itp_search(itp::AbstractInterpolant1D) = itp.search_policy
 
+# ── Call-time extrap override (singular: 1D / ND per-axis) ──
+# The stored extrap is the construction-time contract; the only per-call override
+# is `InBounds` (an in-domain fast-path ASSERTION, not an extrapolation contract —
+# it never changes OOB behavior, since the caller guarantees no OOB query). `nothing`
+# (the omitted default) keeps the stored contract. Any other extrapolation mode would
+# silently change OOB semantics, so it errors. The callables annotate the kwarg
+# `Union{Nothing, AbstractExtrap[, Tuple]}`, so genuine junk (`extrap=5`) is cut at
+# the call boundary (`TypeError`) — only a valid-but-disallowed mode reaches this
+# friendly throw. Dispatch on the override type folds away at specialization (spec §3.1/§3.5).
+@inline _resolve_extrap_override(stored, ::Nothing) = stored
+@inline _resolve_extrap_override(_stored, over::InBounds) = over
+@noinline _resolve_extrap_override(stored, over::AbstractExtrap) =
+    _throw_extrap_not_overridable(stored, over)
+
+@noinline _throw_extrap_not_overridable(stored, over) = throw(
+    ArgumentError(
+        "call-time `extrap` override must be `InBounds(...)` (an in-domain fast-path); got $(over). " *
+            "The stored extrapolation mode ($(stored)) is the interpolant's contract and cannot be " *
+            "changed per call — rebuild the interpolant to use a different mode."
+    )
+)
+
+# ── ND per-axis resolution (plural: broadcast / tuple) ──
+# Resolve a call-time override against the stored per-axis extraps tuple:
+#   nothing  → stored (all axes unchanged)
+#   InBounds → broadcast to every axis (fast-path on all axes)
+#   Tuple    → per-axis, each element `nothing` (keep stored) or `InBounds`
+#             (a disallowed element / single non-InBounds mode routes to the throw)
+# The itp-level entry dispatches on the interpolant so the Hetero guard (a more
+# specific method) can reject an override there; tensor-product ND resolves
+# against its stored `extraps`.
+@inline _resolve_extrap_overrides(itp::AbstractInterpolantND, over) = _resolve_extrap_overrides(itp.extraps, over)
+@inline _resolve_extrap_overrides(stored::NTuple{N, AbstractExtrap}, ::Nothing) where {N} = stored
+@inline _resolve_extrap_overrides(stored::NTuple{N, AbstractExtrap}, over::InBounds) where {N} =
+    ntuple(_ -> over, Val(N))
+@inline function _resolve_extrap_overrides(stored::NTuple{N, AbstractExtrap}, over::Tuple) where {N}
+    length(over) == N || _throw_extrap_ndims(N, length(over))
+    return map(_resolve_extrap_override, stored, over)
+end
+@noinline _resolve_extrap_overrides(stored::NTuple{N, AbstractExtrap}, over::AbstractExtrap) where {N} =
+    _throw_extrap_not_overridable(stored, over)   # single non-InBounds mode never broadcasts
+
+@noinline _throw_extrap_ndims(want::Int, got::Int) = throw(
+    ArgumentError("call-time `extrap` tuple must have $want elements to match grid dimensions, got $got")
+)
+
 # ── Output eltype trait ──
 # Default: arithmetic kernels (Linear/Cubic/Quadratic) divide by `h`, so route
 # through the shared `_interp_op` for Julia inference. Selection
@@ -40,17 +86,19 @@
 @inline function (itp::AbstractInterpolant1D{Tg, Tv})(
         xq;
         deriv::DerivOp = EvalValue(),
+        extrap::Union{Nothing, AbstractExtrap} = nothing,
         search::AbstractSearchPolicy = _itp_search(itp),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv}
     grid = _itp_grid(itp)
-    extrap = _itp_extrap(itp)
+    # `nothing` → stored extrap; `InBounds` → per-call fast-path; else errors.
+    extrap_eff = _resolve_extrap_override(_itp_extrap(itp), extrap)
     # Domain check is delegated to the per-method `_eval_*_at_point` callable
     # below — NoExtrap throws via that path's `@boundscheck _check_domain`,
     # while Clamp/Fill/Wrap handle OOB inside their specialized eval methods
     # without ever calling `_check_domain`. Outer redundancy removed.
     searcher = _resolve_search(grid, xq, search, hint)
-    return _itp_eval_scalar(itp, xq, extrap, deriv, searcher)
+    return _itp_eval_scalar(itp, xq, extrap_eff, deriv, searcher)
 end
 
 # ========================================
@@ -64,14 +112,15 @@ end
 function (itp::AbstractInterpolant1D{Tg, Tv})(
         xq::AbstractVector{Tq};
         deriv::DerivOp = EvalValue(),
+        extrap::Union{Nothing, AbstractExtrap} = nothing,
         search::AbstractSearchPolicy = _itp_search(itp),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, Tq <: Real}
     grid = _itp_grid(itp)
-    extrap = _itp_extrap(itp)
+    extrap_eff = _resolve_extrap_override(_itp_extrap(itp), extrap)
     output = Vector{_promote_eltype(itp, Tq)}(undef, length(xq))
     searcher = _resolve_search(grid, xq, search, hint)
-    _itp_vector_loop!(output, itp, xq, extrap, deriv, searcher)
+    _itp_vector_loop!(output, itp, xq, extrap_eff, deriv, searcher)
     return output
 end
 
@@ -83,14 +132,15 @@ function (itp::AbstractInterpolant1D{Tg, Tv})(
         output::AbstractVector,
         xq::AbstractVector{Tq};
         deriv::DerivOp = EvalValue(),
+        extrap::Union{Nothing, AbstractExtrap} = nothing,
         search::AbstractSearchPolicy = _itp_search(itp),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, Tq <: Real}
     @assert length(output) == length(xq) "output length must match xq length"
     grid = _itp_grid(itp)
-    extrap = _itp_extrap(itp)
+    extrap_eff = _resolve_extrap_override(_itp_extrap(itp), extrap)
     searcher = _resolve_search(grid, xq, search, hint)
-    _itp_vector_loop!(output, itp, xq, extrap, deriv, searcher)
+    _itp_vector_loop!(output, itp, xq, extrap_eff, deriv, searcher)
     return output
 end
 
@@ -160,6 +210,12 @@ end
 # Hetero is *not* routed through here — its callable has GridIdx/NoInterp
 # branches and `_eval_hetero_nd` uses a non-`_locate_cell` path (recursive
 # `_collapse_dims` / `_eval_hetero_precomputed`).
+# 6-arg forwarder: scalar callers with no call-time override inject the stored
+# `itp.extraps`. The 7-arg form is the source of truth (accepts a resolved
+# per-axis extraps tuple, e.g. InBounds-promoted from a call-time override).
+@inline _eval_nd_at_point(itp::AbstractInterpolantND, query, ops, policies, hints, mono) =
+    _eval_nd_at_point(itp, query, ops, policies, hints, mono, itp.extraps)
+
 @inline function _eval_nd_at_point(
         itp::AbstractInterpolantND{Tg, Tv, N},
         query::Tuple{Vararg{Real, N}},
@@ -167,6 +223,7 @@ end
         policies::NTuple{N, AbstractSearchPolicy},
         hints::Tuple{Vararg{Base.RefValue{Int}, N}},
         mono::NTuple{N, Bool},
+        extraps::Tuple{Vararg{AbstractExtrap, N}},
     ) where {Tg, Tv, N}
     # Promote each axis query to its coordinate type Tc ONCE at the eval surface,
     # before validate / try_fill_oob. This (a) makes the OOB/fill VALUE carry the
@@ -177,7 +234,8 @@ end
     qc = map(_promote_coord, query, map(eltype, itp.grids))
     # Validate (NoExtrap throw must precede the FillExtrap short-circuit) AND promote per axis:
     # an in-domain NoExtrap axis becomes InBounds for the search (lean), mirroring the batch path.
-    extraps_eff = _validate_nd_domain(itp.grids, qc, itp.extraps)
+    # `extraps` carries any call-time InBounds override; an InBounds axis skips the domain scan.
+    extraps_eff = _validate_nd_domain(itp.grids, qc, extraps)
     oob_result = _try_fill_oob(qc, itp.grids, extraps_eff, ops, _sample_data(itp))
     oob_result !== nothing && return oob_result
     cell = _locate_cell(itp, qc, extraps_eff, policies, hints, mono)
@@ -192,12 +250,13 @@ end
 @inline function (itp::AbstractInterpolantND{Tg, Tv, N})(
         query::AbstractVector{<:Real};
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
+        extrap::Union{Nothing, AbstractExtrap, Tuple} = nothing,
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
     length(query) == N || _throw_ndims_mismatch("query elements", N, length(query))
     query_tuple = ntuple(i -> @inbounds(query[i]), Val(N))
-    return itp(query_tuple; deriv = deriv, search = search, hint = hint)
+    return itp(query_tuple; deriv = deriv, extrap = extrap, search = search, hint = hint)
 end
 
 # ========================================
@@ -225,6 +284,7 @@ function (itp::AbstractInterpolantND{Tg, Tv, N})(
         output::AbstractVector,
         queries;
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
+        extrap::Union{Nothing, AbstractExtrap, Tuple} = nothing,
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
@@ -232,9 +292,14 @@ function (itp::AbstractInterpolantND{Tg, Tv, N})(
     nq = _query_length(queries)
     length(output) == nq || _throw_query_output_mismatch(nq, length(output))
     _query_validate(queries)
+    # `extrap` (nothing → stored; InBounds → fast-path; else errors) resolved per-axis
+    # BEFORE domain validation — an InBounds axis then skips the O(n) domain scan.
+    # Dispatches on `itp`, so HeteroND (which shares this batch callable) rejects a
+    # non-nothing override here instead of silently half-supporting it (§3.4).
+    extraps0 = _resolve_extrap_overrides(itp, extrap)
     # Validate + batch-level InBounds promotion: throws on OOB NoExtrap and returns per-axis
     # `InBounds()` for SoA queries all in-bounds on an axis (AoS/generic stays original).
-    extraps_eff = _validate_nd_domain(itp.grids, queries, itp.extraps)
+    extraps_eff = _validate_nd_domain(itp.grids, queries, extraps0)
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
     mono = _check_mono_nd(policies, queries)
@@ -251,10 +316,11 @@ end
 function (itp::AbstractInterpolantND{Tg, Tv, N})(
         queries;
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
+        extrap::Union{Nothing, AbstractExtrap, Tuple} = nothing,
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
     Tq = _query_eltype(queries)
     output = Vector{_promote_eltype(itp, Tq)}(undef, _query_length(queries))
-    return itp(output, queries; deriv = deriv, search = search, hint = hint)
+    return itp(output, queries; deriv = deriv, extrap = extrap, search = search, hint = hint)
 end

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -60,15 +60,15 @@
 #             (a disallowed element / single non-InBounds mode routes to the throw)
 # The itp-level entry resolves against the interpolant's stored per-axis `extraps`;
 # every `AbstractInterpolantND` (tensor-product and Hetero alike) shares this method.
-@inline _resolve_extrap_overrides(itp::AbstractInterpolantND, over) = _resolve_extrap_overrides(itp.extraps, over)
-@inline _resolve_extrap_overrides(stored::NTuple{N, AbstractExtrap}, ::Nothing) where {N} = stored
-@inline _resolve_extrap_overrides(stored::NTuple{N, AbstractExtrap}, over::InBounds) where {N} =
+@inline _resolve_extrap_override_nd(itp::AbstractInterpolantND, over) = _resolve_extrap_override_nd(itp.extraps, over)
+@inline _resolve_extrap_override_nd(stored::NTuple{N, AbstractExtrap}, ::Nothing) where {N} = stored
+@inline _resolve_extrap_override_nd(stored::NTuple{N, AbstractExtrap}, over::InBounds) where {N} =
     ntuple(_ -> over, Val(N))
-@inline function _resolve_extrap_overrides(stored::NTuple{N, AbstractExtrap}, over::Tuple) where {N}
+@inline function _resolve_extrap_override_nd(stored::NTuple{N, AbstractExtrap}, over::Tuple) where {N}
     length(over) == N || _throw_extrap_ndims(N, length(over))
     return map(_resolve_extrap_override, stored, over)
 end
-@noinline _resolve_extrap_overrides(stored::NTuple{N, AbstractExtrap}, over::AbstractExtrap) where {N} =
+@noinline _resolve_extrap_override_nd(stored::NTuple{N, AbstractExtrap}, over::AbstractExtrap) where {N} =
     _throw_extrap_not_overridable(stored, over)   # single non-InBounds mode never broadcasts
 
 @noinline _throw_extrap_ndims(want::Int, got::Int) = throw(
@@ -209,18 +209,12 @@ end
 #
 # Single scalar entry point for AbstractInterpolantND subtypes whose eval
 # structure matches `validate → try_fill_oob → locate → eval` (Cubic /
-# Linear / Constant / Quadratic). Each method's callable resolves
-# search/hints/ops then delegates here.
+# Linear / Constant / Quadratic). The per-family callables delegate to
+# `_eval_nd_scalar_query` (below), which resolves search/hints/ops then calls here.
 #
 # Hetero is *not* routed through here — its callable has GridIdx/NoInterp
 # branches and `_eval_hetero_nd` uses a non-`_locate_cell` path (recursive
 # `_collapse_dims` / `_eval_hetero_precomputed`).
-# 6-arg forwarder: scalar callers with no call-time override inject the stored
-# `itp.extraps`. The 7-arg form is the source of truth (accepts a resolved
-# per-axis extraps tuple, e.g. InBounds-promoted from a call-time override).
-@inline _eval_nd_at_point(itp::AbstractInterpolantND, query, ops, policies, hints, mono) =
-    _eval_nd_at_point(itp, query, ops, policies, hints, mono, itp.extraps)
-
 @inline function _eval_nd_at_point(
         itp::AbstractInterpolantND{Tg, Tv, N},
         query::Tuple{Vararg{Real, N}},
@@ -245,6 +239,21 @@ end
     oob_result !== nothing && return oob_result
     cell = _locate_cell(itp, qc, extraps_eff, policies, hints, mono)
     return _eval_at_cell(itp, cell, ops)
+end
+
+# Shared scalar-query entry for the tensor-product ND callables (Linear/Cubic/
+# Quadratic/Constant/Hermite): resolve query/ops/search/hints + the call-time
+# extrap override once, then delegate. Hetero keeps its own callable.
+@inline function _eval_nd_scalar_query(
+        itp::AbstractInterpolantND{Tg, Tv, N}, query, deriv, extrap, search, hint
+    ) where {Tg, Tv, N}
+    resolved = map(_resolve_grididx, query, itp.grids)
+    ops = _resolve_deriv_nd(deriv, Val(N))
+    policies = _resolve_search_nd(search, Val(N))
+    hints = _ensure_hint_nd(hint, Val(N))
+    mono = _scalar_mono(hint, Val(N))
+    extraps = _resolve_extrap_override_nd(itp, extrap)
+    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono, extraps)
 end
 
 # ========================================
@@ -301,7 +310,7 @@ function (itp::AbstractInterpolantND{Tg, Tv, N})(
     # BEFORE domain validation — an InBounds axis then skips the O(n) domain scan.
     # HeteroND shares this batch callable and is fully supported: it is an
     # `AbstractInterpolantND`, so the same resolver threads the override.
-    extraps0 = _resolve_extrap_overrides(itp, extrap)
+    extraps0 = _resolve_extrap_override_nd(itp, extrap)
     # Validate + batch-level InBounds promotion: throws on OOB NoExtrap and returns per-axis
     # `InBounds()` for SoA queries all in-bounds on an axis (AoS/generic stays original).
     extraps_eff = _validate_nd_domain(itp.grids, queries, extraps0)

--- a/src/cubic/nd/cubic_nd_eval.jl
+++ b/src/cubic/nd/cubic_nd_eval.jl
@@ -36,6 +36,7 @@ itp((1.0, 0.5); deriv=(DerivOp(1), EvalValue()))  # ∂f/∂x only
 @inline function (itp::CubicInterpolantND{Tg, Tv, N})(
         query::Tuple{Vararg{Real, N}};  # Allow Real, Dual (AD), and GridIdx
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
+        extrap::Union{Nothing, AbstractExtrap, Tuple} = nothing,
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
@@ -45,7 +46,8 @@ itp((1.0, 0.5); deriv=(DerivOp(1), EvalValue()))  # ∂f/∂x only
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
     mono = _scalar_mono(hint, Val(N))
-    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono)
+    extraps = _resolve_extrap_overrides(itp, extrap)
+    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono, extraps)
 end
 
 # In-place batch evaluation (SoA + AoS) is handled by the unified

--- a/src/cubic/nd/cubic_nd_eval.jl
+++ b/src/cubic/nd/cubic_nd_eval.jl
@@ -15,7 +15,7 @@ const _DEBUG_GENERATED_CELL = Ref(false)  # Debug: inspect @generated code
 # ========================================
 
 """
-    (itp::CubicInterpolantND)(query; deriv=EvalValue(), search=itp.searches)
+    (itp::CubicInterpolantND)(query; deriv=EvalValue(), extrap=nothing, search=itp.searches)
 
 Evaluate N-dimensional cubic Hermite interpolant.
 
@@ -23,6 +23,8 @@ Evaluate N-dimensional cubic Hermite interpolant.
 - `deriv`: Derivative specification
   - `DerivOp`: same order for all axes (fastest), e.g. `DerivOp(1)`
   - `NTuple{N,DerivOp}`: per-axis orders, e.g. `(DerivOp(1), EvalValue())` for ∂f/∂x
+- `extrap`: `InBounds()` opts into the in-domain fast-path (per-axis tuple allowed;
+  `nothing` keeps an axis's stored mode). Any other mode errors — extrap is a build-time contract.
 - `search`: Override search policy (single or per-axis tuple)
 
 # Examples
@@ -30,6 +32,7 @@ Evaluate N-dimensional cubic Hermite interpolant.
 itp((1.0, 0.5))                                  # value
 itp((1.0, 0.5); deriv=DerivOp(1))                # all first derivatives
 itp((1.0, 0.5); deriv=(DerivOp(1), EvalValue()))  # ∂f/∂x only
+itp((1.0, 0.5); extrap=InBounds())               # skip the domain check (in-domain only)
 ```
 """
 # Single-point evaluation
@@ -40,14 +43,7 @@ itp((1.0, 0.5); deriv=(DerivOp(1), EvalValue()))  # ∂f/∂x only
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
-    # Resolve bare GridIdx → GridIdx{Tg}(idx, val). No-op for Real/Dual.
-    resolved = map(_resolve_grididx, query, itp.grids)
-    ops = _resolve_deriv_nd(deriv, Val(N))
-    policies = _resolve_search_nd(search, Val(N))
-    hints = _ensure_hint_nd(hint, Val(N))
-    mono = _scalar_mono(hint, Val(N))
-    extraps = _resolve_extrap_overrides(itp, extrap)
-    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono, extraps)
+    return _eval_nd_scalar_query(itp, query, deriv, extrap, search, hint)
 end
 
 # In-place batch evaluation (SoA + AoS) is handled by the unified

--- a/src/hermite/nd/hermite_nd_interpolant.jl
+++ b/src/hermite/nd/hermite_nd_interpolant.jl
@@ -133,6 +133,7 @@ Evaluate ND cubic Hermite at `query::NTuple{N, Real}`. Supports `deriv` as
 @inline function (itp::CubicHermiteInterpolantND{Tg, Tv, N})(
         query::Tuple{Vararg{Real, N}};
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
+        extrap::Union{Nothing, AbstractExtrap, Tuple} = nothing,
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing,
     ) where {Tg, Tv, N}
@@ -141,7 +142,8 @@ Evaluate ND cubic Hermite at `query::NTuple{N, Real}`. Supports `deriv` as
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
     mono = _scalar_mono(hint, Val(N))
-    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono)
+    extraps = _resolve_extrap_overrides(itp, extrap)
+    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono, extraps)
 end
 
 # ========================================

--- a/src/hermite/nd/hermite_nd_interpolant.jl
+++ b/src/hermite/nd/hermite_nd_interpolant.jl
@@ -125,10 +125,12 @@ end
 # ========================================
 
 """
-    (itp::CubicHermiteInterpolantND)(query; deriv=EvalValue(), search=itp.searches)
+    (itp::CubicHermiteInterpolantND)(query; deriv=EvalValue(), extrap=nothing, search=itp.searches)
 
 Evaluate ND cubic Hermite at `query::NTuple{N, Real}`. Supports `deriv` as
-`DerivOp` (same order all axes) or `NTuple{N, DerivOp}` (per-axis).
+`DerivOp` (same order all axes) or `NTuple{N, DerivOp}` (per-axis). Pass
+`extrap=InBounds()` to skip the domain check for in-domain queries (`nothing`
+keeps the stored extrap; any other extrapolation mode errors).
 """
 @inline function (itp::CubicHermiteInterpolantND{Tg, Tv, N})(
         query::Tuple{Vararg{Real, N}};
@@ -137,13 +139,7 @@ Evaluate ND cubic Hermite at `query::NTuple{N, Real}`. Supports `deriv` as
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing,
     ) where {Tg, Tv, N}
-    resolved = map(_resolve_grididx, query, itp.grids)
-    ops = _resolve_deriv_nd(deriv, Val(N))
-    policies = _resolve_search_nd(search, Val(N))
-    hints = _ensure_hint_nd(hint, Val(N))
-    mono = _scalar_mono(hint, Val(N))
-    extraps = _resolve_extrap_overrides(itp, extrap)
-    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono, extraps)
+    return _eval_nd_scalar_query(itp, query, deriv, extrap, search, hint)
 end
 
 # ========================================

--- a/src/hetero/hetero_eval.jl
+++ b/src/hetero/hetero_eval.jl
@@ -341,11 +341,16 @@ end
 @inline function (itp::HeteroInterpolantND{Tg, Tv, N})(
         query::Tuple{Vararg{Real, N}};
         deriv = EvalValue(),
+        extrap::Union{Nothing, AbstractExtrap, Tuple} = nothing,
         search = itp.searches,
         hint = nothing,
     ) where {Tg, Tv, N}
     resolved = map(_resolve_grididx, query, itp.grids)
     ops = _resolve_deriv_nd(deriv, Val(N))
+    # Call-time extrap override: `nothing` keeps the stored per-axis extraps;
+    # `InBounds` opts into the in-domain fast-path (broadcast or per-axis).
+    # Resolved via the generic `AbstractInterpolantND` method; other modes throw.
+    extraps0 = _resolve_extrap_overrides(itp, extrap)
     if _has_nointerp_method(typeof(itp.methods))
         _validate_nointerp_grididx(itp.methods, resolved)
         search_tuple = _resolve_search_nd(search, Val(N))
@@ -385,7 +390,7 @@ end
         promoted = _promote_grididx_to_nointerp(itp.methods, resolved)
         return _interp_nointerp_oneshot(
             itp.grids, itp.data, resolved, promoted,
-            deriv, itp.extraps, search, hint,
+            deriv, extraps0, search, hint,
         )
     end
     # Promote each axis query to Tc before validate / fill so the OOB/fill VALUE
@@ -395,7 +400,7 @@ end
     # Validate + per-axis promote (in-domain NoExtrap → InBounds for the search), mirroring the
     # homogeneous ND scalar path. PreCompute threads `extraps_eff` to its ND search; the OnTheFly
     # collapse keeps promoting transitively inside each 1D fiber (see `_locate_cell`).
-    extraps_eff = _validate_nd_domain(itp.grids, qc, itp.extraps)
+    extraps_eff = _validate_nd_domain(itp.grids, qc, extraps0)
     oob_result = _try_fill_oob(qc, itp.grids, extraps_eff, ops, _sample_data(itp))
     oob_result !== nothing && return oob_result
     policies = _resolve_search_nd(search, Val(N))
@@ -412,22 +417,6 @@ end
     ) where {Tg, Tv, N}
     return itp(q; kw...)
 end
-
-# Call-time `extrap` override guard. HeteroND shares the generic ND batch callable
-# (interpolant_protocol.jl), so without this a non-nothing override would silently
-# reach `_validate_nd_domain` un-threaded through HeteroND's bespoke eval. Threading
-# it through `_eval_hetero_nd` / the generated `_eval_nointerp` is a deferred follow-up;
-# until then reject loudly. `nothing` (the default) keeps the stored per-axis extraps.
-# (The scalar/vararg callables above have no `extrap` kwarg, so those reject naturally.)
-@inline _resolve_extrap_overrides(itp::HeteroInterpolantND, ::Nothing) = itp.extraps
-@noinline _resolve_extrap_overrides(::HeteroInterpolantND, over) = _throw_hetero_extrap_unsupported(over)
-
-@noinline _throw_hetero_extrap_unsupported(over) = throw(
-    ArgumentError(
-        "call-time `extrap` override ($(over)) is not yet supported for HeteroInterpolantND; " *
-            "rebuild with the desired per-axis extrap, or omit `extrap` to use the stored modes."
-    )
-)
 
 # ========================================
 # _locate_cell / _eval_at_cell Protocol

--- a/src/hetero/hetero_eval.jl
+++ b/src/hetero/hetero_eval.jl
@@ -413,6 +413,22 @@ end
     return itp(q; kw...)
 end
 
+# Call-time `extrap` override guard. HeteroND shares the generic ND batch callable
+# (interpolant_protocol.jl), so without this a non-nothing override would silently
+# reach `_validate_nd_domain` un-threaded through HeteroND's bespoke eval. Threading
+# it through `_eval_hetero_nd` / the generated `_eval_nointerp` is a deferred follow-up;
+# until then reject loudly. `nothing` (the default) keeps the stored per-axis extraps.
+# (The scalar/vararg callables above have no `extrap` kwarg, so those reject naturally.)
+@inline _resolve_extrap_overrides(itp::HeteroInterpolantND, ::Nothing) = itp.extraps
+@noinline _resolve_extrap_overrides(::HeteroInterpolantND, over) = _throw_hetero_extrap_unsupported(over)
+
+@noinline _throw_hetero_extrap_unsupported(over) = throw(
+    ArgumentError(
+        "call-time `extrap` override ($(over)) is not yet supported for HeteroInterpolantND; " *
+            "rebuild with the desired per-axis extrap, or omit `extrap` to use the stored modes."
+    )
+)
+
 # ========================================
 # _locate_cell / _eval_at_cell Protocol
 # ========================================

--- a/src/hetero/hetero_eval.jl
+++ b/src/hetero/hetero_eval.jl
@@ -350,8 +350,10 @@ end
     # Call-time extrap override: `nothing` keeps the stored per-axis extraps;
     # `InBounds` opts into the in-domain fast-path (broadcast or per-axis).
     # Resolved via the generic `AbstractInterpolantND` method; other modes throw.
-    extraps0 = _resolve_extrap_overrides(itp, extrap)
+    extraps0 = _resolve_extrap_override_nd(itp, extrap)
     if _has_nointerp_method(typeof(itp.methods))
+        # InBounds override intentionally not threaded into the generated `_eval_nointerp`
+        # (it reads `itp.extraps`): value-correct, no fast-path — as for the OTF fibers.
         _validate_nointerp_grididx(itp.methods, resolved)
         search_tuple = _resolve_search_nd(search, Val(N))
         return _eval_nointerp(itp, resolved, ops, search_tuple, hint)

--- a/src/linear/nd/linear_nd_eval.jl
+++ b/src/linear/nd/linear_nd_eval.jl
@@ -21,13 +21,7 @@
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
-    resolved = map(_resolve_grididx, query, itp.grids)
-    ops = _resolve_deriv_nd(deriv, Val(N))
-    policies = _resolve_search_nd(search, Val(N))
-    hints = _ensure_hint_nd(hint, Val(N))
-    mono = _scalar_mono(hint, Val(N))
-    extraps = _resolve_extrap_overrides(itp, extrap)
-    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono, extraps)
+    return _eval_nd_scalar_query(itp, query, deriv, extrap, search, hint)
 end
 
 # In-place batch evaluation (SoA + AoS) is handled by the unified

--- a/src/linear/nd/linear_nd_eval.jl
+++ b/src/linear/nd/linear_nd_eval.jl
@@ -17,6 +17,7 @@
 @inline function (itp::LinearInterpolantND{Tg, Tv, N})(
         query::Tuple{Vararg{Real, N}};
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
+        extrap::Union{Nothing, AbstractExtrap, Tuple} = nothing,
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
@@ -25,7 +26,8 @@
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
     mono = _scalar_mono(hint, Val(N))
-    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono)
+    extraps = _resolve_extrap_overrides(itp, extrap)
+    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono, extraps)
 end
 
 # In-place batch evaluation (SoA + AoS) is handled by the unified

--- a/src/quadratic/nd/quadratic_nd_eval.jl
+++ b/src/quadratic/nd/quadratic_nd_eval.jl
@@ -68,13 +68,7 @@ itp((1.0, 0.5); deriv=(DerivOp(1), EvalValue()))      # ∂f/∂x only
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
-    resolved = map(_resolve_grididx, query, itp.grids)
-    ops = _resolve_deriv_nd(deriv, Val(N))
-    policies = _resolve_search_nd(search, Val(N))
-    hints = _ensure_hint_nd(hint, Val(N))
-    mono = _scalar_mono(hint, Val(N))
-    extraps = _resolve_extrap_overrides(itp, extrap)
-    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono, extraps)
+    return _eval_nd_scalar_query(itp, query, deriv, extrap, search, hint)
 end
 
 # In-place batch evaluation (SoA + AoS) is handled by the unified

--- a/src/quadratic/nd/quadratic_nd_eval.jl
+++ b/src/quadratic/nd/quadratic_nd_eval.jl
@@ -64,6 +64,7 @@ itp((1.0, 0.5); deriv=(DerivOp(1), EvalValue()))      # ∂f/∂x only
 @inline function (itp::QuadraticInterpolantND{Tg, Tv, N})(
         query::Tuple{Vararg{Real, N}};
         deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
+        extrap::Union{Nothing, AbstractExtrap, Tuple} = nothing,
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
@@ -72,7 +73,8 @@ itp((1.0, 0.5); deriv=(DerivOp(1), EvalValue()))      # ∂f/∂x only
     policies = _resolve_search_nd(search, Val(N))
     hints = _ensure_hint_nd(hint, Val(N))
     mono = _scalar_mono(hint, Val(N))
-    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono)
+    extraps = _resolve_extrap_overrides(itp, extrap)
+    return _eval_nd_at_point(itp, resolved, ops, policies, hints, mono, extraps)
 end
 
 # In-place batch evaluation (SoA + AoS) is handled by the unified

--- a/src/vector_calculus.jl
+++ b/src/vector_calculus.jl
@@ -66,6 +66,7 @@ Uses locate-once optimization: interval search performed only once per query poi
 itp = cubic_interp((x, y), data)
 gradient(itp, (0.5, 0.5))    # → (∂f/∂x, ∂f/∂y)
 gradient(itp, [0.5, 0.5])    # Vector input also supported
+gradient(itp, 0.5, 0.5)      # splatted scalars also supported
 ```
 
 See also: [`gradient!`](@ref), [`value_gradient`](@ref), [`hessian`](@ref), [`laplacian`](@ref)
@@ -154,6 +155,7 @@ itp = cubic_interp((x, y), data)
 G = zeros(2)
 gradient!(G, itp, (0.5, 0.5))    # G .= (∂f/∂x, ∂f/∂y)
 gradient!(G, itp, [0.5, 0.5])    # G .= (∂f/∂x, ∂f/∂y)
+gradient!(G, itp, 0.5, 0.5)      # splatted scalars also supported
 
 # Optim.jl compatible:
 grad!(G, x) = gradient!(G, itp, x)
@@ -250,6 +252,7 @@ interval search is performed only **once** per query point.
 itp = cubic_interp((x, y), data)
 val, grad = value_gradient(itp, (0.5, 0.5))   # → (f, (∂f/∂x, ∂f/∂y))
 val, grad = value_gradient(itp, [0.5, 0.5])    # Vector input also supported
+val, grad = value_gradient(itp, 0.5, 0.5)      # splatted scalars also supported
 
 # Optim.jl fg! pattern:
 function fg!(F, G, x)
@@ -366,6 +369,7 @@ Uses locate-once optimization: interval search performed only once per query poi
 ```julia
 itp = cubic_interp((x, y), data)
 H = hessian(itp, (0.5, 0.5))
+H = hessian(itp, 0.5, 0.5)    # splatted scalars also supported
 # H = [∂²f/∂x²    ∂²f/∂x∂y]
 #     [∂²f/∂x∂y   ∂²f/∂y² ]
 ```
@@ -465,6 +469,7 @@ Exploits symmetry: computes only `N(N+1)/2` unique elements.
 itp = cubic_interp((x, y), data)
 H = zeros(2, 2)
 hessian!(H, itp, (0.5, 0.5))
+hessian!(H, itp, 0.5, 0.5)    # splatted scalars also supported
 
 # Optim.jl compatible:
 hess!(H, x) = hessian!(H, itp, x)
@@ -552,6 +557,7 @@ Uses locate-once optimization: interval search performed only once per query poi
 ```julia
 itp = cubic_interp((x, y), data)
 ∇²f = laplacian(itp, (0.5, 0.5))  # ∂²f/∂x² + ∂²f/∂y²
+∇²f = laplacian(itp, 0.5, 0.5)    # splatted scalars also supported
 
 # Equivalent to (but faster than):
 # tr(hessian(itp, (0.5, 0.5)))

--- a/src/vector_calculus.jl
+++ b/src/vector_calculus.jl
@@ -78,6 +78,16 @@ See also: [`gradient!`](@ref), [`value_gradient`](@ref), [`hessian`](@ref), [`la
     return _gradient_generic(itp, query, hint)
 end
 
+# Splat convenience: gradient(itp, x, y) → gradient(itp, (x, y)). Scalar-only;
+# `Vararg{Real,N}` can't match a batch container, so it never intercepts one.
+@inline function gradient(
+        itp::AbstractInterpolantND{Tg, Tv, N},
+        q::Vararg{Real, N};
+        kw...,
+    ) where {Tg, Tv, N}
+    return gradient(itp, q; kw...)
+end
+
 # Vector API for compatibility with ForwardDiff patterns
 @inline function gradient(
         itp::AbstractInterpolantND{Tg, Tv, N},
@@ -159,6 +169,16 @@ See also: [`gradient`](@ref), [`value_gradient`](@ref), [`hessian!`](@ref)
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
     return _gradient_generic!(G, itp, query, hint)
+end
+
+# Splat convenience: gradient!(G, itp, x, y) → gradient!(G, itp, (x, y)).
+@inline function gradient!(
+        G::AbstractVector,
+        itp::AbstractInterpolantND{Tg, Tv, N},
+        q::Vararg{Real, N};
+        kw...,
+    ) where {Tg, Tv, N}
+    return gradient!(G, itp, q; kw...)
 end
 
 # Vector query API
@@ -257,6 +277,15 @@ See also: [`gradient`](@ref), [`gradient!`](@ref)
     return _value_gradient_generic(itp, query, hint)
 end
 
+# Splat convenience: value_gradient(itp, x, y) → value_gradient(itp, (x, y)).
+@inline function value_gradient(
+        itp::AbstractInterpolantND{Tg, Tv, N},
+        q::Vararg{Real, N};
+        kw...,
+    ) where {Tg, Tv, N}
+    return value_gradient(itp, q; kw...)
+end
+
 # Vector API
 @inline function value_gradient(
         itp::AbstractInterpolantND{Tg, Tv, N},
@@ -349,6 +378,15 @@ See also: [`gradient`](@ref), [`hessian!`](@ref), [`laplacian`](@ref)
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
     return _hessian_generic(itp, query, hint)
+end
+
+# Splat convenience: hessian(itp, x, y) → hessian(itp, (x, y)).
+@inline function hessian(
+        itp::AbstractInterpolantND{Tg, Tv, N},
+        q::Vararg{Real, N};
+        kw...,
+    ) where {Tg, Tv, N}
+    return hessian(itp, q; kw...)
 end
 
 # Vector API
@@ -444,6 +482,16 @@ See also: [`hessian`](@ref), [`gradient!`](@ref)
     return _hessian_generic!(H, itp, query, hint)
 end
 
+# Splat convenience: hessian!(H, itp, x, y) → hessian!(H, itp, (x, y)).
+@inline function hessian!(
+        H::AbstractMatrix,
+        itp::AbstractInterpolantND{Tg, Tv, N},
+        q::Vararg{Real, N};
+        kw...,
+    ) where {Tg, Tv, N}
+    return hessian!(H, itp, q; kw...)
+end
+
 # Vector query API
 @inline function hessian!(
         H::AbstractMatrix,
@@ -522,6 +570,15 @@ See also: [`gradient`](@ref), [`hessian`](@ref)
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
     return _laplacian_generic(itp, query, hint)
+end
+
+# Splat convenience: laplacian(itp, x, y) → laplacian(itp, (x, y)).
+@inline function laplacian(
+        itp::AbstractInterpolantND{Tg, Tv, N},
+        q::Vararg{Real, N};
+        kw...,
+    ) where {Tg, Tv, N}
+    return laplacian(itp, q; kw...)
 end
 
 # Vector API

--- a/test/test_calltime_extrap_override.jl
+++ b/test/test_calltime_extrap_override.jl
@@ -1,0 +1,197 @@
+# Call-time `extrap` override on a persistent interpolant. The stored extrap is
+# the construction-time contract; the ONLY permitted per-call override is
+# `InBounds` (an in-domain fast-path assertion, not an extrapolation contract).
+# Any other explicit extrap errors. See
+# docs/superpowers/specs/2026-07-03-calltime-extrap-inbounds-override-design.md.
+
+@testitem "call-time extrap override — 1D scalar+vector" begin
+    x = collect(range(0.0, 10.0, 21))
+    y = sin.(x)
+    xq = 5.0
+    xqv = collect(range(0.5, 9.5, 50))
+
+    # Interpolants built with NoExtrap (the default contract). A call-time
+    # InBounds override must reproduce the default in-domain result exactly,
+    # since InBounds only skips the domain check for guaranteed-in-domain queries.
+    for build in (linear_interp, quadratic_interp, cubic_interp, constant_interp)
+        itp = build(x, y)                      # stored extrap = NoExtrap()
+
+        @testset "$build: InBounds override == default (in-domain)" begin
+            @test itp(xq; extrap = InBounds()) == itp(xq)
+            @test itp(xqv; extrap = InBounds()) == itp(xqv)
+            out = similar(xqv)
+            itp(out, xqv; extrap = InBounds())
+            @test out == itp(xqv)
+        end
+
+        @testset "$build: InBounds(last=:exclusive) works in-domain" begin
+            @test itp(xq; extrap = InBounds(last = :exclusive)) == itp(xq)
+        end
+
+        @testset "$build: omitting extrap is unchanged" begin
+            @test itp(xq; extrap = nothing) == itp(xq)
+        end
+
+        @testset "$build: disallowed extrap override errors" begin
+            @test_throws ArgumentError itp(xq; extrap = ClampExtrap())
+            @test_throws ArgumentError itp(xq; extrap = ExtendExtrap())
+            @test_throws ArgumentError itp(xqv; extrap = FillExtrap(0.0))
+            # even re-passing the same stored mode errors (only omission uses stored)
+            @test_throws ArgumentError itp(xq; extrap = NoExtrap())
+            # genuine junk is cut at the kwarg type boundary (not a friendly error)
+            @test_throws TypeError itp(xq; extrap = 5)
+        end
+    end
+end
+
+@testitem "call-time extrap override — ND scalar" begin
+    xg = collect(range(0.0, 10.0, 11))
+    yg = collect(range(0.0, 5.0, 9))
+    data = [sin(xi) * cos(yj) for xi in xg, yj in yg]
+    q = (5.0, 2.5)                                     # in-domain 2D query
+
+    for build in (linear_interp, quadratic_interp, cubic_interp, constant_interp)
+        itp = build((xg, yg), data)                    # stored extraps = (NoExtrap(), NoExtrap())
+
+        @testset "$build: InBounds override == default (in-domain)" begin
+            @test itp(q; extrap = InBounds()) == itp(q)             # broadcast all axes
+            @test itp(q...; extrap = InBounds()) == itp(q)          # vararg form
+        end
+
+        @testset "$build: per-axis tuple (nothing keeps stored)" begin
+            @test itp(q; extrap = (InBounds(), nothing)) == itp(q)  # axis 1 fast, axis 2 stored
+            @test itp(q; extrap = (InBounds(), InBounds())) == itp(q)
+        end
+
+        @testset "$build: disallowed override errors" begin
+            @test_throws ArgumentError itp(q; extrap = ClampExtrap())
+            @test_throws ArgumentError itp(q; extrap = (ClampExtrap(), InBounds()))
+            @test_throws ArgumentError itp(q; extrap = (NoExtrap(), NoExtrap()))
+            @test_throws TypeError itp(q; extrap = 5)      # junk cut at kwarg boundary
+        end
+    end
+end
+
+@testitem "call-time extrap override — ND batch" begin
+    xg = collect(range(0.0, 10.0, 11))
+    yg = collect(range(0.0, 5.0, 9))
+    data = [sin(xi) * cos(yj) for xi in xg, yj in yg]
+    qxs = collect(range(0.5, 9.5, 7))
+    qys = collect(range(0.3, 4.7, 7))
+    soa = (qxs, qys)                                   # SoA: tuple of coord vectors
+    aos = [(qxs[i], qys[i]) for i in eachindex(qxs)]   # AoS: vector of query tuples
+
+    for build in (linear_interp, quadratic_interp, cubic_interp, constant_interp)
+        itp = build((xg, yg), data)
+
+        @testset "$build: batch InBounds override == default (SoA + AoS)" begin
+            @test itp(soa; extrap = InBounds()) == itp(soa)
+            @test itp(aos; extrap = InBounds()) == itp(aos)
+            out = similar(qxs)
+            itp(out, soa; extrap = InBounds())
+            @test out == itp(soa)
+        end
+
+        @testset "$build: batch per-axis + disallowed" begin
+            @test itp(soa; extrap = (InBounds(), nothing)) == itp(soa)
+            @test_throws ArgumentError itp(soa; extrap = ClampExtrap())
+        end
+    end
+end
+
+@testitem "call-time extrap override — HeteroND guarded exclusion" begin
+    x = collect(range(0.0, 1.0, 6))
+    y = collect(range(0.0, 1.0, 5))
+    data = [xi + 2yj for xi in x, yj in y]
+    itp = interp((x, y), data; method = (CubicInterp(), LinearInterp()))
+    q = (0.5, 0.5)
+    soa = ([0.3, 0.7], [0.2, 0.8])
+
+    @testset "default paths unchanged" begin
+        @test itp(q) isa Real
+        @test itp(soa) == itp(soa)
+    end
+
+    @testset "call-time override rejected (not yet supported)" begin
+        # batch shares the generic callable → our friendly ArgumentError guard
+        @test_throws ArgumentError itp(soa; extrap = InBounds())
+        # scalar has its own callable without an `extrap` kwarg → unsupported keyword
+        @test_throws MethodError itp(q; extrap = InBounds())
+    end
+end
+
+@testitem "call-time extrap override — type stability & allocation" setup = [AllocConstants] begin
+    using FastInterpolations: _resolve_extrap_override
+    x = collect(range(0.0, 10.0, 21))
+    y = sin.(x)
+    itp1 = cubic_interp(x, y)
+
+    xg = collect(range(0.0, 10.0, 11))
+    yg = collect(range(0.0, 5.0, 9))
+    data = [sin(xi) * cos(yj) for xi in xg, yj in yg]
+    itpN = cubic_interp((xg, yg), data)
+
+    @testset "inference (concrete return, no Union)" begin
+        @test @inferred(itp1(5.0; extrap = InBounds())) isa Float64
+        @test @inferred(itp1(5.0; extrap = InBounds(last = :exclusive))) isa Float64
+        @test @inferred(itpN((5.0, 2.5); extrap = InBounds())) isa Float64
+        @test @inferred(itpN((5.0, 2.5); extrap = (InBounds(), nothing))) isa Float64
+        # ND per-axis resolution map must infer a concrete tuple (no Union leak)
+        @test @inferred(map(_resolve_extrap_override, (NoExtrap(), NoExtrap()), (InBounds(), nothing))) isa Tuple
+    end
+
+    @testset "allocation-free vs default (function barrier)" begin
+        # Bind the query INSIDE the barrier. Passing an NTuple as an argument to the
+        # measured function boxes 16 bytes at the call ABI boundary — a measurement
+        # artifact, not the eval; with the query bound internally the eval is
+        # allocation-free. `ALLOC_THRESHOLD` is 0 on Julia ≥ 1.12, with LTS slack.
+        ovr1(itp) = itp(5.0; extrap = InBounds())
+        ovrN(itp) = (q = (5.0, 2.5); itp(q; extrap = InBounds()))
+        ovr1(itp1); ovrN(itpN)                     # warm up
+        @test @allocated(ovr1(itp1)) <= ALLOC_THRESHOLD
+        @test @allocated(ovrN(itpN)) <= ALLOC_THRESHOLD
+    end
+end
+
+@testitem "call-time extrap override — Dual queries (AD)" begin
+    using ForwardDiff
+    x = collect(range(0.0, 10.0, 21))
+    y = sin.(x)
+    itp1 = cubic_interp(x, y)
+    # 1D: derivative through an InBounds-override eval matches the default eval
+    @test ForwardDiff.derivative(t -> itp1(t; extrap = InBounds()), 5.0) ≈
+        ForwardDiff.derivative(t -> itp1(t), 5.0)
+
+    xg = collect(range(0.0, 10.0, 11))
+    yg = collect(range(0.0, 5.0, 9))
+    data = [sin(xi) * cos(yj) for xi in xg, yj in yg]
+    itpN = cubic_interp((xg, yg), data)
+    g_ib = ForwardDiff.gradient(p -> itpN((p[1], p[2]); extrap = InBounds()), [5.0, 2.5])
+    g_df = ForwardDiff.gradient(p -> itpN((p[1], p[2])), [5.0, 2.5])
+    @test g_ib ≈ g_df
+end
+
+@testitem "call-time extrap override — InBounds parity across stored extraps" begin
+    x = collect(range(0.0, 10.0, 21))
+    y = sin.(x)
+    xq = 5.0
+    xqv = collect(range(0.5, 9.5, 40))
+
+    # For an in-domain query, InBounds must reproduce the default result regardless
+    # of which extrap the interpolant was built with (Clamp/Fill/Wrap/Extend).
+    @testset "stored extrap = $(nameof(typeof(e)))" for e in
+        (ClampExtrap(), FillExtrap(0.0), WrapExtrap(), ExtendExtrap())
+        itp = cubic_interp(x, y; extrap = e)
+        @test itp(xq; extrap = InBounds()) == itp(xq)
+        @test itp(xqv; extrap = InBounds()) == itp(xqv)
+    end
+
+    @testset "periodic interpolant (stored WrapExtrap)" begin
+        xp = collect(range(0.0, 2π, 21))
+        yp = sin.(xp)                       # yp[1] ≈ yp[end] ≈ 0 (inclusive periodic)
+        itp = cubic_interp(xp, yp; bc = PeriodicBC())
+        @test itp(3.0; extrap = InBounds()) == itp(3.0)              # in-domain, no wrap needed
+        @test itp(collect(range(0.1, 6.0, 30)); extrap = InBounds()) ==
+            itp(collect(range(0.1, 6.0, 30)))
+    end
+end

--- a/test/test_calltime_extrap_override.jl
+++ b/test/test_calltime_extrap_override.jl
@@ -292,3 +292,51 @@ end
             itp(collect(range(0.1, 6.0, 30)))
     end
 end
+
+@testitem "call-time extrap override — boundary-exact + exclusive arm + 3D" begin
+    # Regression pins for edges the family loops skip: exact endpoints, the
+    # `:exclusive` no-cap arm firing near the right endpoint, and N ≥ 3.
+
+    @testset "boundary-exact InBounds() == default" begin
+        x = collect(range(0.0, 10.0, 11))
+        y = sin.(x)
+        itp = cubic_interp(x, y)
+        for q in (first(x), last(x))                            # exact closed endpoints
+            @test itp(q; extrap = InBounds()) == itp(q)
+        end
+        xg = collect(range(0.0, 10.0, 11))
+        yg = collect(range(0.0, 5.0, 6))
+        data = [sin(a) * cos(b) for a in xg, b in yg]
+        nitp = cubic_interp((xg, yg), data)
+        for q in ((first(xg), first(yg)), (last(xg), last(yg)), (first(xg), last(yg)))
+            @test nitp(q; extrap = InBounds()) == nitp(q)       # exact corners
+        end
+    end
+
+    @testset "InBounds(last=:exclusive) no-cap arm near right endpoint" begin
+        # A unit-step range grid selects the exclusive no-cap direct-search arm; for
+        # queries in the last cell (strictly < last) it must match the default search.
+        for x in (0.0:1.0:10.0, collect(0.0:1.0:10.0))         # range (arm fires) + Vector
+            y = sin.(x)
+            itp = cubic_interp(x, y)
+            for q in (9.5, prevfloat(10.0))
+                @test itp(q; extrap = InBounds(last = :exclusive)) == itp(q)
+            end
+            xv = collect(range(0.5, prevfloat(10.0), 20))
+            @test itp(xv; extrap = InBounds(last = :exclusive)) == itp(xv)
+        end
+    end
+
+    @testset "3D broadcast + per-axis + wrong arity" begin
+        xg = collect(range(0.0, 1.0, 5))
+        yg = collect(range(0.0, 1.0, 4))
+        zg = collect(range(0.0, 1.0, 3))
+        data = [a + b + c for a in xg, b in yg, c in zg]
+        itp = linear_interp((xg, yg, zg), data)
+        q = (0.5, 0.5, 0.5)
+        @test itp(q; extrap = InBounds()) == itp(q)                        # ntuple(_->InBounds, Val(3))
+        @test itp(q; extrap = (InBounds(), nothing, InBounds())) == itp(q) # per-axis 3-tuple
+        @test_throws ArgumentError itp(q; extrap = (InBounds(), nothing))  # wrong arity (2 for 3D)
+        @test_throws ArgumentError itp(q; extrap = ClampExtrap())
+    end
+end

--- a/test/test_calltime_extrap_override.jl
+++ b/test/test_calltime_extrap_override.jl
@@ -66,6 +66,7 @@ end
             @test_throws ArgumentError itp(q; extrap = ClampExtrap())
             @test_throws ArgumentError itp(q; extrap = (ClampExtrap(), InBounds()))
             @test_throws ArgumentError itp(q; extrap = (NoExtrap(), NoExtrap()))
+            @test_throws ArgumentError itp(q; extrap = (InBounds(),))  # wrong arity (1 elem for 2D)
             @test_throws TypeError itp(q; extrap = 5)                 # scalar junk cut at kwarg boundary
             @test_throws TypeError itp(q; extrap = (5, nothing))      # junk tuple element cut as TypeError
         end
@@ -99,8 +100,42 @@ end
     end
 end
 
+@testitem "call-time extrap override — Hermite ND + NoInterp Hetero" begin
+    # Two families whose construction differs from the tensor-product loops above.
+    x = collect(range(0.0, 1.0, 6))
+    y = collect(range(0.0, 1.0, 5))
+    data = [sin(xi) * cos(yj) + xi for xi in x, yj in y]
+    q = (0.5, 0.5)
+    soa = (collect(range(0.1, 0.9, 7)), collect(range(0.15, 0.85, 7)))
+
+    @testset "Hermite ND (user partials)" begin
+        dfdx = [cos(xi) * cos(yj) + 1 for xi in x, yj in y]
+        dfdy = [-sin(xi) * sin(yj) for xi in x, yj in y]
+        d2 = [-cos(xi) * sin(yj) for xi in x, yj in y]
+        p = HermitePartials((1, 0) => dfdx, (0, 1) => dfdy, (1, 1) => d2)
+        itp = hermite_interp((x, y), data, p)
+        @test itp(q; extrap = InBounds()) == itp(q)                # broadcast all axes
+        @test itp(q; extrap = (InBounds(), nothing)) == itp(q)     # per-axis
+        @test itp(soa; extrap = InBounds()) == itp(soa)            # batch
+        @test_throws ArgumentError itp(q; extrap = ClampExtrap())
+        @test_throws ArgumentError itp(q; extrap = (InBounds(),))  # wrong arity
+    end
+
+    @testset "NoInterp-axis Hetero: InBounds is a value-safe no-op" begin
+        # The NoInterp branch reads `itp.extraps` directly — the override is accepted
+        # (validated) but must not change the result; a disallowed mode still throws.
+        itp = interp((x, y), data; method = (CubicInterp(), NoInterp()))
+        for k in (1, 3, 5)
+            qn = (0.5, GridIdx(k))
+            @test itp(qn; extrap = InBounds()) == itp(qn)
+            @test itp(qn; extrap = (InBounds(), nothing)) == itp(qn)
+        end
+        @test_throws ArgumentError itp((0.5, GridIdx(2)); extrap = ClampExtrap())
+    end
+end
+
 @testitem "call-time extrap override — HeteroND (all forms)" setup = [AllocConstants] begin
-    using FastInterpolations: _resolve_extrap_overrides, HeteroInterpolantND
+    using FastInterpolations: _resolve_extrap_override_nd, HeteroInterpolantND
     using ForwardDiff
 
     x = collect(range(0.0, 1.0, 6))
@@ -112,8 +147,7 @@ end
     soa = (qxs, qys)                                     # SoA: tuple of coord vectors
     aos = [(qxs[i], qys[i]) for i in eachindex(qxs)]     # AoS: vector of query tuples
 
-    # Three HeteroInterpolantND realizations, each a distinct eval path guarded
-    # out of the tensor-product override PR:
+    # Three HeteroInterpolantND realizations, each a distinct eval path:
     #  - mixed global-solve OnTheFly (CubicInterp × LinearInterp)
     #  - windowed OnTheFly with a local-Hermite axis (Pchip → OnTheFly Hermite ND)
     #  - PreCompute (`_HeteroPartials`) — direct ND kernel, gets the full fast-path
@@ -158,9 +192,9 @@ end
         @test @inferred(itp(q; extrap = (InBounds(), nothing))) isa Float64
         # resolution must infer a CONCRETE per-axis tuple (guards the per-axis
         # extrap-union boxing trap); default returns the stored tuple, same object
-        @test @inferred(_resolve_extrap_overrides(itp, (InBounds(), nothing))) isa
+        @test @inferred(_resolve_extrap_override_nd(itp, (InBounds(), nothing))) isa
             Tuple{<:InBounds, <:AbstractExtrap}
-        @test @inferred(_resolve_extrap_overrides(itp, nothing)) === itp.extraps
+        @test @inferred(_resolve_extrap_override_nd(itp, nothing)) === itp.extraps
 
         # allocation-free: bind the query INSIDE the barrier (a tuple passed as an
         # argument boxes 16B at the call ABI — a measurement artifact, not the eval).

--- a/test/test_calltime_extrap_override.jl
+++ b/test/test_calltime_extrap_override.jl
@@ -99,24 +99,86 @@ end
     end
 end
 
-@testitem "call-time extrap override — HeteroND guarded exclusion" begin
+@testitem "call-time extrap override — HeteroND (all forms)" setup = [AllocConstants] begin
+    using FastInterpolations: _resolve_extrap_overrides, HeteroInterpolantND
+    using ForwardDiff
+
     x = collect(range(0.0, 1.0, 6))
     y = collect(range(0.0, 1.0, 5))
-    data = [xi + 2yj for xi in x, yj in y]
-    itp = interp((x, y), data; method = (CubicInterp(), LinearInterp()))
-    q = (0.5, 0.5)
-    soa = ([0.3, 0.7], [0.2, 0.8])
+    data = [sin(xi) * cos(yj) + xi for xi in x, yj in y]
+    q = (0.5, 0.5)                                       # in-domain 2D query
+    qxs = collect(range(0.1, 0.9, 7))
+    qys = collect(range(0.15, 0.85, 7))
+    soa = (qxs, qys)                                     # SoA: tuple of coord vectors
+    aos = [(qxs[i], qys[i]) for i in eachindex(qxs)]     # AoS: vector of query tuples
 
-    @testset "default paths unchanged" begin
-        @test itp(q) isa Real
-        @test itp(soa) == itp(soa)
+    # Three HeteroInterpolantND realizations, each a distinct eval path guarded
+    # out of the tensor-product override PR:
+    #  - mixed global-solve OnTheFly (CubicInterp × LinearInterp)
+    #  - windowed OnTheFly with a local-Hermite axis (Pchip → OnTheFly Hermite ND)
+    #  - PreCompute (`_HeteroPartials`) — direct ND kernel, gets the full fast-path
+    builds = (
+        "mixed-OTF" => interp((x, y), data; method = (CubicInterp(), LinearInterp()), coeffs = OnTheFly()),
+        "windowed-OTF" => interp((x, y), data; method = (PchipInterp(), LinearInterp()), coeffs = OnTheFly()),
+        "PreCompute" => interp((x, y), data; method = (CubicInterp(), LinearInterp()), coeffs = PreCompute()),
+    )
+
+    @testset "$name: InBounds override == default (in-domain)" for (name, itp) in builds
+        @test itp isa HeteroInterpolantND
+        # scalar tuple + vararg forms; single InBounds broadcasts to all axes
+        @test itp(q; extrap = InBounds()) == itp(q)
+        @test itp(q...; extrap = InBounds()) == itp(q)
+        @test itp(q; extrap = InBounds(last = :exclusive)) == itp(q)
+        # per-axis tuple: `nothing` keeps that axis's stored mode
+        @test itp(q; extrap = (InBounds(), nothing)) == itp(q)
+        @test itp(q; extrap = (InBounds(), InBounds())) == itp(q)
+        # batch: SoA, AoS, in-place
+        @test itp(soa; extrap = InBounds()) == itp(soa)
+        @test itp(aos; extrap = InBounds()) == itp(aos)
+        out = similar(qxs)
+        itp(out, soa; extrap = InBounds())
+        @test out == itp(soa)
+        @test itp(soa; extrap = (InBounds(), nothing)) == itp(soa)
     end
 
-    @testset "call-time override rejected (not yet supported)" begin
-        # batch shares the generic callable → our friendly ArgumentError guard
-        @test_throws ArgumentError itp(soa; extrap = InBounds())
-        # scalar has its own callable without an `extrap` kwarg → unsupported keyword
-        @test_throws MethodError itp(q; extrap = InBounds())
+    @testset "$name: disallowed override errors" for (name, itp) in builds
+        @test_throws ArgumentError itp(q; extrap = ClampExtrap())
+        @test_throws ArgumentError itp(q; extrap = (ClampExtrap(), InBounds()))
+        @test_throws ArgumentError itp(q; extrap = (NoExtrap(), NoExtrap()))  # same-mode also errors
+        @test_throws ArgumentError itp(soa; extrap = ClampExtrap())
+        @test_throws TypeError itp(q; extrap = 5)                             # junk cut at kwarg boundary
+    end
+
+    @testset "type stability & allocation" begin
+        itp = builds[1].second                           # mixed-OTF
+        # @inferred + isa pins: concrete Float64 return, no Union in the hot path
+        @test @inferred(itp(q; extrap = InBounds())) isa Float64
+        @test @inferred(itp(q; extrap = InBounds(last = :exclusive))) isa Float64
+        @test @inferred(itp(q; extrap = (InBounds(), nothing))) isa Float64
+        # resolution must infer a CONCRETE per-axis tuple (guards the per-axis
+        # extrap-union boxing trap); default returns the stored tuple, same object
+        @test @inferred(_resolve_extrap_overrides(itp, (InBounds(), nothing))) isa
+            Tuple{<:InBounds, <:AbstractExtrap}
+        @test @inferred(_resolve_extrap_overrides(itp, nothing)) === itp.extraps
+
+        # allocation-free: bind the query INSIDE the barrier (a tuple passed as an
+        # argument boxes 16B at the call ABI — a measurement artifact, not the eval).
+        # Default path was measured 0-alloc for all three forms; the override must match.
+        ovr(f) = (p = (0.5, 0.5); f(p; extrap = InBounds()))
+        dfl(f) = (p = (0.5, 0.5); f(p))
+        for (_, itpb) in builds
+            ovr(itpb)
+            dfl(itpb)                                     # warm up each specialization
+            @test @allocated(ovr(itpb)) <= ALLOC_THRESHOLD
+            @test @allocated(dfl(itpb)) <= ALLOC_THRESHOLD   # default unchanged
+        end
+    end
+
+    @testset "Dual queries (AD) through InBounds override" begin
+        itp = builds[1].second
+        g_ib = ForwardDiff.gradient(p -> itp((p[1], p[2]); extrap = InBounds()), [0.5, 0.5])
+        g_df = ForwardDiff.gradient(p -> itp((p[1], p[2])), [0.5, 0.5])
+        @test g_ib ≈ g_df
     end
 end
 

--- a/test/test_calltime_extrap_override.jl
+++ b/test/test_calltime_extrap_override.jl
@@ -1,8 +1,7 @@
 # Call-time `extrap` override on a persistent interpolant. The stored extrap is
 # the construction-time contract; the ONLY permitted per-call override is
 # `InBounds` (an in-domain fast-path assertion, not an extrapolation contract).
-# Any other explicit extrap errors. See
-# docs/superpowers/specs/2026-07-03-calltime-extrap-inbounds-override-design.md.
+# Any other explicit extrap errors.
 
 @testitem "call-time extrap override — 1D scalar+vector" begin
     x = collect(range(0.0, 10.0, 21))
@@ -67,7 +66,8 @@ end
             @test_throws ArgumentError itp(q; extrap = ClampExtrap())
             @test_throws ArgumentError itp(q; extrap = (ClampExtrap(), InBounds()))
             @test_throws ArgumentError itp(q; extrap = (NoExtrap(), NoExtrap()))
-            @test_throws TypeError itp(q; extrap = 5)      # junk cut at kwarg boundary
+            @test_throws TypeError itp(q; extrap = 5)                 # scalar junk cut at kwarg boundary
+            @test_throws TypeError itp(q; extrap = (5, nothing))      # junk tuple element cut as TypeError
         end
     end
 end
@@ -146,7 +146,8 @@ end
         @test_throws ArgumentError itp(q; extrap = (ClampExtrap(), InBounds()))
         @test_throws ArgumentError itp(q; extrap = (NoExtrap(), NoExtrap()))  # same-mode also errors
         @test_throws ArgumentError itp(soa; extrap = ClampExtrap())
-        @test_throws TypeError itp(q; extrap = 5)                             # junk cut at kwarg boundary
+        @test_throws TypeError itp(q; extrap = 5)                             # scalar junk cut at kwarg boundary
+        @test_throws TypeError itp(q; extrap = (5, nothing))                  # junk tuple element → TypeError
     end
 
     @testset "type stability & allocation" begin

--- a/test/test_gradient_hessian.jl
+++ b/test/test_gradient_hessian.jl
@@ -715,26 +715,26 @@ end
 @testitem "Vector Calculus: splatted args convenience" setup = [AllocConstants] begin
     # Splatted scalar queries — gradient(itp, x, y) — must be bit-identical to
     # the canonical tuple form gradient(itp, (x, y)) for all 6 functions.
-    # The splat bundler re-dispatches into the same tuple method, so `==` (exact).
-
-    # Assert splat == tuple for every vector-calculus function at one point.
+    # The splat bundler re-dispatches into the same tuple method, so the results
+    # are bit-identical; `isequal` (not `==`) checks that at the bit level
+    # (NaN == NaN, distinguishes ±0.0), matching the exactness intent.
     function check_splat_equiv(itp, q::Tuple{Vararg{Real, N}}; hint = nothing) where {N}
-        @test gradient(itp, q...; hint = hint) == gradient(itp, q; hint = hint)
-        @test value_gradient(itp, q...; hint = hint) == value_gradient(itp, q; hint = hint)
-        @test laplacian(itp, q...; hint = hint) == laplacian(itp, q; hint = hint)
-        @test hessian(itp, q...; hint = hint) == hessian(itp, q; hint = hint)
+        @test isequal(gradient(itp, q...; hint = hint), gradient(itp, q; hint = hint))
+        @test isequal(value_gradient(itp, q...; hint = hint), value_gradient(itp, q; hint = hint))
+        @test isequal(laplacian(itp, q...; hint = hint), laplacian(itp, q; hint = hint))
+        @test isequal(hessian(itp, q...; hint = hint), hessian(itp, q; hint = hint))
 
         Gs = zeros(N)
         Gt = zeros(N)
         gradient!(Gs, itp, q...; hint = hint)
         gradient!(Gt, itp, q; hint = hint)
-        @test Gs == Gt
+        @test isequal(Gs, Gt)
 
         Hs = zeros(N, N)
         Ht = zeros(N, N)
         hessian!(Hs, itp, q...; hint = hint)
         hessian!(Ht, itp, q; hint = hint)
-        @test Hs == Ht
+        @test isequal(Hs, Ht)
     end
 
     @testset "2D splat == tuple (cubic)" begin
@@ -808,7 +808,7 @@ end
         check_splat_equiv(itp, (Float32(1.7), 0.9)) # Float32 + Float64 (mixed width)
 
         # Sanity: a mixed-type splat call actually resolves (no MethodError).
-        @test gradient(itp, 2, 0.9) == gradient(itp, (2, 0.9))
+        @test isequal(gradient(itp, 2, 0.9), gradient(itp, (2, 0.9)))
     end
 
     @testset "GridIdx coordinates through splat" begin
@@ -821,6 +821,6 @@ end
 
         check_splat_equiv(itp, (GridIdx(3), GridIdx(5)))  # both GridIdx
         check_splat_equiv(itp, (GridIdx(3), 0.9))          # GridIdx + Float64
-        @test gradient(itp, GridIdx(3), 0.9) == gradient(itp, (GridIdx(3), 0.9))
+        @test isequal(gradient(itp, GridIdx(3), 0.9), gradient(itp, (GridIdx(3), 0.9)))
     end
 end

--- a/test/test_gradient_hessian.jl
+++ b/test/test_gradient_hessian.jl
@@ -711,3 +711,116 @@ end
     end
 
 end
+
+@testitem "Vector Calculus: splatted args convenience" setup = [AllocConstants] begin
+    # Splatted scalar queries — gradient(itp, x, y) — must be bit-identical to
+    # the canonical tuple form gradient(itp, (x, y)) for all 6 functions.
+    # The splat bundler re-dispatches into the same tuple method, so `==` (exact).
+
+    # Assert splat == tuple for every vector-calculus function at one point.
+    function check_splat_equiv(itp, q::Tuple{Vararg{Real, N}}; hint = nothing) where {N}
+        @test gradient(itp, q...; hint = hint) == gradient(itp, q; hint = hint)
+        @test value_gradient(itp, q...; hint = hint) == value_gradient(itp, q; hint = hint)
+        @test laplacian(itp, q...; hint = hint) == laplacian(itp, q; hint = hint)
+        @test hessian(itp, q...; hint = hint) == hessian(itp, q; hint = hint)
+
+        Gs = zeros(N)
+        Gt = zeros(N)
+        gradient!(Gs, itp, q...; hint = hint)
+        gradient!(Gt, itp, q; hint = hint)
+        @test Gs == Gt
+
+        Hs = zeros(N, N)
+        Ht = zeros(N, N)
+        hessian!(Hs, itp, q...; hint = hint)
+        hessian!(Ht, itp, q; hint = hint)
+        @test Hs == Ht
+    end
+
+    @testset "2D splat == tuple (cubic)" begin
+        x = range(0.0, 2π, 51)
+        y = range(0.0, π, 31)
+        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+        itp = cubic_interp((x, y), data)
+        check_splat_equiv(itp, (1.7, 0.9))
+    end
+
+    @testset "3D splat == tuple (cubic)" begin
+        x = range(0.0, 2π, 21)
+        y = range(0.0, π, 17)
+        z = range(0.0, 1.0, 13)
+        data = [sin(xi) * cos(yj) * exp(zk) for xi in x, yj in y, zk in z]
+        itp = cubic_interp((x, y, z), data)
+        check_splat_equiv(itp, (1.7, 0.9, 0.4))
+    end
+
+    @testset "linear splat == tuple" begin
+        x = range(0.0, 2π, 51)
+        y = range(0.0, π, 31)
+        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+        itp = linear_interp((x, y), data)
+        check_splat_equiv(itp, (1.7, 0.9))
+    end
+
+    @testset "hetero routing: splat == tuple (Cubic, Linear)" begin
+        # Proves the abstract-level bundler delegates into the HeteroInterpolantND
+        # tuple override, not just the generic per-type path.
+        x = range(0.0, 2π, 51)
+        y = range(0.0, π, 31)
+        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+        itp = interp((x, y), data; method = (CubicInterp(), LinearInterp()))
+        check_splat_equiv(itp, (1.7, 0.9))
+    end
+
+    @testset "hint kwarg forwarded through splat" begin
+        x = range(0.0, 2π, 51)
+        y = range(0.0, π, 31)
+        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+        itp = cubic_interp((x, y), data)
+        hint = (Ref(1), Ref(1))
+        check_splat_equiv(itp, (1.7, 0.9); hint = hint)
+    end
+
+    @testset "splat does not intercept tuple or vector forms" begin
+        # A single Tuple arg and a single Vector arg must still hit their own
+        # methods (Vector form returns a Vector; tuple form an NTuple).
+        x = range(0.0, 2π, 51)
+        y = range(0.0, π, 31)
+        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+        itp = cubic_interp((x, y), data)
+        @test gradient(itp, (1.7, 0.9)) isa NTuple{2}
+        @test gradient(itp, [1.7, 0.9]) isa Vector
+        @test gradient(itp, 1.7, 0.9) isa NTuple{2}
+    end
+
+    @testset "mixed & non-Float64 Real coordinate types" begin
+        # Vararg{Real,N} accepts ANY Real subtype, mixed per-argument. Each case
+        # must not MethodError and must stay bit-identical to its tuple form.
+        x = range(0.0, 2π, 51)
+        y = range(0.0, π, 31)
+        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+        itp = cubic_interp((x, y), data)
+
+        check_splat_equiv(itp, (2, 0.9))          # Int + Float64 (mixed)
+        check_splat_equiv(itp, (2, 1))            # all Int
+        check_splat_equiv(itp, (1.7f0, 0.9f0))    # Float32
+        check_splat_equiv(itp, (17 // 10, 9 // 10)) # Rational
+        check_splat_equiv(itp, (Float32(1.7), 0.9)) # Float32 + Float64 (mixed width)
+
+        # Sanity: a mixed-type splat call actually resolves (no MethodError).
+        @test gradient(itp, 2, 0.9) == gradient(itp, (2, 0.9))
+    end
+
+    @testset "GridIdx coordinates through splat" begin
+        # GridIdx <: Real, so it flows through Vararg{Real,N} exactly like the
+        # forward callable path documents. Evaluates at the addressed grid node.
+        x = range(0.0, 2π, 51)
+        y = range(0.0, π, 31)
+        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+        itp = cubic_interp((x, y), data)
+
+        check_splat_equiv(itp, (GridIdx(3), GridIdx(5)))  # both GridIdx
+        check_splat_equiv(itp, (GridIdx(3), 0.9))          # GridIdx + Float64
+        @test gradient(itp, GridIdx(3), 0.9) == gradient(itp, (GridIdx(3), 0.9))
+    end
+end


### PR DESCRIPTION
## Summary

Lets the ND vector-calculus functions accept **splatted scalar coordinates**
as a convenience, in addition to the canonical tuple form:

```julia
gradient(itp, 0.3, 0.2)        # new — same as gradient(itp, (0.3, 0.2))
value_gradient(itp, 0.3, 0.2)
hessian(itp, 0.3, 0.2)
laplacian(itp, 0.3, 0.2)
gradient!(G, itp, 0.3, 0.2)
hessian!(H, itp, 0.3, 0.2)
```

This mirrors the forward callable, which already accepts `itp(0.3, 0.2)`, and
matches the ecosystem convention (`Interpolations.gradient(itp, x...)`). The
canonical `Tuple` form and the `AbstractVector` (ForwardDiff/Optim) form are
unchanged.

## How

Each of the 6 functions gains **one** `@inline` `Vararg{Real,N}` bundler on
`AbstractInterpolantND` that re-dispatches to the existing `Tuple` method:

```julia
@inline gradient(itp::AbstractInterpolantND{Tg,Tv,N}, q::Vararg{Real,N}; kw...) where {Tg,Tv,N} =
    gradient(itp, q; kw...)
```

- **Zero runtime cost** — inside the body `q` is already a tuple, so the call is
  a plain re-dispatch that inlines away.
- **No collision** — `Vararg{Real,N}` matches only N separate scalar-Real args,
  so a single tuple arg or a single vector arg keeps hitting its own method, and
  batch containers (SoA/AoS) are never intercepted. Scalar-vs-batch stays a pure
  dispatch decision.
- **Routes into all backends for free** — delegation on the `Tuple` form lets
  Julia pick the more-specific `HeteroInterpolantND`/NoInterp overrides; no
  per-type duplication.
- **All Real subtypes flow through** — `Int`, `Float32`, `Rational`, mixed
  per-argument, and `GridIdx` (`<: Real`), identical to the forward path.

## Tests

New `@testitem` in `test/test_gradient_hessian.jl` asserting the splat form is
**bit-identical** (`==`) to the tuple form for all 6 functions across:
2D/3D cubic, linear, a `HeteroInterpolantND` (proves hetero-override routing),
the `hint` keyword, dispatch isolation (tuple/vector forms untouched), and mixed
/non-Float64 Real coordinate types incl. `GridIdx`.

Full suite green.

## Scope / notes

- Out of scope (deferred): `DerivativeView` callable splat, ND `integrate`
  bounds splat, batch queries.
- **Base:** stacked on `feat/calltime-extrap-override`; that branch should merge
  to `master` first, after which this PR's diff shows only the splat changes.
