### PR TITLE
feat(nd): collapse 1-tuple-grid N=1 calls to the lean 1D path

### DIFF
--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -263,7 +263,8 @@ function constant_interp!(
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
-        search::AbstractSearchPolicy = AutoSearch()
+        search::AbstractSearchPolicy = AutoSearch(),
+        hint::Union{Nothing, Base.RefValue{Int}} = nothing
     )
     @assert length(y) == length(x) "x and y must have same length"
     @assert length(output) == length(x_targets) "output must match x_targets length"
@@ -273,7 +274,7 @@ function constant_interp!(
     x_eff = _resolve_axis(x, bc, eltype(x))
     y_eff = _resolve_data(y, bc)
     extrap_eff = _resolve_extrap(extrap, bc, x_eff, y_eff)
-    searcher = _resolve_search(x_eff, x_targets, search, nothing)
+    searcher = _resolve_search(x_eff, x_targets, search, hint)
     _constant_vector_loop!(output, x_eff, y_eff, x_targets, extrap_eff, side, deriv, searcher)
     return output
 end
@@ -311,11 +312,12 @@ function constant_interp(
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
-        search::AbstractSearchPolicy = AutoSearch()
+        search::AbstractSearchPolicy = AutoSearch(),
+        hint::Union{Nothing, Base.RefValue{Int}} = nothing
     )
     output = Vector{_promote_eltype(_select_op, eltype(x), eltype(y), eltype(x_targets))}(
         undef, length(x_targets)
     )
-    constant_interp!(output, x, y, x_targets; bc, extrap, side, deriv, search)
+    constant_interp!(output, x, y, x_targets; bc, extrap, side, deriv, search, hint)
     return output
 end

--- a/src/constant/nd/constant_nd_interpolant.jl
+++ b/src/constant/nd/constant_nd_interpolant.jl
@@ -94,11 +94,11 @@ end
 
 # N=1 batch one-shot → lean 1D batch one-shot (bit-identical). See linear_nd_interpolant.jl.
 @inline constant_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    constant_interp(only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
+    constant_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 @inline constant_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    constant_interp!(output, only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
+    constant_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
 @inline constant_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    constant_interp(only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
+    constant_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
 @inline constant_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    constant_interp!(output, only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
+    constant_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)

--- a/src/constant/nd/constant_nd_interpolant.jl
+++ b/src/constant/nd/constant_nd_interpolant.jl
@@ -80,3 +80,25 @@ function constant_interp(
     extrap_vals = map(_resolve_extrap, extrap_vals, grids_typed)
     return ConstantInterpolantND(grids_typed, data_typed, extrap_vals, sides, searches; bcs = bcs_post, store = store)
 end
+
+# N=1 collapse: a 1-axis grid tuple forwards to the genuine 1D constant path (lean
+# 1D batch loop; per-axis 1-tuple kwargs unwrap to scalar). More specific than the
+# `NTuple{N}` method above, so it only claims N=1. See linear_nd_interpolant.jl.
+@inline constant_interp(grids::Tuple{AbstractVector}, data::AbstractVector; kwargs...) =
+    constant_interp(only(grids), data; _unwrap_nd_kwargs(values(kwargs))...)
+
+# N=1 scalar one-shot: bare scalar → scalar query `(q,)` → ND scalar one-shot
+# (scalar output, not `[val]`). See linear_nd_interpolant.jl.
+@inline constant_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Real; kwargs...) =
+    constant_interp(grids, data, (q,); kwargs...)
+
+# N=1 batch one-shot → lean 1D batch one-shot (bit-identical). See linear_nd_interpolant.jl.
+@inline constant_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+    constant_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+@inline constant_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+    constant_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+# Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
+@inline constant_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+    constant_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+@inline constant_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+    constant_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)

--- a/src/constant/nd/constant_nd_interpolant.jl
+++ b/src/constant/nd/constant_nd_interpolant.jl
@@ -94,11 +94,11 @@ end
 
 # N=1 batch one-shot → lean 1D batch one-shot (bit-identical). See linear_nd_interpolant.jl.
 @inline constant_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    constant_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+    constant_interp(only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
 @inline constant_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    constant_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+    constant_interp!(output, only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
 @inline constant_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    constant_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+    constant_interp(only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
 @inline constant_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    constant_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+    constant_interp!(output, only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -24,6 +24,16 @@
 @inline _itp_extrap(itp::AbstractInterpolant1D) = itp.extrap
 @inline _itp_search(itp::AbstractInterpolant1D) = itp.search_policy
 
+# ── N=1 tuple-grid collapse: kwarg unwrapping ──
+# A 1-axis ND constructor `foo_interp((x,), y; ...)` and the 1D tuple-query shims
+# below both forward to the genuine 1D path. Per-axis kwargs arrive ND-style as
+# 1-tuples (`extrap=(WrapExtrap(),)`, `deriv=(DerivOp(1),)`); unwrap them to the
+# scalar the 1D signature expects. Non-tuple values (`store`, `tension`, a scalar
+# `extrap`) pass through untouched.
+@inline _unwrap_axis1(x::Tuple{Any}) = x[1]
+@inline _unwrap_axis1(x) = x
+@inline _unwrap_nd_kwargs(nt::NamedTuple) = map(_unwrap_axis1, nt)
+
 # ── Call-time extrap override (singular: 1D / ND per-axis) ──
 # The stored extrap is the construction-time contract; the only per-call override
 # is `InBounds` (an in-domain fast-path ASSERTION, not an extrapolation contract —
@@ -148,6 +158,19 @@ function (itp::AbstractInterpolant1D{Tg, Tv})(
     _itp_vector_loop!(output, itp, xq, extrap_eff, deriv, searcher)
     return output
 end
+
+# ── ND-style tuple queries on a 1D interpolant ──
+# A 1-axis grid collapses to the 1D path (see the `*_interp((x,), y)` forwarders),
+# so generic tensor code that issues tuple queries stays transparent: `itp((x,))`
+# (scalar), `itp(out, (xv,))` / `itp((xv,))` (SoA batch). Per-axis kwargs given as
+# 1-tuples (`extrap=(WrapExtrap(),)`, `deriv=(DerivOp(1),)`) unwrap to scalar. Each
+# just strips the 1-tuple and forwards to the positional 1D form above.
+@inline (itp::AbstractInterpolant1D)(q::Tuple{Real}; kwargs...) =
+    itp(q[1]; _unwrap_nd_kwargs(values(kwargs))...)
+@inline (itp::AbstractInterpolant1D)(output::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+    itp(output, q[1]; _unwrap_nd_kwargs(values(kwargs))...)
+@inline (itp::AbstractInterpolant1D)(q::Tuple{AbstractVector}; kwargs...) =
+    itp(q[1]; _unwrap_nd_kwargs(values(kwargs))...)
 
 # ╔══════════════════════════════════════╗
 # ║       ND Interpolant Protocol        ║

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -34,13 +34,6 @@
 @inline _unwrap_axis1(x) = x
 @inline _unwrap_nd_kwargs(nt::NamedTuple) = map(_unwrap_axis1, nt)
 
-# Batch one-shot collapse: like `_unwrap_nd_kwargs` but also drops `hint`. The 1D batch
-# one-shots (linear/cubic/quadratic/constant) have no `hint` kwarg — it is the ND path's
-# per-axis sequential-access seed, threaded e.g. by the GridIdx pre-slice. Values are
-# unaffected (a batch reseeds its searcher regardless).
-@inline _unwrap_nd_batch_kwargs(nt::NamedTuple) =
-    map(_unwrap_axis1, Base.structdiff(nt, NamedTuple{(:hint,)}))
-
 # ── Call-time extrap override (singular: 1D / ND per-axis) ──
 # The stored extrap is the construction-time contract; the only per-call override
 # is `InBounds` (an in-domain fast-path ASSERTION, not an extrapolation contract —

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -34,6 +34,13 @@
 @inline _unwrap_axis1(x) = x
 @inline _unwrap_nd_kwargs(nt::NamedTuple) = map(_unwrap_axis1, nt)
 
+# Batch one-shot collapse: like `_unwrap_nd_kwargs` but also drops `hint`. The 1D batch
+# one-shots (linear/cubic/quadratic/constant) have no `hint` kwarg — it is the ND path's
+# per-axis sequential-access seed, threaded e.g. by the GridIdx pre-slice. Values are
+# unaffected (a batch reseeds its searcher regardless).
+@inline _unwrap_nd_batch_kwargs(nt::NamedTuple) =
+    map(_unwrap_axis1, Base.structdiff(nt, NamedTuple{(:hint,)}))
+
 # ── Call-time extrap override (singular: 1D / ND per-axis) ──
 # The stored extrap is the construction-time contract; the only per-call override
 # is `InBounds` (an in-domain fast-path ASSERTION, not an extrapolation contract —

--- a/src/cubic/cubic_oneshot.jl
+++ b/src/cubic/cubic_oneshot.jl
@@ -245,14 +245,15 @@ In-place cubic spline interpolation with optional automatic caching.
         extrap::AbstractExtrap = NoExtrap(),
         autocache::Bool = true,
         deriv::DerivOp = EvalValue(),
-        search::AbstractSearchPolicy = AutoSearch()
+        search::AbstractSearchPolicy = AutoSearch(),
+        hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv}
     # Value-matched Tg: Int/OneTo grid + Float32 data → Float32 axis, so the spline
     # cache builds (and memoises — `_CachedRange` is isbits, objectid-deterministic)
     # at the value width instead of the blind Float64.
     x = _resolve_axis(x, _promote_grid_float(Tg, Tv))
     # No BC on Searcher: seam handled by axis-level dispatch on `cache.x` at eval.
-    searcher = _resolve_search(x, x_query, search, nothing)
+    searcher = _resolve_search(x, x_query, search, hint)
     # Periodic BC
     if _is_periodic_bc(bc)
         return _cubic_interp_periodic!(output, x, y, x_query, bc, autocache, deriv, searcher)
@@ -336,12 +337,13 @@ function cubic_interp(
         extrap::AbstractExtrap = NoExtrap(),
         autocache::Bool = true,
         deriv::DerivOp = EvalValue(),
-        search::AbstractSearchPolicy = AutoSearch()
+        search::AbstractSearchPolicy = AutoSearch(),
+        hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv}
     Tq = eltype(x_query)
     Tr = _promote_eltype(_interp_op, Tg, Tv, Tq)
     output = Vector{Tr}(undef, length(x_query))
-    cubic_interp!(output, x, y, x_query; bc, extrap, autocache, deriv, search)
+    cubic_interp!(output, x, y, x_query; bc, extrap, autocache, deriv, search, hint)
     return output
 end
 

--- a/src/cubic/nd/cubic_nd_interpolant.jl
+++ b/src/cubic/nd/cubic_nd_interpolant.jl
@@ -57,7 +57,12 @@ data_c = [sin(xi) * cos(yj) * zk + im * cos(xi) for xi in x, yj in y, zk in z]
 itp_c = cubic_interp((x, y, z), data_c)
 ```
 """
-function cubic_interp(
+# Public ND constructor (N≥2; N=1 is intercepted by the collapse method below and
+# only reaches the ND builder for the no-1D-equivalent `coeffs=OnTheFly()` case).
+@inline cubic_interp(grids::NTuple{N, AbstractVector}, data::AbstractArray{<:Any, N}; kwargs...) where {N} =
+    _cubic_interp_nd(grids, data; kwargs...)
+
+function _cubic_interp_nd(
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv_raw, N};
         bc::Union{AbstractBC, NTuple{N, AbstractBC}} = CubicFit(),
@@ -144,6 +149,36 @@ function _build_nd_interpolant(
     # (via _resolve_extrap_nd in cubic_interp)
     return CubicInterpolantND(grids, nodal_derivs, bcs_store, extraps_val, searches)
 end
+
+# ── N=1 collapse (shared rationale in linear_nd_interpolant.jl) ──
+# Cubic is the one method where 1D and ND differ in a kwarg: 1D is inherently
+# PreCompute (`autocache::Bool`, no `coeffs`), ND accepts `coeffs`. `coeffs` is a
+# compile-time-known kwarg, so the `coeffs isa OnTheFly` guard folds away — the common
+# path forwards to the lean 1D method; OnTheFly (local, no 1D equivalent) stays on the
+# factored ND internals. The 1D branch passes a bare-vector grid (`only(grids)`), so it
+# hits the genuine 1D method and is never re-intercepted (no infinite recursion).
+@inline function cubic_interp(grids::Tuple{AbstractVector}, data::AbstractVector; coeffs::AbstractCoeffStrategy = PreCompute(), kwargs...)
+    coeffs isa OnTheFly && return _cubic_interp_nd(grids, data; coeffs, kwargs...)
+    return cubic_interp(only(grids), data; _unwrap_nd_kwargs(values(kwargs))...)
+end
+
+# Scalar one-shot: bare scalar → `(q,)` → ND scalar one-shot (handles coeffs natively).
+@inline cubic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Real; kwargs...) =
+    cubic_interp(grids, data, (q,); kwargs...)
+
+# Batch one-shot (bare vector; the SoA `(xv,)` form below unwraps into it).
+@inline function cubic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...)
+    coeffs isa OnTheFly && return _cubic_interp_nd_oneshot_alloc(grids, data, q; coeffs, kwargs...)
+    return cubic_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+end
+@inline function cubic_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...)
+    coeffs isa OnTheFly && return _cubic_interp_nd_oneshot_batch!(output, grids, data, q; coeffs, kwargs...)
+    return cubic_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+end
+@inline cubic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+    cubic_interp(grids, data, only(q); kwargs...)
+@inline cubic_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+    cubic_interp!(output, grids, data, only(q); kwargs...)
 
 # OnTheFly is handled in cubic_interp() above (delegates to _build_hetero_nd).
 # No _build_nd_interpolant(::OnTheFly) needed.

--- a/src/cubic/nd/cubic_nd_interpolant.jl
+++ b/src/cubic/nd/cubic_nd_interpolant.jl
@@ -169,11 +169,11 @@ end
 # Batch one-shot (bare vector; the SoA `(xv,)` form below unwraps into it).
 @inline function cubic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...)
     coeffs isa OnTheFly && return _cubic_interp_nd_oneshot_alloc(grids, data, q; coeffs, kwargs...)
-    return cubic_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+    return cubic_interp(only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
 end
 @inline function cubic_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...)
     coeffs isa OnTheFly && return _cubic_interp_nd_oneshot_batch!(output, grids, data, q; coeffs, kwargs...)
-    return cubic_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+    return cubic_interp!(output, only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
 end
 @inline cubic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
     cubic_interp(grids, data, only(q); kwargs...)

--- a/src/cubic/nd/cubic_nd_interpolant.jl
+++ b/src/cubic/nd/cubic_nd_interpolant.jl
@@ -169,11 +169,11 @@ end
 # Batch one-shot (bare vector; the SoA `(xv,)` form below unwraps into it).
 @inline function cubic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...)
     coeffs isa OnTheFly && return _cubic_interp_nd_oneshot_alloc(grids, data, q; coeffs, kwargs...)
-    return cubic_interp(only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
+    return cubic_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 end
 @inline function cubic_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...)
     coeffs isa OnTheFly && return _cubic_interp_nd_oneshot_batch!(output, grids, data, q; coeffs, kwargs...)
-    return cubic_interp!(output, only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
+    return cubic_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 end
 @inline cubic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
     cubic_interp(grids, data, only(q); kwargs...)

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -71,7 +71,12 @@ Accepts any query format implementing the query protocol
 (`_query_length`, `_query_extract`, `_query_eltype`).
 Zero-allocation for workspace after warmup; output vector is heap-allocated.
 """
-function cubic_interp(
+# Public ND allocating batch one-shot (N≥2; N=1 intercepted by the collapse method,
+# reaching here only for the no-1D-equivalent OnTheFly branch).
+@inline cubic_interp(grids::NTuple{N, AbstractVector}, data::AbstractArray{<:Any, N}, queries; kwargs...) where {N} =
+    _cubic_interp_nd_oneshot_alloc(grids, data, queries; kwargs...)
+
+function _cubic_interp_nd_oneshot_alloc(
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         queries;
@@ -86,7 +91,7 @@ function cubic_interp(
     Tq = _query_eltype(queries)
     Tr = _promote_eltype(_interp_op, Tg, Tv, Tq)
     output = Vector{Tr}(undef, _query_length(queries))
-    cubic_interp!(output, grids, data, queries; deriv, bc, extrap, search, coeffs, hint)
+    _cubic_interp_nd_oneshot_batch!(output, grids, data, queries; deriv, bc, extrap, search, coeffs, hint)
     return output
 end
 
@@ -239,7 +244,12 @@ In-place one-shot ND cubic interpolation at multiple points (batch).
 Accepts any query format implementing the query protocol.
 Writes results into pre-allocated `output` vector.
 """
-function cubic_interp!(
+# Public ND in-place batch one-shot (N≥2; N=1 is intercepted by the collapse method
+# below and only reaches here via the OnTheFly branch, which has no 1D equivalent).
+@inline cubic_interp!(output::AbstractVector, grids::NTuple{N, AbstractVector}, data::AbstractArray{<:Any, N}, queries; kwargs...) where {N} =
+    _cubic_interp_nd_oneshot_batch!(output, grids, data, queries; kwargs...)
+
+function _cubic_interp_nd_oneshot_batch!(
         output::AbstractVector,
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},

--- a/src/hetero/local_hermite_nd_forward.jl
+++ b/src/hetero/local_hermite_nd_forward.jl
@@ -74,14 +74,14 @@ end
 
 # N=1 batch one-shot → lean 1D batch one-shot. See linear_nd_interpolant.jl.
 @inline pchip_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    pchip_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+    pchip_interp(only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
 @inline pchip_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    pchip_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+    pchip_interp!(output, only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
 @inline pchip_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    pchip_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+    pchip_interp(only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
 @inline pchip_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    pchip_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+    pchip_interp!(output, only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
 
 @inline function pchip_interp(
         grids::NTuple{N, AbstractVector},
@@ -141,14 +141,14 @@ end
 
 # N=1 batch one-shot → lean 1D batch one-shot. See linear_nd_interpolant.jl.
 @inline cardinal_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    cardinal_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+    cardinal_interp(only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
 @inline cardinal_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    cardinal_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+    cardinal_interp!(output, only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
 @inline cardinal_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    cardinal_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+    cardinal_interp(only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
 @inline cardinal_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    cardinal_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+    cardinal_interp!(output, only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
 
 @inline function cardinal_interp(
         grids::NTuple{N, AbstractVector},
@@ -210,14 +210,14 @@ end
 
 # N=1 batch one-shot → lean 1D batch one-shot. See linear_nd_interpolant.jl.
 @inline akima_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    akima_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+    akima_interp(only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
 @inline akima_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    akima_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+    akima_interp!(output, only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
 @inline akima_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    akima_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+    akima_interp(only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
 @inline akima_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    akima_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+    akima_interp!(output, only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
 
 @inline function akima_interp(
         grids::NTuple{N, AbstractVector},

--- a/src/hetero/local_hermite_nd_forward.jl
+++ b/src/hetero/local_hermite_nd_forward.jl
@@ -74,14 +74,14 @@ end
 
 # N=1 batch one-shot → lean 1D batch one-shot. See linear_nd_interpolant.jl.
 @inline pchip_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    pchip_interp(only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
+    pchip_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 @inline pchip_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    pchip_interp!(output, only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
+    pchip_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
 @inline pchip_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    pchip_interp(only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
+    pchip_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
 @inline pchip_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    pchip_interp!(output, only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
+    pchip_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
 
 @inline function pchip_interp(
         grids::NTuple{N, AbstractVector},
@@ -141,14 +141,14 @@ end
 
 # N=1 batch one-shot → lean 1D batch one-shot. See linear_nd_interpolant.jl.
 @inline cardinal_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    cardinal_interp(only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
+    cardinal_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 @inline cardinal_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    cardinal_interp!(output, only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
+    cardinal_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
 @inline cardinal_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    cardinal_interp(only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
+    cardinal_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
 @inline cardinal_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    cardinal_interp!(output, only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
+    cardinal_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
 
 @inline function cardinal_interp(
         grids::NTuple{N, AbstractVector},
@@ -210,14 +210,14 @@ end
 
 # N=1 batch one-shot → lean 1D batch one-shot. See linear_nd_interpolant.jl.
 @inline akima_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    akima_interp(only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
+    akima_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 @inline akima_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    akima_interp!(output, only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
+    akima_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
 @inline akima_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    akima_interp(only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
+    akima_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
 @inline akima_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    akima_interp!(output, only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
+    akima_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
 
 @inline function akima_interp(
         grids::NTuple{N, AbstractVector},

--- a/src/hetero/local_hermite_nd_forward.jl
+++ b/src/hetero/local_hermite_nd_forward.jl
@@ -60,6 +60,29 @@ end
     return interp(grids, data; method = methods, kwargs...)
 end
 
+# N=1 collapse: a 1-axis grid tuple forwards to the native 1D pchip (skips the
+# HeteroInterpolantND wrapper entirely). Per-axis 1-tuple kwargs unwrap to scalar;
+# omitting `bc` lets the 1D NoBC() default apply. More specific than the `NTuple{N}`
+# forwarder above, so it only claims N=1.
+@inline pchip_interp(grids::Tuple{AbstractVector}, data::AbstractVector; kwargs...) =
+    pchip_interp(only(grids), data; _unwrap_nd_kwargs(values(kwargs))...)
+
+# N=1 scalar one-shot: bare scalar → scalar query `(q,)` → ND scalar one-shot
+# (scalar output, not `[val]`). See linear_nd_interpolant.jl.
+@inline pchip_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Real; kwargs...) =
+    pchip_interp(grids, data, (q,); kwargs...)
+
+# N=1 batch one-shot → lean 1D batch one-shot. See linear_nd_interpolant.jl.
+@inline pchip_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+    pchip_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+@inline pchip_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+    pchip_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+# Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
+@inline pchip_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+    pchip_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+@inline pchip_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+    pchip_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+
 @inline function pchip_interp(
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{<:Any, N},
@@ -106,6 +129,26 @@ end
     methods = _build_local_hermite_method_tuple(CardinalInterp, Val(N), bc, tension)
     return interp(grids, data; method = methods, kwargs...)
 end
+
+# N=1 collapse: forward to native 1D cardinal (`tension`/per-axis 1-tuple kwargs
+# unwrap to scalar). More specific than the `NTuple{N}` forwarder above.
+@inline cardinal_interp(grids::Tuple{AbstractVector}, data::AbstractVector; kwargs...) =
+    cardinal_interp(only(grids), data; _unwrap_nd_kwargs(values(kwargs))...)
+
+# N=1 scalar one-shot: bare scalar → scalar query `(q,)` → ND scalar one-shot.
+@inline cardinal_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Real; kwargs...) =
+    cardinal_interp(grids, data, (q,); kwargs...)
+
+# N=1 batch one-shot → lean 1D batch one-shot. See linear_nd_interpolant.jl.
+@inline cardinal_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+    cardinal_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+@inline cardinal_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+    cardinal_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+# Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
+@inline cardinal_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+    cardinal_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+@inline cardinal_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+    cardinal_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
 
 @inline function cardinal_interp(
         grids::NTuple{N, AbstractVector},
@@ -155,6 +198,26 @@ end
     methods = _build_local_hermite_method_tuple(AkimaInterp, Val(N), bc)
     return interp(grids, data; method = methods, kwargs...)
 end
+
+# N=1 collapse: forward to native 1D akima (per-axis 1-tuple kwargs unwrap to
+# scalar). More specific than the `NTuple{N}` forwarder above.
+@inline akima_interp(grids::Tuple{AbstractVector}, data::AbstractVector; kwargs...) =
+    akima_interp(only(grids), data; _unwrap_nd_kwargs(values(kwargs))...)
+
+# N=1 scalar one-shot: bare scalar → scalar query `(q,)` → ND scalar one-shot.
+@inline akima_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Real; kwargs...) =
+    akima_interp(grids, data, (q,); kwargs...)
+
+# N=1 batch one-shot → lean 1D batch one-shot. See linear_nd_interpolant.jl.
+@inline akima_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+    akima_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+@inline akima_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+    akima_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+# Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
+@inline akima_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+    akima_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+@inline akima_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+    akima_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
 
 @inline function akima_interp(
         grids::NTuple{N, AbstractVector},

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -64,7 +64,8 @@ function linear_interp!(
         bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
-        search::AbstractSearchPolicy = AutoSearch()
+        search::AbstractSearchPolicy = AutoSearch(),
+        hint::Union{Nothing, Base.RefValue{Int}} = nothing
     )
     @assert length(y) == length(x) "x and y must have same length"
     @assert length(output) == length(x_targets) "output must match x_targets length"
@@ -81,7 +82,7 @@ function linear_interp!(
     x_eff = _resolve_axis(x, bc, _promote_grid_float(eltype(x), eltype(y)))
     y_eff = _resolve_data(y, bc)
     extrap_eff = _resolve_extrap(extrap, bc, x_eff, y_eff)
-    searcher = _resolve_search(x_eff, x_targets, search, nothing)
+    searcher = _resolve_search(x_eff, x_targets, search, hint)
     return _linear_interp_loop!(output, x_eff, y_eff, x_targets, extrap_eff, deriv, searcher)
 end
 
@@ -349,12 +350,13 @@ function linear_interp(
         bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
-        search::AbstractSearchPolicy = AutoSearch()
+        search::AbstractSearchPolicy = AutoSearch(),
+        hint::Union{Nothing, Base.RefValue{Int}} = nothing
     )
     Tg = _promote_grid_float(eltype(x), eltype(y))
     T_out = _promote_eltype(_interp_op, Tg, eltype(y), eltype(x_targets))
     output = Vector{T_out}(undef, length(x_targets))
-    linear_interp!(output, x, y, x_targets; bc, extrap, deriv, search)
+    linear_interp!(output, x, y, x_targets; bc, extrap, deriv, search, hint)
     return output
 end
 

--- a/src/linear/nd/linear_nd_interpolant.jl
+++ b/src/linear/nd/linear_nd_interpolant.jl
@@ -107,11 +107,11 @@ end
 # batch one-shot (bit-identical value; skips the generic-N per-query machinery). Per-axis
 # 1-tuple kwargs unwrap to scalar.
 @inline linear_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    linear_interp(only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
+    linear_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 @inline linear_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    linear_interp!(output, only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
+    linear_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` unwraps to the 1D batch (same vectorized domain check).
 @inline linear_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    linear_interp(only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
+    linear_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
 @inline linear_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    linear_interp!(output, only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
+    linear_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)

--- a/src/linear/nd/linear_nd_interpolant.jl
+++ b/src/linear/nd/linear_nd_interpolant.jl
@@ -107,11 +107,11 @@ end
 # batch one-shot (bit-identical value; skips the generic-N per-query machinery). Per-axis
 # 1-tuple kwargs unwrap to scalar.
 @inline linear_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    linear_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+    linear_interp(only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
 @inline linear_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    linear_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+    linear_interp!(output, only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` unwraps to the 1D batch (same vectorized domain check).
 @inline linear_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    linear_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+    linear_interp(only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
 @inline linear_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    linear_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+    linear_interp!(output, only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)

--- a/src/linear/nd/linear_nd_interpolant.jl
+++ b/src/linear/nd/linear_nd_interpolant.jl
@@ -88,3 +88,30 @@ function linear_interp(
     extrap_vals = map(_resolve_extrap, extrap_vals, grids_typed)
     return LinearInterpolantND(grids_typed, data_typed, extrap_vals, searches; bcs = bcs_post, store = store)
 end
+
+# N=1 collapse: a 1-axis grid tuple IS the 1D path. `axes(y)` (a 1-tuple of OneTo)
+# lands here — forwarding to the 1D constructor keeps the lean 1D batch loop (the
+# generic-N ND loop carries a small per-query tensor overhead). Per-axis 1-tuple
+# kwargs unwrap to scalar. Strictly more specific than the `NTuple{N}` method above,
+# so it only claims N=1.
+@inline linear_interp(grids::Tuple{AbstractVector}, data::AbstractVector; kwargs...) =
+    linear_interp(only(grids), data; _unwrap_nd_kwargs(values(kwargs))...)
+
+# N=1 scalar one-shot: a bare scalar on a 1-tuple grid is sugar for the scalar
+# query `(q,)` → ND scalar one-shot (scalar output), not the `[val]` length-1 batch
+# that a bare `queries` would otherwise trigger. Batch queries stay on the ND path.
+@inline linear_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Real; kwargs...) =
+    linear_interp(grids, data, (q,); kwargs...)
+
+# N=1 batch one-shot: a plain-vector query on a 1-tuple grid forwards to the lean 1D
+# batch one-shot (bit-identical value; skips the generic-N per-query machinery). Per-axis
+# 1-tuple kwargs unwrap to scalar.
+@inline linear_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+    linear_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+@inline linear_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+    linear_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+# Single-axis SoA `(xv,)` unwraps to the 1D batch (same vectorized domain check).
+@inline linear_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+    linear_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+@inline linear_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+    linear_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)

--- a/src/quadratic/nd/quadratic_nd_interpolant.jl
+++ b/src/quadratic/nd/quadratic_nd_interpolant.jl
@@ -135,11 +135,11 @@ end
 
 # N=1 batch one-shot → lean 1D batch one-shot (bit-identical). See linear_nd_interpolant.jl.
 @inline quadratic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...) =
-    quadratic_interp(only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
+    quadratic_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 @inline quadratic_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...) =
-    quadratic_interp!(output, only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
+    quadratic_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
 @inline quadratic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...) =
-    quadratic_interp(only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
+    quadratic_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
 @inline quadratic_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...) =
-    quadratic_interp!(output, only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
+    quadratic_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)

--- a/src/quadratic/nd/quadratic_nd_interpolant.jl
+++ b/src/quadratic/nd/quadratic_nd_interpolant.jl
@@ -121,3 +121,25 @@ function _build_nd_quadratic_interpolant(
 
     return QuadraticInterpolantND(grids_cached, nodal_derivs, bcs, extraps_val, searches)
 end
+
+# N=1 collapse: a 1-axis grid tuple forwards to the genuine 1D quadratic path (lean
+# 1D batch loop; per-axis 1-tuple kwargs unwrap to scalar). More specific than the
+# `NTuple{N}` method above, so it only claims N=1. See linear_nd_interpolant.jl.
+@inline quadratic_interp(grids::Tuple{AbstractVector}, data::AbstractVector; kwargs...) =
+    quadratic_interp(only(grids), data; _unwrap_nd_kwargs(values(kwargs))...)
+
+# N=1 scalar one-shot: bare scalar → scalar query `(q,)` → ND scalar one-shot
+# (scalar output, not `[val]`). See linear_nd_interpolant.jl.
+@inline quadratic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Real; kwargs...) =
+    quadratic_interp(grids, data, (q,); kwargs...)
+
+# N=1 batch one-shot → lean 1D batch one-shot (bit-identical). See linear_nd_interpolant.jl.
+@inline quadratic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+    quadratic_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+@inline quadratic_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+    quadratic_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+# Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
+@inline quadratic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+    quadratic_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+@inline quadratic_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+    quadratic_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)

--- a/src/quadratic/nd/quadratic_nd_interpolant.jl
+++ b/src/quadratic/nd/quadratic_nd_interpolant.jl
@@ -134,12 +134,12 @@ end
     quadratic_interp(grids, data, (q,); kwargs...)
 
 # N=1 batch one-shot → lean 1D batch one-shot (bit-identical). See linear_nd_interpolant.jl.
-@inline quadratic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    quadratic_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
-@inline quadratic_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
-    quadratic_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
+@inline quadratic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...) =
+    quadratic_interp(only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
+@inline quadratic_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...) =
+    quadratic_interp!(output, only(grids), data, q; _unwrap_nd_batch_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
-@inline quadratic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    quadratic_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
-@inline quadratic_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
-    quadratic_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
+@inline quadratic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...) =
+    quadratic_interp(only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)
+@inline quadratic_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...) =
+    quadratic_interp!(output, only(grids), data, only(q); _unwrap_nd_batch_kwargs(values(kwargs))...)

--- a/src/quadratic/quadratic_oneshot.jl
+++ b/src/quadratic/quadratic_oneshot.jl
@@ -222,7 +222,8 @@ quadratic_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear
         bc::QuadraticBC = Left(QuadraticFit()),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
-        search::AbstractSearchPolicy = AutoSearch()
+        search::AbstractSearchPolicy = AutoSearch(),
+        hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, Tq <: Real}
     @assert length(y) == length(x) "x and y must have same length"
     @assert length(output) == length(x_targets) "output must match x_targets length"
@@ -239,7 +240,7 @@ quadratic_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear
     bc_promoted = _normalize_bc(bc, first(y))
     _compute_quadratic_coeffs!(d, a, x, y, bc_promoted)
 
-    searcher = _resolve_search(x, x_targets, search, nothing)
+    searcher = _resolve_search(x, x_targets, search, hint)
     extrap_eff = _resolve_extrap(extrap, x)
     _quadratic_vector_loop!(output, x, y, a, d, x_targets, extrap_eff, deriv, searcher)
     return output
@@ -273,10 +274,11 @@ function quadratic_interp(
         bc::QuadraticBC = Left(QuadraticFit()),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
-        search::AbstractSearchPolicy = AutoSearch()
+        search::AbstractSearchPolicy = AutoSearch(),
+        hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tq <: Real}
     Tr = _promote_eltype(_interp_op, _promote_grid_float(Tg, eltype(y)), eltype(y), Tq)
     output = Vector{Tr}(undef, length(x_targets))
-    quadratic_interp!(output, x, y, x_targets; bc, extrap, deriv, search)
+    quadratic_interp!(output, x, y, x_targets; bc, extrap, deriv, search, hint)
     return output
 end

--- a/test/test_nd1_collapse.jl
+++ b/test/test_nd1_collapse.jl
@@ -1,0 +1,216 @@
+# Behavior-pinning tests for N=1 tuple-grid collapse (`axes(y)` convenience).
+#
+# Contract being pinned:
+#   1. A 1-length grid tuple `foo_interp((x,), y)` COLLAPSES to the genuine 1D
+#      interpolant (`<: AbstractInterpolant1D`), not an N=1 `*InterpolantND`.
+#      This is what makes `foo_interp(axes(y), y)` take the fast 1D path.
+#   2. The collapsed interpolant is VALUE-IDENTICAL to `foo_interp(x, y)` — the
+#      grid tuple is merely unwrapped, nothing about the math changes.
+#   3. Per-axis kwargs given ND-style as 1-tuples (`extrap=(WrapExtrap(),)`) are
+#      unwrapped to their scalar form for the 1D constructor.
+#   4. 1D interpolants accept ND-style tuple queries so collapse is transparent
+#      to generic tensor code: `itp((x,))`, `itp(out,(xv,))`, `itp((xv,))`, and
+#      per-axis kwargs `itp((x,); extrap=(WrapExtrap(),))` / `deriv=(op,)`.
+
+@testitem "N=1 tuple-grid collapses to 1D" begin
+    using FastInterpolations
+    using FastInterpolations: AbstractInterpolant1D, AbstractInterpolantND
+
+    x = collect(1.0:10.0)
+    y = @. sin(x) + 0.3 * x
+    xq = 3.7
+
+    # Every method whose 2-arg `(grid, data)` form has an ND path.
+    for f in (
+            linear_interp, cubic_interp, quadratic_interp, constant_interp,
+            pchip_interp, akima_interp, cardinal_interp,
+        )
+        itp_nd = f((x,), y)          # tuple grid
+        itp_1d = f(x, y)             # genuine 1D
+        @test itp_nd isa AbstractInterpolant1D
+        @test !(itp_nd isa AbstractInterpolantND)
+        # value-identical to the 1D path (scalar query)
+        @test itp_nd(xq) == itp_1d(xq)
+        # `axes(y)` — the motivating OneTo case
+        itp_ax = f(axes(y), y)
+        @test itp_ax isa AbstractInterpolant1D
+    end
+end
+
+@testitem "N=1 collapse is type-stable and yields the 1D type" begin
+    using FastInterpolations
+    using FastInterpolations: AbstractInterpolant1D, AbstractInterpolantND
+    using Test: @inferred
+
+    x = collect(1.0:10.0)
+    y = @. sin(x) + 0.3 * x
+
+    # The collapse forwarder must not introduce any inference instability beyond
+    # the genuine 1D constructor: `@inferred` succeeds AND the returned object is a
+    # 1D interpolant. `@inferred` throws if the call site is not concretely inferred,
+    # so pairing it with the `isa` check pins both stability and the collapsed type.
+    for f in (
+            linear_interp, cubic_interp, quadratic_interp, constant_interp,
+            pchip_interp, akima_interp, cardinal_interp,
+        )
+        itp = @inferred f((x,), y)
+        @test itp isa AbstractInterpolant1D
+        @test !(itp isa AbstractInterpolantND)
+        # collapse produces the SAME concrete type as the direct 1D call
+        @test typeof(itp) === typeof(f(x, y))
+    end
+
+    # Hot path: value queries through the 1D tuple-query shims stay concretely typed.
+    itp = linear_interp(x, y)
+    @test (@inferred itp((3.7,))) isa Float64
+    xv = [2.3, 5.1, 8.8]; out = similar(xv)
+    @test (@inferred itp(out, (xv,))) isa Vector{Float64}
+    @test (@inferred itp((xv,))) isa Vector{Float64}
+end
+
+@testitem "2D path unchanged by N=1 collapse (no regression)" begin
+    using FastInterpolations
+    using FastInterpolations: AbstractInterpolantND
+    using Test: @inferred
+
+    x = collect(1.0:6.0)
+    z = collect(1.0:5.0)
+    data = [sin(xi) * cos(zj) for xi in x, zj in z]
+    q = (3.3, 2.7)
+
+    # The more-specific `Tuple{AbstractVector}` collapse method must NOT shadow the
+    # generic `NTuple{N}` ND constructor for N≥2 — a 2-tuple grid still builds ND.
+    for f in (
+            linear_interp, cubic_interp, quadratic_interp, constant_interp,
+            pchip_interp, akima_interp, cardinal_interp,
+        )
+        itp = @inferred f((x, z), data)
+        @test itp isa AbstractInterpolantND
+        @test itp(q) isa Real            # ND tuple query still works
+    end
+end
+
+@testitem "N=1 collapse unwraps per-axis kwargs" begin
+    using FastInterpolations
+
+    x = collect(1.0:10.0)
+    y = @. cos(x)
+    xq = 6.3
+
+    # ND-style 1-tuple extrap must unwrap to the scalar 1D form.
+    itp_t = linear_interp((x,), y; extrap = (WrapExtrap(),))
+    itp_s = linear_interp(x, y; extrap = WrapExtrap())
+    @test itp_t(11.5) == itp_s(11.5)   # exercises the wrap branch (OOB)
+    @test itp_t(xq) == itp_s(xq)
+end
+
+@testitem "cubic N=1 collapse: PreCompute → 1D, OnTheFly stays ND" begin
+    using FastInterpolations
+    using FastInterpolations: AbstractInterpolant1D, AbstractInterpolantND
+
+    x = collect(1.0:10.0)
+    y = @. sin(x)
+    q = 4.6
+
+    # 1D cubic has no `coeffs` (it is inherently PreCompute) — the default/PreCompute
+    # collapse must reach the lean 1D path without leaking the ND-only kwarg.
+    itp_pc = cubic_interp((x,), y)
+    @test itp_pc isa AbstractInterpolant1D
+    @test cubic_interp((x,), y; coeffs = PreCompute()) isa AbstractInterpolant1D
+    @test itp_pc(q) == cubic_interp(x, y)(q)
+
+    # OnTheFly has no 1D equivalent → the N=1 ND (Hetero) path is preserved.
+    itp_otf = cubic_interp((x,), y; coeffs = OnTheFly())
+    @test itp_otf isa AbstractInterpolantND
+    @test itp_otf((q,)) isa Real
+
+    # The unified `interp` N=1 path (routes through the method fn) still evaluates.
+    @test interp((x,), reshape(y, :); method = (CubicInterp(),))((q,)) ≈ cubic_interp(x, y)(q) rtol = 1.0e-12
+end
+
+@testitem "N=1 scalar one-shot collapses to a scalar (not a 1-elem Vector)" begin
+    using FastInterpolations
+    using FastInterpolations: AbstractInterpolantND
+
+    x = collect(1.0:10.0)
+    y = @. sin(x) + 0.3 * x
+    q = 4.6
+
+    for f in (
+            linear_interp, cubic_interp, quadratic_interp, constant_interp,
+            pchip_interp, akima_interp, cardinal_interp,
+        )
+        # Bare scalar one-shot on a 1-tuple grid must return a SCALAR — not the ND
+        # `[val]` length-1 batch. A bare `q` is sugar for the scalar query `(q,)`, so
+        # it routes to the ND scalar one-shot; `(q,)` already returned a scalar.
+        v_bare = f((x,), y, q)
+        @test v_bare isa Real
+        @test v_bare == f((x,), y, (q,))       # bare ≡ tuple scalar query
+        @test v_bare ≈ f(x, y, q) rtol = 1.0e-12  # matches the 1D one-shot (within ULP)
+        # OOB bare scalar still errors (NoExtrap), not silently returning a vector.
+        @test_throws Exception f((x,), y, -5.0)
+    end
+
+    # Batch one-shot is unchanged — a plain vector query returns a Vector.
+    xq = [2.5, 7.5]
+    @test linear_interp((x,), y, xq) isa Vector
+    @test linear_interp((x,), y, xq) == linear_interp(x, y, xq)
+end
+
+@testitem "N=1 batch one-shot collapses to the 1D one-shot" begin
+    using FastInterpolations
+
+    x = collect(1.0:20.0)
+    y = @. sin(x) + 0.3 * x
+    xq = collect(range(2.0, 19.0, length = 40))
+    out = similar(xq)
+
+    for f in (
+            linear_interp, cubic_interp, quadratic_interp, constant_interp,
+            pchip_interp, akima_interp, cardinal_interp,
+        )
+        # A 1-tuple grid batch one-shot forwards to the 1D one-shot → bit-identical
+        # (it *is* the 1D path), returning a Vector.
+        v = f((x,), y, xq)
+        @test v isa Vector
+        @test v == f(x, y, xq)
+    end
+
+    # In-place batch collapses too.
+    linear_interp!(out, (x,), y, xq)
+    ref = similar(xq); linear_interp!(ref, x, y, xq)
+    @test out == ref
+
+    # SoA `(xv,)` on a 1-tuple grid also collapses to the 1D batch (single-axis SoA
+    # is logically the same vectorized domain check as a bare 1D vector).
+    for f in (
+            linear_interp, cubic_interp, quadratic_interp, constant_interp,
+            pchip_interp, akima_interp, cardinal_interp,
+        )
+        @test f((x,), y, (xq,)) == f(x, y, xq)
+    end
+    linear_interp!(out, (x,), y, (xq,))
+    @test out == ref
+end
+
+@testitem "1D interpolant accepts ND-style tuple queries" begin
+    using FastInterpolations
+
+    x = collect(1.0:10.0)
+    y = @. sin(x)
+    itp = linear_interp(x, y)
+
+    xv = [2.3, 5.1, 8.8]
+    out_t = similar(xv)
+    out_s = similar(xv)
+
+    # scalar 1-tuple query
+    @test itp((3.7,)) == itp(3.7)
+    # SoA in-place batch
+    itp(out_t, (xv,)); itp(out_s, xv)
+    @test out_t == out_s
+    # SoA allocating batch
+    @test itp((xv,)) == itp(xv)
+    # per-axis kwarg unwrap on the query path
+    @test itp((3.7,); deriv = (DerivOp(1),)) == itp(3.7; deriv = DerivOp(1))
+end

--- a/test/test_nd1_collapse.jl
+++ b/test/test_nd1_collapse.jl
@@ -193,6 +193,52 @@ end
     @test out == ref
 end
 
+@testitem "N=1 batch collapse tolerates the ND-only `hint` kwarg (GridIdx regression)" begin
+    using FastInterpolations
+
+    x = collect(1.0:20.0)
+    y = @. sin(x) + 0.3 * x
+    xq = collect(range(2.0, 19.0, length = 6))
+    out = similar(xq)
+    ref = similar(xq)
+
+    # The ND batch one-shot threads a per-axis `hint`; the 1D batch one-shots for
+    # linear/cubic/quadratic/constant have no such kwarg. The collapse must drop it,
+    # not forward it — otherwise a bare-vector / SoA batch on a 1-tuple grid with an
+    # explicit (or default) `hint` throws MethodError. Values match the hint-less call.
+    for f in (
+            linear_interp, cubic_interp, quadratic_interp, constant_interp,
+            pchip_interp, akima_interp, cardinal_interp,
+        )
+        @test f((x,), y, xq; hint = nothing) == f(x, y, xq)      # allocating, bare vector
+        @test f((x,), y, (xq,); hint = nothing) == f(x, y, xq)   # allocating, SoA
+    end
+    for f! in (
+            linear_interp!, cubic_interp!, quadratic_interp!, constant_interp!,
+            pchip_interp!, akima_interp!, cardinal_interp!,
+        )
+        f!(out, (x,), y, xq; hint = nothing)
+        @test out == (ref .= f!(similar(ref), x, y, xq))          # in-place, bare vector
+        f!(out, (x,), y, (xq,); hint = nothing)
+        @test out == ref                                          # in-place, SoA
+    end
+
+    # End-to-end: `interp!` with a `GridIdx` pins one axis and pre-slices to a 1-tuple
+    # grid, threading `hint` into the collapse. This is the docs `unified_api.md` example.
+    gx = collect(range(0.0, 5.0, length = 11))
+    gy = collect(range(0.0, 5.0, length = 11))
+    data = [xi + yj for xi in gx, yj in gy]
+    output = zeros(5)
+    q = collect(range(0.5, 4.5, length = 5))
+    for m in (
+            LinearInterp(), CubicInterp(), QuadraticInterp(), ConstantInterp(),
+            PchipInterp(), AkimaInterp(), CardinalInterp(),
+        )
+        interp!(output, (gx, gy), data, (q, GridIdx(5)); method = m)
+        @test all(isfinite, output)
+    end
+end
+
 @testitem "1D interpolant accepts ND-style tuple queries" begin
     using FastInterpolations
 

--- a/test/test_nd1_collapse.jl
+++ b/test/test_nd1_collapse.jl
@@ -202,16 +202,22 @@ end
     out = similar(xq)
     ref = similar(xq)
 
-    # The ND batch one-shot threads a per-axis `hint`; the 1D batch one-shots for
-    # linear/cubic/quadratic/constant have no such kwarg. The collapse must drop it,
-    # not forward it — otherwise a bare-vector / SoA batch on a 1-tuple grid with an
-    # explicit (or default) `hint` throws MethodError. Values match the hint-less call.
+    # The ND batch one-shot threads a per-axis `hint` (mutable search state that
+    # advances through the batch). The collapse forwards it to the 1D one-shot, which
+    # now accepts `hint` (previously only the scalar one-shot / persistent callable did).
+    # `hint = nothing` (the GridIdx / NoInterp pre-slice default) must not throw; a real
+    # `(h,)` must advance `h[]` to the last query's cell — matching the ND N=1 contract.
     for f in (
             linear_interp, cubic_interp, quadratic_interp, constant_interp,
             pchip_interp, akima_interp, cardinal_interp,
         )
         @test f((x,), y, xq; hint = nothing) == f(x, y, xq)      # allocating, bare vector
         @test f((x,), y, (xq,); hint = nothing) == f(x, y, xq)   # allocating, SoA
+        # A real hint advances to the same cell the direct 1D one-shot lands on.
+        hc = Ref(1); f((x,), y, xq; hint = (hc,))
+        h1 = Ref(1); f(x, y, xq; hint = h1)
+        @test hc[] == h1[] > 1
+        hs = Ref(1); f((x,), y, (xq,); hint = (hs,)); @test hs[] == h1[]   # SoA advances too
     end
     for f! in (
             linear_interp!, cubic_interp!, quadratic_interp!, constant_interp!,
@@ -221,6 +227,9 @@ end
         @test out == (ref .= f!(similar(ref), x, y, xq))          # in-place, bare vector
         f!(out, (x,), y, (xq,); hint = nothing)
         @test out == ref                                          # in-place, SoA
+        hc = Ref(1); f!(out, (x,), y, xq; hint = (hc,))
+        h1 = Ref(1); f!(similar(out), x, y, xq; hint = h1)
+        @test hc[] == h1[] > 1                                     # in-place hint advances
     end
 
     # End-to-end: `interp!` with a `GridIdx` pins one axis and pre-slices to a 1-tuple


### PR DESCRIPTION
## Summary

`axes(y)` — the natural way to grid a vector — is a 1-length *tuple* `(OneTo(n),)`, so it dispatched to the **ND** path (`*InterpolantND{…,1}`). A 1-tuple grid is definitionally 1-D, so route it there instead:

```julia
                                 #  master (ND N=1)          →  this PR (1D)
linear_interp(axes(y), y)        #  LinearInterpolantND      →  LinearInterpolant
linear_interp(axes(y), y, 5.5)   #  [0.55]  (1-elem Vector)  →  0.55  (scalar)
```

`Tuple{AbstractVector}` methods (strictly more specific than the `NTuple{N}` ones, so they only claim N=1) forward the constructor, scalar / batch / SoA one-shots, and ND-style tuple queries to the 1D path across all seven `*_interp` families.

**Result.** `axes(y)` now matches `1:length(y)` — same scalar result, no `[val]` wart, faster; values bit-identical to the 1D path:

| call (n=100–200) | master (ND N=1) | this PR (1D) |
|---|--:|--:|
| persistent batch `itp(out, xq)` | 224 ns | **155 ns** |
| scalar one-shot `f(axes,y,5.5)` | 11.0 ns / 128 B | **4.6 ns / 0 B** |
| batch one-shot `f(axes,y,xq)` | 245 ns | **180 ns** |
| SoA one-shot `f(axes,y,(xq,))` | 231 ns | **180 ns** |

## Why ND N=1 was slower (it was **not** OneTo or the kernel)

The eval kernel is codegen-identical (scalar LLVM: ND 22 instr = 1D 22 instr; batch with `extrap=InBounds()` closes the gap to **0 ns**). ND also uses the OneTo/unit-step fast search correctly (ND-OneTo 245 < ND-float 296). The entire ~75 ns gap is **`_validate_nd_domain`**:

- A bare `Vector` query on an ND interpolant is treated as AoS (a point list) and validated per-query (~97 ns) instead of the 1D vectorized min/max check (~22 ns).
- Even the SoA fast lane pays ~25 ns over 1D: the InBounds `:inclusive/:exclusive` promotion is **data-dependent**, so the per-axis result is a runtime `Union`; the ND lane re-tests it (`effs isa NTuple{N,InBounds{…}}`) and rebuilds an all-or-nothing tuple to dodge nested-union boxing. For N=1 that rebuild is redundant; the 1D path consumes its `_check_domain` result directly.

Collapsing to 1D sidesteps exactly this validation overhead — the right representation for a 1-D problem, not a workaround for an ND inefficiency.

## Cubic detail

Cubic is the only family where 1D and ND differ in a kwarg (1D is inherently PreCompute via `autocache`; ND accepts `coeffs`). The collapse guards on the compile-time-known `coeffs`: `PreCompute` (the default, and what `AutoCoeffs` resolves to for a persistent/batch cubic) folds to 1D; `OnTheFly` (a local-Hermite interpolant with no 1D equivalent) stays on the factored `_cubic_interp_nd_*` internals. The 1D branch passes a bare-vector grid, so it never re-intercepts (no recursion).

## Scope / Safety

- **N≥2 untouched**: the `Tuple{AbstractVector}` methods are strictly more specific and only match N=1; a 2-tuple grid still builds ND (pinned by test). AoS-of-1-tuples (`f(axes,y,[(v,)…])`) stays ND by design — collapsing it would need an allocating re-gather.
- `@inferred` + `isa` pin type-stability: every collapse returns the *same concrete type* as the direct 1D call; the tuple-query shims stay concrete on the hot path.
- Value bit-identity vs the 1D path pinned across all seven families (scalar + bare-vector + SoA); cubic `OnTheFly` preserved.
- New tests in `test_nd1_collapse.jl`; affected ND / hetero / one-shot / unified-API / allocation suites green.
