### PR TITLE
perf(series): compact contiguous anchor indices on ordinary grids

### DIFF
--- a/src/constant/constant_adjoint.jl
+++ b/src/constant/constant_adjoint.jl
@@ -20,7 +20,7 @@
 # ========================================
 
 """
-    ConstantAdjoint{Tg, Tq, BC, SD, EP}
+    ConstantAdjoint{Tg, Tq, BC, SD, EP, I}
 
 Adjoint (transpose) operator for 1D constant interpolation.
 Computes `f̄ = Wᵀȳ` where `W` is the forward constant interpolation weight matrix.
@@ -34,6 +34,8 @@ The same adjoint can be applied to any `ȳ` vector.
 - `BC`: Boundary condition type
 - `SD`: Side selection mode (`NearestSide`, `LeftSide`, `RightSide`)
 - `EP`: Extrapolation policy type (`NoExtrap`, `ExtendExtrap`, `ClampExtrap`, `FillExtrap`, `WrapExtrap`)
+- `I <: _AbstractIndices{2}`: Interval representation — `_ContiguousIndices{2}` (one Int) for
+  ordinary grids, `_ExplicitIndices{2}` (two Int) for periodic-exclusive seam cells
 
 # Fields
 - `anchors`: Pre-computed `_ConstantAnchoredQuery` per query point
@@ -58,8 +60,8 @@ itp = constant_interp(x, f; side=NearestSide())
 @assert dot(itp.(xq), y_bar) ≈ dot(f, adj(y_bar))
 ```
 """
-struct ConstantAdjoint{Tg, Tq, BC <: AbstractBC, SD <: AbstractSide, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
-    anchors::Vector{_ConstantAnchoredQuery{Tg, Tq}}
+struct ConstantAdjoint{Tg, Tq, BC <: AbstractBC, SD <: AbstractSide, EP <: AbstractExtrap, I <: _AbstractIndices{2}} <: AbstractAdjoint1D{Tg}
+    anchors::Vector{_ConstantAnchoredQuery{Tg, Tq, I}}
     grid_size::Int  # internal length: n+1 for PeriodicBC{:exclusive}, n otherwise
     x_hi::Tg
     bc::BC
@@ -179,7 +181,7 @@ function _bake_constant_clampfill_anchors(
         searcher::P = _to_searcher(LinearBinarySearch())
     ) where {Tg, Tq <: Real, P <: Searcher}
     searcher_resolved = _resolve_searcher_for_grid(x, searcher)
-    output = Vector{_ConstantAnchoredQuery{Tg, promote_type(Tg, Tq)}}(undef, length(xq))
+    output = Vector{_ConstantAnchoredQuery{Tg, promote_type(Tg, Tq), _interval_type(x)}}(undef, length(xq))
     @inbounds for k in eachindex(xq)
         xq_raw = xq[k]
         aq = _constant_anchor_query_impl(x, _clamp_to_grid(xq_raw, x), false, searcher_resolved)
@@ -272,7 +274,7 @@ function constant_adjoint(
     end
 
     Tq = eltype(anchors).parameters[2]
-    return ConstantAdjoint{Tg, Tq, typeof(bc), typeof(side), typeof(extrap_eff)}(
+    return ConstantAdjoint{Tg, Tq, typeof(bc), typeof(side), typeof(extrap_eff), _interval_type(x_axis)}(
         anchors, length(x_axis), x_hi, bc, side, extrap_eff
     )
 end

--- a/src/constant/constant_anchor.jl
+++ b/src/constant/constant_anchor.jl
@@ -12,7 +12,7 @@
 # ========================================
 
 """
-    _ConstantAnchoredQuery{Tg, Tq}
+    _ConstantAnchoredQuery{Tg, Tq, I}
 
 Precomputed geometry for ultra-fast constant interpolation at a fixed query point.
 Internal API: no runtime grid validation; callers must ensure the anchor
@@ -21,9 +21,11 @@ matches the interpolant grid.
 # Type Parameters
 - `Tg`: Grid element type (stored in `h`)
 - `Tq <: Real`: Query point type (stored in `xq`, `dL`); may widen `Tg` (e.g. `Dual` for AD)
+- `I <: _AbstractIndices{2}`: Interval representation — `_ContiguousIndices{2}` (one Int) for
+  ordinary grids, `_ExplicitIndices{2}` (two Int) for periodic-exclusive seam cells
 
 # Fields
-- `interval::_ExplicitIndices{2}`: Physical cell interval; `interval[1]` is the left index, `interval[2]` the right
+- `interval::I`: Physical cell interval; `interval[1]` is the left index, `interval[2]` the right
   (legacy `aq.idxL` / `aq.idxR` virtual properties read through `getproperty` — see below).
   For non-periodic cells `idxR == idxL + 1`; at periodic-exclusive seam `idxL == n`, `idxR == 1` (wrap).
 - `xq`: Original query point (or wrapped value for periodic)
@@ -47,14 +49,15 @@ itp2(aq)              # Reuses same anchor
 Anchored evaluation is faster than `itp(xq)` for non-uniform grids,
 as it eliminates O(log n) binary search.
 """
-struct _ConstantAnchoredQuery{Tg, Tq <: Real}
-    # Physical cell interval: `interval[1]` is the left index (idxL),
-    # `interval[2]` is the right index (idxR). For non-periodic cells
-    # `idxR == idxL + 1`; for periodic-exclusive seam cells `idxR == 1` (wrap).
-    # Unified across all wrap-aware methods via `_ExplicitIndices{K}`
-    # (src/core/axis_indices.jl). Legacy `aq.idxL` / `aq.idxR` accessors are
-    # preserved via `getproperty` below.
-    interval::_ExplicitIndices{2}
+struct _ConstantAnchoredQuery{Tg, Tq <: Real, I <: _AbstractIndices{2}}
+    # Physical cell interval: `interval[1]` is the left index (idxL), `interval[2]`
+    # is the right index (idxR). For non-periodic cells `idxR == idxL + 1`; for
+    # periodic-exclusive seam cells `idxR == 1` (wrap). Ordinary grids store the
+    # compact `_ContiguousIndices{2}` (one Int); periodic-exclusive seam cells
+    # store `_ExplicitIndices{2}` (src/core/axis_indices.jl).
+    # Legacy `aq.idxL` / `aq.idxR` accessors are preserved via `getproperty`
+    # below — every existing call site reads through the virtual property.
+    interval::I
     xq::Tq                     # query point (possibly wrapped, may be Dual for AD)
     state::UInt8               # IN_DOMAIN / OOB_LEFT / OOB_RIGHT
     h::Tg                      # interval width
@@ -75,11 +78,13 @@ end
 @inline Base.propertynames(::_ConstantAnchoredQuery) =
     (:interval, :idxL, :idxR, :xq, :state, :h, :dL)
 
-# Stencil-native outer — infers `Tg, Tq` from arg types so callers can write
-# `_ConstantAnchoredQuery(_ExplicitIndices(idxL, idxR), xq, state, h, dL)` without
-# specifying type params. Mirrors Linear's interval-native outer.
-@inline _ConstantAnchoredQuery(interval::_ExplicitIndices{2}, xq::Tq, state::UInt8, h::Tg, dL::Tq) where {Tg, Tq} =
-    _ConstantAnchoredQuery{Tg, Tq}(interval, xq, state, h, dL)
+# Outer constructor: infers `Tg, Tq, I` from arg types so callers can write
+# `_ConstantAnchoredQuery(interval, xq, state, h, dL)` without specifying type
+# params. `I` is inferred from the caller's `interval` (contiguous for ordinary
+# grids, explicit at periodic-exclusive seams — chosen local to the call site).
+# Mirrors Linear's interval-native outer.
+@inline _ConstantAnchoredQuery(interval::I, xq::Tq, state::UInt8, h::Tg, dL::Tq) where {Tg, Tq, I <: _AbstractIndices{2}} =
+    _ConstantAnchoredQuery{Tg, Tq, I}(interval, xq, state, h, dL)
 
 # ========================================
 # Anchor Construction
@@ -159,7 +164,7 @@ function _anchor_query(
     ) where {T, S <: Real, P <: Searcher}
     searcher_resolved = _resolve_searcher_for_grid(x, searcher)
     Tq = promote_type(T, S)
-    output = Vector{_ConstantAnchoredQuery{T, Tq}}(undef, length(xq))
+    output = Vector{_ConstantAnchoredQuery{T, Tq, _interval_type(x)}}(undef, length(xq))
 
     @inbounds for k in eachindex(xq)
         output[k] = _constant_anchor_query_impl(x, xq[k], wrap, searcher_resolved)
@@ -185,7 +190,7 @@ the caller reuses `buffer`. Writes `length(xq)` entries.
 The same `buffer` object, filled with anchored queries.
 """
 @inline function _fill_anchors!(
-        buffer::AbstractVector{_ConstantAnchoredQuery{T, Tq}},
+        buffer::AbstractVector{<:_ConstantAnchoredQuery{T, Tq}},
         x::AbstractVector{T},
         xq::AbstractVector{S},
         ::Val{:constant},
@@ -226,7 +231,7 @@ Internal implementation of _anchor_query for constant interpolation.
     # Promote xq to match dL type (Float64 query + Dual grid → dL is Dual)
     xq_promoted = oftype(dL, loc.xq)
 
-    return _ConstantAnchoredQuery(_ExplicitIndices(loc.idxL, loc.idxR), xq_promoted, loc.state, h, dL)
+    return _ConstantAnchoredQuery(loc.interval, xq_promoted, loc.state, h, dL)
 end
 
 # ========================================

--- a/src/constant/constant_oneshot_series.jl
+++ b/src/constant/constant_oneshot_series.jl
@@ -47,7 +47,7 @@
     dL = xq_wrapped - xL
     # Promote xq to match dL type (Float64 query + Dual grid → dL is Dual).
     xq_promoted = oftype(dL, xq_wrapped)
-    aq = _ConstantAnchoredQuery(_ExplicitIndices(idxL, idxR), xq_promoted, IN_DOMAIN, h, dL)
+    aq = _ConstantAnchoredQuery(_interval_indices(x_eff, idxL, idxR), xq_promoted, IN_DOMAIN, h, dL)
 
     x_last = @inbounds Tg(last(x_eff))
 
@@ -162,7 +162,7 @@ end
             h = _get_h(x_eff, idxL)
             dL = xq_wrapped - xL
             xq_promoted = oftype(dL, xq_wrapped)
-            aq = _ConstantAnchoredQuery(_ExplicitIndices(idxL, idxR), xq_promoted, IN_DOMAIN, h, dL)
+            aq = _ConstantAnchoredQuery(_interval_indices(x_eff, idxL, idxR), xq_promoted, IN_DOMAIN, h, dL)
             for k in 1:K
                 outputs[k][j] = _constant_eval_at_anchor(vecs[k], x_last, aq, op, side, extrap_p)
             end
@@ -207,14 +207,14 @@ end
         extrap_p = _resolve_extrap(NoExtrap(), bc, x_eff)
         searcher = _resolve_search(x_eff, xqs, search, nothing)
         x_last = @inbounds Tg_actual(last(x_eff))
-        aq_vec = acquire!(pool, _ConstantAnchoredQuery{Tg_actual, Tqp}, NQ)
+        aq_vec = acquire!(pool, _ConstantAnchoredQuery{Tg_actual, Tqp, _interval_type(x_eff)}, NQ)
         @inbounds for j in 1:NQ
             xq_wrapped = _wrap_to_domain(xqs[j], x_eff)
             idxL, idxR, xL, _ = search_interval(searcher, x_eff, xq_wrapped)
             h = _get_h(x_eff, idxL)
             dL = xq_wrapped - xL
             xq_promoted = oftype(dL, xq_wrapped)
-            aq_vec[j] = _ConstantAnchoredQuery(_ExplicitIndices(idxL, idxR), xq_promoted, IN_DOMAIN, h, dL)
+            aq_vec[j] = _ConstantAnchoredQuery(_interval_indices(x_eff, idxL, idxR), xq_promoted, IN_DOMAIN, h, dL)
         end
         @inbounds for k in 1:K
             for j in 1:NQ
@@ -228,7 +228,7 @@ end
     searcher = _resolve_search(x, xqs, search, nothing)
     wrap = extrap_eff isa WrapExtrap
     x_last = @inbounds Tg_actual(last(x))
-    aq_vec = acquire!(pool, _ConstantAnchoredQuery{Tg_actual, Tqp}, NQ)
+    aq_vec = acquire!(pool, _ConstantAnchoredQuery{Tg_actual, Tqp, _interval_type(x)}, NQ)
     _fill_anchors!(aq_vec, x, xqs, Val(:constant), wrap, searcher)
     @inbounds for k in 1:K
         for j in 1:NQ

--- a/src/constant/constant_series_interp.jl
+++ b/src/constant/constant_series_interp.jl
@@ -541,7 +541,7 @@ end
     x_max = Tg(last(sitp.x))
     NQ = length(xq_typed)
     Tqp = promote_type(Tg, eltype(xq_typed))
-    aq_vec = acquire!(pool, _ConstantAnchoredQuery{Tg, Tqp}, NQ)
+    aq_vec = acquire!(pool, _ConstantAnchoredQuery{Tg, Tqp, _interval_type(x_grid)}, NQ)
     _fill_anchors!(aq_vec, x_grid, xq_typed, Val(:constant), wrap, searcher)
     @inbounds for k in 1:n_ser
         for j in 1:NQ

--- a/src/constant/nd/constant_nd_adjoint.jl
+++ b/src/constant/nd/constant_nd_adjoint.jl
@@ -44,7 +44,7 @@ function _bake_constant_nd_anchors(
 
     # Tq widens to query precision so narrower grids never truncate.
     Tq = promote_type(Tg, _query_eltype(queries))
-    anchors = Vector{NTuple{N, _ConstantAnchoredQuery{Tg, Tq}}}(undef, nq)
+    anchors = Vector{NTuple{N, _ConstantAnchoredQuery{Tg, Tq, _ExplicitIndices{2}}}}(undef, nq)
     @inbounds for q in 1:nq
         query_q = _extract_query_point(queries, q, Val(N))
         per_axis = ntuple(Val(N)) do d
@@ -58,7 +58,7 @@ function _bake_constant_nd_anchors(
             # true `_CachedRange` endpoint is IN_DOMAIN, matching the forward.
             state_flag = _oob_state(grids[d], xq_raw)
 
-            return _ConstantAnchoredQuery{Tg, Tq}(_ExplicitIndices(idx, idxR), xq_d, state_flag, h, dL)
+            return _ConstantAnchoredQuery{Tg, Tq, _ExplicitIndices{2}}(_ExplicitIndices(idx, idxR), xq_d, state_flag, h, dL)
         end
         anchors[q] = per_axis
     end

--- a/src/constant/nd/constant_nd_adjoint_types.jl
+++ b/src/constant/nd/constant_nd_adjoint_types.jl
@@ -62,14 +62,18 @@ struct ConstantAdjointND{
     bcs::B
     extraps::EP
     sides::SD
-    anchors::Vector{NTuple{N, _ConstantAnchoredQuery{Tg, Tq}}}
+    # Pinned to `_ExplicitIndices{2}` (not a free `I` param): axes can differ
+    # per-axis (mixed periodic/ordinary), so one concrete anchor type across
+    # all N axes needs a single interval representation. No size/behavior
+    # change — the 1D `ConstantAdjoint` still gets the compact-grid win.
+    anchors::Vector{NTuple{N, _ConstantAnchoredQuery{Tg, Tq, _ExplicitIndices{2}}}}
     grid_size::NTuple{N, Int}
 
     # Inner ctor: ownership copy via wrapper-aware `_convert_copy`,
     # idempotent `_cache_axis` insurance for direct ctor calls.
     function ConstantAdjointND(
             grids::Tuple{Vararg{AbstractVector{Tg}, N}}, bcs::B, extraps::EP, sides::SD,
-            anchors::Vector{NTuple{N, _ConstantAnchoredQuery{Tg, Tq}}}, grid_size::NTuple{N, Int}
+            anchors::Vector{NTuple{N, _ConstantAnchoredQuery{Tg, Tq, _ExplicitIndices{2}}}}, grid_size::NTuple{N, Int}
         ) where {
             Tg, N, B <: NTuple{N, AbstractBC},
             EP <: Tuple{Vararg{AbstractExtrap, N}}, SD <: Tuple{Vararg{AbstractSide, N}}, Tq,

--- a/src/cubic/cubic_adjoint.jl
+++ b/src/cubic/cubic_adjoint.jl
@@ -55,7 +55,7 @@ end
 # ========================================
 
 """
-    CubicAdjoint{Tg, C, BC}
+    CubicAdjoint{Tg, C, BC, I}
 
 Adjoint (transpose) operator for cubic spline interpolation.
 Computes `f̄ = Wᵀȳ` where `W` is the forward interpolation weight matrix.
@@ -67,6 +67,7 @@ The same adjoint can be applied to any `ȳ` vector regardless of value type.
 - `Tg`: Grid float type (Float32 or Float64)
 - `C`: `CubicSplineCache` type (reused from forward interpolation)
 - `BC`: `BCPair` or `PeriodicBC` (normalized boundary condition)
+- `I`: Per-axis interval representation — `_ContiguousIndices{2}` (ordinary grid) or `_ExplicitIndices{2}` (exclusive-periodic seam)
 
 # Usage
 ```julia

--- a/src/cubic/cubic_adjoint.jl
+++ b/src/cubic/cubic_adjoint.jl
@@ -96,12 +96,12 @@ Here `A` is the tridiagonal moment matrix, `R` the finite-difference RHS operato
 PolyFit stencil coefficients and periodic `q_transpose = A'^{-T}u` are computed on the
 fly at each `adj(ȳ)` call (O(D) and O(n) respectively, negligible vs overall pipeline).
 """
-struct CubicAdjoint{Tg, C <: CubicSplineCache{Tg}, BC <: Union{BCPair, PeriodicBC}} <: AbstractAdjoint1D{Tg}
+struct CubicAdjoint{Tg, C <: CubicSplineCache{Tg}, BC <: Union{BCPair, PeriodicBC}, I <: _AbstractIndices{2}} <: AbstractAdjoint1D{Tg}
     cache::C
     # Coordinate type is grid-pinned (`Tc = Tg`), not the canonical `_coord_eltype(Tq, Tg)`:
     # the adjoint operates on baked coefficients, so AD-through-adjoint is unsupported. The
     # forward Dual-grid contract is satisfied independently.
-    anchors::Vector{_CubicAnchoredQuery{Tg, Tg}}
+    anchors::Vector{_CubicAnchoredQuery{Tg, Tg, I}}
     bc::BC
 end
 
@@ -383,7 +383,7 @@ function _bake_cubic_clampfill_anchors(
     keep_w0 = extrap isa ClampExtrap
     z = zero(T)
     z4 = (z, z, z, z)
-    output = Vector{_CubicAnchoredQuery{T, T}}(undef, length(xq))
+    output = Vector{_CubicAnchoredQuery{T, T, _interval_type(x)}}(undef, length(xq))
     @inbounds for k in eachindex(xq)
         xq_raw = xq[k]
         aq = _anchor_query_impl(x, _promote_coord(_clamp_to_grid(xq_raw, x), T), false, searcher_resolved)
@@ -391,7 +391,7 @@ function _bake_cubic_clampfill_anchors(
             output[k] = aq
         else
             w0_new = keep_w0 ? aq.w0 : z4
-            output[k] = _CubicAnchoredQuery{T, T}(
+            output[k] = _CubicAnchoredQuery{T, T, _interval_type(x)}(
                 getfield(aq, :interval), aq.xq, IN_DOMAIN,
                 w0_new, z4, (z, z), (z, z)
             )

--- a/src/cubic/cubic_anchor.jl
+++ b/src/cubic/cubic_anchor.jl
@@ -12,7 +12,7 @@
 # ========================================
 
 """
-    _CubicAnchoredQuery{Tg, Tq}
+    _CubicAnchoredQuery{Tg, Tq, I}
 
 Precomputed weights for ultra-fast cubic spline evaluation at a fixed query point.
 Internal API: no runtime grid validation; callers must ensure the anchor
@@ -21,9 +21,11 @@ matches the interpolant grid.
 # Type Parameters
 - `Tg`: Grid float type (Float32 or Float64)
 - `Tq`: Query type (Float or ForwardDiff.Dual for AD support)
+- `I <: _AbstractIndices{2}`: Interval representation — `_ContiguousIndices{2}` (one Int) for
+  ordinary grids, `_ExplicitIndices{2}` (two Int) for periodic-exclusive seam cells
 
 # Fields
-- `interval`: `_ExplicitIndices{2}` carrying the corner pair `(idxL, idxR)`.
+- `interval::I`: Physical cell interval carrying the corner pair `(idxL, idxR)`.
   `idxR == idxL + 1` for non-seam cells; `idxR == 1` at periodic-exclusive
   seam cells (wrap). Virtual properties `aq.idx` (= `idxL`), `aq.idxL`,
   and `aq.idxR` are exposed via `getproperty` for ergonomics.
@@ -60,12 +62,14 @@ When `xq` is a `ForwardDiff.Dual`, the anchor preserves the Dual type
 in both `xq` and weight fields, enabling automatic differentiation through
 series interpolant evaluation.
 """
-struct _CubicAnchoredQuery{Tg, Tq <: Real}
+struct _CubicAnchoredQuery{Tg, Tq <: Real, I <: _AbstractIndices{2}}
     # Physical cell interval: `interval[1]` is the left index (idxL), `interval[2]`
     # is the right index (idxR). For non-periodic cells `idxR == idxL + 1`; for
-    # periodic-exclusive seam cells `idxR == 1` (wrap). Mirrors `_LinearAnchoredQuery`.
+    # periodic-exclusive seam cells `idxR == 1` (wrap). Ordinary grids store the
+    # compact `_ContiguousIndices{2}` (one Int); periodic-exclusive seam cells
+    # store `_ExplicitIndices{2}` (src/core/axis_indices.jl). Mirrors `_LinearAnchoredQuery`.
     # Legacy `aq.idx` accessor is preserved via `getproperty` (= idxL).
-    interval::_ExplicitIndices{2}
+    interval::I
     xq::Tq                     # query point (possibly wrapped), Float or Dual
     state::UInt8               # IN_DOMAIN / OOB_LEFT / OOB_RIGHT
     w0::NTuple{4, Tq}           # (wyL, wyR, wzL, wzR) for value
@@ -88,11 +92,13 @@ end
     (:interval, :idx, :idxL, :idxR, :xq, :state, :w0, :w1, :w2, :w3)
 
 # Outer constructor: infer Tq from weight element type (not from input xq).
-# When grid is Dual, weights are Dual even if xq is Float64.
+# When grid is Dual, weights are Dual even if xq is Float64. `I` is inferred
+# from the caller's `interval` (contiguous for ordinary grids, explicit at
+# periodic-exclusive seams — chosen local to the call site).
 # Widens xq to match weight type for struct consistency.
-@inline function _CubicAnchoredQuery(interval::_ExplicitIndices{2}, xq, state::UInt8, w0::NTuple{4, Tw}, w1::NTuple{4, Tw}, w2::NTuple{2, Tw}, w3::NTuple{2, Tw}, ::Type{Tg}) where {Tg, Tw}
+@inline function _CubicAnchoredQuery(interval::I, xq, state::UInt8, w0::NTuple{4, Tw}, w1::NTuple{4, Tw}, w2::NTuple{2, Tw}, w3::NTuple{2, Tw}, ::Type{Tg}) where {Tg, Tw, I <: _AbstractIndices{2}}
     xq_p = convert(Tw, xq)
-    return _CubicAnchoredQuery{Tg, Tw}(interval, xq_p, state, w0, w1, w2, w3)
+    return _CubicAnchoredQuery{Tg, Tw, I}(interval, xq_p, state, w0, w1, w2, w3)
 end
 
 # ========================================
@@ -269,7 +275,7 @@ function _anchor_query(
         wrap::Bool = false,
         searcher::P = _to_searcher(LinearBinarySearch())
     ) where {T, S <: Real, P <: Searcher}
-    isempty(xq) && return _CubicAnchoredQuery{T, T}[]
+    isempty(xq) && return _CubicAnchoredQuery{T, T, _interval_type(x)}[]
     searcher_resolved = _resolve_searcher_for_grid(x, searcher)
     # First anchor determines concrete element type (Tq may widen for duck-typed grids)
     aq1 = _anchor_query_impl(x, _promote_coord(xq[1], T), wrap, searcher_resolved)
@@ -288,7 +294,7 @@ Fill a pre-allocated buffer with anchored queries for cubic spline evaluation.
 In-place version of `_anchor_query(x, xq, Val(:cubic))` for zero-allocation pooled usage.
 
 # Arguments
-- `buffer::AbstractVector{_CubicAnchoredQuery{Tg,Tq}}`: Pre-allocated buffer (length >= length(xq))
+- `buffer::AbstractVector{<:_CubicAnchoredQuery{Tg,Tq}}`: Pre-allocated buffer (length >= length(xq))
 - `x::AbstractVector{Tg}`: Grid points (must match interpolant's grid)
 - `xq::AbstractVector{Tq}`: Query points (must match buffer's query type)
 - `::Val{:cubic}`: Type tag for cubic interpolation
@@ -301,12 +307,12 @@ The same `buffer` object, filled with anchored queries.
 ```julia
 x = collect(range(0.0, 1.0, 101))
 xq = [0.15, 0.35, 0.75]
-buffer = Vector{_CubicAnchoredQuery{Float64,Float64}}(undef, length(xq))
+buffer = Vector{_CubicAnchoredQuery{Float64,Float64,_ContiguousIndices{2}}}(undef, length(xq))
 _fill_anchors!(buffer, x, xq, Val(:cubic))
 ```
 """
 @inline function _fill_anchors!(
-        buffer::AbstractVector{_CubicAnchoredQuery{Tg, Tq}},
+        buffer::AbstractVector{<:_CubicAnchoredQuery{Tg, Tq}},
         x::AbstractVector{Tg},
         xq::AbstractVector{S},
         ::Val{:cubic},
@@ -360,7 +366,7 @@ while preserving the full Dual value for weight computation.
     w2 = _compute_anchor_weights(EvalDeriv2(), h, inv_h, dL, dR)
     w3 = _compute_anchor_weights(EvalDeriv3(), h, inv_h, dL, dR)
 
-    return _CubicAnchoredQuery(_ExplicitIndices(loc.idxL, loc.idxR), loc.xq, loc.state, w0, w1, w2, w3, Tg)
+    return _CubicAnchoredQuery(loc.interval, loc.xq, loc.state, w0, w1, w2, w3, Tg)
 end
 
 # ========================================

--- a/src/cubic/cubic_oneshot_series.jl
+++ b/src/cubic/cubic_oneshot_series.jl
@@ -66,7 +66,7 @@ end
     w1 = _compute_anchor_weights(EvalDeriv1(), h, inv_h, dL, dR)
     w2 = _compute_anchor_weights(EvalDeriv2(), h, inv_h, dL, dR)
     w3 = _compute_anchor_weights(EvalDeriv3(), h, inv_h, dL, dR)
-    return _CubicAnchoredQuery(_ExplicitIndices(idxL, idxR), xq_wrapped, IN_DOMAIN, w0, w1, w2, w3, eltype(cache.x))
+    return _CubicAnchoredQuery(_interval_indices(cache.x, idxL, idxR), xq_wrapped, IN_DOMAIN, w0, w1, w2, w3, eltype(cache.x))
 end
 
 # Periodic scalar: zero-copy. One search → seam-aware `_ExplicitIndices` anchor → loop
@@ -144,7 +144,7 @@ end
     # Pre-fill seam-aware anchors via `_build_periodic_cubic_anchor`.
     Tg_c = eltype(cache.x)
     Tq_w = _coord_eltype(Tq, Tg_c)
-    aq_vec = acquire!(pool, _CubicAnchoredQuery{Tg_c, Tq_w}, length(xqs))
+    aq_vec = acquire!(pool, _CubicAnchoredQuery{Tg_c, Tq_w, _interval_type(cache.x)}, length(xqs))
     # `cache.x` is wrapped (`_ExclusivePeriodicAxis(_CachedVector, period)` for
     # `:exclusive`) — axis-level seam dispatch fires via `g.period`. No `bc` thread.
     searcher = _resolve_search(cache.x, xqs, search, nothing)
@@ -277,7 +277,7 @@ end
 
     # Pre-compute anchors once (search Q times, not K×Q)
     Tq_w = _coord_eltype(Tq, eltype(cache.x))
-    aq_vec = acquire!(pool, _CubicAnchoredQuery{eltype(cache.x), Tq_w}, length(xqs))
+    aq_vec = acquire!(pool, _CubicAnchoredQuery{eltype(cache.x), Tq_w, _interval_type(cache.x)}, length(xqs))
     searcher = _resolve_search(cache.x, xqs, search, nothing)
     _fill_anchors!(aq_vec, cache.x, xqs, Val(:cubic), extrap_eff isa WrapExtrap, searcher)
 

--- a/src/cubic/cubic_series_interp.jl
+++ b/src/cubic/cubic_series_interp.jl
@@ -865,7 +865,7 @@ Builds anchors from original `xq` (preserving precision in weights) for scalar/v
 
     # Build anchors — Tq widens via _coord_eltype (Float32 on Float64 grid → Float64)
     Tq_w = _coord_eltype(Tq, Tg)
-    aq_vec = acquire!(pool, _CubicAnchoredQuery{Tg, Tq_w}, n_query)
+    aq_vec = acquire!(pool, _CubicAnchoredQuery{Tg, Tq_w, _interval_type(sitp.cache.x)}, n_query)
     searcher = _resolve_search(sitp.cache.x, xq, search, hint)
     _fill_anchors!(aq_vec, sitp.cache.x, xq, Val(:cubic), _should_wrap(sitp), searcher)
 

--- a/src/linear/linear_adjoint.jl
+++ b/src/linear/linear_adjoint.jl
@@ -51,11 +51,11 @@ itp = linear_interp(x, f)
 @assert dot(itp.(xq), y_bar) ≈ dot(f, adj(y_bar))
 ```
 """
-struct LinearAdjoint{Tg, BC <: AbstractBC, EP <: AbstractExtrap} <: AbstractAdjoint1D{Tg}
+struct LinearAdjoint{Tg, BC <: AbstractBC, EP <: AbstractExtrap, I <: _AbstractIndices{2}} <: AbstractAdjoint1D{Tg}
     # Coordinate type is grid-pinned (`Tc = Tg`), not the canonical `_coord_eltype(Tq, Tg)`:
     # the adjoint operates on baked coefficients, so AD-through-adjoint is unsupported. The
     # forward Dual-grid contract is satisfied independently.
-    anchors::Vector{_LinearAnchoredQuery{Tg, Tg}}
+    anchors::Vector{_LinearAnchoredQuery{Tg, Tg, I}}
     grid_size::Int  # internal length: n+1 for PeriodicBC{:exclusive}, n otherwise
     bc::BC
     extrap::EP
@@ -188,7 +188,7 @@ function _bake_linear_clampfill_anchors(
         searcher::P = _to_searcher(LinearBinarySearch())
     ) where {Tg, Tq <: Real, P <: Searcher}
     searcher_resolved = _resolve_searcher_for_grid(x, searcher)
-    output = Vector{_LinearAnchoredQuery{Tg, promote_type(Tq, Tg)}}(undef, length(xq))
+    output = Vector{_LinearAnchoredQuery{Tg, promote_type(Tq, Tg), _interval_type(x)}}(undef, length(xq))
     @inbounds for k in eachindex(xq)
         xq_raw = xq[k]
         aq = _linear_anchor_query_impl(x, _clamp_to_grid(xq_raw, x), false, searcher_resolved)
@@ -279,7 +279,7 @@ function linear_adjoint(
         anchors = _anchor_query(x_axis, xq_p, Val(:linear), wrap)
     end
 
-    return LinearAdjoint{Tg, typeof(bc), typeof(extrap_eff)}(
+    return LinearAdjoint{Tg, typeof(bc), typeof(extrap_eff), _interval_type(x_axis)}(
         anchors, length(x_axis), bc, extrap_eff
     )
 end

--- a/src/linear/linear_adjoint.jl
+++ b/src/linear/linear_adjoint.jl
@@ -17,7 +17,7 @@
 # ========================================
 
 """
-    LinearAdjoint{Tg, EP}
+    LinearAdjoint{Tg, BC, EP, I}
 
 Adjoint (transpose) operator for 1D linear interpolation.
 Computes `f̄ = Wᵀȳ` where `W` is the forward linear interpolation weight matrix.
@@ -27,7 +27,9 @@ The same adjoint can be applied to any `ȳ` vector.
 
 # Type Parameters
 - `Tg`: Grid float type (Float32 or Float64)
+- `BC`: Boundary condition type (normalized)
 - `EP`: Extrapolation policy type (`NoExtrap`, `ExtendExtrap`, `ClampExtrap`, `FillExtrap`, `WrapExtrap`)
+- `I`: Per-axis interval representation — `_ContiguousIndices{2}` (ordinary grid) or `_ExplicitIndices{2}` (exclusive-periodic seam)
 
 # Fields
 - `anchors`: Pre-computed `_LinearAnchoredQuery` per query point

--- a/src/linear/linear_anchor.jl
+++ b/src/linear/linear_anchor.jl
@@ -12,7 +12,7 @@
 # ========================================
 
 """
-    _LinearAnchoredQuery{Tg, Tq}
+    _LinearAnchoredQuery{Tg, Tq, I}
 
 Precomputed geometry for ultra-fast linear interpolation at a fixed query point.
 Internal API: no runtime grid validation; callers must ensure the anchor
@@ -21,9 +21,11 @@ matches the interpolant grid.
 # Type Parameters
 - `Tg`: Grid type — normally Float32/Float64, but unconstrained for duck-typed grids (e.g. ForwardDiff.Dual)
 - `Tq`: Query type (widened to `promote_type(Tq, Tg)` by the outer constructor)
+- `I <: _AbstractIndices{2}`: Interval representation — `_ContiguousIndices{2}` (one Int) for
+  ordinary grids, `_ExplicitIndices{2}` (two Int) for periodic-exclusive seam cells
 
 # Fields
-- `interval::_ExplicitIndices{2}`: Physical cell interval; `interval[1]` is the left index, `interval[2]` the right
+- `interval::I`: Physical cell interval; `interval[1]` is the left index, `interval[2]` the right
   (legacy `aq.idxL` / `aq.idxR` virtual properties read through `getproperty` — see below).
   For non-periodic cells `idxR == idxL + 1`; at periodic-exclusive seam `idxL == n`, `idxR == 1` (wrap).
 - `xq`: Original query point (or wrapped value for periodic), preserves original precision
@@ -53,14 +55,15 @@ as it eliminates O(log n) binary search.
 - `alpha` for EvalValue: `alpha*yR + (1-alpha)*yL` (convex blend, no division)
 - `inv_h` for EvalDeriv1: `_fielddiff(Tc, yR, yL) * inv_h` (wrap-safe, no division)
 """
-struct _LinearAnchoredQuery{Tg, Tq <: Real}
+struct _LinearAnchoredQuery{Tg, Tq <: Real, I <: _AbstractIndices{2}}
     # Physical cell interval: `interval[1]` is the left index (idxL), `interval[2]`
     # is the right index (idxR). For non-periodic cells `idxR == idxL + 1`; for
-    # periodic-exclusive seam cells `idxR == 1` (wrap). Unified across all
-    # wrap-aware methods via `_ExplicitIndices{K}` (src/core/axis_indices.jl).
+    # periodic-exclusive seam cells `idxR == 1` (wrap). Ordinary grids store the
+    # compact `_ContiguousIndices{2}` (one Int); periodic-exclusive seam cells
+    # store `_ExplicitIndices{2}` (src/core/axis_indices.jl).
     # Legacy `aq.idxL` / `aq.idxR` accessors are preserved via `getproperty`
     # below — every existing call site reads through the virtual property.
-    interval::_ExplicitIndices{2}
+    interval::I
     xq::Tq                     # query point (possibly wrapped)
     state::UInt8               # IN_DOMAIN / OOB_LEFT / OOB_RIGHT
     xL::Tg                     # left grid point
@@ -90,16 +93,16 @@ end
     (:interval, :idxL, :idxR, :xq, :state, :xL, :h, :inv_h, :alpha)
 
 # Outer constructor: infers `Tq` from alpha's arithmetic type and promotes
-# `xq` to match. Callers pass an explicit `_ExplicitIndices` (or any `_ExplicitIndices{2}`)
-# so seam-aware index handling is local to the call site.
+# `xq` to match; `I` is inferred from the caller's `interval` (contiguous for
+# ordinary grids, explicit at periodic-exclusive seams — chosen local to the call site).
 #
 # For Float grids:  alpha::Tq, xq::Tq — no conversion (identity).
 # For Dual grids + Float query:  alpha::Dual (from grid arithmetic),
 #   xq promoted to Dual via convert (zero partials = "query has no grid sensitivity").
-@inline function _LinearAnchoredQuery(interval::_ExplicitIndices{2}, xq, state::UInt8, xL::Tg, h::Tg, inv_h::Tg, alpha) where {Tg}
+@inline function _LinearAnchoredQuery(interval::I, xq, state::UInt8, xL::Tg, h::Tg, inv_h::Tg, alpha) where {Tg, I <: _AbstractIndices{2}}
     Ta = typeof(alpha)
     xq_p = convert(Ta, xq)
-    return _LinearAnchoredQuery{Tg, Ta}(interval, xq_p, state, xL, h, inv_h, alpha)
+    return _LinearAnchoredQuery{Tg, Ta, I}(interval, xq_p, state, xL, h, inv_h, alpha)
 end
 
 # ========================================
@@ -221,7 +224,7 @@ function _anchor_query(
     # Tq_promoted accounts for Tg×Tq arithmetic: promote_type(Tq, Tg) gives the
     # widened query type that the outer constructor will use for alpha and xq.
     Tq_promoted = promote_type(Tq, Tg)
-    output = Vector{_LinearAnchoredQuery{Tg, Tq_promoted}}(undef, length(xq))
+    output = Vector{_LinearAnchoredQuery{Tg, Tq_promoted, _interval_type(x)}}(undef, length(xq))
 
     @inbounds for k in eachindex(xq)
         output[k] = _linear_anchor_query_impl(x, xq[k], wrap, searcher_resolved)
@@ -237,7 +240,7 @@ In-place version of `_anchor_query(x, xq, Val(:linear))` — zero-allocation as 
 the caller reuses `buffer`. Writes `length(xq)` entries.
 
 # Arguments
-- `buffer::Vector{_LinearAnchoredQuery{Tg,Tq}}`: Caller-allocated buffer (length >= length(xq))
+- `buffer::AbstractVector{<:_LinearAnchoredQuery{Tg,Tq}}`: Caller-allocated buffer (length >= length(xq))
 - `x::AbstractVector{Tg}`: Grid points (must match interpolant's grid)
 - `xq::AbstractVector`: Query points (any Real type)
 - `::Val{:linear}`: Type tag for linear interpolation
@@ -248,7 +251,7 @@ The outer `_LinearAnchoredQuery` constructor promotes via `promote_type(S, Tg)`,
 so wider precision is preserved when `S` differs from `Tg`.
 """
 @inline function _fill_anchors!(
-        buffer::AbstractVector{_LinearAnchoredQuery{Tg, Tq}},
+        buffer::AbstractVector{<:_LinearAnchoredQuery{Tg, Tq}},
         x::AbstractVector{Tg},
         xq::AbstractVector{S},
         ::Val{:linear},
@@ -296,7 +299,7 @@ in `xq` and `alpha` fields. The interval search uses `_extract_primal(xq)` for c
     inv_h = _get_inv_h(x, loc.idxL)
     alpha = (loc.xq - loc.xL) * inv_h
 
-    return _LinearAnchoredQuery(_ExplicitIndices(loc.idxL, loc.idxR), loc.xq, loc.state, loc.xL, h, inv_h, alpha)
+    return _LinearAnchoredQuery(loc.interval, loc.xq, loc.state, loc.xL, h, inv_h, alpha)
 end
 
 # ========================================

--- a/src/linear/linear_oneshot_series.jl
+++ b/src/linear/linear_oneshot_series.jl
@@ -62,7 +62,7 @@
     h = _get_h(x_eff, idxL)
     inv_h = _get_inv_h(x_eff, idxL)
     alpha = (xq_wrapped - xL) * inv_h
-    aq = _LinearAnchoredQuery(_ExplicitIndices(idxL, idxR), xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
+    aq = _LinearAnchoredQuery(_interval_indices(x_eff, idxL, idxR), xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
 
     @inbounds for k in 1:K
         output[k] = _linear_eval_at_anchor(vecs[k], aq, op, extrap_p)
@@ -198,7 +198,7 @@ In-place one-shot linear interpolation at multiple query points.
             h = _get_h(x_eff, idxL)
             inv_h = _get_inv_h(x_eff, idxL)
             alpha = (xq_wrapped - xL) * inv_h
-            aq = _LinearAnchoredQuery(_ExplicitIndices(idxL, idxR), xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
+            aq = _LinearAnchoredQuery(_interval_indices(x_eff, idxL, idxR), xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
             for k in 1:K
                 outputs[k][j] = _linear_eval_at_anchor(vecs[k], aq, op, extrap_p)
             end
@@ -240,14 +240,14 @@ end
         x_eff = _resolve_axis(x, bc)
         extrap_p = _resolve_extrap(NoExtrap(), bc, x_eff)
         searcher = _resolve_search(x_eff, xqs, search, nothing)
-        aq_vec = acquire!(pool, _LinearAnchoredQuery{Tg_actual, Tqp}, NQ)
+        aq_vec = acquire!(pool, _LinearAnchoredQuery{Tg_actual, Tqp, _interval_type(x_eff)}, NQ)
         @inbounds for j in 1:NQ
             xq_wrapped = _wrap_to_domain(xqs[j], x_eff)
             idxL, idxR, xL, _ = search_interval(searcher, x_eff, xq_wrapped)
             h = _get_h(x_eff, idxL)
             inv_h = _get_inv_h(x_eff, idxL)
             alpha = (xq_wrapped - xL) * inv_h
-            aq_vec[j] = _LinearAnchoredQuery(_ExplicitIndices(idxL, idxR), xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
+            aq_vec[j] = _LinearAnchoredQuery(_interval_indices(x_eff, idxL, idxR), xq_wrapped, IN_DOMAIN, xL, h, inv_h, alpha)
         end
         @inbounds for k in 1:K
             for j in 1:NQ
@@ -260,7 +260,7 @@ end
     extrap_eff = _check_domain(x, xqs, extrap)
     searcher = _resolve_search(x, xqs, search, nothing)
     wrap = extrap_eff isa WrapExtrap
-    aq_vec = acquire!(pool, _LinearAnchoredQuery{Tg_actual, Tqp}, NQ)
+    aq_vec = acquire!(pool, _LinearAnchoredQuery{Tg_actual, Tqp, _interval_type(x)}, NQ)
     _fill_anchors!(aq_vec, x, xqs, Val(:linear), wrap, searcher)
     @inbounds for k in 1:K
         for j in 1:NQ

--- a/src/linear/linear_series_interp.jl
+++ b/src/linear/linear_series_interp.jl
@@ -535,7 +535,7 @@ end
     x_max = Tg(last(sitp.x))
     NQ = length(xq)
     Tqp = promote_type(Tg, eltype(xq))
-    aq_vec = acquire!(pool, _LinearAnchoredQuery{Tg, Tqp}, NQ)
+    aq_vec = acquire!(pool, _LinearAnchoredQuery{Tg, Tqp, _interval_type(x_grid)}, NQ)
     _fill_anchors!(aq_vec, x_grid, xq, Val(:linear), wrap, searcher)
     @inbounds for k in 1:n_ser
         for j in 1:NQ

--- a/test/test_1d_bc_consistency.jl
+++ b/test/test_1d_bc_consistency.jl
@@ -319,7 +319,11 @@ end
     x_inc = vcat(x_exc, x_exc[1] + period)
     n_q = 30
     xq = vcat(0.5 * h, period - 0.5 * h, period .* rand(n_q - 2))
-    y_bar = randn(n_q)
+    # Cardinal slopes are f-independent, so the NoBC−Periodic adjoint gap is
+    # rank-1 — a single scalar δ = Σ wq·ȳq with wq ≥ 0 (h10 ≥ 0, −h11 ≥ 0 on
+    # boundary cells). Mixed-sign randn ȳ cancels δ below rtol on ~1.4% of
+    # draws (CI flake). Positive ȳ: every term ≥ 0, pinned queries give δ ≥ 1/8.
+    y_bar = 1.0 .+ rand(n_q)
     bc_inc = PeriodicBC()
     bc_exc = PeriodicBC(endpoint = :exclusive, period = period)
 

--- a/test/test_constant_anchor.jl
+++ b/test/test_constant_anchor.jl
@@ -396,7 +396,7 @@
             xq = [0.0, 0.15, 0.35, 0.5, 0.75, 0.99, 1.0]
 
             expected = FI._anchor_query(x, xq, Val(:constant))
-            buffer = Vector{FI._ConstantAnchoredQuery{Float64, Float64}}(undef, length(xq))
+            buffer = Vector{FI._ConstantAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}}(undef, length(xq))
             FI._fill_anchors!(buffer, x, xq, Val(:constant))
 
             for i in eachindex(xq)
@@ -413,7 +413,7 @@
             xq = [-0.3, 0.5, 1.3, 2.5]
 
             expected = FI._anchor_query(x, xq, Val(:constant), true)
-            buffer = Vector{FI._ConstantAnchoredQuery{Float64, Float64}}(undef, length(xq))
+            buffer = Vector{FI._ConstantAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}}(undef, length(xq))
             FI._fill_anchors!(buffer, x, xq, Val(:constant), true)
 
             for i in eachindex(xq)
@@ -426,7 +426,7 @@
         @testset "length assertion when buffer too small" begin
             x = collect(range(0.0, 1.0, 101))
             xq = [0.15, 0.35, 0.5, 0.75]
-            buffer = Vector{FI._ConstantAnchoredQuery{Float64, Float64}}(undef, 2)
+            buffer = Vector{FI._ConstantAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}}(undef, 2)
 
             @test_throws AssertionError FI._fill_anchors!(buffer, x, xq, Val(:constant))
         end
@@ -434,7 +434,7 @@
         @testset "zero allocation after warmup" begin
             x = collect(range(0.0, 1.0, 101))
             xq = collect(range(0.1, 0.9, 50))
-            buffer = Vector{FI._ConstantAnchoredQuery{Float64, Float64}}(undef, length(xq))
+            buffer = Vector{FI._ConstantAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}}(undef, length(xq))
 
             FI._fill_anchors!(buffer, x, xq, Val(:constant))
             allocs = @allocated FI._fill_anchors!(buffer, x, xq, Val(:constant))

--- a/test/test_constant_eltype.jl
+++ b/test/test_constant_eltype.jl
@@ -521,7 +521,7 @@ end
 # end-to-end via the forward/adjoint dot-product identity.
 @testitem "Constant anchor: Tq = promote_type(Tg, eltype(xq))" begin
     using LinearAlgebra: dot
-    import FastInterpolations: ConstantAdjoint, _ConstantAnchoredQuery
+    import FastInterpolations: ConstantAdjoint, _ConstantAnchoredQuery, _ContiguousIndices
 
     @testset "Int grid + Float query — 1D adjoint, dot identity" begin
         x = collect(0:9)
@@ -532,7 +532,7 @@ end
         itp = constant_interp(x, y)
         adj = constant_adjoint(x, xq)
         @test adj isa ConstantAdjoint{Int, Float64}
-        @test eltype(adj.anchors) === _ConstantAnchoredQuery{Int, Float64}
+        @test eltype(adj.anchors) === _ConstantAnchoredQuery{Int, Float64, _ContiguousIndices{2}}
         @test dot(itp.(xq), y_bar) ≈ dot(y, adj(y_bar))
     end
 

--- a/test/test_cubic_anchor.jl
+++ b/test/test_cubic_anchor.jl
@@ -540,7 +540,7 @@
             expected = FI._anchor_query(x, xq, Val(:cubic))
 
             # In-place version
-            buffer = Vector{FI._CubicAnchoredQuery{Float64, Float64}}(undef, length(xq))
+            buffer = Vector{FI._CubicAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}}(undef, length(xq))
             FI._fill_anchors!(buffer, x, xq, Val(:cubic))
 
             # Verify all fields match exactly (bit-wise)
@@ -562,7 +562,7 @@
             expected = FI._anchor_query(x, xq, Val(:cubic), true)
 
             # In-place
-            buffer = Vector{FI._CubicAnchoredQuery{Float64, Float64}}(undef, length(xq))
+            buffer = Vector{FI._CubicAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}}(undef, length(xq))
             FI._fill_anchors!(buffer, x, xq, Val(:cubic), true)
 
             for i in eachindex(xq)
@@ -576,7 +576,7 @@
         @testset "length assertion when buffer too small" begin
             x = collect(range(0.0, 1.0, 101))
             xq = [0.15, 0.35, 0.5, 0.75]  # 4 points
-            buffer = Vector{FI._CubicAnchoredQuery{Float64, Float64}}(undef, 2)  # Only 2 slots
+            buffer = Vector{FI._CubicAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}}(undef, 2)  # Only 2 slots
 
             @test_throws AssertionError FI._fill_anchors!(buffer, x, xq, Val(:cubic))
         end
@@ -584,7 +584,7 @@
         @testset "empty vector case" begin
             x = collect(range(0.0, 1.0, 101))
             xq = Float64[]
-            buffer = Vector{FI._CubicAnchoredQuery{Float64, Float64}}(undef, 0)
+            buffer = Vector{FI._CubicAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}}(undef, 0)
 
             # Should not throw
             FI._fill_anchors!(buffer, x, xq, Val(:cubic))
@@ -595,7 +595,7 @@
             x = Float32.(collect(range(0.0f0, 1.0f0, 101)))
             xq = Float32[0.15f0, 0.35f0, 0.5f0]  # Float32 queries
 
-            buffer = Vector{FI._CubicAnchoredQuery{Float32, Float32}}(undef, length(xq))
+            buffer = Vector{FI._CubicAnchoredQuery{Float32, Float32, FI._ContiguousIndices{2}}}(undef, length(xq))
             FI._fill_anchors!(buffer, x, xq, Val(:cubic))
 
             @test all(aq -> aq isa FI._CubicAnchoredQuery{Float32, Float32}, buffer)
@@ -604,7 +604,7 @@
         @testset "zero allocation after warmup" begin
             x = collect(range(0.0, 1.0, 101))
             xq = collect(range(0.1, 0.9, 50))
-            buffer = Vector{FI._CubicAnchoredQuery{Float64, Float64}}(undef, length(xq))
+            buffer = Vector{FI._CubicAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}}(undef, length(xq))
 
             # Warmup
             FI._fill_anchors!(buffer, x, xq, Val(:cubic))

--- a/test/test_linear_anchor.jl
+++ b/test/test_linear_anchor.jl
@@ -406,7 +406,7 @@
             expected = FI._anchor_query(x, xq, Val(:linear))
 
             # In-place version - now uses {Tg, Tq} type parameters
-            buffer = Vector{FI._LinearAnchoredQuery{Float64, Float64}}(undef, length(xq))
+            buffer = Vector{FI._LinearAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}}(undef, length(xq))
             FI._fill_anchors!(buffer, x, xq, Val(:linear))
 
             # Verify all fields match exactly (bit-wise)
@@ -425,7 +425,7 @@
             xq = [-0.3, 0.5, 1.3, 2.5]
 
             expected = FI._anchor_query(x, xq, Val(:linear), true)
-            buffer = Vector{FI._LinearAnchoredQuery{Float64, Float64}}(undef, length(xq))
+            buffer = Vector{FI._LinearAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}}(undef, length(xq))
             FI._fill_anchors!(buffer, x, xq, Val(:linear), true)
 
             for i in eachindex(xq)
@@ -438,7 +438,7 @@
         @testset "length assertion when buffer too small" begin
             x = collect(range(0.0, 1.0, 101))
             xq = [0.15, 0.35, 0.5, 0.75]
-            buffer = Vector{FI._LinearAnchoredQuery{Float64, Float64}}(undef, 2)
+            buffer = Vector{FI._LinearAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}}(undef, 2)
 
             @test_throws AssertionError FI._fill_anchors!(buffer, x, xq, Val(:linear))
         end
@@ -446,7 +446,7 @@
         @testset "zero allocation after warmup" begin
             x = collect(range(0.0, 1.0, 101))
             xq = collect(range(0.1, 0.9, 50))
-            buffer = Vector{FI._LinearAnchoredQuery{Float64, Float64}}(undef, length(xq))
+            buffer = Vector{FI._LinearAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}}(undef, length(xq))
 
             FI._fill_anchors!(buffer, x, xq, Val(:linear))
             allocs = @allocated FI._fill_anchors!(buffer, x, xq, Val(:linear))

--- a/test/test_search_anchor_integration.jl
+++ b/test/test_search_anchor_integration.jl
@@ -1,7 +1,7 @@
 @testitem "Search Policy Anchor Integration" begin
     using FastInterpolations: _anchor_query, _fill_anchors!,
         _LinearAnchoredQuery, _ConstantAnchoredQuery, _QuadraticAnchoredQuery, _CubicAnchoredQuery,
-        Searcher, LinearBinarySearch, RefHint
+        _ContiguousIndices, Searcher, LinearBinarySearch, RefHint
 
     # ========================================
     # Linear Anchor Tests
@@ -112,7 +112,7 @@
 
         @testset "Vector Query" begin
             xq = collect(range(0.1, 0.9, 9))
-            buffer = Vector{_CubicAnchoredQuery{Float64, Float64}}(undef, length(xq))
+            buffer = Vector{_CubicAnchoredQuery{Float64, Float64, _ContiguousIndices{2}}}(undef, length(xq))
 
             _fill_anchors!(buffer, x, xq, Val(:cubic))
 

--- a/test/test_series_contiguous_indices.jl
+++ b/test/test_series_contiguous_indices.jl
@@ -1,0 +1,24 @@
+@testitem "Series anchors use _ContiguousIndices on ordinary grids" begin
+    const FI = FastInterpolations
+    x = collect(range(0.0, 1.0, 101))           # ordinary AbstractVector grid
+
+    for tag in (Val(:linear), Val(:cubic), Val(:constant))
+        aq = FI._anchor_query(x, 0.37, tag)
+        # ordinary grid ⇒ compact representation
+        @test getfield(aq, :interval) isa FI._ContiguousIndices{2}
+        # virtual props still resolve the physical cell
+        @test aq.idxL == searchsortedlast(x, 0.37)
+        @test aq.idxR == aq.idxL + 1
+    end
+end
+
+@testitem "Series wrap/periodic seam keeps _ExplicitIndices" begin
+    const FI = FastInterpolations
+    x = collect(range(0.0, 1.0, 11))
+    # exclusive-periodic axis: seam cell (n, 1) must stay explicit + preserve idxR
+    xax = FI._resolve_axis(x, PeriodicBC(endpoint = :exclusive, period = 1.1))
+    idxL, idxR, _, _ = FI.search_interval(FI.DEFAULT_SEARCHER, xax, 0.999 * last(xax))
+    iv = FI._interval_indices(xax, idxL, idxR)
+    @test iv isa FI._ExplicitIndices{2}
+    @test iv[Val(1)] == idxL && iv[Val(2)] == idxR
+end

--- a/test/test_series_contiguous_indices.jl
+++ b/test/test_series_contiguous_indices.jl
@@ -63,3 +63,24 @@ end
     @test itp(aqc) === itp(aqe)
     @test sizeof(aqc) < sizeof(aqe)                                     # 40 < 48
 end
+
+@testitem "Series adjoints pin anchor representation" begin
+    const FI = FastInterpolations
+    # ordinary grid ⇒ adjoint storage uses compact _ContiguousIndices
+    x = collect(range(0.0, 1.0, 21)); xq = collect(range(0.05, 0.95, 15))
+    ladj = linear_adjoint(x, xq)
+    cadj = cubic_adjoint(x, xq)                          # default bc = CubicFit()
+    @test eltype(ladj.anchors) === FI._LinearAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}
+    @test eltype(cadj.anchors) === FI._CubicAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}
+
+    # Exclusive-periodic representation is method-specific — both correct, same seam
+    # cell: Linear wraps the axis (`_ExclusivePeriodicAxis` ⇒ explicit seam pair),
+    # while Cubic materializes the extended inclusive grid so the seam is an ordinary
+    # contiguous interior cell (n, n+1), folded to index 1 at scatter time.
+    xper = collect(range(0.0, 2π, 21))[1:(end - 1)]; xqp = collect(range(0.3, 5.5, 15))
+    bcp = PeriodicBC(endpoint = :exclusive, period = 2π)
+    ladjp = linear_adjoint(xper, xqp; bc = bcp)
+    cadjp = cubic_adjoint(xper, xqp; bc = bcp)
+    @test eltype(ladjp.anchors) === FI._LinearAnchoredQuery{Float64, Float64, FI._ExplicitIndices{2}}
+    @test eltype(cadjp.anchors) === FI._CubicAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}
+end

--- a/test/test_series_contiguous_indices.jl
+++ b/test/test_series_contiguous_indices.jl
@@ -50,3 +50,16 @@ end
     @test itp(aqc; deriv = FI.DerivOp(1)) === itp(aqe; deriv = FI.DerivOp(1))
     @test sizeof(aqc) < sizeof(aqe)                                     # 120 < 128
 end
+
+@testitem "Constant anchor: contiguous is bit-identical to explicit + smaller" begin
+    const FI = FastInterpolations
+    x = collect(range(0.0, 1.0, 101)); y = sin.(x)
+    itp = FI.constant_interp(x, y; side = FI.NearestSide())
+    aqc = FI._anchor_query(x, 0.37, Val(:constant))
+    aqe = FI._ConstantAnchoredQuery(
+        FI._ExplicitIndices(aqc.idxL, aqc.idxR),
+        aqc.xq, aqc.state, aqc.h, aqc.dL
+    )
+    @test itp(aqc) === itp(aqe)
+    @test sizeof(aqc) < sizeof(aqe)                                     # 40 < 48
+end

--- a/test/test_series_contiguous_indices.jl
+++ b/test/test_series_contiguous_indices.jl
@@ -36,3 +36,17 @@ end
     @test itp(aqc; deriv = FI.DerivOp(1)) === itp(aqe; deriv = FI.DerivOp(1))
     @test sizeof(aqc) < sizeof(aqe)                                     # 56 < 64
 end
+
+@testitem "Cubic anchor: contiguous is bit-identical to explicit + smaller" begin
+    const FI = FastInterpolations
+    x = collect(range(0.0, 1.0, 101)); y = sin.(x)
+    itp = FI.cubic_interp(x, y)
+    aqc = FI._anchor_query(x, 0.37, Val(:cubic))
+    aqe = FI._CubicAnchoredQuery(
+        FI._ExplicitIndices(aqc.idxL, aqc.idxR),
+        aqc.xq, aqc.state, aqc.w0, aqc.w1, aqc.w2, aqc.w3, eltype(x)
+    )
+    @test itp(aqc) === itp(aqe)
+    @test itp(aqc; deriv = FI.DerivOp(1)) === itp(aqe; deriv = FI.DerivOp(1))
+    @test sizeof(aqc) < sizeof(aqe)                                     # 120 < 128
+end

--- a/test/test_series_contiguous_indices.jl
+++ b/test/test_series_contiguous_indices.jl
@@ -1,86 +1,66 @@
-@testitem "Series anchors use _ContiguousIndices on ordinary grids" begin
-    const FI = FastInterpolations
-    x = collect(range(0.0, 1.0, 101))           # ordinary AbstractVector grid
+@testitem "Series _ContiguousIndices representation contract" setup = [Basic] begin
+    x = collect(range(0.0, 1.0, 101)); y = sin.(x)     # shared ordinary grid
 
-    for tag in (Val(:linear), Val(:cubic), Val(:constant))
-        aq = FI._anchor_query(x, 0.37, tag)
-        # ordinary grid ⇒ compact representation
+    @testset "forward anchor: ordinary grid ⇒ compact _ContiguousIndices ($sym)" for sym in
+        (:linear, :cubic, :constant)
+        aq = FI._anchor_query(x, 0.37, Val(sym))
         @test getfield(aq, :interval) isa FI._ContiguousIndices{2}
-        # virtual props still resolve the physical cell
-        @test aq.idxL == searchsortedlast(x, 0.37)
+        @test aq.idxL == searchsortedlast(x, 0.37)      # virtual props still resolve the cell
         @test aq.idxR == aq.idxL + 1
     end
-end
 
-@testitem "Series wrap/periodic seam keeps _ExplicitIndices" begin
-    const FI = FastInterpolations
-    x = collect(range(0.0, 1.0, 11))
-    # exclusive-periodic axis: seam cell (n, 1) must stay explicit + preserve idxR
-    xax = FI._resolve_axis(x, PeriodicBC(endpoint = :exclusive, period = 1.1))
-    idxL, idxR, _, _ = FI.search_interval(FI.DEFAULT_SEARCHER, xax, 0.999 * last(xax))
-    iv = FI._interval_indices(xax, idxL, idxR)
-    @test iv isa FI._ExplicitIndices{2}
-    @test iv[Val(1)] == idxL && iv[Val(2)] == idxR
-end
+    @testset "forward anchor: exclusive-periodic seam keeps _ExplicitIndices (idxR wraps)" begin
+        xax = FI._resolve_axis(x, PeriodicBC(endpoint = :exclusive, period = 1.1))
+        idxL, idxR, _, _ = FI.search_interval(FI.DEFAULT_SEARCHER, xax, 0.999 * last(xax))
+        iv = FI._interval_indices(xax, idxL, idxR)
+        @test iv isa FI._ExplicitIndices{2}
+        @test iv[Val(1)] == idxL && iv[Val(2)] == idxR
+    end
 
-@testitem "Linear anchor: contiguous is bit-identical to explicit + smaller" begin
-    const FI = FastInterpolations
-    x = collect(range(0.0, 1.0, 101)); y = sin.(x)
-    itp = FI.linear_interp(x, y)
-    aqc = FI._anchor_query(x, 0.37, Val(:linear))                       # contiguous
-    aqe = FI._LinearAnchoredQuery(
-        FI._ExplicitIndices(aqc.idxL, aqc.idxR),
-        aqc.xq, aqc.state, aqc.xL, aqc.h, aqc.inv_h, aqc.alpha
-    )
-    @test itp(aqc) === itp(aqe)                                         # bitwise
-    @test itp(aqc; deriv = FI.DerivOp(1)) === itp(aqe; deriv = FI.DerivOp(1))
-    @test sizeof(aqc) < sizeof(aqe)                                     # 56 < 64
-end
+    @testset "eval: contiguous anchor bit-identical to an explicit rebuild + smaller" begin
+        litp = FI.linear_interp(x, y)
+        la = FI._anchor_query(x, 0.37, Val(:linear))
+        le = FI._LinearAnchoredQuery(
+            FI._ExplicitIndices(la.idxL, la.idxR), la.xq, la.state, la.xL, la.h, la.inv_h, la.alpha
+        )
+        @test litp(la) === litp(le)
+        @test litp(la; deriv = FI.DerivOp(1)) === litp(le; deriv = FI.DerivOp(1))
+        @test sizeof(la) < sizeof(le)                   # 56 < 64
 
-@testitem "Cubic anchor: contiguous is bit-identical to explicit + smaller" begin
-    const FI = FastInterpolations
-    x = collect(range(0.0, 1.0, 101)); y = sin.(x)
-    itp = FI.cubic_interp(x, y)
-    aqc = FI._anchor_query(x, 0.37, Val(:cubic))
-    aqe = FI._CubicAnchoredQuery(
-        FI._ExplicitIndices(aqc.idxL, aqc.idxR),
-        aqc.xq, aqc.state, aqc.w0, aqc.w1, aqc.w2, aqc.w3, eltype(x)
-    )
-    @test itp(aqc) === itp(aqe)
-    @test itp(aqc; deriv = FI.DerivOp(1)) === itp(aqe; deriv = FI.DerivOp(1))
-    @test sizeof(aqc) < sizeof(aqe)                                     # 120 < 128
-end
+        citp = FI.cubic_interp(x, y)
+        ca = FI._anchor_query(x, 0.37, Val(:cubic))
+        ce = FI._CubicAnchoredQuery(
+            FI._ExplicitIndices(ca.idxL, ca.idxR), ca.xq, ca.state, ca.w0, ca.w1, ca.w2, ca.w3, eltype(x)
+        )
+        @test citp(ca) === citp(ce)
+        @test citp(ca; deriv = FI.DerivOp(1)) === citp(ce; deriv = FI.DerivOp(1))
+        @test sizeof(ca) < sizeof(ce)                   # 120 < 128
 
-@testitem "Constant anchor: contiguous is bit-identical to explicit + smaller" begin
-    const FI = FastInterpolations
-    x = collect(range(0.0, 1.0, 101)); y = sin.(x)
-    itp = FI.constant_interp(x, y; side = FI.NearestSide())
-    aqc = FI._anchor_query(x, 0.37, Val(:constant))
-    aqe = FI._ConstantAnchoredQuery(
-        FI._ExplicitIndices(aqc.idxL, aqc.idxR),
-        aqc.xq, aqc.state, aqc.h, aqc.dL
-    )
-    @test itp(aqc) === itp(aqe)
-    @test sizeof(aqc) < sizeof(aqe)                                     # 40 < 48
-end
+        kitp = FI.constant_interp(x, y; side = FI.NearestSide())
+        ka = FI._anchor_query(x, 0.37, Val(:constant))
+        ke = FI._ConstantAnchoredQuery(
+            FI._ExplicitIndices(ka.idxL, ka.idxR), ka.xq, ka.state, ka.h, ka.dL
+        )
+        @test kitp(ka) === kitp(ke)
+        @test sizeof(ka) < sizeof(ke)                   # 40 < 48
+    end
 
-@testitem "Series adjoints pin anchor representation" begin
-    const FI = FastInterpolations
-    # ordinary grid ⇒ adjoint storage uses compact _ContiguousIndices
-    x = collect(range(0.0, 1.0, 21)); xq = collect(range(0.05, 0.95, 15))
-    ladj = linear_adjoint(x, xq)
-    cadj = cubic_adjoint(x, xq)                          # default bc = CubicFit()
-    @test eltype(ladj.anchors) === FI._LinearAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}
-    @test eltype(cadj.anchors) === FI._CubicAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}
+    @testset "adjoint storage pins the representation" begin
+        xa = collect(range(0.0, 1.0, 21)); xqa = collect(range(0.05, 0.95, 15))
+        ladj = linear_adjoint(xa, xqa)
+        cadj = cubic_adjoint(xa, xqa)                   # default bc = CubicFit()
+        @test eltype(ladj.anchors) === FI._LinearAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}
+        @test eltype(cadj.anchors) === FI._CubicAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}
 
-    # Exclusive-periodic representation is method-specific — both correct, same seam
-    # cell: Linear wraps the axis (`_ExclusivePeriodicAxis` ⇒ explicit seam pair),
-    # while Cubic materializes the extended inclusive grid so the seam is an ordinary
-    # contiguous interior cell (n, n+1), folded to index 1 at scatter time.
-    xper = collect(range(0.0, 2π, 21))[1:(end - 1)]; xqp = collect(range(0.3, 5.5, 15))
-    bcp = PeriodicBC(endpoint = :exclusive, period = 2π)
-    ladjp = linear_adjoint(xper, xqp; bc = bcp)
-    cadjp = cubic_adjoint(xper, xqp; bc = bcp)
-    @test eltype(ladjp.anchors) === FI._LinearAnchoredQuery{Float64, Float64, FI._ExplicitIndices{2}}
-    @test eltype(cadjp.anchors) === FI._CubicAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}
+        # Exclusive-periodic representation is method-specific — both correct, same seam
+        # cell: Linear wraps the axis (`_ExclusivePeriodicAxis` ⇒ explicit seam pair),
+        # while Cubic materializes the extended inclusive grid so the seam is an ordinary
+        # contiguous interior cell (n, n+1), folded to index 1 at scatter time.
+        xper = collect(range(0.0, 2π, 21))[1:(end - 1)]; xqp = collect(range(0.3, 5.5, 15))
+        bcp = PeriodicBC(endpoint = :exclusive, period = 2π)
+        ladjp = linear_adjoint(xper, xqp; bc = bcp)
+        cadjp = cubic_adjoint(xper, xqp; bc = bcp)
+        @test eltype(ladjp.anchors) === FI._LinearAnchoredQuery{Float64, Float64, FI._ExplicitIndices{2}}
+        @test eltype(cadjp.anchors) === FI._CubicAnchoredQuery{Float64, Float64, FI._ContiguousIndices{2}}
+    end
 end

--- a/test/test_series_contiguous_indices.jl
+++ b/test/test_series_contiguous_indices.jl
@@ -22,3 +22,17 @@ end
     @test iv isa FI._ExplicitIndices{2}
     @test iv[Val(1)] == idxL && iv[Val(2)] == idxR
 end
+
+@testitem "Linear anchor: contiguous is bit-identical to explicit + smaller" begin
+    const FI = FastInterpolations
+    x = collect(range(0.0, 1.0, 101)); y = sin.(x)
+    itp = FI.linear_interp(x, y)
+    aqc = FI._anchor_query(x, 0.37, Val(:linear))                       # contiguous
+    aqe = FI._LinearAnchoredQuery(
+        FI._ExplicitIndices(aqc.idxL, aqc.idxR),
+        aqc.xq, aqc.state, aqc.xL, aqc.h, aqc.inv_h, aqc.alpha
+    )
+    @test itp(aqc) === itp(aqe)                                         # bitwise
+    @test itp(aqc; deriv = FI.DerivOp(1)) === itp(aqe; deriv = FI.DerivOp(1))
+    @test sizeof(aqc) < sizeof(aqe)                                     # 56 < 64
+end


### PR DESCRIPTION
## Summary

Completes the `_AbstractIndices` migration begun in #185. The 1D **Series** persistent anchors — and their adjoints — were the last layer still hardcoding the 2-`Int` `_ExplicitIndices{2}`. They now carry a trailing `I <: _AbstractIndices{2}`, so ordinary grids store the compact `_ContiguousIndices{2}` (one `Int`, right index derived) while exclusive-periodic seams keep the explicit wrapped pair. Struct sizes drop **Constant 48→40 / Linear 64→56 / Cubic 128→120 B**, and the leaner anchor is measurably faster on the batch/persistent eval paths.

## Why it's faster, and where

The gain is specific to the **K×Q batch shape** (series-outer loop, taken once the query count is large): there the pooled anchor array is *streamed* — one anchor read per (series, query) — and since the kernel is only a couple of FLOPs, the loop is bandwidth-bound on that array, so a smaller struct is directly less to move.

It does **not** help the other shapes, and that's expected — this is a footprint win, not an instruction-count one:
- **single scalar eval** — one anchor, held in registers;
- the **Q×K batch shape** (query-outer loop, taken for small batches) — one anchor built per query and reused across the series from registers, so its size is irrelevant.

The change also reclaims the single-`Int` cubic anchor that predated the `_IdxStencil` unification (#128).

## Benchmark — apple-to-apple, `master` vs this branch

Same-process best-of-400, 2 interleaved rounds, ordinary `Vector` grid (n = 512), pre-built anchors streamed over 20 000 queries; ns per output element, zero allocations throughout.

| eval path | master | this PR | Δ |
|-----------|-------:|--------:|----:|
| Constant — batch value | 1.41 | 1.06 | **−24.6%** |
| Linear — batch value | 0.96 | 0.82 | **−14.5%** |
| Linear — batch deriv1 | 0.96 | 0.82 | **−14.5%** |
| Cubic — batch deriv1 | 1.78 | 1.54 | **−13.6%** |
| Cubic — batch value | 1.58 | 1.54 | −2.4% |

Anchor size: Constant 48→40 B · Linear 64→56 B · Cubic 128→120 B. These rows are the K×Q (streamed-anchor) shape; measured separately, single scalar eval and the Q×K shape (`NQ ≤ 16`) are flat (~0%), confirming the footprint mechanism. Within K×Q the win grows with the series count K as the streamed anchor array dominates — Linear −12% at K = 1 rising to −26% at K = 32.

## What changed

- **1D Series anchors** (`_LinearAnchoredQuery` / `_CubicAnchoredQuery` / `_ConstantAnchoredQuery`) and their **1D adjoints** (`LinearAdjoint` / `CubicAdjoint` / `ConstantAdjoint`) gain the trailing `I` parameter. Construction threads the already-typed interval (`loc.interval`, or `_interval_indices(axis, …)`) instead of rebuilding an explicit pair.
- **`ConstantAdjointND`** is pinned to `_ExplicitIndices{2}` — ND per-axis heterogeneity is out of scope, so its storage and behavior are unchanged; it only fills the now-mandatory third parameter.
- **Quadratic is untouched** — its anchor already stores a bare `idx::Int`, so it was already minimal.

## Compatibility

Internal only — no public API change, results **bit-identical**. The representation is chosen by axis *type* (ordinary → contiguous, exclusive-periodic → explicit), never by an `idxR == idxL+1` value test, so wrap/periodic behavior is unchanged. A representation-contract test pins the invariant across forward anchors and adjoint storage (including the method-specific periodic case — Linear stores the explicit seam pair, Cubic materializes an extended inclusive grid so its seam is a contiguous cell). The method, adjoint, and periodic suites pass locally; CI runs the full suite.
