### PR TITLE
refactor(core): nominal _AbstractAnchorPayload marker for axis anchor payloads

### DIFF
--- a/src/constant/constant_series_payloads.jl
+++ b/src/constant/constant_series_payloads.jl
@@ -24,7 +24,7 @@
 
 # Deriv gather payload: the node is `idxL` normally, `idxR` (== n) at domain-max
 # (matches the value payload there for NaN cell-locality). The kernel scales by 0.
-struct _ConstantZeroPayload{Tq}
+struct _ConstantZeroPayload{Tq} <: _AbstractAnchorPayload
     select_right::Bool
 end
 

--- a/src/core/axis_anchor_types.jl
+++ b/src/core/axis_anchor_types.jl
@@ -11,10 +11,19 @@
 # `interval::I` is the physical search cell (shared `_AbstractIndices{2}` layer,
 # same as `_AnchorLoc`): ordinary axes store one index (`_ContiguousIndices{2}`,
 # right tap derived), exclusive-periodic axes store both (`_ExplicitIndices{2}`,
-# the seam wraps). `payload::P` is a concrete named type — its identity is the
-# method/op tag, so no phantom method parameter is needed.
+# the seam wraps). `payload::P` is a concrete named `_AbstractAnchorPayload`
+# subtype — its identity is the method/op tag, so no phantom method parameter is
+# needed.
+#
+# This file also owns `_AbstractAnchorPayload`: the internal nominal root every
+# payload occupying the `P` slot of `_AxisAnchor` subtypes. It is a marker only
+# (no shared behavior/trait fallback) and stays unexported. `P` remains a
+# concrete subtype at every instantiation, so the bound adds a type invariant
+# without dynamic dispatch or layout change.
 
-struct _AxisAnchor{I <: _AbstractIndices{2}, P}
+abstract type _AbstractAnchorPayload end
+
+struct _AxisAnchor{I <: _AbstractIndices{2}, P <: _AbstractAnchorPayload}
     interval::I
     payload::P
 end
@@ -40,7 +49,7 @@ end
 # classification. Selected at anchor-build time for the flat extraps
 # (Clamp/Fill) whose OOB handling needs an eval-time state branch; all other
 # extraps use the bare payload and a branch-free kernel.
-struct _StatefulPayload{P}
+struct _StatefulPayload{P <: _AbstractAnchorPayload} <: _AbstractAnchorPayload
     inner::P
     state::UInt8      # IN_DOMAIN / OOB_LEFT / OOB_RIGHT
 end

--- a/src/core/series_lean_anchors.jl
+++ b/src/core/series_lean_anchors.jl
@@ -15,8 +15,8 @@
 # Clamp/Fill wrap the bare payload so the OOB state branch stays eval-time; every
 # other extrap uses the bare payload with a branch-free kernel. Compile-time
 # (extrap is known at the Series entry), so the anchor type is fully concrete.
-@inline _maybe_stateful_payload(::_ClampOrFill, ::Type{P}) where {P} = _StatefulPayload{P}
-@inline _maybe_stateful_payload(::AbstractExtrap, ::Type{P}) where {P} = P
+@inline _maybe_stateful_payload(::_ClampOrFill, ::Type{P}) where {P <: _AbstractAnchorPayload} = _StatefulPayload{P}
+@inline _maybe_stateful_payload(::AbstractExtrap, ::Type{P}) where {P <: _AbstractAnchorPayload} = P
 
 # ─── Resolution (method-generic; family provides `_resolve_anchor(m, …)`) ─────
 # `m::M` (type parameter) forces specialization on the concrete interp singleton so

--- a/src/cubic/cubic_series_payloads.jl
+++ b/src/cubic/cubic_series_payloads.jl
@@ -11,19 +11,19 @@
 # Weight formulas reuse `_compute_anchor_weights` verbatim → bit-identical to
 # the corresponding `_CubicAdjointAnchor` field (w0/w1/w2/w3) by construction.
 
-struct _CubicValuePayload1D{Tq}
+struct _CubicValuePayload1D{Tq} <: _AbstractAnchorPayload
     w::NTuple{4, Tq}
 end
-struct _CubicDeriv1Payload1D{Tq}
+struct _CubicDeriv1Payload1D{Tq} <: _AbstractAnchorPayload
     w::NTuple{4, Tq}
 end
-struct _CubicDeriv2Payload1D{Tq}
+struct _CubicDeriv2Payload1D{Tq} <: _AbstractAnchorPayload
     w::NTuple{2, Tq}
 end
-struct _CubicDeriv3Payload1D{Tq}
+struct _CubicDeriv3Payload1D{Tq} <: _AbstractAnchorPayload
     w::NTuple{2, Tq}
 end
-struct _CubicZeroPayload1D{Tq} end   # DerivOp{N≥4}: result is a carrier zero, no weights
+struct _CubicZeroPayload1D{Tq} <: _AbstractAnchorPayload end   # DerivOp{N≥4}: result is a carrier zero, no weights
 
 # Weighted payloads share one resolve arm; the zero payload has its own.
 const _CubicWeightedPayload1D = Union{

--- a/src/gridded/gridded_constant.jl
+++ b/src/gridded/gridded_constant.jl
@@ -18,7 +18,7 @@
 # Constant: the physical interval is stored; `select_right` picks the node at
 # gather time. Carrier `one(Tq)` is reconstructed from the type param (op-agnostic
 # — the derivative `* 0` is a gather-kernel concern, not a payload one).
-struct _ConstantValuePayload{Tq}
+struct _ConstantValuePayload{Tq} <: _AbstractAnchorPayload
     select_right::Bool
 end
 @inline _carrier(::_ConstantValuePayload{Tq}) where {Tq} = one(Tq)

--- a/src/gridded/gridded_hermite.jl
+++ b/src/gridded/gridded_hermite.jl
@@ -36,7 +36,7 @@
 # Geometry-only `(dL, h, inv_h)`; slopes are data-dependent and computed in-pass.
 # All fields are consumed by the Hermite basis for every op, so the payload is
 # not op-minimal (unlike Linear).
-struct _LocalHermitePayload{Tdl, Th, Tinv}
+struct _LocalHermitePayload{Tdl, Th, Tinv} <: _AbstractAnchorPayload
     dL::Tdl
     h::Th
     inv_h::Tinv

--- a/src/gridded/gridded_linear.jl
+++ b/src/gridded/gridded_linear.jl
@@ -31,13 +31,13 @@
 # zero → a zero-size payload. The per-op payload type is chosen once in
 # `_axis_anchor_type`; `_resolve_anchor` and the fused/fullbuffer kernels then
 # dispatch on it.
-struct _LinearValuePayload{Talpha}
+struct _LinearValuePayload{Talpha} <: _AbstractAnchorPayload
     alpha::Talpha
 end
-struct _LinearDeriv1Payload{Talpha, Tinv}
+struct _LinearDeriv1Payload{Talpha, Tinv} <: _AbstractAnchorPayload
     inv_h::Tinv
 end
-struct _LinearZeroPayload{Talpha} end
+struct _LinearZeroPayload{Talpha} <: _AbstractAnchorPayload end
 
 @inline _linear_payload_type(::EvalValue, ::Type{Tα}, ::Type{Tinv}) where {Tα, Tinv} = _LinearValuePayload{Tα}
 @inline _linear_payload_type(::EvalDeriv1, ::Type{Tα}, ::Type{Tinv}) where {Tα, Tinv} = _LinearDeriv1Payload{Tα, Tinv}

--- a/src/gridded/gridded_partials.jl
+++ b/src/gridded/gridded_partials.jl
@@ -10,7 +10,7 @@
 # Cubic/quadratic partials cell geometry: distinct named payloads (byte-equal
 # fields today, but the quadratic cell kernel does not consume `h`). One method
 # per method type so each carries its own payload identity.
-struct _CubicPartialsPayloadND{Tdl, Th, Tinv}
+struct _CubicPartialsPayloadND{Tdl, Th, Tinv} <: _AbstractAnchorPayload
     dL::Tdl
     h::Th
     inv_h::Tinv
@@ -18,7 +18,7 @@ end
 
 # Quadratic omits `h`: its cell kernel (`_quadratic_kernel_nd`) works in physical
 # coords and consumes only `inv_h`/`dL`.
-struct _QuadraticPartialsPayloadND{Tdl, Tinv}
+struct _QuadraticPartialsPayloadND{Tdl, Tinv} <: _AbstractAnchorPayload
     dL::Tdl
     inv_h::Tinv
 end

--- a/src/quadratic/quadratic_series_payloads.jl
+++ b/src/quadratic/quadratic_series_payloads.jl
@@ -23,7 +23,7 @@
 
 # Op-independent payload: bakes the offset `dL` (== `loc.xq - loc.xL`, carrier
 # `_coord_eltype(Tq, Tg)`). `idx` rides in the interval.
-struct _QuadraticPayload{Tdl}
+struct _QuadraticPayload{Tdl} <: _AbstractAnchorPayload
     dL::Tdl
 end
 

--- a/test/test_axis_anchor_core.jl
+++ b/test/test_axis_anchor_core.jl
@@ -2,6 +2,45 @@
 # properties (promoted out of gridded so 1D method files can reference them) and
 # the generic _StatefulPayload extrap wrapper.
 
+@testitem "_AbstractAnchorPayload marker" begin
+    using FastInterpolations: _AbstractAnchorPayload
+
+    @test isabstracttype(_AbstractAnchorPayload)
+    @test supertype(_AbstractAnchorPayload) === Any
+end
+
+@testitem "all axis payloads share the marker root" begin
+    using FastInterpolations: _AbstractAnchorPayload, _StatefulPayload,
+        _LinearValuePayload, _LinearDeriv1Payload, _LinearZeroPayload,
+        _ConstantValuePayload, _ConstantZeroPayload, _QuadraticPayload,
+        _CubicValuePayload1D, _CubicDeriv1Payload1D,
+        _CubicDeriv2Payload1D, _CubicDeriv3Payload1D, _CubicZeroPayload1D,
+        _LocalHermitePayload, _CubicPartialsPayloadND,
+        _QuadraticPartialsPayloadND, IN_DOMAIN
+
+    payload_types = (
+        _LinearValuePayload{Float64},
+        _LinearDeriv1Payload{Float64, Float64},
+        _LinearZeroPayload{Float64},
+        _ConstantValuePayload{Float64},
+        _ConstantZeroPayload{Float64},
+        _QuadraticPayload{Float64},
+        _CubicValuePayload1D{Float64},
+        _CubicDeriv1Payload1D{Float64},
+        _CubicDeriv2Payload1D{Float64},
+        _CubicDeriv3Payload1D{Float64},
+        _CubicZeroPayload1D{Float64},
+        _LocalHermitePayload{Float64, Float64, Float64},
+        _CubicPartialsPayloadND{Float64, Float64, Float64},
+        _QuadraticPartialsPayloadND{Float64, Float64},
+    )
+
+    @test all(P -> P <: _AbstractAnchorPayload, payload_types)
+    @test _StatefulPayload{_LinearValuePayload{Float64}} <:
+    _AbstractAnchorPayload
+    @test_throws MethodError _StatefulPayload((alpha = 0.25,), IN_DOMAIN)
+end
+
 @testitem "_StatefulPayload wrapper" begin
     using FastInterpolations: _StatefulPayload, _LinearValuePayload,
         IN_DOMAIN, OOB_LEFT, OOB_RIGHT
@@ -52,6 +91,15 @@ end
         a = _AxisAnchor(_ExplicitIndices(10, 1), _StatefulPayload(inner, IN_DOMAIN))
         @test a.idxL == 10
         @test a.idxR == 1
+    end
+
+    @testset "Rejects non-payload structural lookalike" begin
+        # A named tuple with an `alpha` property is a structural lookalike, but
+        # the `P <: _AbstractAnchorPayload` bound makes the contract nominal.
+        @test_throws MethodError _AxisAnchor(
+            _ContiguousIndices{2}(5),
+            (alpha = 0.25,),
+        )
     end
 
     @testset "_interval_type selector unchanged" begin


### PR DESCRIPTION
## What

Introduces an internal `_AbstractAnchorPayload` root that every payload occupying the `P` slot of `_AxisAnchor{I,P}` now subtypes, and enforces it as a bound on both `_StatefulPayload{P}` and `_AxisAnchor{I,P}` — while keeping the concrete `payload::P` field.

## Why

PRs #187–#189 expanded the `_AxisAnchor` backbone into all four Series families, leaving 14 bare payload structs plus the `_StatefulPayload` wrapper with an unconstrained `P`. This makes the "P is an anchor payload" contract explicit and nominal: a structural lookalike (e.g. a named tuple with an `alpha` field) is now rejected at construction with a `MethodError` instead of silently occupying the payload slot.

## Design

- Flat marker hierarchy — **no** shared `_payload_op`/`_payload_eltype`/kernel fallback on the root (those concepts are not universal across families).
- All 14 bare payloads (Linear/Constant/Quadratic/Cubic Series + gridded query + ND partials + local Hermite) + `_StatefulPayload` subtype the marker.
- Optional tightening: the two `_maybe_stateful_payload` helpers now require `P <: _AbstractAnchorPayload`, surfacing a bad payload at the helper boundary.
- Marker defined in `src/core/axis_anchor_types.jl` before `_AxisAnchor`; no include-order change.

## Zero cost

The bound lives on the type parameter only — storage stays `payload::P` (concrete at every instantiation), so `isbits`/`sizeof` and all runtime formulas are unchanged. No public API or behavior change; the type stays unexported.

## Tests

New `test_axis_anchor_core` cases: marker is abstract/rooted at `Any`; all 14 concrete payload parameterizations + `_StatefulPayload` subtype the marker; wrapping/anchoring a named tuple throws `MethodError`. Existing `isbits`/`sizeof` pins retained.

Affected suites run and passing: `test_axis_anchor_core`, `test_cubic_series_payloads`, `test_gridded_query`, and all four Series point-kernel suites (Constant/Linear/Quadratic/Cubic). Full suite left to CI.