### PR TITLE
feat: query-shape-preserving batch evaluation

### DIFF
--- a/docs/design/PLAN_query_shape_preserving_batch_evaluation.md
+++ b/docs/design/PLAN_query_shape_preserving_batch_evaluation.md
@@ -547,7 +547,7 @@ coverage.
 - Phase 3: ☑ planned ☑ in progress ☑ done
 - Phase 4: ☑ planned ☑ in progress ☑ done
 - Phase 5: ☑ planned ☑ in progress ☑ done
-- Phase 6: ☑ planned ☐ in progress ☐ done
+- Phase 6: ☑ planned ☑ in progress ☑ done (impl/docs/review; full-suite + Julia 1.10 + benchmark = user)
 
 ## Notes / learnings
 
@@ -670,5 +670,21 @@ coverage.
 - **Coverage note**: OnTheFly + N=1-collapse + matrix query is a narrow untested edge (my tests use the default
   AutoCoeffs path → native 1-D); flag for Phase 6 if full OnTheFly-collapse coverage is required.
 
-- Benchmark results: (Phase 6)
-- Julia 1.10 result: (Phase 6)
+### Phase 6 — DONE (review + docs + edge cases; perf/version = user)
+
+- **Adversarial review**: a 6-agent workflow reviewed the full `master..HEAD` diff across 5 dimensions
+  (missed-sinks, dispatch/ambiguity, allocation/specialization, correctness/contracts, edge/non-goals);
+  895K subagent tokens, 202 tool-uses, ~17 min. **Zero real defects survived adversarial verification.** The
+  only candidate (LOW) was a test-coverage note (no empty/zero-dim pin) — actioned below.
+- **Edge-case tests**: added `empty + degenerate shaped queries` testitem (7 assertions) — 1-D empty Matrix →
+  `(0,3)`, N-D empty AoS/SoA, empty in-place, wrong-shape sink rejection. Green.
+- **Docs**: shape-aware docstrings on the 5 "Returns Vector" one-shot APIs + a "Shape preservation" section in
+  `docs/src/nd/overview.md` with the `vec(itp(q))` migration note.
+- **Test suite total**: `test/test_query_shape_preservation.jl` = 19 testitems covering all four quadrants,
+  both APIs, both call forms, 8 families, DerivativeView, N=1 collapse, allocation parity, edge cases.
+
+### Remaining (user-run, per the package's test-tier policy)
+- Full package test suite (all files) + extension tests.
+- Julia 1.10 (LTS) run.
+- CI benchmark (the 10% same-machine regression gate). §7.2 SoA-array fast-check peers were deferred here as a
+  potential SPEED (not alloc) optimization — add only if the SoA-matrix path measures >10% slower than SoA-vector.

--- a/docs/design/PLAN_query_shape_preserving_batch_evaluation.md
+++ b/docs/design/PLAN_query_shape_preserving_batch_evaluation.md
@@ -545,7 +545,7 @@ coverage.
 - Phase 1: ☑ planned ☑ in progress ☑ done
 - Phase 2: ☑ planned ☑ in progress ☑ done
 - Phase 3: ☑ planned ☑ in progress ☑ done
-- Phase 4: ☑ planned ☐ in progress ☐ done
+- Phase 4: ☑ planned ☑ in progress ☑ done
 - Phase 5: ☑ planned ☐ in progress ☐ done
 - Phase 6: ☑ planned ☐ in progress ☐ done
 
@@ -640,6 +640,19 @@ coverage.
   produce 3 Aqua ambiguities; added the full ND tie-breaker set (verified 0). Kept `eachindex(xq,output)` in the
   widened loops rather than switching to linear indexing (§5.4/adj #6) — it is 0-alloc and axes-correct for every
   in-scope case (dense/3-D/contiguous+noncontiguous view); offset axes stay a §12 non-goal either way.
+
+### Phase 4 — DONE (one-shot 1-D core families)
+
+- **Source edits (5 files, runic-clean)**: `{linear,constant,quadratic,cubic,hermite}/*_oneshot.jl` — public
+  allocating/in-place sinks widened `AbstractVector`→`AbstractArray`; allocators → `_alloc_query_output`;
+  `@assert length`/`@boundscheck` output-length check → `_check_query_output_size`. Linear's own one-shot loop
+  widened; constant/quadratic/cubic/hermite reuse the Phase-3-widened persistent family loops; cubic covers both
+  raw-grid and cache in-place entries + the periodic/bcpair batch helpers.
+- **Tests**: one-shot 1-D core families 25 (5 families × Matrix shape / in-place / exact-size rejection) +
+  allocation parity 4 — all green.
+- **Allocation**: shaped 1-D one-shot in-place (dense Matrix) = 0 B warm, matching the vector lane (A/B standalone
+  confirms both linear and cubic at 0 B — pool-amortized spline build).
+- **Aqua**: zero new ambiguities. **Regression**: cubic, linear, quadratic, allocation suites — green.
 
 - Benchmark results: (Phase 6)
 - Julia 1.10 result: (Phase 6)

--- a/docs/design/PLAN_query_shape_preserving_batch_evaluation.md
+++ b/docs/design/PLAN_query_shape_preserving_batch_evaluation.md
@@ -1,0 +1,605 @@
+# PLAN: Query-Shape-Preserving Forward Evaluation
+
+> Status: Draft — implementation not started
+> Owner: Codex + yoo
+> Created: 2026-07-14
+> Architecture: `docs/design/query_shape_preserving_evaluation.md`
+
+## Overview
+
+- **Goal**: Make all four forward-evaluation quadrants preserve query `size`:
+  `(1-D / N-D) × (persistent / one-shot)`, including allocating and in-place
+  forms, dedicated family APIs, and unified `interp` / `interp!`.
+- **Supported shaped queries**:
+  - 1-D `AbstractArray{<:Real}`.
+  - N-D AoS `AbstractArray` whose elements are N-coordinate point objects.
+  - N-D shaped SoA `NTuple{N,AbstractArray{<:Real}}` with identical per-axis
+    sizes.
+  - Existing Vector AoS/SoA as the one-dimensional special case.
+  - Existing `GriddedQuery` Cartesian-product semantics, unchanged.
+- **Non-goals**:
+  - Series, adjoints, pre-anchored query buffers, and vector-calculus layouts.
+  - Preserving query container type or nonstandard axes; allocating calls return
+    a dense `Array` of the same `size`.
+  - GPU execution or a numeric points-in-columns matrix encoding.
+  - New AD rules for shaped array queries; existing scalar/vector AD must remain
+    unchanged.
+- **User-facing API / constraints**:
+  - `result = f(query)` implies `size(result) == _query_size(query)` for every
+    batch form.
+  - `f(output, query)` requires `size(output) == _query_size(query)` for shaped
+    methods; equal length with a different shape is rejected.
+  - Scalar inputs remain scalar; vectors remain vectors.
+  - N-D `AbstractVector{<:Real}` remains one coordinate point.
+  - `(qx, qy, ...)` is pairwise SoA; `GriddedQuery(qx, qy, ...)` is the Cartesian
+    product.
+- **Performance targets**:
+  - Existing vector in-place allocations remain identical (normally 0 B warm).
+  - New dense/view shaped in-place calls are 0 B warm where the corresponding
+    vector path is 0 B.
+  - Allocating shaped calls add only the returned dense array over the existing
+    vector method's inherent work.
+  - No `vec`/`reshape` wrappers in hot paths.
+  - No confirmed >10% regression under the repository's same-machine benchmark
+    and re-verification policy.
+- **Compatibility targets**:
+  - Julia 1.10+.
+  - Existing BC/extrap/search/derivative/coefficient semantics.
+  - Zero Aqua method ambiguities.
+
+## Architecture decisions
+
+- **Decision 1: `_query_size` is the single output-shape protocol.**
+  - Rationale: it already exists for `GriddedQuery` and is already consumed by
+    the unified N-D one-shot allocator.
+  - Implementation: ordinary `AbstractArray` reports `size(q)`; shaped SoA
+    reports `size(first(q))`; non-array custom containers keep the flat default.
+  - Risk / mitigation: this is an intentional return-shape change for matrix/
+    higher-dimensional batches; document `vec(f(q))` as the flattening migration.
+
+- **Decision 2: shaped SoA is included.**
+  - Rationale: `(qx::Matrix, qy::Matrix)` already contains an unambiguous pairwise
+    shape and is the natural extension of tuple-of-vectors SoA.
+  - Constraint: all coordinate arrays must have identical `size`, not merely
+    equal length.
+  - Risk / mitigation: tuple dispatch currently assumes vectors; add explicit
+    tuple-of-arrays protocol methods and dimensionality tests.
+
+- **Decision 3: write shaped outputs directly by logical query number.**
+  - Rationale: every batch kernel already uses query number `k`; `output[k]`
+    preserves column-major alignment without a data copy or view object.
+  - Alternative rejected: `vec`/`reshape` is zero-copy but feasibility probes
+    retained 32–64 B wrappers in relevant calls.
+  - Risk / mitigation: benchmark dense arrays and noncontiguous views; leave
+    exotic axes/container preservation out of scope.
+
+- **Decision 4: preserve existing public vector dispatch.**
+  - Rationale: it isolates the established hot path and makes regression evidence
+    attributable.
+  - Implementation: add less-specific shaped public overloads; internal sinks may
+    accept `AbstractArray` while still specializing on concrete `Vector`.
+    Existing N-D `output::AbstractVector, queries` methods must nevertheless
+    validate `_query_size(queries)`, not length, and need a narrow intersection
+    method if the new array overload creates crossed-signature ambiguity.
+  - Risk / mitigation: Aqua and `@which` routing tests after every phase.
+
+- **Decision 5: one-shot shaped methods reuse kernels, not persistent builders.**
+  - Rationale: building a persistent interpolant as an adapter can copy data,
+    change pool/cache lifetime, and introduce allocations.
+  - Implementation: add shaped output/query overloads to the existing one-shot
+    preparation and family loops.
+
+- **Decision 6: N=1 tuple-grid calls collapse to native 1-D shaped methods.**
+  - Rationale: keeps tuple-grid and bare-grid APIs bit/allocation-identical and
+    avoids treating scalar elements of a matrix as N-D point containers.
+
+## Phase plan (TDD)
+
+**CRITICAL**: Execute phases **one at a time**.
+
+For each phase:
+- 🔴 RED: tests first, confirm they fail for the intended reason
+- 🟢 GREEN: minimal implementation for this phase only
+- 🔵 REFACTOR: cleanup while staying green
+- ✅ QUALITY GATE: required correctness, allocation, routing, and ambiguity gates
+
+---
+
+### Phase 1 — Query-shape protocol + persistent N-D quadrant
+
+**Estimated size**: 3–4 hours
+
+**Goal**: Every persistent N-D interpolant returns/writes the shape of AoS arrays
+and shaped SoA arrays, while existing vector/scalar behavior remains unchanged.
+
+**Primary files**:
+
+- `src/core/query_protocol.jl`
+- `src/core/interpolant_protocol.jl`
+- `src/core/nd_utils.jl`
+- `src/core/search.jl`
+- `src/gridded/gridded_dispatch.jl`
+- `test/test_query_shape_preservation.jl`
+
+**Test strategy**:
+
+- Unit tests:
+  - `_query_size`, `_query_length`, `_query_extract`, `_query_eltype`, and
+    `_query_validate` for Matrix/3-D AoS and Matrix SoA.
+  - SoA mismatched `size` throws before evaluation.
+  - custom non-array query default remains flat; `GriddedQuery` remains shaped.
+- Integration tests:
+  - persistent Constant, Linear, Quadratic, Cubic, user-Hermite, and Hetero
+    interpolants on AoS Matrix and shaped SoA Matrix.
+  - allocating result equals scalar `map` reference and has exact size.
+  - in-place result writes to exact-size Matrix and returns it.
+- Edge cases:
+  - empty dimensions, 3-D query container, SVector AoS, mixed coordinate types,
+    derivative ops, Clamp/Fill/Wrap, and same-length/wrong-shape output.
+  - exact-size rejection for `Vector` output paired with a same-length Matrix
+    query, which must not fall through the current length-only N-D method.
+  - N-D `Vector{<:Real}` remains a scalar point.
+  - `Vector{NTuple}` remains a vector batch.
+
+**Tasks**:
+
+- [ ] 🔴 RED: create `test/test_query_shape_preservation.jl` with query-protocol
+  tests for AoS arrays and shaped SoA arrays; run and capture current flat/failing
+  behavior.
+- [ ] 🔴 RED: add persistent N-D allocating/in-place tests for Linear and Hetero
+  as two protocol-wide representatives; confirm failures before implementation.
+- [ ] 🔴 RED: add dispatch guards for scalar real vectors, vector AoS, and
+  `GriddedQuery`.
+- [ ] 🟢 GREEN: implement `_query_size(::AbstractArray) = size(q)` and non-empty
+  tuple-of-arrays SoA protocol methods.
+- [ ] 🟢 GREEN: validate shaped SoA using exact `size`; add size-specific error
+  helpers without changing existing scalar error behavior.
+- [ ] 🟢 GREEN: add shared dense output allocation and exact-size validation
+  helpers.
+- [ ] 🟢 GREEN: make the existing N-D `output::AbstractVector, queries` path use
+  exact `_query_size`; route it and the new `output::AbstractArray, queries`
+  method through a common helper. Add an intersection tie-breaker only if the
+  final signatures constrain both arguments and Aqua requires it.
+- [ ] 🟢 GREEN: make persistent N-D allocation use `_query_size`; add direct
+  `AbstractArray` output sinks in `_nd_batch_pointwise!` / `_interp_nd_batch!`.
+- [ ] 🟢 GREEN: remove `vec(out)` from the non-separable persistent
+  `GriddedQuery` fallback only; keep separable dispatch unchanged.
+- [ ] 🟢 GREEN: add shaped SoA monotonicity/domain fast checks where vector-only
+  specializations would otherwise be lost.
+- [ ] 🔵 REFACTOR: retain explicit vector public methods and centralize only
+  shape-neutral setup/loop bodies.
+- [ ] 🔵 REFACTOR: update query-protocol comments to define AoS, shaped SoA, and
+  `GriddedQuery` semantics.
+
+**Quality gate**:
+
+- [ ] `cc-julia-test-runner . "query shape"` passes for Phase 1 items.
+- [ ] Existing N-D batch, hint-persistence, GriddedQuery, domain, FillExtrap,
+  mixed-precision, and duck-typing tests pass.
+- [ ] Persistent Matrix AoS and Matrix SoA in-place calls allocate 0 B warm.
+- [ ] Existing Vector AoS/SoA allocation tests remain unchanged.
+- [ ] `Aqua.test_ambiguities(FastInterpolations)` reports zero ambiguities.
+- [ ] No source changes for one-shot or 1-D behavior are included early.
+
+**Rollback**:
+
+- Revert Phase 1 edits in the five core/gridded files and the Phase 1 test items.
+- No family-specific implementation files should need rollback in this phase.
+
+---
+
+### Phase 2 — One-shot N-D quadrant: unified + dedicated APIs
+
+**Estimated size**: 3–4 hours
+
+**Goal**: All N-D one-shot APIs preserve AoS/shaped-SoA query size with direct
+shaped in-place output.
+
+**Primary files**:
+
+- `src/hetero/hetero_oneshot.jl`
+- `src/linear/nd/linear_nd_oneshot.jl`
+- `src/constant/nd/constant_nd_oneshot.jl`
+- `src/quadratic/nd/quadratic_nd_oneshot.jl`
+- `src/cubic/nd/cubic_nd_oneshot.jl`
+- `src/hermite/nd/hermite_nd_oneshot.jl`
+- `src/hetero/local_hermite_nd_forward.jl`
+- `test/test_query_shape_preservation.jl`
+
+**Test strategy**:
+
+- Unit/integration tests:
+  - unified `interp`/`interp!` and dedicated named APIs on shaped AoS/SoA.
+  - Constant, Linear, Quadratic, Cubic, user `HermitePartials`, PCHIP,
+    Cardinal, Akima, and a mixed Hetero method tuple.
+  - unified/dedicated value, shape, eltype, and allocation parity.
+- Edge cases:
+  - `PreCompute`/`OnTheFly`/`AutoCoeffs`, periodic axes, FillExtrap,
+    per-axis derivatives, empty query shape, and wrong output shape.
+  - supported `GriddedQuery` still reaches the separable path; unsupported method
+    tuples still use correct direct pointwise shaped fallback.
+
+**Tasks**:
+
+- [ ] 🔴 RED: add failing unified N-D one-shot AoS/SoA shape tests.
+- [ ] 🔴 RED: add failing dedicated family tests, including user-Hermite and local
+  Hermite forwarders.
+- [ ] 🔴 RED: add same-length/wrong-shape output tests and assert output remains
+  untouched when validation/domain checks fail.
+- [ ] 🟢 GREEN: add exact output-size validation in generic unified `interp!`.
+- [ ] 🟢 GREEN: remove the unified one-shot `vec(output)` adapter and pass shaped
+  output directly into batch dispatch.
+- [ ] 🟢 GREEN: widen/add family internal output sinks to `AbstractArray` while
+  preserving vector-specialized public methods.
+- [ ] 🟢 GREEN: make every dedicated N-D public/vector sink validate exact
+  `_query_size`, including `Vector output × Matrix query` rejection.
+- [ ] 🟢 GREEN: change each dedicated allocator to the shared shape allocator,
+  preserving its existing output-eltype formula.
+- [ ] 🟢 GREEN: widen PCHIP/Cardinal/Akima N-D forwarding methods to shaped
+  output/query containers.
+- [ ] 🔵 REFACTOR: deduplicate shape validation/allocation only; do not merge
+  family coefficient/BC preparation.
+
+**Quality gate**:
+
+- [ ] Phase 1 and Phase 2 query-shape tests pass.
+- [ ] Existing dedicated N-D one-shot and unified API suites pass.
+- [ ] Warm shaped in-place calls have the same allocation count as corresponding
+  vector calls.
+- [ ] Unified/dedicated allocations are equal after warmup.
+- [ ] GriddedQuery routing and zero-allocation tests pass.
+- [ ] Aqua ambiguity checks pass.
+
+**Rollback**:
+
+- Revert Phase 2 family/unified one-shot edits and Phase 2 tests.
+- Persistent N-D shaped behavior from Phase 1 remains independently useful.
+
+---
+
+### Phase 3 — Persistent 1-D quadrant
+
+**Estimated size**: 3–4 hours
+
+**Goal**: All persistent 1-D interpolants and their DerivativeViews accept shaped
+real query arrays and preserve size.
+
+**Primary files**:
+
+- `src/core/interpolant_protocol.jl`
+- `src/core/search.jl`
+- `src/core/utils.jl`
+- `src/linear/linear_interpolant.jl`
+- `src/constant/constant_interpolant.jl`
+- `src/quadratic/quadratic_interpolant.jl`
+- `src/cubic/cubic_eval.jl`
+- `src/hermite/hermite_eval.jl`
+- `src/derivative_view.jl`
+- `test/test_query_shape_preservation.jl`
+
+**Test strategy**:
+
+- Integration tests:
+  - persistent Constant, Linear, Quadratic, Cubic, Hermite, PCHIP, Cardinal, and
+    Akima on Matrix and 3-D real query arrays.
+  - allocating/in-place parity with `map(itp, q)`.
+  - `deriv1/2/3` and `deriv_view` allocating/in-place forwarding.
+  - native shaped queries and the persistent one-axis SoA spelling `(q,)` have
+    identical values, shapes, and allocations.
+- Edge cases:
+  - dense Matrix, noncontiguous view, empty dimensions, alias-exact query/output
+    where the vector API already supports it, mixed precision, No/Clamp/Fill/
+    Wrap, explicit/adaptive search, and external hint.
+
+**Tasks**:
+
+- [ ] 🔴 RED: add failing persistent 1-D shaped tests for all eight families.
+- [ ] 🔴 RED: add warm allocation pins for dense Matrix and noncontiguous view;
+  pin existing vector allocations in the same function barriers.
+- [ ] 🔴 RED: add DerivativeView shaped in-place test and dispatch guard.
+- [ ] 🟢 GREEN: add less-specific shaped allocating/in-place methods on
+  `AbstractInterpolant1D`; leave vector methods unchanged.
+- [ ] 🟢 GREEN: add `AbstractArray` batch domain checks, including empty arrays and
+  `_CachedRange` exclusive-last promotion.
+- [ ] 🟢 GREEN: add array AutoSearch prefix classification in logical order.
+- [ ] 🟢 GREEN: add array-capable peers for Constant/Linear/Quadratic/Cubic/
+  Hermite-family internal loops and function barriers.
+- [ ] 🟢 GREEN: add shaped in-place DerivativeView forwarding.
+- [ ] 🟢 GREEN: widen persistent one-axis tuple forwarders to `(q::AbstractArray,)`
+  and exact-shape in-place output, reusing the native 1-D path.
+- [ ] 🔵 REFACTOR: audit inference so extrap/searcher unions are resolved outside
+  inner loops; avoid higher-order closures unless codegen proves zero-cost.
+
+**Quality gate**:
+
+- [ ] Persistent 1-D shaped tests pass across all families.
+- [ ] Existing 1-D scalar/vector, periodic, mixed-precision, search, derivative,
+  and AD extension tests pass.
+- [ ] New dense/view in-place paths allocate 0 B warm.
+- [ ] Existing vector allocation counts remain identical.
+- [ ] Representative vector microbenchmarks are within noise before continuing.
+- [ ] Aqua ambiguity checks pass, including GriddedQuery N=1/anchor methods.
+
+**Rollback**:
+
+- Revert Phase 3 protocol/domain/search/family-loop/DerivativeView edits and tests.
+- N-D shaped behavior from Phases 1–2 remains intact.
+
+---
+
+### Phase 4 — One-shot 1-D core families
+
+**Estimated size**: 2–4 hours
+
+**Goal**: Dedicated Constant, Linear, Quadratic, Cubic, and user-Hermite one-shot
+APIs preserve shaped query size without building persistent adapters.
+
+**Primary files**:
+
+- `src/constant/constant_oneshot.jl`
+- `src/linear/linear_oneshot.jl`
+- `src/quadratic/quadratic_oneshot.jl`
+- `src/cubic/cubic_oneshot.jl`
+- `src/hermite/hermite_oneshot.jl`
+- `test/test_query_shape_preservation.jl`
+
+**Test strategy**:
+
+- Allocating and in-place Matrix/3-D query tests for all five families.
+- Cubic raw-grid and `CubicSplineCache` entry points.
+- output eltype parity with vector calls under Int/Float32/Float64/Dual-compatible
+  type combinations already covered by the repo.
+- BC/extrap/derivative/search parity and wrong-shape validation.
+
+**Tasks**:
+
+- [ ] 🔴 RED: add failing shaped one-shot tests for the five core families and
+  cache/raw-grid Cubic entry points.
+- [ ] 🔴 RED: add allocating-output byte parity and warm in-place allocation
+  parity against vectors.
+- [ ] 🟢 GREEN: add shaped in-place overloads that reuse existing axis/BC/cache/
+  coefficient preparation and array-capable Phase 3 loops.
+- [ ] 🟢 GREEN: add shaped allocating overloads using each family's unchanged
+  output-eltype formula and shared shape allocator.
+- [ ] 🔵 REFACTOR: keep vector public methods as the more-specific dispatch;
+  centralize only allocation/shape checks.
+
+**Quality gate**:
+
+- [ ] Phase 4 shaped tests pass.
+- [ ] Existing Constant/Linear/Quadratic/Cubic/Hermite one-shot suites pass.
+- [ ] In-place allocation parity with vector methods passes after warmup.
+- [ ] Cubic cache/pool/thread-safety tests pass.
+- [ ] Aqua ambiguity checks pass.
+
+**Rollback**:
+
+- Revert only the five Phase 4 one-shot files and Phase 4 test items.
+- Persistent 1-D shaped behavior remains available.
+
+---
+
+### Phase 5 — One-shot 1-D local-Hermite + unified API + N=1 collapse
+
+**Estimated size**: 3–4 hours
+
+**Goal**: PCHIP/Cardinal/Akima, unified `interp`/`interp!`, and every tuple-grid
+N=1 forward expose the same shaped 1-D contract.
+
+**Primary files**:
+
+- `src/pchip/pchip_oneshot.jl`
+- `src/cardinal/cardinal_oneshot.jl`
+- `src/akima/akima_oneshot.jl`
+- `src/hetero/interp_1d.jl`
+- `src/linear/nd/linear_nd_interpolant.jl`
+- `src/constant/nd/constant_nd_interpolant.jl`
+- `src/quadratic/nd/quadratic_nd_interpolant.jl`
+- `src/cubic/nd/cubic_nd_interpolant.jl`
+- `src/hetero/local_hermite_nd_forward.jl`
+- `test/test_query_shape_preservation.jl`
+
+**Test strategy**:
+
+- Dedicated PCHIP/Cardinal/Akima allocating/in-place shape tests under
+  `AutoCoeffs`, `PreCompute`, and `OnTheFly` as supported.
+- Unified `interp`/`interp!` parity with every routable 1-D method object.
+- Bare-grid and one-axis tuple-grid parity for direct `q::AbstractArray` and
+  single-axis SoA `(q,)`.
+- Periodic, tension, side, BC, deriv, and extrap keyword forwarding.
+
+**Tasks**:
+
+- [ ] 🔴 RED: add failing shaped one-shot tests for PCHIP/Cardinal/Akima.
+- [ ] 🔴 RED: add unified/dedicated shape, value, output-eltype, and allocation
+  parity tests for all routable method objects.
+- [ ] 🔴 RED: add N=1 tuple-grid parity and dispatch-collision tests for all named
+  families, including `(q,)` forwarding.
+- [ ] 🟢 GREEN: add local-Hermite shaped allocating/in-place overloads using the
+  Phase 3 Hermite loop sinks.
+- [ ] 🟢 GREEN: add shaped unified 1-D methods through `_interp1d_route`; preserve
+  wrapper zero-cost allocation parity.
+- [ ] 🟢 GREEN: add explicit N=1 shaped collapse forwards and unwrap per-axis
+  keyword tuples exactly as current vector forwards do.
+- [ ] 🔵 REFACTOR: consolidate repeated N=1 forwarding patterns only if Aqua and
+  inference remain clean; prefer explicit narrow methods over broad ambiguous ones.
+
+**Quality gate**:
+
+- [ ] All four API quadrants now pass the complete shape test matrix.
+- [ ] Existing unified 1-D allocation-parity tests remain exact.
+- [ ] Existing PCHIP/Cardinal/Akima coefficient/periodic tests pass.
+- [ ] Tuple-grid N=1 and native 1-D results are bit-identical where the current
+  vector contract is bit-identical.
+- [ ] Warm in-place unified and dedicated shaped calls have equal allocations.
+- [ ] Aqua ambiguity checks pass.
+
+**Rollback**:
+
+- Revert Phase 5 local-Hermite/unified/N=1 forwarding edits and tests.
+- Core-family one-shot support from Phase 4 remains independently valid.
+
+---
+
+### Phase 6 — Full compatibility, performance, and documentation gate
+
+**Estimated size**: 3–4 hours
+
+**Goal**: Close the feature with full-suite, supported-version, allocation,
+benchmark, method-table, and documentation evidence.
+
+**Primary files**:
+
+- `benchmark/ci_benchmark.jl`
+- `docs/src/nd/overview.md`
+- `docs/src/guides/performance_tips.md`
+- relevant 1-D/ND API docstrings
+- release notes for the target release
+- this plan's Notes / learnings section
+
+**Test strategy**:
+
+- Full test suite on primary Julia and Julia 1.10.
+- Aqua all checks.
+- Benchmark matrix:
+  - existing Vector AoS/SoA sentinels;
+  - 1-D Matrix and noncontiguous view;
+  - N-D AoS Matrix and shaped SoA Matrix;
+  - persistent and one-shot;
+  - Range/Vector grids;
+  - sorted/random logical order;
+  - Linear plus Cubic or PCHIP.
+- Documentation examples execute and distinguish pairwise shaped SoA from
+  Cartesian-product `GriddedQuery`.
+
+**Tasks**:
+
+- [ ] 🔴 RED: perform a final public method-table and docs audit; add tests first
+  for any uncovered callable or ambiguity before changing it.
+- [ ] 🟢 GREEN: add CI benchmark cases and baseline names for vector and shaped
+  paths.
+- [ ] 🟢 GREEN: update docstrings that say “Returns a Vector” and all 1-D/ND batch
+  examples.
+- [ ] 🟢 GREEN: add release-note migration guidance for callers relying on flattened
+  matrix-of-points output.
+- [ ] 🔵 REFACTOR: remove stale flattening comments and ensure no hot path calls
+  `vec`/`reshape` merely to satisfy vector signatures.
+- [ ] ✅ QUALITY GATE: run full suites, allocation audit, and same-machine
+  benchmark with re-verification; record commands/results below.
+
+**Quality gate**:
+
+- [ ] Full package test suite passes.
+- [ ] Julia 1.10 targeted/full suite passes.
+- [ ] Aqua passes with zero ambiguities.
+- [ ] Existing vector allocation counts are identical.
+- [ ] New shaped in-place dense/view paths meet 0 B warm targets.
+- [ ] No confirmed benchmark regression exceeds 10% after re-verification.
+- [ ] User docs and release notes fully state the new shape contract.
+
+**Rollback**:
+
+- Docs/benchmarks are independently revertible.
+- A performance failure blocks completion and rolls back the responsible earlier
+  phase, not merely the benchmark assertion.
+
+## Required test matrix
+
+The implementing agent must treat this as a completion checklist, not optional
+coverage.
+
+| Dimension | Lifetime | API | Query layout | Allocating | In-place |
+|---|---|---|---|---:|---:|
+| 1-D | persistent | callable | real Matrix / 3-D array / view | [ ] | [ ] |
+| 1-D | persistent | N=1 SoA forward | `(Matrix,)` | [ ] | [ ] |
+| 1-D | one-shot | dedicated core families | real Matrix / 3-D array / view | [ ] | [ ] |
+| 1-D | one-shot | PCHIP/Cardinal/Akima | real Matrix / view | [ ] | [ ] |
+| 1-D | one-shot | unified `interp` | real Matrix / view | [ ] | [ ] |
+| 1-D | one-shot | N=1 tuple-grid forwards | real Matrix / `(Matrix,)` | [ ] | [ ] |
+| N-D | persistent | callable | AoS Matrix / SVector Matrix | [ ] | [ ] |
+| N-D | persistent | callable | shaped SoA matrices | [ ] | [ ] |
+| N-D | one-shot | dedicated named | AoS / shaped SoA | [ ] | [ ] |
+| N-D | one-shot | unified `interp` | AoS / shaped SoA | [ ] | [ ] |
+| N-D | either | `GriddedQuery` | independent target axes | [ ] | [ ] |
+| 1-D/N-D | persistent | `DerivativeView` | shaped query | [ ] | [ ] |
+
+## Risks
+
+| Risk | Impact | Likelihood | Mitigation | Detection |
+|---|---:|---:|---|---|
+| Broad array overload intersects GriddedQuery/anchors | H | M | Real-element constraints and narrow tie-breakers | Aqua + `@which` tests |
+| N-D real vector changes from scalar point to batch | H | L | keep existing method more specific | Optim/ForwardDiff dispatch guards |
+| shaped SoA accidentally treated as scalar Tuple | H | M | explicit tuple-of-arrays protocol | extraction/ndims tests |
+| `vec` wrapper adds heap allocation | M | H | direct shaped output sinks | exact warm `@allocated` |
+| existing Vector codegen slows | H | L | retain public vector methods, benchmark sentinels | CI benchmark + allocation parity |
+| NoExtrap writes before throwing | H | L | preserve whole-batch pre-scan | sentinel-output tests |
+| family allocator changes output eltype | H | M | keep every existing `Tout` formula | eltype parity matrix |
+| N=1 tuple-grid falls into generic N-D batch | H | M | explicit shaped collapse forwards | bit/allocation parity tests |
+| same-length wrong-shape output silently accepted | M | M | exact-size helper | mismatch tests |
+| custom query users relied on flat array default | M | M | intentional compatibility note; `vec` migration | release notes |
+| exotic IndexCartesian container is slow | M | M | dense/view benchmark scope; custom axes non-goal | benchmark matrix |
+| one-shot adapter builds persistent state | H | L | prohibit constructor adapter in design | allocation/code review |
+
+## Progress tracking
+
+- Phase 1: ☑ planned ☑ in progress ☑ done
+- Phase 2: ☑ planned ☐ in progress ☐ done
+- Phase 3: ☑ planned ☐ in progress ☐ done
+- Phase 4: ☑ planned ☐ in progress ☐ done
+- Phase 5: ☑ planned ☐ in progress ☐ done
+- Phase 6: ☑ planned ☐ in progress ☐ done
+
+## Notes / learnings
+
+- Current `src/core/query_protocol.jl` already defines `_query_size`, but its
+  generic result is flat; only `GriddedQuery` overrides it.
+- Unified N-D one-shot allocation already consumes `_query_size`, while
+  persistent N-D and dedicated N-D one-shot allocators still construct vectors.
+- Existing N-D pointwise kernels already evaluate by logical `k`, so shaped
+  output needs no numerical-kernel change.
+- 1-D persistent family traits are centralized, but their core loops and the
+  one-shot public signatures are vector-restricted.
+- `DerivativeView` already forwards shaped out-of-place queries; only shaped
+  in-place forwarding is missing.
+- Tuple-grid N=1 forwarders are explicitly vector-restricted in every family and
+  must be part of the 1-D one-shot completion gate.
+- Local Julia 1.12.6 feasibility probes showed direct Matrix loops at 0 B/call;
+  `vec` adapters retained 32–64 B. Release claims require Phase 6 benchmarks.
+- `docs/plans` is a symlink outside the workspace. This repository-local plan is
+  intentionally stored under `docs/design`.
+
+## Implementation results (fill during execution)
+
+### Phase 1 — DONE (protocol + persistent N-D quadrant)
+
+- **Branch/worktree**: `feat/query-shape-preserving` @ `~/.julia/dev/FastInterpolations-query-shape` off master `a1bed78e7`.
+- **Source edits (3 files, runic-clean)**:
+  - `src/core/query_protocol.jl`: `_query_size(::AbstractArray)=size`, SoA-array peers for
+    `_query_length/_query_size/_query_extract/_query_eltype/_query_validate/_query_check_ndims`
+    (the last two MANDATORY — a tuple-of-matrices otherwise throws a spurious ndims error), plus
+    `_alloc_query_output`/`_check_query_output_size` + `_throw_query_axis_size_mismatch`/`_throw_query_output_size_mismatch`.
+    Vector-SoA methods KEPT more-specific (bit-identical hot path).
+  - `src/core/interpolant_protocol.jl`: widened `_interp_nd_batch!`/`_nd_batch_pointwise!` sinks to
+    `AbstractArray`; in-place = `AbstractArray`+`AbstractVector` peers through one `_nd_batch_inplace!`
+    with exact `_check_query_output_size` (replaces the length-only check → rejects vector-sink-for-matrix-query);
+    allocation via `_alloc_query_output` (matrix query → matrix; vector query → `Vector` unchanged).
+  - `src/gridded/gridded_dispatch.jl`: removed the `vec(out)` non-separable fallback (sink now `AbstractArray`).
+- **Tests**: `test/test_query_shape_preservation.jl` — 6 testitems, 111 assertions, all pass. Protocol 15,
+  SoA validation+ndims 6, persistent N-D 5-family 60, dispatch guards 8, edge cases (deriv/NoExtrap-sentinel/
+  Clamp/view/mixed-precision × Linear+Cubic) 18, allocation parity 4.
+- **Allocation**: all four in-place lanes (AoS matrix, SoA matrix, AoS vector, SoA vector) = 0 B warm,
+  measured inside a function barrier. A/B vs master (`~/.julia/dev/FastInterpolations-master-ab`) confirms
+  SoA-vector in-place is 0 B on both — the 32 B a first (barrier-less) draft saw was a boxed-local
+  measurement artifact, not code allocation.
+- **Aqua**: `Method ambiguity` check passes (0 ambiguities) — the broad `AbstractArray` overloads add no
+  ambiguity vs GriddedQuery/anchors/SoA, as the pre-implementation verification predicted.
+- **Regression**: ND In-Place Batch 42/42, GriddedQuery matrix 86/86 + all GriddedQuery-collection/zero-alloc
+  testitems, hint-persistence, domain/promotion/clamp, mixed-precision, duck-typing (624) — all green.
+- **Deviation from design**: §7.2 SoA-array fast-check peers (`_validate_nd_domain`/`_check_mono_nd` for
+  `Tuple{Vararg{AbstractArray{<:Real},N}}`) DEFERRED to Phase 6 perf gate. Rationale: they are a SPEED
+  optimization (min/max scan vs per-query), NOT allocation — SoA-matrix already hits 0 B via the generic
+  path (same one AoS uses). "Measure first": add only if Phase 6 shows the SoA-matrix path >10% slower than
+  SoA-vector. Avoids unmeasured method surface + a re-Aqua cycle.
+
+- Benchmark results: (Phase 6)
+- Julia 1.10 result: (Phase 6)

--- a/docs/design/PLAN_query_shape_preserving_batch_evaluation.md
+++ b/docs/design/PLAN_query_shape_preserving_batch_evaluation.md
@@ -544,7 +544,7 @@ coverage.
 
 - Phase 1: ☑ planned ☑ in progress ☑ done
 - Phase 2: ☑ planned ☑ in progress ☑ done
-- Phase 3: ☑ planned ☐ in progress ☐ done
+- Phase 3: ☑ planned ☑ in progress ☑ done
 - Phase 4: ☑ planned ☐ in progress ☐ done
 - Phase 5: ☑ planned ☐ in progress ☐ done
 - Phase 6: ☑ planned ☐ in progress ☐ done
@@ -619,6 +619,27 @@ coverage.
   `_query_size` reports the tuple arity (wrong); the top-level exact-size gate is skipped for them (their
   pre-slice sub-problem self-validates), preserving master's GridIdx behavior. Full GridIdx shape support is
   out of scope (adjacent to the §12 pre-anchored-query non-goal). Caught by the existing nd1_collapse regression pin.
+
+### Phase 3 — DONE (persistent 1-D quadrant + DerivativeView)
+
+- **Source edits (9 files, runic-clean)**: `core/interpolant_protocol.jl` (less-specific
+  `(itp)(q::AbstractArray{<:Real})` allocating + `(out::AbstractArray, q::AbstractArray{<:Real})` in-place with
+  exact-size gate; shaped `(q_matrix,)` single-axis SoA forwarders); `core/utils.jl` + `core/search.jl` (batch
+  domain `_check_domain`/`_is_all_inbounds`/`_throw_batch_oob` and search `_is_likely_monotone`/
+  `_resolve_search_policy` widened `AbstractVector{<:Real}`→`AbstractArray{<:Real}` — annotation-only);
+  5 family eval loops (`linear/constant/quadratic/cubic/hermite`) widened `output`/`xq` to `AbstractArray`;
+  `derivative_view.jl` (shaped in-place forward for 1-D parents + N-D `(AbstractArray, queries)` forward + the
+  three ND-specialized tie-breakers that keep it unambiguous).
+- **Tests**: persistent 1-D shape 88 (11 × 8 families: Matrix/3-D/view/exact-size/N=1-SoA), DerivativeView
+  deriv1/2/3 shaped 15, allocation parity 3 — all green.
+- **Allocation**: shaped 1-D in-place (dense Matrix + noncontiguous view) = 0 B warm; vector lane unchanged.
+  test_allocation.jl 155/155 confirms the hot-path widening is compile-time-identical for the Vector path.
+- **Aqua**: zero ambiguities (the DerivativeView tie-breaker set is the design's under-specified §4.1 gap, resolved).
+  **Regression**: allocation, constant (incl. DerivativeView), hermite_1d, akima_1d, cardinal_1d — all green.
+- **Design refinement (adj #1 & #6)**: the design's §4.1 named only two DerivativeView in-place forwards, which
+  produce 3 Aqua ambiguities; added the full ND tie-breaker set (verified 0). Kept `eachindex(xq,output)` in the
+  widened loops rather than switching to linear indexing (§5.4/adj #6) — it is 0-alloc and axes-correct for every
+  in-scope case (dense/3-D/contiguous+noncontiguous view); offset axes stay a §12 non-goal either way.
 
 - Benchmark results: (Phase 6)
 - Julia 1.10 result: (Phase 6)

--- a/docs/design/PLAN_query_shape_preserving_batch_evaluation.md
+++ b/docs/design/PLAN_query_shape_preserving_batch_evaluation.md
@@ -546,7 +546,7 @@ coverage.
 - Phase 2: ☑ planned ☑ in progress ☑ done
 - Phase 3: ☑ planned ☑ in progress ☑ done
 - Phase 4: ☑ planned ☑ in progress ☑ done
-- Phase 5: ☑ planned ☐ in progress ☐ done
+- Phase 5: ☑ planned ☑ in progress ☑ done
 - Phase 6: ☑ planned ☐ in progress ☐ done
 
 ## Notes / learnings
@@ -653,6 +653,22 @@ coverage.
 - **Allocation**: shaped 1-D one-shot in-place (dense Matrix) = 0 B warm, matching the vector lane (A/B standalone
   confirms both linear and cubic at 0 B — pool-amortized spline build).
 - **Aqua**: zero new ambiguities. **Regression**: cubic, linear, quadratic, allocation suites — green.
+
+### Phase 5 — DONE (local-Hermite one-shot + unified interp + N=1 collapse)
+
+- **Source edits (10 files, runic-clean)**: `{pchip,cardinal,akima}/*_oneshot.jl` (public + OnTheFly/PreCompute
+  helper sinks → `AbstractArray`, `@boundscheck` output check → `_check_query_output_size`, allocators →
+  `_alloc_query_output`) + `core/coeff_policy.jl` (the AutoCoeffs query-length crossover
+  `_resolve_coeffs(::AutoCoeffs, ::AbstractVector, ::AbstractArray)` widened — it drives OnTheFly-vs-PreCompute); `hetero/interp_1d.jl` (unified `interp`/`interp!` widened; delegate through
+  `_interp1d_route` so the dedicated methods size-check); N=1 collapse forwarders in
+  `{linear,constant,quadratic,cubic}/nd/*_nd_interpolant.jl` + `hetero/local_hermite_nd_forward.jl` — the
+  QUERY widens (`AbstractVector{<:Real}`→`AbstractArray{<:Real}`, `Tuple{AbstractVector}`→`Tuple{AbstractArray}`)
+  and the in-place output widens, GRID stays vector-only (`only(grids)` → genuine 1-D). For Cubic this also
+  fixes an AutoCoeffs matrix query that previously mis-routed to the generic `_resolve_coeffs`.
+- **Tests**: local-Hermite 1-D one-shot, unified interp/interp! 1-D, N=1 tuple-grid collapse (bare-grid ==
+  tuple-grid == single-axis-SoA, in-place) across 5 families — all green. Aqua zero new ambiguities.
+- **Coverage note**: OnTheFly + N=1-collapse + matrix query is a narrow untested edge (my tests use the default
+  AutoCoeffs path → native 1-D); flag for Phase 6 if full OnTheFly-collapse coverage is required.
 
 - Benchmark results: (Phase 6)
 - Julia 1.10 result: (Phase 6)

--- a/docs/design/PLAN_query_shape_preserving_batch_evaluation.md
+++ b/docs/design/PLAN_query_shape_preserving_batch_evaluation.md
@@ -543,7 +543,7 @@ coverage.
 ## Progress tracking
 
 - Phase 1: ☑ planned ☑ in progress ☑ done
-- Phase 2: ☑ planned ☐ in progress ☐ done
+- Phase 2: ☑ planned ☑ in progress ☑ done
 - Phase 3: ☑ planned ☐ in progress ☐ done
 - Phase 4: ☑ planned ☐ in progress ☐ done
 - Phase 5: ☑ planned ☐ in progress ☐ done
@@ -600,6 +600,25 @@ coverage.
   optimization (min/max scan vs per-query), NOT allocation — SoA-matrix already hits 0 B via the generic
   path (same one AoS uses). "Measure first": add only if Phase 6 shows the SoA-matrix path >10% slower than
   SoA-vector. Avoids unmeasured method surface + a re-Aqua cycle.
+
+### Phase 2 — DONE (one-shot N-D quadrant)
+
+- **Source edits (7 files, runic-clean)**: `hetero/hetero_oneshot.jl` (unified: hetero core sink →
+  `AbstractArray`; exact-size gate at the public entry, SKIPPED for GridIdx queries; `vec(output)` adapter
+  removed from the main dispatch, kept locally only for the vector-typed GridIdx branch);
+  `{linear,constant,quadratic,cubic,hermite}/nd/*_nd_oneshot.jl` (batch-core sinks → `AbstractArray`,
+  `length`-check → `_check_query_output_size`, allocators → `_alloc_query_output`); `hetero/local_hermite_nd_forward.jl`
+  (3 ND in-place forwarders → `AbstractArray`; allocating forwarders already preserved shape via the unified path).
+- **Tests**: one-shot unified 7, dedicated core families 24 (incl. cubic in-place), local-Hermite + user-Hermite
+  23, allocation parity 6 — all green.
+- **Allocation**: every shaped one-shot in-place lane (unified + dedicated, AoS matrix + shaped SoA) = 0 B warm,
+  matching the vector lanes (A/B standalone confirms). The `vec` removal was necessary for the unified 0-B target.
+- **Aqua**: zero new ambiguities. **Regression**: hetero_oneshot, cubic_nd_oneshot, hermite_nd_partials,
+  local_hermite_nd_forward, calltime_extrap_override, nd1_collapse (incl. GridIdx) — all green.
+- **Deviation/finding**: GridIdx queries `(q, GridIdx(i))` mix free arrays with pinned scalar indices, so
+  `_query_size` reports the tuple arity (wrong); the top-level exact-size gate is skipped for them (their
+  pre-slice sub-problem self-validates), preserving master's GridIdx behavior. Full GridIdx shape support is
+  out of scope (adjacent to the §12 pre-anchored-query non-goal). Caught by the existing nd1_collapse regression pin.
 
 - Benchmark results: (Phase 6)
 - Julia 1.10 result: (Phase 6)

--- a/docs/design/query_shape_preserving_evaluation.md
+++ b/docs/design/query_shape_preserving_evaluation.md
@@ -1,0 +1,615 @@
+# Design: Query-Shape-Preserving Forward Evaluation
+
+> Status: Implementation-ready proposal
+> Scope: design and planning only; no implementation is included here
+> Created: 2026-07-14
+> Companion plan: `docs/design/PLAN_query_shape_preserving_batch_evaluation.md`
+
+## 1. Executive summary
+
+Every forward batch-evaluation surface should preserve the logical shape carried
+by its query container:
+
+| Interpolant | Lifetime | Query | Result |
+|---|---|---|---|
+| 1-D | persistent | `q::AbstractArray{<:Real}` | dense `Array` with `size(q)` |
+| 1-D | one-shot | `q::AbstractArray{<:Real}` | dense `Array` with `size(q)` |
+| N-D | persistent | AoS `q::AbstractArray` of N-coordinate points | dense `Array` with `size(q)` |
+| N-D | one-shot | AoS `q::AbstractArray` of N-coordinate points | dense `Array` with `size(q)` |
+| N-D | either | shaped SoA `q::NTuple{N,AbstractArray}` | dense `Array` with shared axis-array size |
+
+In-place forms accept an `AbstractArray` output with exactly the requested
+`size` and fill it directly in logical column-major order. Existing vector
+queries remain vectors. `GriddedQuery` remains the distinct Cartesian-product
+query and keeps its separable fast paths.
+
+The implementation must not flatten via `vec` or `reshape` in a hot path. Those
+operations are zero-copy, but local feasibility probes measured small retained
+wrapper allocations. The batch kernels already operate by logical query number;
+they can write shaped outputs directly with `output[k]`.
+
+## 2. Terminology and query encodings
+
+### 2.1 Shape
+
+This feature preserves `size`, not the concrete query container type and not
+custom axes.
+
+```julia
+q = reshape(range(0.1, 0.9, 12), 3, 4)
+size(itp(q)) == (3, 4)
+itp(q) isa Matrix
+```
+
+Allocating calls return a standard dense `Array{Tout}`. They must not use
+`similar(q, Tout)`: a query container may be read-only, lazy, GPU-backed, or
+specialized for coordinate-point elements and may not be an appropriate output
+container for interpolated values.
+
+### 2.2 1-D coordinate array
+
+For a 1-D interpolant, every element of the query array is one scalar coordinate.
+
+```julia
+q1 = reshape([0.1, 0.2, 0.3, 0.4], 2, 2)
+r1 = itp1(q1)                    # 2×2
+@assert r1 == map(itp1, q1)
+```
+
+### 2.3 N-D AoS: array of points
+
+For an N-D interpolant, each element of an AoS query array is one N-coordinate
+point accepted by the existing `_as_ntuple` protocol: normally an `NTuple`, an
+`SVector`, or another indexable N-component point.
+
+```julia
+q2 = reshape([(0.1, 0.2), (0.3, 0.4),
+              (0.5, 0.6), (0.7, 0.8)], 2, 2)
+r2 = itp2(q2)                    # 2×2
+@assert r2 == map(itp2, q2)
+```
+
+A plain `Matrix{Float64}` is not reinterpreted as “points in rows” or “points in
+columns”. Its elements are scalar, so it is not an N-D AoS query for N > 1. This
+feature does not introduce a new points-as-columns encoding.
+
+### 2.4 N-D shaped SoA: tuple of coordinate arrays
+
+Coordinate arrays with the same size form a pairwise shaped SoA batch.
+
+```julia
+qx = [0.1 0.2; 0.3 0.4]
+qy = [0.5 0.6; 0.7 0.8]
+r = itp2((qx, qy))               # 2×2, pairwise
+@assert r[i, j] == itp2((qx[i, j], qy[i, j]))
+```
+
+All SoA coordinate arrays must have identical `size`, not merely identical
+`length`. The existing tuple-of-vectors API is the one-dimensional special case
+and keeps returning a `Vector`.
+
+### 2.5 `GriddedQuery`: Cartesian product, unchanged
+
+`GriddedQuery((xq, yq))` means every combination of independent axis targets.
+It is intentionally different from shaped SoA:
+
+```julia
+itp2((qx, qy))                    # pairwise, requires size(qx) == size(qy)
+itp2(GriddedQuery(xaxis, yaxis))  # Cartesian product, size = (length(xaxis), length(yaxis))
+```
+
+Its explicit `_query_size` method and dedicated separable dispatch stay in place
+even though the new generic `AbstractArray` rule would report the same size.
+
+## 3. Public API contract
+
+### 3.1 Allocating calls
+
+The output type is determined exactly as today. Only its dimensions change.
+
+```julia
+Tout = _promote_eltype(...)       # existing family-specific rule
+out = Array{Tout}(undef, _query_size(queries))
+```
+
+Rules:
+
+- scalar query -> scalar result, unchanged;
+- vector query -> `Vector`, unchanged;
+- shaped array query -> dense `Array` of that size;
+- shaped SoA -> dense `Array` of the shared coordinate-array size;
+- custom non-array query container -> existing flat default unless it overrides
+  `_query_size`;
+- `GriddedQuery` -> its current N-D output and fast path.
+
+### 3.2 In-place calls
+
+For shaped query methods:
+
+```julia
+size(output) == _query_size(queries) || throw(DimensionMismatch(...))
+```
+
+Equal length with a different shape is rejected. The existing vector methods may
+retain their current error type only when `_query_size(queries) == (length(queries),)`.
+Any public method whose query protocol reports a shaped result must perform the
+exact-size check even when `output` itself is a `Vector`. In particular, a
+four-element output vector is not a valid sink for a `2×2` query.
+
+### 3.3 Evaluation order
+
+Results align in logical column-major order:
+
+```julia
+out[k] == evaluate(query_point_k)
+```
+
+This matches the existing `_query_length` / `_query_extract(q, k)` protocol and
+`GriddedQuery`'s documented linear order.
+
+### 3.4 Error ordering
+
+Existing safety contracts remain load-bearing:
+
+- `_query_validate` and dimensionality checks happen before evaluation;
+- NoExtrap validates the complete batch before the first output write;
+- same-size validation happens before domain validation and output mutation;
+- Fill/Clamp/Wrap semantics and derivative carrier behavior are unchanged.
+
+## 4. Coverage matrix
+
+### 4.1 Persistent 1-D
+
+Covered through `AbstractInterpolant1D` and the family traits/loops:
+
+- `ConstantInterpolant`
+- `LinearInterpolant`
+- `QuadraticInterpolant`
+- `CubicInterpolant`
+- `CubicHermiteInterpolant1D`
+- `PchipInterpolant1D`
+- `CardinalInterpolant1D`
+- `AkimaInterpolant1D`
+
+`DerivativeView` out-of-place forwarding already admits arrays; add both the
+1-D `output::AbstractArray, q::AbstractArray{<:Real}` forward and the N-D
+parent-specialized `output::AbstractArray, queries` forward so derivative views
+follow the parent contract without colliding with the series scalar-query form.
+The existing persistent N=1 SoA spelling `(q,)` is also covered: if `q` is a
+matrix, the result is a matrix rather than a flattened vector.
+
+### 4.2 One-shot 1-D
+
+Dedicated allocating and in-place functions:
+
+- `constant_interp` / `constant_interp!`
+- `linear_interp` / `linear_interp!`
+- `quadratic_interp` / `quadratic_interp!`
+- `cubic_interp` / `cubic_interp!` (raw-grid and cache entry points)
+- `hermite_interp` / `hermite_interp!`
+- `pchip_interp` / `pchip_interp!`
+- `cardinal_interp` / `cardinal_interp!`
+- `akima_interp` / `akima_interp!`
+- unified `interp` / `interp!` for the seven routable method objects
+
+The tuple-grid N=1 forwarders must accept a shaped real array and route to the
+genuine 1-D method, just as their current vector forwarders do.
+
+### 4.3 Persistent N-D
+
+Covered through `AbstractInterpolantND`'s shared batch protocol:
+
+- `ConstantInterpolantND`
+- `LinearInterpolantND`
+- `QuadraticInterpolantND`
+- `CubicInterpolantND`
+- `CubicHermiteInterpolantND`
+- `HeteroInterpolantND`, including PCHIP/Cardinal/Akima/mixed axes
+
+### 4.4 One-shot N-D
+
+Both the unified and dedicated names are covered:
+
+- unified `interp` / `interp!`
+- `constant_interp` / `constant_interp!`
+- `linear_interp` / `linear_interp!`
+- `quadratic_interp` / `quadratic_interp!`
+- `cubic_interp` / `cubic_interp!`
+- `hermite_interp` / `hermite_interp!` with `HermitePartials`
+- PCHIP/Cardinal/Akima N-D forwarders in `local_hermite_nd_forward.jl`
+
+## 5. Core protocol design
+
+### 5.1 Query shape
+
+Extend `src/core/query_protocol.jl` conceptually as follows. Names may be adjusted
+to fit repository style, but semantics are fixed.
+
+```julia
+@inline _query_size(q) = (_query_length(q),)
+@inline _query_size(q::AbstractArray) = size(q)
+
+@inline _query_length(q::Tuple{AbstractArray, Vararg{AbstractArray}}) = length(first(q))
+@inline _query_size(q::Tuple{AbstractArray, Vararg{AbstractArray}}) = size(first(q))
+@inline _query_eltype(q::Tuple{AbstractArray, Vararg{AbstractArray}}) =
+    promote_type(map(eltype, q)...)
+
+@inline _query_extract(q::Tuple{Vararg{AbstractArray, N}}, k) where {N} =
+    ntuple(d -> @inbounds(q[d][k]), Val(N))
+```
+
+Use a non-empty tuple signature for methods that call `first`. Keep the
+`GriddedQuery` specializations.
+
+### 5.2 Shaped SoA validation
+
+Replace the SoA length-only validation for the shaped protocol with exact-size
+validation:
+
+```julia
+function _query_validate(q::Tuple{AbstractArray, Vararg{AbstractArray}})
+    expected = size(first(q))
+    for d in 2:length(q)
+        size(q[d]) == expected || _throw_query_axis_size_mismatch(...)
+    end
+    nothing
+end
+```
+
+For vectors this checks the same `(n,)` size and is behaviorally equivalent to
+the current length check. `_query_check_ndims` should recognize tuple-of-arrays as
+SoA and compare tuple length to interpolation dimension N without extracting the
+first point.
+
+### 5.3 Output helpers
+
+Add one source of truth, preferably beside the query protocol:
+
+```julia
+@inline _alloc_query_output(::Type{T}, q) where {T} =
+    Array{T}(undef, _query_size(q))
+
+@inline function _check_query_output_size(output, q)
+    expected = _query_size(q)
+    size(output) == expected ||
+        _throw_query_output_size_mismatch(expected, size(output))
+    nothing
+end
+```
+
+Do not use `similar(q, T)` and do not flatten output.
+
+### 5.4 Direct shaped output sink
+
+Change batch-loop output annotations from `AbstractVector` to `AbstractArray`
+where a shaped call can reach them. The loop remains:
+
+```julia
+@inbounds for k in 1:_query_length(queries)
+    query_k = _extract_query_point(queries, k, Val(N))
+    output[k] = evaluate(query_k)
+end
+```
+
+Concrete `Vector` calls still specialize on `Vector`; widening an internal sink
+annotation does not imply dynamic dispatch. Public vector overloads should remain
+in place so current dispatch and documentation are stable.
+
+## 6. 1-D implementation design
+
+### 6.1 Persistent public methods
+
+In `src/core/interpolant_protocol.jl`, add less-specific shaped overloads beside
+the existing vector methods:
+
+```julia
+(itp::AbstractInterpolant1D)(q::AbstractArray{Tq}; kwargs...) where {Tq<:Real}
+(itp::AbstractInterpolant1D)(out::AbstractArray,
+                             q::AbstractArray{Tq}; kwargs...) where {Tq<:Real}
+```
+
+The allocating method uses `_promote_eltype(itp, Tq)` and
+`_alloc_query_output`. The in-place method checks exact size. Both reuse the
+existing extrap/search resolution and `_itp_vector_loop!` trait.
+
+The current `AbstractVector` overloads are more specific and must remain
+unchanged.
+
+Also widen the existing one-axis tuple forwarders from `Tuple{AbstractVector}`
+to the shaped equivalent `Tuple{AbstractArray}` for both allocating and in-place
+calls. They unwrap `(q,)` and reuse the native 1-D shaped method; they must not
+enter the generic N-D point protocol.
+
+### 6.2 Array-aware domain checks
+
+Add `AbstractArray{<:Real}` peers for the vector batch methods in
+`src/core/utils.jl`:
+
+- `_is_all_inbounds`
+- `_check_domain(..., ::NoExtrap)`
+- unit-step `_CachedRange` exclusive-last promotion
+- non-NoExtrap pass-through
+- Clamp/Fill/Wrap all-in-bounds promotion
+- `_throw_batch_oob`
+
+Keep vector methods more specific. Preserve empty-query behavior and
+throw-before-write behavior.
+
+### 6.3 Array-aware AutoSearch
+
+In `src/core/search.jl`, add array peers without replacing the vector methods:
+
+- `_is_likely_monotone(::AbstractArray{<:Real})`
+- `_resolve_search_policy(::AutoSearch, ::AbstractArray)`
+- `_resolve_search_policy(::AutoSearch, ::AbstractArray{<:Real}, ::Nothing)`
+
+Monotonicity is measured in logical column-major order. An explicit policy and
+hint retain current semantics.
+
+### 6.4 Family loop sinks
+
+The following internal loops must accept same-size `AbstractArray` query/output
+pairs while retaining their vector specializations:
+
+- `_constant_vector_loop!`
+- `_linear_vector_loop!` and `_linear_vector_loop_inner!`
+- `_linear_interp_loop!` and `_linear_interp_loop_inner!` (one-shot-specific)
+- `_quadratic_vector_loop!` and inner loop
+- `_cubic_vector_loop!` and inner loop
+- both `_hermite_vector_loop!` variants and inner loops
+
+Avoid higher-order closures in the hot loop unless allocation/codegen tests prove
+them harmless. Small duplicated family loops are preferable to a boxed generic
+closure.
+
+### 6.5 Dedicated one-shot allocators
+
+Each allocating one-shot method keeps its existing `Tout` formula and changes
+only buffer construction from `Vector{Tout}(undef, length(q))` to
+`_alloc_query_output(Tout, q)` in its new shaped overload.
+
+Each in-place shaped overload checks exact size, performs the same coefficient/
+axis preparation once, and calls the array-aware family loop. It must not build a
+persistent interpolant as an adapter: constructors may copy data or allocate
+long-lived coefficients and would violate one-shot allocation behavior.
+
+### 6.6 Unified 1-D and N=1 tuple-grid forwards
+
+Widen/add shaped query overloads in `src/hetero/interp_1d.jl`; continue routing
+through `_interp1d_route` so unified and dedicated APIs remain allocation-equal.
+
+Add shaped N=1 forwards in:
+
+- `linear/nd/linear_nd_interpolant.jl`
+- `constant/nd/constant_nd_interpolant.jl`
+- `quadratic/nd/quadratic_nd_interpolant.jl`
+- `cubic/nd/cubic_nd_interpolant.jl`
+- `hetero/local_hermite_nd_forward.jl`
+
+For a one-axis tuple grid, `q::AbstractArray{<:Real}` goes directly to the native
+1-D method. A single-axis SoA wrapper `(q,)` may also forward after unwrapping, so
+generic tensor code sees the same shape.
+
+## 7. N-D implementation design
+
+### 7.1 Persistent shared protocol
+
+In `src/core/interpolant_protocol.jl`:
+
+- allocating batch calls use `_alloc_query_output` instead of `Vector`;
+- add an `AbstractArray` in-place entry with exact-size validation;
+- change the existing `output::AbstractVector, queries` entry to validate
+  `_query_size(queries)`, not only `_query_length(queries)`. Otherwise
+  `itp(vector_output, matrix_queries)` silently keeps the old flattened path;
+- prefer `output::AbstractArray, queries` as the generic shaped entry and keep
+  `output::AbstractVector, queries` as its more-specific vector entry, with both
+  routed through one shape-checking helper. If an implementation instead
+  constrains the generic method's query argument and creates crossed signatures,
+  add the narrow `AbstractVector × AbstractArray` intersection explicitly;
+- let `_nd_batch_pointwise!` and `_interp_nd_batch!` write directly to
+  `AbstractArray` outputs;
+- keep existing scalar-vector point dispatch unchanged.
+
+In `src/gridded/gridded_dispatch.jl`, replace the fallback
+`_nd_batch_pointwise!(vec(out), ...)` with direct shaped output. Separable methods
+and their output checks remain unchanged.
+
+### 7.2 Shaped SoA fast checks
+
+The generic query protocol is sufficient for correctness. For performance parity
+with vector SoA, add tuple-of-real-array peers where current code specializes on
+tuple-of-real-vectors:
+
+- `_validate_nd_domain` in `query_protocol.jl`
+- `_resolve_search_nd` and `_check_mono_nd` in `nd_utils.jl`
+- the relevant AutoSearch tuple classification in `search.jl`
+
+These methods apply `minimum`/`maximum` and prefix monotonicity per coordinate
+array in its logical order. Existing vector methods stay more specific.
+
+### 7.3 Unified one-shot
+
+`src/hetero/hetero_oneshot.jl` already allocates with `_query_size`. Required
+changes:
+
+- validate `size(output) == _query_size(queries)` in the generic public in-place
+  path;
+- remove `flat = ... vec(output)`;
+- let `_interp_nd_oneshot_batch_dispatch!` receive the shaped output directly;
+- keep the pre-flatten separable `GriddedQuery` hook exactly where it is.
+
+### 7.4 Dedicated one-shot families
+
+Update allocators and output sinks in:
+
+- `linear/nd/linear_nd_oneshot.jl`
+- `constant/nd/constant_nd_oneshot.jl`
+- `quadratic/nd/quadratic_nd_oneshot.jl`
+- `cubic/nd/cubic_nd_oneshot.jl`
+- `hermite/nd/hermite_nd_oneshot.jl`
+- `hetero/local_hermite_nd_forward.jl`
+
+Each family must preserve its current output eltype rule, coefficient strategy,
+pool usage, BC preparation, query validation, and domain pre-scan. Only output
+shape/sink typing changes. Existing public `output::AbstractVector, queries`
+methods in these files must also adopt exact `_query_size` validation, so they
+cannot accept a shaped query merely because lengths match.
+
+## 8. Dispatch and ambiguity audit
+
+| Intersection | Required winner |
+|---|---|
+| 1-D scalar `Real` vs shaped array | scalar for `Real`, shaped for `AbstractArray{<:Real}` |
+| 1-D vector vs shaped array | existing `AbstractVector` method |
+| N-D `AbstractVector{<:Real}` | existing single-point vector-to-tuple method |
+| N-D AoS `AbstractVector{<:Tuple/SVector}` | existing vector batch behavior |
+| N-D AoS matrix | shaped generic batch |
+| N-D vector output + shaped query | exact-size rejection, never length-only fallback |
+| shaped SoA tuple | tuple-of-arrays protocol, not generic Tuple scalar logic |
+| 1-axis `GriddedQuery` | explicit GriddedQuery disambiguators |
+| N>1 `GriddedQuery` | explicit separable/fallback GriddedQuery methods |
+| anchored query vectors | existing anchor-specific methods |
+| `DerivativeView(out, q_array)` vs series scalar output | shaped query method; scalar `q::Real` remains series path |
+| N=1 tuple-grid one-shot vs generic N-D one-shot | explicit N=1 collapse forward |
+
+Every implementation phase must run `Aqua.test_ambiguities`. Do not solve an
+ambiguity by deleting a current specific vector/Gridded method; add the narrow
+tie-breaker at the abstract protocol level when possible.
+
+## 9. Allocation and performance design
+
+### 9.1 Hard allocation targets
+
+- Persistent in-place dense/view shaped queries: 0 B after warmup.
+- One-shot in-place shaped queries: no allocations beyond the corresponding
+  vector method after warmup; pool-backed coefficient methods should remain 0 B
+  under the repository's existing pool test discipline.
+- Allocating shaped queries: exactly the returned dense array plus allocations
+  already present in the corresponding vector call.
+- Existing vector allocation counts: identical.
+
+### 9.2 Why no `vec`
+
+Feasibility probe on Julia 1.12.6, 10,000 Float64 queries:
+
+| Path | Warm allocation | Indicative time |
+|---|---:|---:|
+| 1-D direct matrix traversal | 0 B | ~94.9 µs |
+| 1-D `vec` input/output adapter | 64 B | ~102.7 µs |
+| existing 1-D vector | 0 B | ~96.2 µs |
+| N-D direct matrix-of-tuples | 0 B | ~109 µs |
+| existing N-D vector-of-tuples | 0 B | ~111 µs |
+
+These are architecture probes, not release benchmarks.
+
+### 9.3 Release performance gate
+
+Add representative persistent and one-shot benchmarks to
+`benchmark/ci_benchmark.jl`:
+
+- old Vector AoS and SoA lanes (regression sentinels);
+- 1-D dense Matrix and noncontiguous view;
+- N-D AoS Matrix and shaped SoA matrices;
+- Range and Vector grids;
+- sorted and random logical query order;
+- Linear plus one coefficient-heavy family (Cubic or PCHIP).
+
+Use the repository's confirmed regression rule: greater than 10% against the
+same-machine baseline, followed by its re-verification pass, blocks completion.
+
+## 10. Test design
+
+Create `test/test_query_shape_preservation.jl` and add test items incrementally.
+
+### 10.1 Protocol tests
+
+- `_query_size` for vector, matrix, 3-D array, shaped SoA, custom flat query, and
+  `GriddedQuery`.
+- `_query_length == prod(_query_size)`.
+- `_query_extract` column-major order for AoS and shaped SoA.
+- SoA mismatched sizes throw before evaluation.
+- empty shaped arrays and zero-sized dimensions.
+
+### 10.2 Four-quadrant correctness
+
+For every quadrant, test allocating and in-place forms:
+
+1. 1-D persistent
+2. 1-D one-shot
+3. N-D persistent
+4. N-D one-shot
+
+Use `map`/comprehension scalar evaluation as the reference. Cover value,
+derivative, NoExtrap, Clamp, Fill, Wrap/periodic, mixed precision, and views.
+
+### 10.3 Family coverage
+
+- 1-D: Constant, Linear, Quadratic, Cubic, Hermite, PCHIP, Cardinal, Akima.
+- N-D: Constant, Linear, Quadratic, Cubic, user Hermite partials, local-Hermite
+  forwarders, and heterogeneous method tuples.
+- Unified/dedicated parity for both dimensions.
+- N=1 tuple-grid parity with native 1-D APIs.
+
+### 10.4 Dispatch guards
+
+- N-D `Vector{Float64}` of length N is still one scalar point.
+- N-D `Vector{NTuple{N,T}}` is still a vector batch.
+- Matrix of points returns a matrix.
+- Vector output paired with a same-length Matrix query throws before mutation.
+- shaped SoA returns shared shape.
+- `GriddedQuery` still takes the separable path where supported.
+- `DerivativeView` forwards shaped allocating and in-place calls.
+- Aqua reports zero ambiguities.
+
+### 10.5 Allocation tests
+
+Put setup, warmup, and `@allocated` inside a function barrier, matching existing
+tests. Pin:
+
+- 0 B persistent in-place for 1-D Matrix, N-D AoS Matrix, and N-D shaped SoA;
+- allocation parity of unified vs dedicated one-shot;
+- unchanged existing vector lanes;
+- no `vec`/reshape wrapper allocation on shaped paths.
+
+## 11. Documentation and compatibility
+
+Update:
+
+- 1-D batch API docs and examples;
+- `docs/src/nd/overview.md` AoS/SoA/GriddedQuery distinction;
+- `docs/src/guides/performance_tips.md` shaped in-place allocation guidance;
+- public docstrings that currently say “Returns a Vector”;
+- release notes with the intentional result-shape change for array-of-points
+  inputs and the migration `vec(itp(q))` for callers that require flattening.
+
+Vector and scalar behavior is backward-compatible. The intentional compatibility
+change is limited to batch query containers that already carry more than one
+dimension but previously returned a flattened vector.
+
+## 12. Explicit non-goals
+
+- Series interpolants. Their natural layout needs a separate decision about the
+  series axis plus query axes.
+- Adjoint operator construction/application.
+- Pre-anchored query arrays and anchor-buffer shape.
+- Vector-calculus APIs whose outputs add component/derivative axes.
+- Automatic differentiation rules for newly shaped array queries. Existing
+  scalar/vector AD behavior must not regress; array-query AD can be designed
+  separately.
+- Preserving query container type, custom axes, or GPU execution.
+- Interpreting numeric N-D matrices as points-in-columns/rows.
+
+## 13. Handoff order
+
+An implementing agent should work strictly in this order:
+
+1. Add RED protocol + N-D persistent tests.
+2. Implement query-size/SoA protocol and direct N-D output sinks.
+3. Complete N-D one-shot dedicated/unified surfaces.
+4. Add array batch domain/search support and 1-D persistent methods.
+5. Complete polynomial and Hermite-family 1-D one-shot surfaces plus N=1
+   forwards.
+6. Run ambiguity/allocation/performance gates and update docs.
+
+Do not mix the phases: each phase has an independently testable public result and
+rollback boundary in the companion plan.

--- a/docs/src/nd/overview.md
+++ b/docs/src/nd/overview.md
@@ -189,6 +189,28 @@ _query_eltype(q::MyQueries)      = ...   # scalar floating type (e.g. Float64)
 !!! note "Value types vs Query types"
     This is orthogonal to [Custom Value Types (Duck Typing)](../guides/custom_value_types.md), which governs what types can be *interpolated* (`Tv`). The query protocol governs what container types can *hold query points*.
 
+### Shape preservation
+
+Batch evaluation preserves the **shape** of the query container. A vector query returns a `Vector`; a query that carries more than one dimension returns a dense `Array` of the same `size`:
+
+```julia
+pts = reshape([(0.1, 0.2), (0.3, 0.4), (0.5, 0.6), (0.7, 0.8)], 2, 2)
+itp(pts)                       # 2×2 Matrix — itp(pts)[i,j] == itp(pts[i,j])
+
+qx = [0.1 0.3; 0.5 0.7]; qy = [0.2 0.4; 0.6 0.8]
+itp((qx, qy))                  # 2×2 Matrix (shaped SoA — requires size(qx) == size(qy))
+```
+
+In-place calls require the output to match the query shape **exactly** (equal length with a different shape is rejected):
+
+```julia
+out = Matrix{Float64}(undef, 2, 2)
+itp(out, pts)                  # fills the 2×2 matrix
+itp(Vector{Float64}(undef, 4), pts)   # DimensionMismatch — a length-4 vector is not a 2×2 sink
+```
+
+Scalar and vector queries are unchanged, and `GriddedQuery` keeps its Cartesian-product shape. Only a query container that already carried more than one dimension changes: it previously returned a flattened vector and now returns a same-shape array. To recover the old flat result, wrap the call: `vec(itp(pts))`.
+
 ---
 
 ## Visualization (2D)

--- a/src/akima/akima_oneshot.jl
+++ b/src/akima/akima_oneshot.jl
@@ -35,10 +35,10 @@ end
 
 # Vector in-place — bc-aware unified path.
 @inline @with_pool pool function _akima_interp_precompute!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector,
+        x_query::AbstractArray,
         bc::AbstractBC,
         extrap::AbstractExtrap,
         deriv::DerivOp,
@@ -46,7 +46,7 @@ end
         hint::Union{Nothing, Base.RefValue{Int}}
     ) where {Tg, Tv}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
-    @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
+    _check_query_output_size(output, x_query)
     x_eff, y_ext, bc_eff, extrap_eff = _periodic_extend_1d(x, y, bc, extrap)
 
     # Value-matched width: dy buffer + slope arithmetic run at `Tw` — see pchip_oneshot.jl.
@@ -84,10 +84,10 @@ end
 
 # Vector in-place — bc-aware unified path.
 @inline function _akima_interp_onthefly!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector,
+        x_query::AbstractArray,
         bc::AbstractBC,
         extrap::AbstractExtrap,
         deriv::DerivOp,
@@ -96,7 +96,7 @@ end
     ) where {Tg, Tv}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     length(x) >= 2 || throw(ArgumentError("Akima interpolation requires at least 2 points, got $(length(x))"))
-    @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
+    _check_query_output_size(output, x_query)
     x_eff = _resolve_axis(x, bc)
     y_eff = _resolve_data(y, bc)
 
@@ -146,10 +146,10 @@ end
 In-place Akima interpolation with outlier-robust slopes.
 """
 @inline function akima_interp!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tq};
+        x_query::AbstractArray{Tq};
         bc::AbstractBC = NoBC(),
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         extrap::AbstractExtrap = NoExtrap(),
@@ -174,7 +174,7 @@ Akima interpolation at multiple query points. Returns `Vector`.
 function akima_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tq};
+        x_query::AbstractArray{Tq};
         bc::AbstractBC = NoBC(),
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         extrap::AbstractExtrap = NoExtrap(),
@@ -183,7 +183,7 @@ function akima_interp(
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, Tq <: Real}
     Tr = _promote_eltype(_interp_op, _promote_grid_float(Tg, Tv), Tv, Tq)
-    output = Vector{Tr}(undef, length(x_query))
+    output = _alloc_query_output(Tr, x_query)
     akima_interp!(output, x, y, x_query; bc = bc, coeffs = coeffs, extrap = extrap, deriv = deriv, search = search, hint = hint)
     return output
 end

--- a/src/akima/akima_oneshot.jl
+++ b/src/akima/akima_oneshot.jl
@@ -169,7 +169,8 @@ end
 """
     akima_interp(x, y, x_query; coeffs=PreCompute(), ...)
 
-Akima interpolation at multiple query points. Returns `Vector`.
+Akima interpolation at multiple query points. Returns an `Array`
+matching the query's shape (a `Vector` for a vector query).
 """
 function akima_interp(
         x::AbstractVector{Tg},

--- a/src/cardinal/cardinal_oneshot.jl
+++ b/src/cardinal/cardinal_oneshot.jl
@@ -42,10 +42,10 @@ end
 
 # Vector in-place — periodic BC follows the same extend-then-eval pattern.
 @inline @with_pool pool function _cardinal_interp_precompute!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector,
+        x_query::AbstractArray,
         bc::AbstractBC,
         tension::Real,
         extrap::AbstractExtrap,
@@ -54,7 +54,7 @@ end
         hint::Union{Nothing, Base.RefValue{Int}}
     ) where {Tg, Tv}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
-    @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
+    _check_query_output_size(output, x_query)
     x_eff, y_ext, bc_eff, extrap_eff = _periodic_extend_1d(x, y, bc, extrap)
 
     # Value-matched width: dy buffer + slope arithmetic (incl. the `1 - tension`
@@ -104,10 +104,10 @@ end
 
 # Vector in-place — same axis-as-truth pattern.
 @inline function _cardinal_interp_onthefly!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector,
+        x_query::AbstractArray,
         bc::AbstractBC,
         tension::Real,
         extrap::AbstractExtrap,
@@ -117,7 +117,7 @@ end
     ) where {Tg, Tv}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     length(x) >= 2 || throw(ArgumentError("Cardinal interpolation requires at least 2 points, got $(length(x))"))
-    @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
+    _check_query_output_size(output, x_query)
     x_eff = _resolve_axis(x, bc)
     y_eff = _resolve_data(y, bc)
     searcher = _resolve_search(x_eff, x_query, search, hint)
@@ -167,10 +167,10 @@ end
 In-place cardinal spline interpolation.
 """
 @inline function cardinal_interp!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tq};
+        x_query::AbstractArray{Tq};
         bc::AbstractBC = NoBC(),
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         tension::Real = 0.0,
@@ -197,7 +197,7 @@ Cardinal spline interpolation at multiple query points. Returns `Vector`.
 function cardinal_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tq};
+        x_query::AbstractArray{Tq};
         bc::AbstractBC = NoBC(),
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         tension::Real = 0.0,
@@ -207,7 +207,7 @@ function cardinal_interp(
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, Tq <: Real}
     Tr = _promote_eltype(_interp_op, _promote_grid_float(Tg, Tv), Tv, Tq)
-    output = Vector{Tr}(undef, length(x_query))
+    output = _alloc_query_output(Tr, x_query)
     cardinal_interp!(output, x, y, x_query; bc = bc, coeffs = coeffs, tension = tension, extrap = extrap, deriv = deriv, search = search, hint = hint)
     return output
 end

--- a/src/cardinal/cardinal_oneshot.jl
+++ b/src/cardinal/cardinal_oneshot.jl
@@ -192,7 +192,8 @@ end
 """
     cardinal_interp(x, y, x_query; coeffs=AutoCoeffs(), tension=0.0, ...)
 
-Cardinal spline interpolation at multiple query points. Returns `Vector`.
+Cardinal spline interpolation at multiple query points. Returns an `Array`
+matching the query's shape (a `Vector` for a vector query).
 """
 function cardinal_interp(
         x::AbstractVector{Tg},

--- a/src/constant/constant_interpolant.jl
+++ b/src/constant/constant_interpolant.jl
@@ -38,10 +38,10 @@ end
 # of RefHint's Ref, causing 16-byte heap allocation per call.
 # ─────────────────────────────────────────────────────────────
 @inline function _constant_vector_loop!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        xq::AbstractVector{<:Real},
+        xq::AbstractArray{<:Real},
         extrap::E,
         side::SD,
         deriv::O,

--- a/src/constant/constant_oneshot.jl
+++ b/src/constant/constant_oneshot.jl
@@ -255,10 +255,10 @@ constant_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear_
 # Unified in-place entry. Resolvers normalize inputs; selection kernel
 # preserves `eltype(y)`. No Real/Mixed wrapper needed.
 function constant_interp!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector,
         y::AbstractVector,
-        x_targets::AbstractVector;
+        x_targets::AbstractArray;
         bc::AbstractBC = NoBC(),
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
@@ -267,7 +267,7 @@ function constant_interp!(
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     )
     @assert length(y) == length(x) "x and y must have same length"
-    @assert length(output) == length(x_targets) "output must match x_targets length"
+    _check_query_output_size(output, x_targets)
 
     # Surface-level BC-aware resolvers (same template as Linear oneshot);
     # raw Tg — selection kernel keeps natural promotion (no float forcing).
@@ -307,7 +307,7 @@ vals = constant_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_wi
 function constant_interp(
         x::AbstractVector,
         y::AbstractVector,
-        x_targets::AbstractVector;
+        x_targets::AbstractArray;
         bc::AbstractBC = NoBC(),
         side::AbstractSide = NearestSide(),
         extrap::AbstractExtrap = NoExtrap(),
@@ -315,9 +315,7 @@ function constant_interp(
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     )
-    output = Vector{_promote_eltype(_select_op, eltype(x), eltype(y), eltype(x_targets))}(
-        undef, length(x_targets)
-    )
+    output = _alloc_query_output(_promote_eltype(_select_op, eltype(x), eltype(y), eltype(x_targets)), x_targets)
     constant_interp!(output, x, y, x_targets; bc, extrap, side, deriv, search, hint)
     return output
 end

--- a/src/constant/nd/constant_nd_interpolant.jl
+++ b/src/constant/nd/constant_nd_interpolant.jl
@@ -93,12 +93,12 @@ end
     constant_interp(grids, data, (q,); kwargs...)
 
 # N=1 batch one-shot → lean 1D batch one-shot (bit-identical). See linear_nd_interpolant.jl.
-@inline constant_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+@inline constant_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractArray{<:Real}; kwargs...) =
     constant_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
-@inline constant_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+@inline constant_interp!(output::AbstractArray, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractArray{<:Real}; kwargs...) =
     constant_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
-@inline constant_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+@inline constant_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractArray}; kwargs...) =
     constant_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
-@inline constant_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+@inline constant_interp!(output::AbstractArray, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractArray}; kwargs...) =
     constant_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -56,7 +56,7 @@ end
 In-place batch one-shot ND constant evaluation.
 """
 function _constant_interp_nd_oneshot_batch!(
-        output::AbstractVector,
+        output::AbstractArray,
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         queries,
@@ -69,7 +69,7 @@ function _constant_interp_nd_oneshot_batch!(
     ) where {Tg, Tv, N}
     policies, hints = _resolve_oneshot_search_nd(search, queries, hint, Val(N))
     nq = _query_length(queries)
-    length(output) == nq || _throw_query_output_mismatch(nq, length(output))
+    _check_query_output_size(output, queries)
     _query_validate(queries)
     grids_eff = map(_resolve_axis, grids, bcs)
     extraps_eff = _resolve_extrap(extraps_val, bcs, grids_eff, data, Val(N))
@@ -108,7 +108,7 @@ function _constant_interp_nd_oneshot_batch(
     ) where {Tg, Tv, N}
     # Buffer eltype via Constant's kernel shape (mirrors 1D oneshot wrapper).
     Tq = _query_eltype(queries)
-    output = Vector{_promote_eltype(_select_op, Tg, Tv, Tq)}(undef, _query_length(queries))
+    output = _alloc_query_output(_promote_eltype(_select_op, Tg, Tv, Tq), queries)
     return _constant_interp_nd_oneshot_batch!(output, grids, data, queries, bcs, extraps_val, side_vals, search, ops, hint)
 end
 
@@ -199,7 +199,7 @@ Accepts any query format implementing the query protocol.
 Writes results into pre-allocated `output` vector.
 """
 function constant_interp!(
-        output::AbstractVector,
+        output::AbstractArray,
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         queries;

--- a/src/core/coeff_policy.jl
+++ b/src/core/coeff_policy.jl
@@ -19,7 +19,7 @@
 
 # ── AutoCoeffs: 1D vector query → runtime length check ──
 # Crossover: PreCompute O(n + K) vs OnTheFly O(2K). At K ≈ n, PreCompute wins.
-@inline function _resolve_coeffs(::AutoCoeffs, x::AbstractVector, xq::AbstractVector)
+@inline function _resolve_coeffs(::AutoCoeffs, x::AbstractVector, xq::AbstractArray)
     return length(xq) > length(x) ? PreCompute() : OnTheFly()
 end
 

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -159,6 +159,45 @@ function (itp::AbstractInterpolant1D{Tg, Tv})(
     return output
 end
 
+# ========================================
+# 1D Shaped Array Call — Allocating + In-Place
+# ========================================
+# A real array query (Matrix, 3-D, noncontiguous view) yields an array of the same
+# shape; the `AbstractVector` methods above stay more specific, so the vector hot path
+# is unchanged. Both reuse the extrap/searcher resolution and the (array-widened) family
+# loop, which fills by `eachindex(xq, output)` — column-major for same-shape arrays.
+
+function (itp::AbstractInterpolant1D{Tg, Tv})(
+        q::AbstractArray{Tq};
+        deriv::DerivOp = EvalValue(),
+        extrap::Union{Nothing, AbstractExtrap} = nothing,
+        search::AbstractSearchPolicy = _itp_search(itp),
+        hint::Union{Nothing, Base.RefValue{Int}} = nothing
+    ) where {Tg, Tv, Tq <: Real}
+    grid = _itp_grid(itp)
+    extrap_eff = _resolve_extrap_override(_itp_extrap(itp), extrap)
+    output = _alloc_query_output(_promote_eltype(itp, Tq), q)
+    searcher = _resolve_search(grid, q, search, hint)
+    _itp_vector_loop!(output, itp, q, extrap_eff, deriv, searcher)
+    return output
+end
+
+function (itp::AbstractInterpolant1D{Tg, Tv})(
+        output::AbstractArray,
+        q::AbstractArray{Tq};
+        deriv::DerivOp = EvalValue(),
+        extrap::Union{Nothing, AbstractExtrap} = nothing,
+        search::AbstractSearchPolicy = _itp_search(itp),
+        hint::Union{Nothing, Base.RefValue{Int}} = nothing
+    ) where {Tg, Tv, Tq <: Real}
+    _check_query_output_size(output, q)
+    grid = _itp_grid(itp)
+    extrap_eff = _resolve_extrap_override(_itp_extrap(itp), extrap)
+    searcher = _resolve_search(grid, q, search, hint)
+    _itp_vector_loop!(output, itp, q, extrap_eff, deriv, searcher)
+    return output
+end
+
 # ── ND-style tuple queries on a 1D interpolant ──
 # A 1-axis grid collapses to the 1D path (see the `*_interp((x,), y)` forwarders),
 # so generic tensor code that issues tuple queries stays transparent: `itp((x,))`
@@ -170,6 +209,13 @@ end
 @inline (itp::AbstractInterpolant1D)(output::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
     itp(output, q[1]; _unwrap_nd_kwargs(values(kwargs))...)
 @inline (itp::AbstractInterpolant1D)(q::Tuple{AbstractVector}; kwargs...) =
+    itp(q[1]; _unwrap_nd_kwargs(values(kwargs))...)
+# Shaped single-axis SoA: `(q_matrix,)` collapses to the shaped 1D path (vector
+# forms above stay more specific), so generic tensor code that issues `(q,)` is
+# transparent for array queries too.
+@inline (itp::AbstractInterpolant1D)(output::AbstractArray, q::Tuple{AbstractArray}; kwargs...) =
+    itp(output, q[1]; _unwrap_nd_kwargs(values(kwargs))...)
+@inline (itp::AbstractInterpolant1D)(q::Tuple{AbstractArray}; kwargs...) =
     itp(q[1]; _unwrap_nd_kwargs(values(kwargs))...)
 
 # ╔══════════════════════════════════════╗

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -188,7 +188,7 @@ end
 # Query extraction dispatches via _query_extract on query container type.
 
 @inline function _interp_nd_batch!(
-        output::AbstractVector,
+        output::AbstractArray,
         itp::AbstractInterpolantND{Tg, Tv, N},
         queries,
         extraps_eff::Tuple{Vararg{AbstractExtrap, N}},
@@ -317,6 +317,21 @@ end
 # Protocol functions (_query_length, _query_extract, _query_eltype) dispatch
 # directly on query container type — no normalization needed.
 
+# Shaped in-place batch: `output` must match `_query_size(queries)` EXACTLY — a
+# length-only match would silently flatten a matrix query into a vector sink. The
+# `AbstractVector` peer keeps the established vector-batch dispatch stable; both route
+# through one shape-checking helper. (Column-major linear indexing fills the shape.)
+function (itp::AbstractInterpolantND{Tg, Tv, N})(
+        output::AbstractArray,
+        queries;
+        deriv::Union{DerivOp, Tuple{Vararg{DerivOp, N}}} = EvalValue(),
+        extrap::Union{Nothing, AbstractExtrap, Tuple} = nothing,
+        search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
+    ) where {Tg, Tv, N}
+    return _nd_batch_inplace!(itp, output, queries, deriv, extrap, search, hint)
+end
+
 function (itp::AbstractInterpolantND{Tg, Tv, N})(
         output::AbstractVector,
         queries;
@@ -325,9 +340,14 @@ function (itp::AbstractInterpolantND{Tg, Tv, N})(
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}} = itp.searches,
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
+    return _nd_batch_inplace!(itp, output, queries, deriv, extrap, search, hint)
+end
+
+@inline function _nd_batch_inplace!(
+        itp::AbstractInterpolantND{Tg, Tv, N}, output, queries, deriv, extrap, search, hint
+    ) where {Tg, Tv, N}
     ops = _resolve_deriv_nd(deriv, Val(N))
-    nq = _query_length(queries)
-    length(output) == nq || _throw_query_output_mismatch(nq, length(output))
+    _check_query_output_size(output, queries)
     # `extrap` (nothing → stored; InBounds → fast-path; else errors) resolved per-axis.
     extraps0 = _resolve_extrap_override_nd(itp, extrap)
     return _nd_batch_pointwise!(output, itp, queries, ops, extraps0, search, hint)
@@ -339,7 +359,7 @@ end
 # already override-resolved; `ops` already per-axis. HeteroND rides this too —
 # it is an `AbstractInterpolantND`, so the resolver threads its stored state.
 @inline function _nd_batch_pointwise!(
-        output::AbstractVector,
+        output::AbstractArray,
         itp::AbstractInterpolantND{Tg, Tv, N},
         queries,
         ops::Tuple{Vararg{AbstractEvalOp, N}},
@@ -372,6 +392,6 @@ function (itp::AbstractInterpolantND{Tg, Tv, N})(
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
     Tq = _query_eltype(queries)
-    output = Vector{_promote_eltype(itp, Tq)}(undef, _query_length(queries))
+    output = _alloc_query_output(_promote_eltype(itp, Tq), queries)
     return itp(output, queries; deriv = deriv, extrap = extrap, search = search, hint = hint)
 end

--- a/src/core/query_protocol.jl
+++ b/src/core/query_protocol.jl
@@ -18,6 +18,8 @@
 # ── Protocol function 1: query count ──
 
 @inline _query_length(q::Tuple{Vararg{AbstractVector}}) = length(q[1])
+# Shaped SoA (tuple of same-size coordinate arrays): count from the first axis.
+@inline _query_length(q::Tuple{AbstractArray, Vararg{AbstractArray}}) = length(first(q))
 @inline _query_length(q) = length(q)
 
 # ── Optional: query output shape ──
@@ -29,6 +31,24 @@
 # is a flat 1-D output (a plain vector), so ordinary batch queries are unchanged.
 
 @inline _query_size(q) = (_query_length(q),)
+# An ordinary array query reports its own shape, so the allocating path returns an
+# `Array` of that shape and in-place callers pass a matching array (column-major
+# linear indexing lands each result at its N-D slot). SoA reports the shared axis size.
+@inline _query_size(q::AbstractArray) = size(q)
+@inline _query_size(q::Tuple{AbstractArray, Vararg{AbstractArray}}) = size(first(q))
+
+# ── Optional: shaped output allocation + exact-size validation ──
+# Single source of truth for batch output shape. Allocating builds a dense `Array`
+# of the query shape (never `similar(q)`: a query container may be read-only, lazy,
+# or point-valued). In-place requires an EXACT size match — equal length with a
+# different shape is rejected (a length-4 vector is not a valid sink for a 2×2 query).
+@inline _alloc_query_output(::Type{T}, q) where {T} = Array{T}(undef, _query_size(q))
+
+@inline function _check_query_output_size(output, q)
+    expected = _query_size(q)
+    size(output) == expected || _throw_query_output_size_mismatch(expected, size(output))
+    return nothing
+end
 
 # ── Protocol function 2: k-th query point extraction ──
 # User-facing: simple getindex-like interface. No Val{N} needed.
@@ -36,6 +56,9 @@
 # SoA returns NTuple directly (N known from tuple type parameter).
 
 @inline _query_extract(q::Tuple{Vararg{AbstractVector, N}}, k) where {N} =
+    ntuple(d -> @inbounds(q[d][k]), Val(N))
+# Shaped SoA: linear index k into each coordinate array (column-major pairwise).
+@inline _query_extract(q::Tuple{Vararg{AbstractArray, N}}, k) where {N} =
     ntuple(d -> @inbounds(q[d][k]), Val(N))
 @inline _query_extract(q, k) = @inbounds q[k]
 
@@ -54,6 +77,7 @@
 # e.g. Vector{NTuple{2,Float64}} → Float64, not NTuple{2,Float64}.
 
 @inline _query_eltype(q::Tuple{Vararg{AbstractVector}}) = promote_type(map(eltype, q)...)
+@inline _query_eltype(q::Tuple{AbstractArray, Vararg{AbstractArray}}) = promote_type(map(eltype, q)...)
 @inline _query_eltype(q) = _scalar_eltype(eltype(q))
 
 # Scalar type extraction helpers — dispatch on element type
@@ -84,6 +108,16 @@
     return nothing
 end
 
+# Shaped SoA: every coordinate array must share the SAME size, not merely length
+# (a 2×2 and a 4×1 have equal length but different shape and cannot align pairwise).
+@inline function _query_validate(q::Tuple{AbstractArray, Vararg{AbstractArray}})
+    sz = size(first(q))
+    for d in 2:length(q)
+        size(q[d]) == sz || _throw_query_axis_size_mismatch(sz, d, size(q[d]))
+    end
+    return nothing
+end
+
 # ── Dimensionality validation ──
 # SoA: ndims = tuple length (checked directly, no point extraction needed).
 # Generic (AoS, SVector, etc.): check the first point's length
@@ -92,6 +126,14 @@ end
 # SoA: ndims is the tuple length (number of axes), not a point property.
 # Avoids BoundsError from _query_extract when axes have inconsistent lengths.
 function _query_check_ndims(queries::Tuple{Vararg{AbstractVector}}, ::Val{N}) where {N}
+    length(queries) == N || _throw_query_ndims_mismatch(N, length(queries))
+    return nothing
+end
+
+# Shaped SoA: ndims = number of axes (tuple length). Mandatory peer — without it a
+# tuple-of-arrays falls to the generic method below, which reads the first WHOLE
+# array as "point 1" and throws a spurious ndims mismatch.
+function _query_check_ndims(queries::Tuple{AbstractArray, Vararg{AbstractArray}}, ::Val{N}) where {N}
     length(queries) == N || _throw_query_ndims_mismatch(N, length(queries))
     return nothing
 end
@@ -109,8 +151,12 @@ end
 
 @noinline _throw_query_output_mismatch(nq, no) =
     throw(DimensionMismatch("output length $no != query length $nq"))
+@noinline _throw_query_output_size_mismatch(expected, got) =
+    throw(DimensionMismatch("output size $got != query size $expected"))
 @noinline _throw_query_axis_mismatch(n1, d, nd) =
     throw(DimensionMismatch("query axis lengths differ: dim 1 has $n1, dim $d has $nd"))
+@noinline _throw_query_axis_size_mismatch(sz1, d, szd) =
+    throw(DimensionMismatch("query axis sizes differ: dim 1 has size $sz1, dim $d has size $szd"))
 @noinline _throw_query_ndims_mismatch(expected, got) =
     throw(DimensionMismatch("expected $expected-dimensional query points, got $got-dimensional"))
 

--- a/src/core/search.jl
+++ b/src/core/search.jl
@@ -229,7 +229,7 @@ Returns `false` for short vectors (length < K) since LinearBinarySearch offers n
 
 False positive rate: 1/K! ≈ 2.5e-5 for K=8 (random data appearing sorted in first K elements).
 """
-@inline function _is_likely_monotone(xq::AbstractVector{<:Real}, ::Val{K} = Val(8)) where {K}
+@inline function _is_likely_monotone(xq::AbstractArray{<:Real}, ::Val{K} = Val(8)) where {K}
     n = length(xq)
     n < K && return false
     # Single-pass direction tracking: state ∈ {-1, 0, 1}.
@@ -294,7 +294,7 @@ end
 @inline _resolve_search_policy(::AutoSearch, xq, ::Base.RefValue{Int}) = LinearBinarySearch()
 
 # AutoSearch + no hint + vector → adaptive per prefix monotonicity check.
-@inline function _resolve_search_policy(::AutoSearch, xq::AbstractVector{<:Real}, ::Nothing)
+@inline function _resolve_search_policy(::AutoSearch, xq::AbstractArray{<:Real}, ::Nothing)
     return _is_likely_monotone(xq) ? LinearBinarySearch() : BinarySearch()
 end
 

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -653,7 +653,7 @@ exact `_CachedRange`s and Vectors use `lo/hi` / `first/last`) and is
 partial-sign-safe under ForwardDiff. Throw message uses `first(x)/last(x)` —
 exact endpoints, not the widened bracket.
 """
-@inline function _check_domain(x::AbstractVector, xi::AbstractVector{<:Real}, ::NoExtrap, dim::Int = 0)
+@inline function _check_domain(x::AbstractVector, xi::AbstractArray{<:Real}, ::NoExtrap, dim::Int = 0)
     @boundscheck _is_all_inbounds(x, xi) || _throw_batch_oob(x, xi, dim)
     return InBounds()
 end
@@ -665,7 +665,7 @@ end
 # on its partial into a false exclusive promotion (→ no-cap OOB read).
 # Only the throws are `@boundscheck`-elidable; the promotion is build-mode independent.
 @inline function _check_domain(
-        x::_CachedRange{T, Tinv, Tag}, xi::AbstractVector{<:Real}, ::NoExtrap, dim::Int = 0
+        x::_CachedRange{T, Tinv, Tag}, xi::AbstractArray{<:Real}, ::NoExtrap, dim::Int = 0
     ) where {T, Tinv, Tag <: _AbstractUnitStep}
     isempty(xi) && return InBounds()
     lo, hi = _domain_bounds(x)
@@ -676,7 +676,7 @@ end
     return _lt(mx, hip) ? InBounds(last = :exclusive) : InBounds()
 end
 
-@noinline function _throw_batch_oob(x::AbstractVector, xi::AbstractVector{<:Real}, dim::Int = 0)
+@noinline function _throw_batch_oob(x::AbstractVector, xi::AbstractArray{<:Real}, dim::Int = 0)
     qmin, qmax = minimum(xi), maximum(xi)
     x_min = _extract_primal(first(x))
     x_max = _extract_primal(last(x))
@@ -684,13 +684,13 @@ end
 end
 
 "No-op vector domain check for non-NoExtrap modes: pass-through extrap."
-@inline _check_domain(::AbstractVector, ::AbstractVector{<:Real}, extrap::AbstractExtrap) = extrap
+@inline _check_domain(::AbstractVector, ::AbstractArray{<:Real}, extrap::AbstractExtrap) = extrap
 
 # Closed-domain batch fast path: every OOB policy (`ClampExtrap`, `FillExtrap`,
 # `WrapExtrap`) treats `[first(x), last(x)]` as the in-domain interval, so they
 # share one batch promotion to `InBounds()`.
 @inline function _check_domain(
-        x::AbstractVector, xi::AbstractVector{<:Real},
+        x::AbstractVector, xi::AbstractArray{<:Real},
         e::Union{ClampExtrap, FillExtrap, WrapExtrap}
     )
     return _is_all_inbounds(x, xi) ? InBounds() : e
@@ -699,7 +699,7 @@ end
 # Unit-step twin: original extrap (any OOB) / exclusive-last (strictly below `last`)
 # / closed (touches `last`). Primal extrema — see the NoExtrap twin.
 @inline function _check_domain(
-        x::_CachedRange{T, Tinv, Tag}, xi::AbstractVector{<:Real},
+        x::_CachedRange{T, Tinv, Tag}, xi::AbstractArray{<:Real},
         e::Union{ClampExtrap, FillExtrap, WrapExtrap}
     ) where {T, Tinv, Tag <: _AbstractUnitStep}
     isempty(xi) && return InBounds()
@@ -760,7 +760,7 @@ the OOB slow-path, so this form stays preferred even post-1.10-LTS.
 # partial sign at equal primals, so a Float query at the boundary against a Dual
 # grid endpoint must classify on primal alone (see test/ext/test_linear_dual_grid.jl).
 # Routes through `_domain_bounds` (widened bracket in one place); `&&` short-circuits.
-@inline function _is_all_inbounds(x::AbstractVector, queries::AbstractVector{<:Real})
+@inline function _is_all_inbounds(x::AbstractVector, queries::AbstractArray{<:Real})
     isempty(queries) && return true
     lo, hi = _domain_bounds(x)
     # `_ge`/`_le` promote-compare (see search.jl): dodge Base's exact mixed

--- a/src/cubic/cubic_eval.jl
+++ b/src/cubic/cubic_eval.jl
@@ -122,11 +122,11 @@ end
 
 "Vector loop for cubic spline. Accepts any Real query type (AD-compatible)."
 @inline function _cubic_vector_loop!(
-        output::AbstractVector,
+        output::AbstractArray,
         cache::CubicSplineCache{Tg},
         y::AbstractVector{Tv},
         z::AbstractVector,
-        x_query::AbstractVector{<:Real},
+        x_query::AbstractArray{<:Real},
         ev::E,
         op::O,
         searcher::P
@@ -142,11 +142,11 @@ end
 end
 
 @inline function _cubic_vector_loop_inner!(
-        output::AbstractVector,
+        output::AbstractArray,
         cache::CubicSplineCache{Tg},
         y::AbstractVector{Tv},
         z::AbstractVector,
-        x_query::AbstractVector{<:Real},
+        x_query::AbstractArray{<:Real},
         ev::E,
         op::O,
         searcher::P

--- a/src/cubic/cubic_oneshot.jl
+++ b/src/cubic/cubic_oneshot.jl
@@ -29,16 +29,16 @@ Thread-safe: workspaces allocated from task-local pool.
 - `search::AbstractSearchPolicy=AutoSearch()`: Search algorithm for interval finding
 """
 @inline @with_pool pool function cubic_interp!(
-        output::AbstractVector,
+        output::AbstractArray,
         cache::CubicSplineCache{Tg, X, F, BC},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tq};
+        x_query::AbstractArray{Tq};
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
     ) where {Tg, Tv, Tq <: Real, X, F, BC}
     @assert length(y) == length(cache.x) "y length must match cache grid"
-    @assert length(output) == length(x_query) "output length must match x_query"
+    _check_query_output_size(output, x_query)
 
     Tz = _promote_eltype(_coeff_op, eltype(cache.x), Tv)
     z = acquire!(pool, Tz, length(y))
@@ -72,10 +72,10 @@ Type-Free design: handles both concrete (Deriv1{T}) and lazy (PolyFit{D}) types.
 - Solve uses original BC for proper RHS materialization (PolyFit materializes via compute_rhs!)
 """
 @inline @with_pool pool function _cubic_interp_bcpair!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector,
-        x_query::AbstractVector{<:Real},
+        x_query::AbstractArray{<:Real},
         bc::BCPair{L, R},
         extrap::AbstractExtrap,
         autocache::Bool,
@@ -83,7 +83,7 @@ Type-Free design: handles both concrete (Deriv1{T}) and lazy (PolyFit{D}) types.
         searcher::S
     ) where {Tg, L <: PointBC, R <: PointBC, O <: AbstractEvalOp, S <: Searcher}
     @assert length(y) == length(x) "y length must match x"
-    @assert length(output) == length(x_query) "output length must match x_query"
+    _check_query_output_size(output, x_query)
 
     # Cache uses structural equivalent (PolyFit → Deriv1 via _cache_bc_pair internally).
     # Value-matched `Tg_eff` (Int grid + Float32 data → Float32) selects the data-aware
@@ -183,16 +183,16 @@ Thread-safe: uses _get_cubic_cache + @with_pool pattern.
 Pool-based exclusive extension: zero-alloc after warmup.
 """
 @inline @with_pool pool function _cubic_interp_periodic!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector,
-        x_query::AbstractVector{<:Real},
+        x_query::AbstractArray{<:Real},
         bc::PeriodicBC,
         autocache::Bool,
         op::O,
         searcher::S
     ) where {Tg, O <: AbstractEvalOp, S <: Searcher}
-    @assert length(output) == length(x_query) "output length must match x_query"
+    _check_query_output_size(output, x_query)
 
     cache, y_p, z = _cubic_periodic_solve!(pool, x, y, bc, autocache)
 
@@ -237,10 +237,10 @@ end
 In-place cubic spline interpolation with optional automatic caching.
 """
 @inline function cubic_interp!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{<:Real};
+        x_query::AbstractArray{<:Real};
         bc::AbstractBC = CubicFit(),
         extrap::AbstractExtrap = NoExtrap(),
         autocache::Bool = true,
@@ -291,13 +291,13 @@ vals = cubic_interp(cache, y, sorted_queries; search=LinearBinarySearch(linear_w
 function cubic_interp(
         cache::CubicSplineCache{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tq};
+        x_query::AbstractArray{Tq};
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
     ) where {Tg, Tv, Tq <: Real}
     Tr = _promote_eltype(_interp_op, eltype(cache.x), Tv, Tq)
-    output = Vector{Tr}(undef, length(x_query))
+    output = _alloc_query_output(Tr, x_query)
     cubic_interp!(output, cache, y, x_query; extrap = extrap, deriv = deriv, search = search)
     return output
 end
@@ -332,7 +332,7 @@ vals = cubic_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_windo
 function cubic_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{<:Real};
+        x_query::AbstractArray{<:Real};
         bc::AbstractBC = CubicFit(),
         extrap::AbstractExtrap = NoExtrap(),
         autocache::Bool = true,
@@ -342,7 +342,7 @@ function cubic_interp(
     ) where {Tg, Tv}
     Tq = eltype(x_query)
     Tr = _promote_eltype(_interp_op, Tg, Tv, Tq)
-    output = Vector{Tr}(undef, length(x_query))
+    output = _alloc_query_output(Tr, x_query)
     cubic_interp!(output, x, y, x_query; bc, extrap, autocache, deriv, search, hint)
     return output
 end

--- a/src/cubic/nd/cubic_nd_interpolant.jl
+++ b/src/cubic/nd/cubic_nd_interpolant.jl
@@ -167,17 +167,17 @@ end
     cubic_interp(grids, data, (q,); kwargs...)
 
 # Batch one-shot (bare vector; the SoA `(xv,)` form below unwraps into it).
-@inline function cubic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...)
+@inline function cubic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractArray{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...)
     coeffs isa OnTheFly && return _cubic_interp_nd_oneshot_alloc(grids, data, q; coeffs, kwargs...)
     return cubic_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 end
-@inline function cubic_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...)
+@inline function cubic_interp!(output::AbstractArray, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractArray{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...)
     coeffs isa OnTheFly && return _cubic_interp_nd_oneshot_batch!(output, grids, data, q; coeffs, kwargs...)
     return cubic_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 end
-@inline cubic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+@inline cubic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractArray}; kwargs...) =
     cubic_interp(grids, data, only(q); kwargs...)
-@inline cubic_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+@inline cubic_interp!(output::AbstractArray, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractArray}; kwargs...) =
     cubic_interp!(output, grids, data, only(q); kwargs...)
 
 # OnTheFly is handled in cubic_interp() above (delegates to _build_hetero_nd).

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -90,7 +90,7 @@ function _cubic_interp_nd_oneshot_alloc(
     _, Tg, _, _ = _nd_promote_grids(grids, data)
     Tq = _query_eltype(queries)
     Tr = _promote_eltype(_interp_op, Tg, Tv, Tq)
-    output = Vector{Tr}(undef, _query_length(queries))
+    output = _alloc_query_output(Tr, queries)
     _cubic_interp_nd_oneshot_batch!(output, grids, data, queries; deriv, bc, extrap, search, coeffs, hint)
     return output
 end
@@ -182,7 +182,7 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
 `extraps_val` must be a pre-resolved tuple of concrete `AbstractExtrap` instances.
 """
 @with_pool pool function _cubic_interp_nd_oneshot_batch!(
-        output::AbstractVector,
+        output::AbstractArray,
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         queries,
@@ -195,7 +195,7 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
     # Resolve here so the fresh Ref tuple stays local to this frame (stack-elidable).
     policies, hints = _resolve_oneshot_search_nd(search, queries, hint, Val(N))
     nq = _query_length(queries)
-    length(output) == nq || _throw_query_output_mismatch(nq, length(output))
+    _check_query_output_size(output, queries)
     _query_validate(queries)
 
     # Build phase (same as scalar, done once)
@@ -246,11 +246,11 @@ Writes results into pre-allocated `output` vector.
 """
 # Public ND in-place batch one-shot (N≥2; N=1 is intercepted by the collapse method
 # below and only reaches here via the OnTheFly branch, which has no 1D equivalent).
-@inline cubic_interp!(output::AbstractVector, grids::NTuple{N, AbstractVector}, data::AbstractArray{<:Any, N}, queries; kwargs...) where {N} =
+@inline cubic_interp!(output::AbstractArray, grids::NTuple{N, AbstractVector}, data::AbstractArray{<:Any, N}, queries; kwargs...) where {N} =
     _cubic_interp_nd_oneshot_batch!(output, grids, data, queries; kwargs...)
 
 function _cubic_interp_nd_oneshot_batch!(
-        output::AbstractVector,
+        output::AbstractArray,
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         queries;

--- a/src/derivative_view.jl
+++ b/src/derivative_view.jl
@@ -308,30 +308,43 @@ end
     return d.parent(output, xq; deriv = _deriv_kw(Val(Order)), kwargs...)
 end
 
-# In-place ND batch (AoS/SoA/etc.) => shaped output. The generic `queries` argument
-# needs the three ND-specialized tie-breakers below so that every intersection with
-# the all-ITP methods has a unique most-specific winner (Aqua-verified).
+# In-place ND batch (AoS/SoA/etc.) => shaped output. The generic `queries`
+# argument needs the three ND-specialized tie-breakers below so that every
+# intersection with the all-ITP in-place methods has a unique most-specific
+# winner (Aqua-verified — removing any one reintroduces an ambiguity).
 @inline function (d::DerivativeView{Order, ITP})(
         output::AbstractArray, queries; deriv = nothing, kwargs...
     ) where {Order, ITP <: AbstractInterpolantND}
     _check_no_deriv_override(Val(Order), deriv)
     return d.parent(output, queries; deriv = _deriv_kw(Val(Order)), kwargs...)
 end
+
+# The three tie-breakers below exist SOLELY to disambiguate dispatch against the
+# all-ITP `(AbstractArray,::Real)` / `(AbstractVector,::AbstractVector{<:Real})` /
+# `(AbstractArray,::AbstractArray{<:Real})` in-place forms. A bare Real scalar or
+# Real array is never a valid N-D point query, so they reject up front rather than
+# forward an ill-typed query into the parent (whose handling of it is undefined).
+@noinline _throw_nd_point_query_required() = throw(
+    ArgumentError(
+        "an N-D DerivativeView requires N-D point queries (a coordinate tuple, an AoS array " *
+            "of point tuples, or an SoA tuple of coordinate arrays); a bare Real scalar or Real array is not valid"
+    )
+)
 @inline function (d::DerivativeView{Order, ITP})(
-        out::AbstractArray, xq::Real; deriv = nothing, kwargs...
+        ::AbstractArray, ::Real; deriv = nothing, kwargs...
     ) where {Order, ITP <: AbstractInterpolantND}
     _check_no_deriv_override(Val(Order), deriv)
-    return d.parent(out, xq; deriv = _deriv_kw(Val(Order)), kwargs...)
+    return _throw_nd_point_query_required()
 end
 @inline function (d::DerivativeView{Order, ITP})(
-        output::AbstractVector, xq::AbstractVector{<:Real}; deriv = nothing, kwargs...
+        ::AbstractVector, ::AbstractVector{<:Real}; deriv = nothing, kwargs...
     ) where {Order, ITP <: AbstractInterpolantND}
     _check_no_deriv_override(Val(Order), deriv)
-    return d.parent(output, xq; deriv = _deriv_kw(Val(Order)), kwargs...)
+    return _throw_nd_point_query_required()
 end
 @inline function (d::DerivativeView{Order, ITP})(
-        output::AbstractArray, xq::AbstractArray{<:Real}; deriv = nothing, kwargs...
+        ::AbstractArray, ::AbstractArray{<:Real}; deriv = nothing, kwargs...
     ) where {Order, ITP <: AbstractInterpolantND}
     _check_no_deriv_override(Val(Order), deriv)
-    return d.parent(output, xq; deriv = _deriv_kw(Val(Order)), kwargs...)
+    return _throw_nd_point_query_required()
 end

--- a/src/derivative_view.jl
+++ b/src/derivative_view.jl
@@ -297,3 +297,41 @@ end
     _check_no_deriv_override(Val(Order), deriv)
     return d.parent(out, xq; deriv = _deriv_kw(Val(Order)), kwargs...)
 end
+
+# In-place shaped array query => same-shape array output (1D parents + the ND
+# fallback below). All-ITP; disjoint from the series-scalar `(AbstractArray, Real)`
+# above and less specific than the `(AbstractVector, AbstractVector{<:Real})` form.
+@inline function (d::DerivativeView{Order, ITP})(
+        output::AbstractArray, xq::AbstractArray{<:Real}; deriv = nothing, kwargs...
+    ) where {Order, ITP}
+    _check_no_deriv_override(Val(Order), deriv)
+    return d.parent(output, xq; deriv = _deriv_kw(Val(Order)), kwargs...)
+end
+
+# In-place ND batch (AoS/SoA/etc.) => shaped output. The generic `queries` argument
+# needs the three ND-specialized tie-breakers below so that every intersection with
+# the all-ITP methods has a unique most-specific winner (Aqua-verified).
+@inline function (d::DerivativeView{Order, ITP})(
+        output::AbstractArray, queries; deriv = nothing, kwargs...
+    ) where {Order, ITP <: AbstractInterpolantND}
+    _check_no_deriv_override(Val(Order), deriv)
+    return d.parent(output, queries; deriv = _deriv_kw(Val(Order)), kwargs...)
+end
+@inline function (d::DerivativeView{Order, ITP})(
+        out::AbstractArray, xq::Real; deriv = nothing, kwargs...
+    ) where {Order, ITP <: AbstractInterpolantND}
+    _check_no_deriv_override(Val(Order), deriv)
+    return d.parent(out, xq; deriv = _deriv_kw(Val(Order)), kwargs...)
+end
+@inline function (d::DerivativeView{Order, ITP})(
+        output::AbstractVector, xq::AbstractVector{<:Real}; deriv = nothing, kwargs...
+    ) where {Order, ITP <: AbstractInterpolantND}
+    _check_no_deriv_override(Val(Order), deriv)
+    return d.parent(output, xq; deriv = _deriv_kw(Val(Order)), kwargs...)
+end
+@inline function (d::DerivativeView{Order, ITP})(
+        output::AbstractArray, xq::AbstractArray{<:Real}; deriv = nothing, kwargs...
+    ) where {Order, ITP <: AbstractInterpolantND}
+    _check_no_deriv_override(Val(Order), deriv)
+    return d.parent(output, xq; deriv = _deriv_kw(Val(Order)), kwargs...)
+end

--- a/src/gridded/gridded_dispatch.jl
+++ b/src/gridded/gridded_dispatch.jl
@@ -149,9 +149,8 @@ end
 
 # Default (non-separable) arm: first ask the shared method dispatcher whether
 # this interpolant can use a separable GriddedQuery kernel. If not, use the
-# shared point-wise batch core writing through a flat, aliasing view of the N-D
-# output (GriddedQuery unravels column-major, so linear-index fills land at the
-# right N-D position).
+# shared point-wise batch core, writing directly into the N-D output (GriddedQuery
+# unravels column-major, so linear-index fills land at the right N-D position).
 @inline function _gridded_eval_itp!(
         out::AbstractArray{<:Any, N},
         itp::AbstractInterpolantND{Tg, Tv, N},
@@ -162,7 +161,7 @@ end
         hint
     ) where {Tg, Tv, N}
     _gridded_eval_itp_methods!(out, itp, gq, ops, extraps, _gridded_methods(itp)) && return out
-    return _nd_batch_pointwise!(vec(out), itp, gq, ops, extraps, search, hint)
+    return _nd_batch_pointwise!(out, itp, gq, ops, extraps, search, hint)
 end
 
 # ============================================================================

--- a/src/hermite/hermite_eval.jl
+++ b/src/hermite/hermite_eval.jl
@@ -102,11 +102,11 @@ end
 # more robust than relying on LLVM loop unswitching, which can give up on
 # union splitting when the inner kernel exceeds heuristic size thresholds.
 @inline function _hermite_vector_loop!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         dy::AbstractVector,
-        xq::AbstractVector{<:Real},
+        xq::AbstractArray{<:Real},
         extrap::E,
         deriv::O,
         searcher::P
@@ -116,11 +116,11 @@ end
 end
 
 @inline function _hermite_vector_loop_inner!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         dy::AbstractVector,
-        xq::AbstractVector{<:Real},
+        xq::AbstractArray{<:Real},
         extrap::E,
         deriv::O,
         searcher::P
@@ -227,11 +227,11 @@ end
 # resolves domain, inner sees concrete `extrap` (see pre-baked-slopes
 # variant above for rationale).
 @inline function _hermite_vector_loop!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         sm::AbstractSlopeMethod,
-        xq::AbstractVector{<:Real},
+        xq::AbstractArray{<:Real},
         extrap::E,
         deriv::O,
         searcher::P
@@ -241,11 +241,11 @@ end
 end
 
 @inline function _hermite_vector_loop_inner!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         sm::AbstractSlopeMethod,
-        xq::AbstractVector{<:Real},
+        xq::AbstractArray{<:Real},
         extrap::E,
         deriv::O,
         searcher::P

--- a/src/hermite/hermite_oneshot.jl
+++ b/src/hermite/hermite_oneshot.jl
@@ -79,7 +79,8 @@ end
     hermite_interp(x, y, dy, x_query; extrap=NoExtrap(), deriv=EvalValue(), search=AutoSearch(), hint=nothing)
 
 Cubic Hermite interpolation at multiple query points using user-supplied slopes.
-Returns `Vector` of interpolated values.
+Returns an `Array` of interpolated values matching the query's shape
+(a `Vector` for a vector query, a `Matrix` for a matrix query).
 """
 function hermite_interp(
         x::AbstractVector{Tg},

--- a/src/hermite/hermite_oneshot.jl
+++ b/src/hermite/hermite_oneshot.jl
@@ -51,11 +51,11 @@ end
 In-place cubic Hermite interpolation using user-supplied slopes.
 """
 function hermite_interp!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         dy::AbstractVector,
-        x_query::AbstractVector{Tq};
+        x_query::AbstractArray{Tq};
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
@@ -64,7 +64,7 @@ function hermite_interp!(
     x = _resolve_axis(x, _hermite_grid_float(Tg, Tv, eltype(dy)))
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
     @boundscheck length(dy) == length(x) || _throw_length_mismatch(length(x), length(dy), "x", "dy")
-    @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
+    _check_query_output_size(output, x_query)
 
     searcher = _resolve_search(x, x_query, search, hint)
     extrap = _resolve_extrap(extrap, x)
@@ -85,7 +85,7 @@ function hermite_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         dy::AbstractVector,
-        x_query::AbstractVector{Tq};
+        x_query::AbstractArray{Tq};
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch(),
@@ -100,7 +100,7 @@ function hermite_interp(
         _promote_eltype(_interp_op, Tg_p, Tv, Tq),
         _promote_eltype(_interp_op, Tg_p, eltype(dy), Tq),
     )
-    output = Vector{Tr}(undef, length(x_query))
+    output = _alloc_query_output(Tr, x_query)
     hermite_interp!(output, x, y, dy, x_query; extrap = extrap, deriv = deriv, search = search, hint = hint)
     return output
 end

--- a/src/hermite/nd/hermite_nd_oneshot.jl
+++ b/src/hermite/nd/hermite_nd_oneshot.jl
@@ -65,7 +65,7 @@ function hermite_interp(
     Tg = _promote_grid_float(_promote_grid_eltype(grids), promote_type(Tv, Tv_part))
     Tq = _query_eltype(queries)
     Tr = _promote_eltype(_interp_op, Tg, promote_type(Tv, Tv_part), Tq)
-    output = Vector{Tr}(undef, _query_length(queries))
+    output = _alloc_query_output(Tr, queries)
     hermite_interp!(
         output, grids, data, partials, queries;
         deriv, bc, extrap, search, hint
@@ -79,7 +79,7 @@ end
 In-place batch ND cubic Hermite one-shot. Zero-alloc workspace after warmup.
 """
 function hermite_interp!(
-        output::AbstractVector,
+        output::AbstractArray,
         grids::Tuple{Vararg{AbstractVector, N}},
         data::AbstractArray{<:Any, N},
         partials::HermitePartials{N},
@@ -184,7 +184,7 @@ end
 # Build pass (pack + extend + per-axis extrap resolution + InBounds promotion)
 # happens ONCE; then a tight per-query eval loop writes into `output`.
 @with_pool pool function _hermite_interp_nd_oneshot_batch!(
-        output::AbstractVector,
+        output::AbstractArray,
         grids::Tuple{Vararg{AbstractVector, N}},
         data::AbstractArray{Tv, N},
         partials::HermitePartials{N, Tv, K},
@@ -197,7 +197,7 @@ end
     ) where {Tv, N, K}
     policies, hints = _resolve_oneshot_search_nd(search, queries, hint, Val(N))
     nq = _query_length(queries)
-    length(output) == nq || _throw_query_output_mismatch(nq, length(output))
+    _check_query_output_size(output, queries)
     _query_validate(queries)
 
     # `bcs_post` (3rd return) is unused here — see the scalar path note.

--- a/src/hetero/hetero_oneshot.jl
+++ b/src/hetero/hetero_oneshot.jl
@@ -65,7 +65,7 @@ end
 # ========================================
 
 @with_pool pool function _interp_nd_hetero_oneshot_batch!(
-        output::AbstractVector,
+        output::AbstractArray,
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{<:Any, N},
         queries,
@@ -454,19 +454,23 @@ function _interp_nd_oneshot_batch_public!(
         hint,
     ) where {N}
     method_tuple = _method_tuple(method, Val(N))
-    # Separable fast path (before any flattening, so the N-D output reaches the
-    # gridded kernel without a reshape): true iff a gridded evaluator exists for
-    # this (query, method) tuple.
+    # A GridIdx query mixes free arrays with pinned scalar indices, so `_query_size`
+    # does not describe it; the GridIdx branch pre-slices the pinned axes and its
+    # reduced sub-problem validates its own length. Every other query gets the exact-
+    # size gate before any write (including the separable fast path): a shaped query
+    # requires a matching-shape output, and a length-only match that silently flattened
+    # a matrix query into a vector sink is rejected.
+    is_grididx = queries isa Tuple && _has_grididx(typeof(queries))
+    is_grididx || _check_query_output_size(output, queries)
+    # Separable fast path: fills the N-D output directly (no reshape). True iff a
+    # gridded evaluator exists for this (query, method) tuple.
     _try_gridded_separable!(output, grids, data, queries, method_tuple, extrap, deriv, coeffs) && return output
-    # The batch cores fill by LINEAR index, so a shaped output (e.g. an N-D array
-    # for a GriddedQuery) is written through a flat 1-D view. `vec`/`reshape`
-    # aliases (never copies), so the caller's array is filled in place; we hand
-    # back the caller's original `output`, not the flat view.
-    flat = output isa AbstractVector ? output : vec(output)
-    # Mixed queries with GridIdx → delegate to GridIdx batch path. Forward
-    # `coeffs` so the reduced (post-slice) sub-problem honors and validates the
-    # caller's strategy choice rather than silently falling back to AutoCoeffs.
-    if queries isa Tuple && _has_grididx(typeof(queries))
+    # Mixed queries with GridIdx → delegate to GridIdx batch path. Forward `coeffs`
+    # so the reduced (post-slice) sub-problem honors the caller's strategy. That core
+    # is vector-typed, so a shaped output is flattened through a zero-copy `vec` view
+    # HERE only (niche path); the main dispatch below writes the N-D output directly.
+    if is_grididx
+        flat = output isa AbstractVector ? output : vec(output)
         _interp_batch_with_grididx!(
             flat, grids, data, queries;
             method = method, deriv = deriv, extrap = extrap,
@@ -479,7 +483,9 @@ function _interp_nd_oneshot_batch_public!(
     # AutoCoeffs path never trips this because resolution returns OnTheFly for
     # local methods. Mirrors the scalar `interp` validation at line 309.
     _validate_nd_coeffs(coeffs_resolved, method_tuple)
-    _interp_nd_oneshot_batch_dispatch!(flat, grids, data, queries, method_tuple, deriv, extrap, search, hint, coeffs_resolved)
+    # Write directly into the (possibly N-D) output — the batch cores fill by linear
+    # index and array/GriddedQuery queries unravel column-major.
+    _interp_nd_oneshot_batch_dispatch!(output, grids, data, queries, method_tuple, deriv, extrap, search, hint, coeffs_resolved)
     return output
 end
 

--- a/src/hetero/interp_1d.jl
+++ b/src/hetero/interp_1d.jl
@@ -119,7 +119,8 @@ end
 """
     interp(x::AbstractVector, y::AbstractVector, queries::AbstractVector{<:Real}; method, deriv=EvalValue(), extrap=NoExtrap(), search=AutoSearch())
 
-Allocating one-shot 1D interpolation at multiple points. Returns a `Vector`.
+Allocating one-shot 1D interpolation at multiple points. Returns an `Array`
+matching the query's shape (a `Vector` for a vector query, a `Matrix` for a matrix query).
 Equivalent to the dedicated 1D batch call (e.g. `cubic_interp(x, y, queries)`).
 """
 @inline function interp(

--- a/src/hetero/interp_1d.jl
+++ b/src/hetero/interp_1d.jl
@@ -125,7 +125,7 @@ Equivalent to the dedicated 1D batch call (e.g. `cubic_interp(x, y, queries)`).
 @inline function interp(
         x::AbstractVector,
         y::AbstractVector,
-        queries::AbstractVector{<:Real};
+        queries::AbstractArray{<:Real};
         method::AbstractInterpMethod,
         deriv::DerivOp = EvalValue(),
         extrap::AbstractExtrap = NoExtrap(),
@@ -142,10 +142,10 @@ In-place one-shot 1D interpolation at multiple points. Writes into `output`.
 Equivalent to the dedicated 1D in-place call (e.g. `cubic_interp!(output, x, y, queries)`).
 """
 @inline function interp!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector,
         y::AbstractVector,
-        queries::AbstractVector{<:Real};
+        queries::AbstractArray{<:Real};
         method::AbstractInterpMethod,
         deriv::DerivOp = EvalValue(),
         extrap::AbstractExtrap = NoExtrap(),

--- a/src/hetero/local_hermite_nd_forward.jl
+++ b/src/hetero/local_hermite_nd_forward.jl
@@ -73,14 +73,14 @@ end
     pchip_interp(grids, data, (q,); kwargs...)
 
 # N=1 batch one-shot → lean 1D batch one-shot. See linear_nd_interpolant.jl.
-@inline pchip_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+@inline pchip_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractArray{<:Real}; kwargs...) =
     pchip_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
-@inline pchip_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+@inline pchip_interp!(output::AbstractArray, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractArray{<:Real}; kwargs...) =
     pchip_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
-@inline pchip_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+@inline pchip_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractArray}; kwargs...) =
     pchip_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
-@inline pchip_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+@inline pchip_interp!(output::AbstractArray, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractArray}; kwargs...) =
     pchip_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
 
 @inline function pchip_interp(
@@ -140,14 +140,14 @@ end
     cardinal_interp(grids, data, (q,); kwargs...)
 
 # N=1 batch one-shot → lean 1D batch one-shot. See linear_nd_interpolant.jl.
-@inline cardinal_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+@inline cardinal_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractArray{<:Real}; kwargs...) =
     cardinal_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
-@inline cardinal_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+@inline cardinal_interp!(output::AbstractArray, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractArray{<:Real}; kwargs...) =
     cardinal_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
-@inline cardinal_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+@inline cardinal_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractArray}; kwargs...) =
     cardinal_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
-@inline cardinal_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+@inline cardinal_interp!(output::AbstractArray, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractArray}; kwargs...) =
     cardinal_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
 
 @inline function cardinal_interp(
@@ -209,14 +209,14 @@ end
     akima_interp(grids, data, (q,); kwargs...)
 
 # N=1 batch one-shot → lean 1D batch one-shot. See linear_nd_interpolant.jl.
-@inline akima_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+@inline akima_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractArray{<:Real}; kwargs...) =
     akima_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
-@inline akima_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+@inline akima_interp!(output::AbstractArray, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractArray{<:Real}; kwargs...) =
     akima_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
-@inline akima_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+@inline akima_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractArray}; kwargs...) =
     akima_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
-@inline akima_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+@inline akima_interp!(output::AbstractArray, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractArray}; kwargs...) =
     akima_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
 
 @inline function akima_interp(

--- a/src/hetero/local_hermite_nd_forward.jl
+++ b/src/hetero/local_hermite_nd_forward.jl
@@ -106,7 +106,7 @@ end
 end
 
 @inline function pchip_interp!(
-        output::AbstractVector,
+        output::AbstractArray,
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{<:Any, N},
         queries;
@@ -175,7 +175,7 @@ end
 end
 
 @inline function cardinal_interp!(
-        output::AbstractVector,
+        output::AbstractArray,
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{<:Any, N},
         queries;
@@ -242,7 +242,7 @@ end
 end
 
 @inline function akima_interp!(
-        output::AbstractVector,
+        output::AbstractArray,
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{<:Any, N},
         queries;

--- a/src/linear/linear_interpolant.jl
+++ b/src/linear/linear_interpolant.jl
@@ -29,10 +29,10 @@ end
 # union-splitting the per-iter dispatch. Args must be fully typed — untyped
 # blocks SROA of RefHint's Ref (16 B/call alloc).
 @inline function _linear_vector_loop!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        xq::AbstractVector{<:Real},
+        xq::AbstractArray{<:Real},
         extrap::E,
         deriv::O,
         searcher::P
@@ -42,10 +42,10 @@ end
 end
 
 @inline function _linear_vector_loop_inner!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        xq::AbstractVector{<:Real},
+        xq::AbstractArray{<:Real},
         extrap::E,
         deriv::O,
         searcher::P

--- a/src/linear/linear_oneshot.jl
+++ b/src/linear/linear_oneshot.jl
@@ -57,10 +57,10 @@ function linear_interp! end
 # Unified in-place entry point. Handles promotion internally via _promote_itp_inputs,
 # so no separate Real/Mixed-type wrapper is needed (same pattern as the scalar API).
 function linear_interp!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector,
         y::AbstractVector,
-        x_targets::AbstractVector;
+        x_targets::AbstractArray;
         bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
@@ -68,7 +68,7 @@ function linear_interp!(
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     )
     @assert length(y) == length(x) "x and y must have same length"
-    @assert length(output) == length(x_targets) "output must match x_targets length"
+    _check_query_output_size(output, x_targets)
 
     # Surface-level BC-aware resolvers (zero-alloc reference wrapping):
     #   `_resolve_axis(x, bc)` shapes the axis (Range→`_CachedRange`, Vector→passthrough,
@@ -93,10 +93,10 @@ end
 # `NoExtrap` paths the return type is already `InBounds`, so this is a
 # no-op. Supports mixed types: Tg for grid, Tv for values.
 @inline function _linear_interp_loop!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector,
-        x_targets::AbstractVector,
+        x_targets::AbstractArray,
         extrap::AbstractExtrap,
         op::O,
         searcher::S
@@ -106,10 +106,10 @@ end
 end
 
 @inline function _linear_interp_loop_inner!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector,
-        x_targets::AbstractVector,
+        x_targets::AbstractArray,
         extrap::E,
         op::O,
         searcher::S
@@ -346,7 +346,7 @@ end
 function linear_interp(
         x::AbstractVector,
         y::AbstractVector,
-        x_targets::AbstractVector;
+        x_targets::AbstractArray;
         bc::AbstractBC = NoBC(),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
@@ -355,7 +355,7 @@ function linear_interp(
     )
     Tg = _promote_grid_float(eltype(x), eltype(y))
     T_out = _promote_eltype(_interp_op, Tg, eltype(y), eltype(x_targets))
-    output = Vector{T_out}(undef, length(x_targets))
+    output = _alloc_query_output(T_out, x_targets)
     linear_interp!(output, x, y, x_targets; bc, extrap, deriv, search, hint)
     return output
 end

--- a/src/linear/nd/linear_nd_interpolant.jl
+++ b/src/linear/nd/linear_nd_interpolant.jl
@@ -106,12 +106,12 @@ end
 # N=1 batch one-shot: a plain-vector query on a 1-tuple grid forwards to the lean 1D
 # batch one-shot (bit-identical value; skips the generic-N per-query machinery). Per-axis
 # 1-tuple kwargs unwrap to scalar.
-@inline linear_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+@inline linear_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractArray{<:Real}; kwargs...) =
     linear_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
-@inline linear_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; kwargs...) =
+@inline linear_interp!(output::AbstractArray, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractArray{<:Real}; kwargs...) =
     linear_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` unwraps to the 1D batch (same vectorized domain check).
-@inline linear_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+@inline linear_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractArray}; kwargs...) =
     linear_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
-@inline linear_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; kwargs...) =
+@inline linear_interp!(output::AbstractArray, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractArray}; kwargs...) =
     linear_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)

--- a/src/linear/nd/linear_nd_oneshot.jl
+++ b/src/linear/nd/linear_nd_oneshot.jl
@@ -75,7 +75,7 @@ end
 In-place batch one-shot ND multilinear evaluation.
 """
 function _linear_interp_nd_oneshot_batch!(
-        output::AbstractVector,
+        output::AbstractArray,
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         queries,
@@ -88,7 +88,7 @@ function _linear_interp_nd_oneshot_batch!(
     # Resolve here so the fresh Ref tuple stays local to this frame (stack-elidable).
     policies, hints = _resolve_oneshot_search_nd(search, queries, hint, Val(N))
     nq = _query_length(queries)
-    length(output) == nq || _throw_query_output_mismatch(nq, length(output))
+    _check_query_output_size(output, queries)
     _query_validate(queries)
     grids_eff = map(_resolve_axis, grids, bcs)
     extraps_eff = _resolve_extrap(extraps_val, bcs, grids_eff, data, Val(N))
@@ -171,7 +171,7 @@ function linear_interp(
     _, Tg, _, _ = _nd_promote_grids(grids, data)
     Tq = _query_eltype(queries)
     Tr = _promote_eltype(_interp_op, Tg, Tv, Tq)
-    output = Vector{Tr}(undef, _query_length(queries))
+    output = _alloc_query_output(Tr, queries)
     linear_interp!(output, grids, data, queries; bc, extrap, search, deriv, hint)
     return output
 end
@@ -188,7 +188,7 @@ Accepts any query format implementing the query protocol.
 Writes results into pre-allocated `output` vector.
 """
 function linear_interp!(
-        output::AbstractVector,
+        output::AbstractArray,
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         queries;

--- a/src/pchip/pchip_oneshot.jl
+++ b/src/pchip/pchip_oneshot.jl
@@ -39,10 +39,10 @@ end
 
 # Vector in-place
 @inline @with_pool pool function _pchip_interp_precompute!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector,
+        x_query::AbstractArray,
         bc::AbstractBC,
         extrap::AbstractExtrap,
         deriv::DerivOp,
@@ -50,7 +50,7 @@ end
         hint::Union{Nothing, Base.RefValue{Int}}
     ) where {Tg, Tv}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
-    @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
+    _check_query_output_size(output, x_query)
     x_eff, y_ext, bc_eff, extrap_eff = _periodic_extend_1d(x, y, bc, extrap)
 
     # Value-matched width: the dy buffer AND the slope arithmetic inside the
@@ -91,10 +91,10 @@ end
 
 # Vector in-place
 @inline function _pchip_interp_onthefly!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector,
+        x_query::AbstractArray,
         bc::AbstractBC,
         extrap::AbstractExtrap,
         deriv::DerivOp,
@@ -102,7 +102,7 @@ end
         hint::Union{Nothing, Base.RefValue{Int}}
     ) where {Tg, Tv}
     @boundscheck length(y) == length(x) || _throw_length_mismatch(length(x), length(y))
-    @boundscheck length(output) == length(x_query) || _throw_length_mismatch(length(x_query), length(output), "x_query", "output")
+    _check_query_output_size(output, x_query)
     x_eff = _resolve_axis(x, bc)
     y_eff = _resolve_data(y, bc)
 
@@ -157,10 +157,10 @@ end
 In-place PCHIP interpolation with monotone-preserving slopes.
 """
 @inline function pchip_interp!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tq};
+        x_query::AbstractArray{Tq};
         bc::AbstractBC = NoBC(),
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         extrap::AbstractExtrap = NoExtrap(),
@@ -185,7 +185,7 @@ PCHIP interpolation at multiple query points. Returns `Vector`.
 function pchip_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_query::AbstractVector{Tq};
+        x_query::AbstractArray{Tq};
         bc::AbstractBC = NoBC(),
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         extrap::AbstractExtrap = NoExtrap(),
@@ -194,7 +194,7 @@ function pchip_interp(
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, Tq <: Real}
     Tr = _promote_eltype(_interp_op, _promote_grid_float(Tg, Tv), Tv, Tq)
-    output = Vector{Tr}(undef, length(x_query))
+    output = _alloc_query_output(Tr, x_query)
     pchip_interp!(output, x, y, x_query; bc = bc, coeffs = coeffs, extrap = extrap, deriv = deriv, search = search, hint = hint)
     return output
 end

--- a/src/pchip/pchip_oneshot.jl
+++ b/src/pchip/pchip_oneshot.jl
@@ -180,7 +180,8 @@ end
 """
     pchip_interp(x, y, x_query; coeffs=PreCompute(), ...)
 
-PCHIP interpolation at multiple query points. Returns `Vector`.
+PCHIP interpolation at multiple query points. Returns an `Array`
+matching the query's shape (a `Vector` for a vector query).
 """
 function pchip_interp(
         x::AbstractVector{Tg},

--- a/src/quadratic/nd/quadratic_nd_interpolant.jl
+++ b/src/quadratic/nd/quadratic_nd_interpolant.jl
@@ -139,12 +139,12 @@ end
     quadratic_interp(grids, data, (q,); kwargs...)
 
 # N=1 batch one-shot → lean 1D batch one-shot (bit-identical). See linear_nd_interpolant.jl.
-@inline quadratic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...) =
+@inline quadratic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractArray{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...) =
     quadratic_interp(only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
-@inline quadratic_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractVector{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...) =
+@inline quadratic_interp!(output::AbstractArray, grids::Tuple{AbstractVector}, data::AbstractVector, q::AbstractArray{<:Real}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...) =
     quadratic_interp!(output, only(grids), data, q; _unwrap_nd_kwargs(values(kwargs))...)
 # Single-axis SoA `(xv,)` → 1D batch. See linear_nd_interpolant.jl.
-@inline quadratic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...) =
+@inline quadratic_interp(grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractArray}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...) =
     quadratic_interp(only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)
-@inline quadratic_interp!(output::AbstractVector, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractVector}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...) =
+@inline quadratic_interp!(output::AbstractArray, grids::Tuple{AbstractVector}, data::AbstractVector, q::Tuple{AbstractArray}; coeffs::AbstractCoeffStrategy = AutoCoeffs(), kwargs...) =
     quadratic_interp!(output, only(grids), data, only(q); _unwrap_nd_kwargs(values(kwargs))...)

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -74,7 +74,7 @@ Computes partials ONCE, then evaluates at all query points into `output`.
 Uses query protocol (`_query_length`, `_query_extract`) — works with any query format.
 """
 @with_pool pool function _quadratic_interp_nd_oneshot_batch!(
-        output::AbstractVector,
+        output::AbstractArray,
         grids::NTuple{N, AbstractVector{Tg}},
         data::AbstractArray{Tv, N},
         queries,
@@ -87,7 +87,7 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
     # Resolve here so the fresh Ref tuple stays local to this frame (stack-elidable).
     policies, hints = _resolve_oneshot_search_nd(search, queries, hint, Val(N))
     nq = _query_length(queries)
-    length(output) == nq || _throw_query_output_mismatch(nq, length(output))
+    _check_query_output_size(output, queries)
     _query_validate(queries)
 
     # Pool-backed per-axis cache — build phase + eval loop reuse h/inv_h.
@@ -201,7 +201,7 @@ function quadratic_interp(
     _, Tg, _, _ = _nd_promote_grids(grids, data)
     Tq = _query_eltype(queries)
     Tr = _promote_eltype(_interp_op, Tg, Tv, Tq)
-    output = Vector{Tr}(undef, _query_length(queries))
+    output = _alloc_query_output(Tr, queries)
     quadratic_interp!(output, grids, data, queries; deriv, bc, extrap, search, coeffs, hint)
     return output
 end
@@ -218,7 +218,7 @@ Accepts any query format implementing the query protocol.
 Writes results into pre-allocated `output` vector.
 """
 function quadratic_interp!(
-        output::AbstractVector,
+        output::AbstractArray,
         grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         queries;

--- a/src/quadratic/quadratic_interpolant.jl
+++ b/src/quadratic/quadratic_interpolant.jl
@@ -27,12 +27,12 @@ end
 # blocks SROA of RefHint's Ref (16 B/call alloc).
 # ─────────────────────────────────────────────────────────────
 @inline function _quadratic_vector_loop!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         a::AbstractVector{Tc},
         d::AbstractVector{Tc},
-        xq::AbstractVector{<:Real},
+        xq::AbstractArray{<:Real},
         extrap::E,
         deriv::O,
         searcher::P
@@ -42,12 +42,12 @@ end
 end
 
 @inline function _quadratic_vector_loop_inner!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
         a::AbstractVector{Tc},
         d::AbstractVector{Tc},
-        xq::AbstractVector{<:Real},
+        xq::AbstractArray{<:Real},
         extrap::E,
         deriv::O,
         searcher::P

--- a/src/quadratic/quadratic_oneshot.jl
+++ b/src/quadratic/quadratic_oneshot.jl
@@ -215,10 +215,10 @@ quadratic_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear
 ```
 """
 @with_pool pool function quadratic_interp!(
-        output::AbstractVector,
+        output::AbstractArray,
         x::AbstractVector{Tg},
         y::AbstractVector{Tv},
-        x_targets::AbstractVector{Tq};
+        x_targets::AbstractArray{Tq};
         bc::QuadraticBC = Left(QuadraticFit()),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
@@ -226,7 +226,7 @@ quadratic_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tv, Tq <: Real}
     @assert length(y) == length(x) "x and y must have same length"
-    @assert length(output) == length(x_targets) "output must match x_targets length"
+    _check_query_output_size(output, x_targets)
     @assert length(x) >= 2 "x must have at least 2 elements"
 
     # Value-matched pooled wrap — keeps the batch interior consistent with scalar.
@@ -270,7 +270,7 @@ vals = quadratic_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_w
 function quadratic_interp(
         x::AbstractVector{Tg},
         y::AbstractVector,
-        x_targets::AbstractVector{Tq};
+        x_targets::AbstractArray{Tq};
         bc::QuadraticBC = Left(QuadraticFit()),
         extrap::AbstractExtrap = NoExtrap(),
         deriv::DerivOp = EvalValue(),
@@ -278,7 +278,7 @@ function quadratic_interp(
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tq <: Real}
     Tr = _promote_eltype(_interp_op, _promote_grid_float(Tg, eltype(y)), eltype(y), Tq)
-    output = Vector{Tr}(undef, length(x_targets))
+    output = _alloc_query_output(Tr, x_targets)
     quadratic_interp!(output, x, y, x_targets; bc, extrap, deriv, search, hint)
     return output
 end

--- a/test/test_query_shape_preservation.jl
+++ b/test/test_query_shape_preservation.jl
@@ -672,3 +672,31 @@ end
         @test o == native
     end
 end
+
+# ============================================================
+# Phase 6 · Empty / degenerate shaped queries (design §10.1)
+# ============================================================
+@testitem "query shape: empty + degenerate shaped queries" begin
+    x = collect(range(0.0, 2π, 25))
+    y = sin.(x)
+    yb = collect(range(0.0, 1.0, 11))
+
+    # --- 1-D: empty matrix query → empty-shaped result ---
+    itp1 = cubic_interp(x, y)
+    qe = Matrix{Float64}(undef, 0, 3)
+    @test size(itp1(qe)) == (0, 3)
+    oe = Matrix{Float64}(undef, 0, 3)
+    @test itp1(oe, qe) === oe
+    @test itp1(Float64[]) == Float64[]                     # empty vector still a vector
+    @test_throws DimensionMismatch itp1(Matrix{Float64}(undef, 1, 3), qe)   # wrong-shape sink
+
+    # --- N-D: empty AoS matrix + empty SoA ---
+    data = [sin(a) * cos(b) for a in x, b in yb]
+    itp2 = linear_interp((x, yb), data)
+    q_aos_e = Matrix{NTuple{2, Float64}}(undef, 0, 2)
+    @test size(itp2(q_aos_e)) == (0, 2)
+    soa_e = (Matrix{Float64}(undef, 0, 2), Matrix{Float64}(undef, 0, 2))
+    @test size(itp2(soa_e)) == (0, 2)
+    oe2 = Matrix{Float64}(undef, 0, 2)
+    @test itp2(oe2, q_aos_e) === oe2
+end

--- a/test/test_query_shape_preservation.jl
+++ b/test/test_query_shape_preservation.jl
@@ -548,3 +548,63 @@ end
     # existing vector lane unchanged: 0 B warm
     @test measure(itp, out_vec, q12) <= ALLOC_THRESHOLD
 end
+
+# ============================================================
+# Phase 4 · One-shot 1-D core families (dedicated)
+# ============================================================
+# Reference = the vector one-shot path, reshaped.
+
+@testitem "query shape: one-shot 1-D core families" begin
+    x = collect(range(0.0, 2π, 25))
+    y = sin.(x)
+    dy = cos.(x)
+
+    q12 = collect(range(0.3, 6.0, 12))
+    q_mat = reshape(q12, 3, 4)
+
+    families = (
+        ("linear", q -> linear_interp(x, y, q), (o, q) -> linear_interp!(o, x, y, q)),
+        ("constant", q -> constant_interp(x, y, q), (o, q) -> constant_interp!(o, x, y, q)),
+        ("quadratic", q -> quadratic_interp(x, y, q), (o, q) -> quadratic_interp!(o, x, y, q)),
+        ("cubic", q -> cubic_interp(x, y, q), (o, q) -> cubic_interp!(o, x, y, q)),
+        ("hermite", q -> hermite_interp(x, y, dy, q), (o, q) -> hermite_interp!(o, x, y, dy, q)),
+    )
+
+    @testset "$name" for (name, f, f!) in families
+        ref = reshape(f(q12), 3, 4)
+
+        @testset "allocating preserves shape" begin
+            r = f(q_mat)
+            @test r isa Matrix && size(r) == (3, 4)
+            @test r == ref
+        end
+
+        @testset "in-place preserves shape" begin
+            o = Matrix{Float64}(undef, 3, 4)
+            @test f!(o, q_mat) === o
+            @test o == ref
+        end
+
+        @testset "exact-size rejection" begin
+            @test_throws DimensionMismatch f!(Vector{Float64}(undef, 12), q_mat)
+        end
+    end
+end
+
+@testitem "query shape: one-shot 1-D allocation parity" setup = [AllocConstants] begin
+    mL(o, x, y, q) = (linear_interp!(o, x, y, q); linear_interp!(o, x, y, q); @allocated linear_interp!(o, x, y, q))
+    mC(o, x, y, q) = (cubic_interp!(o, x, y, q); cubic_interp!(o, x, y, q); @allocated cubic_interp!(o, x, y, q))
+
+    x = collect(range(0.0, 2π, 25))
+    y = sin.(x)
+    q12 = collect(range(0.3, 6.0, 12))
+    q_mat = reshape(q12, 3, 4)
+    om = Matrix{Float64}(undef, 3, 4)
+    ov = Vector{Float64}(undef, 12)
+
+    # shaped 1-D one-shot in-place: 0 B warm (matrix); vector lane unchanged
+    @test mL(om, x, y, q_mat) <= ALLOC_THRESHOLD
+    @test mL(ov, x, y, q12) <= ALLOC_THRESHOLD
+    @test mC(om, x, y, q_mat) <= ALLOC_THRESHOLD
+    @test mC(ov, x, y, q12) <= ALLOC_THRESHOLD
+end

--- a/test/test_query_shape_preservation.jl
+++ b/test/test_query_shape_preservation.jl
@@ -14,74 +14,76 @@
 # reshaped: `reshape(itp(vec_of_points), sz)`. This pins the new shaped
 # result against the flat path bit-for-bit.
 #
-# Phase 1 covers the query-shape protocol + the persistent N-D quadrant.
+# Testitems are grouped by shared compilation surface (each @testitem is a
+# module that compiles fresh, so one-@testitem-per-case is slow); related
+# families live under logical @testsets inside a handful of testitems.
 
 # ------------------------------------------------------------
-# Phase 1 · Protocol: _query_size / _query_length / _query_extract / _query_eltype
+# Query-shape protocol + shaped-SoA validation (no interpolants — fast)
 # ------------------------------------------------------------
-@testitem "query shape: protocol size/length/extract/eltype" begin
-    import FastInterpolations: _query_size, _query_length, _query_extract, _query_eltype
+@testitem "query shape: protocol + SoA validation" begin
+    import FastInterpolations: _query_size, _query_length, _query_extract, _query_eltype,
+        _query_validate, _query_check_ndims
 
-    # --- AoS matrix of N-D points ---
-    pts12 = [(0.1 * k, 0.2 * k) for k in 1:12]
-    q_aos_mat = reshape(pts12, 3, 4)
-    q_aos_3d = reshape([(0.1 * k, 0.2 * k) for k in 1:12], 2, 2, 3)
+    @testset "protocol size/length/extract/eltype" begin
+        # --- AoS matrix of N-D points ---
+        pts12 = [(0.1 * k, 0.2 * k) for k in 1:12]
+        q_aos_mat = reshape(pts12, 3, 4)
+        q_aos_3d = reshape([(0.1 * k, 0.2 * k) for k in 1:12], 2, 2, 3)
 
-    @test _query_size(q_aos_mat) == (3, 4)
-    @test _query_size(q_aos_3d) == (2, 2, 3)
-    @test _query_length(q_aos_mat) == 12
-    @test _query_length(q_aos_mat) == prod(_query_size(q_aos_mat))     # length == prod(size)
-    # column-major linear extraction lands each point at its N-D slot
-    @test _query_extract(q_aos_mat, 5) == q_aos_mat[5]
+        @test _query_size(q_aos_mat) == (3, 4)
+        @test _query_size(q_aos_3d) == (2, 2, 3)
+        @test _query_length(q_aos_mat) == 12
+        @test _query_length(q_aos_mat) == prod(_query_size(q_aos_mat))     # length == prod(size)
+        # column-major linear extraction lands each point at its N-D slot
+        @test _query_extract(q_aos_mat, 5) == q_aos_mat[5]
 
-    # --- 1-D real matrix (each element one scalar coordinate) ---
-    q1 = reshape([0.1, 0.2, 0.3, 0.4], 2, 2)
-    @test _query_size(q1) == (2, 2)
-    @test _query_length(q1) == 4
-    @test _query_eltype(q1) == Float64
+        # --- 1-D real matrix (each element one scalar coordinate) ---
+        q1 = reshape([0.1, 0.2, 0.3, 0.4], 2, 2)
+        @test _query_size(q1) == (2, 2)
+        @test _query_length(q1) == 4
+        @test _query_eltype(q1) == Float64
 
-    # --- shaped SoA: tuple of coordinate matrices ---
-    qx = [0.1 0.2; 0.3 0.4]
-    qy = [0.5 0.6; 0.7 0.8]
-    @test _query_size((qx, qy)) == (2, 2)
-    @test _query_length((qx, qy)) == 4
-    @test _query_extract((qx, qy), 3) == (qx[3], qy[3])               # column-major pairwise
-    @test _query_eltype((qx, qy)) == Float64
+        # --- shaped SoA: tuple of coordinate matrices ---
+        qx = [0.1 0.2; 0.3 0.4]
+        qy = [0.5 0.6; 0.7 0.8]
+        @test _query_size((qx, qy)) == (2, 2)
+        @test _query_length((qx, qy)) == 4
+        @test _query_extract((qx, qy), 3) == (qx[3], qy[3])               # column-major pairwise
+        @test _query_eltype((qx, qy)) == Float64
 
-    # --- Vector queries unchanged (regression pin) ---
-    v = [0.1, 0.2, 0.3]
-    @test _query_size(v) == (3,)
-    @test _query_size([(0.1, 0.2), (0.3, 0.4)]) == (2,)              # vector AoS stays flat
-    @test _query_size(([1.0, 2.0], [3.0, 4.0])) == (2,)             # vector SoA stays flat
+        # --- Vector queries unchanged (regression pin) ---
+        v = [0.1, 0.2, 0.3]
+        @test _query_size(v) == (3,)
+        @test _query_size([(0.1, 0.2), (0.3, 0.4)]) == (2,)              # vector AoS stays flat
+        @test _query_size(([1.0, 2.0], [3.0, 4.0])) == (2,)             # vector SoA stays flat
+    end
+
+    @testset "shaped SoA validation + ndims" begin
+        qx = [0.1 0.2; 0.3 0.4]
+        qy = [0.5 0.6; 0.7 0.8]
+
+        # matching-size SoA: validation is a no-op, ndims recognizes tuple length
+        @test _query_validate((qx, qy)) === nothing
+        @test _query_check_ndims((qx, qy), Val(2)) === nothing            # must NOT throw spurious ndims
+
+        # mismatched SIZE (equal length would not catch this) throws before evaluation
+        qy_bad = reshape([0.5, 0.6, 0.7, 0.8], 4, 1)                      # same length (4), different size
+        @test size(qx) != size(qy_bad)
+        @test length(qx) == length(qy_bad)
+        @test_throws DimensionMismatch _query_validate((qx, qy_bad))
+
+        # wrong axis count for the interpolation dimension still errors clearly
+        @test_throws DimensionMismatch _query_check_ndims((qx, qy), Val(3))
+    end
 end
 
 # ------------------------------------------------------------
-# Phase 1 · Shaped SoA validation + ndims (mandatory correctness peers)
+# Persistent N-D: shape preservation + dispatch guards + edge cases
 # ------------------------------------------------------------
-@testitem "query shape: shaped SoA validation + ndims" begin
-    import FastInterpolations: _query_validate, _query_check_ndims
+@testitem "query shape: persistent N-D" begin
+    import FastInterpolations: GriddedQuery
 
-    qx = [0.1 0.2; 0.3 0.4]
-    qy = [0.5 0.6; 0.7 0.8]
-
-    # matching-size SoA: validation is a no-op, ndims recognizes tuple length
-    @test _query_validate((qx, qy)) === nothing
-    @test _query_check_ndims((qx, qy), Val(2)) === nothing            # must NOT throw spurious ndims
-
-    # mismatched SIZE (equal length would not catch this) throws before evaluation
-    qy_bad = reshape([0.5, 0.6, 0.7, 0.8], 4, 1)                      # same length (4), different size
-    @test size(qx) != size(qy_bad)
-    @test length(qx) == length(qy_bad)
-    @test_throws DimensionMismatch _query_validate((qx, qy_bad))
-
-    # wrong axis count for the interpolation dimension still errors clearly
-    @test_throws DimensionMismatch _query_check_ndims((qx, qy), Val(3))
-end
-
-# ------------------------------------------------------------
-# Phase 1 · Persistent N-D shape preservation (allocating + in-place)
-# ------------------------------------------------------------
-@testitem "query shape: persistent N-D shape preservation" begin
     x = collect(range(0.0, 2.0, 21))
     y = collect(range(0.0, 1.0, 11))
     data = [sin(xi) * cos(yj) for xi in x, yj in y]
@@ -90,20 +92,17 @@ end
     qx12 = [0.3, 0.7, 1.1, 1.5, 1.9, 0.4, 0.8, 1.2, 1.6, 0.2, 0.6, 1.0]
     qy12 = [0.1, 0.3, 0.5, 0.7, 0.9, 0.2, 0.4, 0.6, 0.8, 0.15, 0.35, 0.55]
     pts_vec = [(qx12[k], qy12[k]) for k in eachindex(qx12)]
-
     q_aos_mat = reshape(pts_vec, 3, 4)
     qx_mat = reshape(qx12, 3, 4)
     qy_mat = reshape(qy12, 3, 4)
 
-    configs = (
-        ("LinearInterpolantND", linear_interp((x, y), data)),
-        ("ConstantInterpolantND", constant_interp((x, y), data)),
-        ("QuadraticInterpolantND", quadratic_interp((x, y), data)),
-        ("CubicInterpolantND", cubic_interp((x, y), data)),
-        ("HeteroInterpolantND", interp((x, y), data; method = (CubicInterp(), LinearInterp()))),
-    )
-
-    @testset "$name" for (name, itp) in configs
+    @testset "shape preservation — $name" for (name, itp) in (
+            ("LinearInterpolantND", linear_interp((x, y), data)),
+            ("ConstantInterpolantND", constant_interp((x, y), data)),
+            ("QuadraticInterpolantND", quadratic_interp((x, y), data)),
+            ("CubicInterpolantND", cubic_interp((x, y), data)),
+            ("HeteroInterpolantND", interp((x, y), data; method = (CubicInterp(), LinearInterp()))),
+        )
         # reference = existing vector path, reshaped
         ref_aos = reshape(itp(pts_vec), 3, 4)
         ref_soa = reshape(itp((qx12, qy12)), 3, 4)
@@ -114,89 +113,59 @@ end
             @test size(r) == (3, 4)
             @test r == ref_aos
         end
-
         @testset "allocating shaped SoA -> matrix" begin
             r = itp((qx_mat, qy_mat))
             @test r isa Matrix
             @test size(r) == (3, 4)
             @test r == ref_soa
         end
-
         @testset "in-place AoS matrix" begin
             out = Matrix{Float64}(undef, 3, 4)
-            res = itp(out, q_aos_mat)
-            @test res === out
+            @test itp(out, q_aos_mat) === out
             @test out == ref_aos
         end
-
         @testset "in-place shaped SoA" begin
             out = Matrix{Float64}(undef, 3, 4)
-            res = itp(out, (qx_mat, qy_mat))
-            @test res === out
+            @test itp(out, (qx_mat, qy_mat)) === out
             @test out == ref_soa
         end
-
         @testset "exact-size rejection (right length, wrong shape)" begin
             # a length-12 vector output is NOT a valid sink for a 3x4 query
             @test_throws DimensionMismatch itp(Vector{Float64}(undef, 12), q_aos_mat)
             @test_throws DimensionMismatch itp(Vector{Float64}(undef, 12), (qx_mat, qy_mat))
         end
     end
-end
 
-# ------------------------------------------------------------
-# Phase 1 · Dispatch guards (regression pins — must stay green throughout)
-# ------------------------------------------------------------
-@testitem "query shape: dispatch guards" begin
-    import FastInterpolations: GriddedQuery
+    @testset "dispatch guards" begin
+        itp = linear_interp((x, y), data)
 
-    x = collect(range(0.0, 2.0, 21))
-    y = collect(range(0.0, 1.0, 11))
-    data = [sin(xi) * cos(yj) for xi in x, yj in y]
-    itp = linear_interp((x, y), data)
+        # N-D Vector{<:Real} of length N is ONE coordinate point, not a batch
+        p = itp([0.5, 0.5])
+        @test p isa Real
+        @test p ≈ itp(([0.5], [0.5]))[1]
 
-    # N-D Vector{<:Real} of length N is ONE coordinate point, not a batch
-    p = itp([0.5, 0.5])
-    @test p isa Real
-    @test p ≈ itp(([0.5], [0.5]))[1]
+        # Vector{NTuple} is a vector batch -> Vector result
+        batch = itp([(0.3, 0.1), (0.7, 0.3)])
+        @test batch isa Vector
+        @test length(batch) == 2
 
-    # Vector{NTuple} is a vector batch -> Vector result
-    batch = itp([(0.3, 0.1), (0.7, 0.3)])
-    @test batch isa Vector
-    @test length(batch) == 2
+        # GriddedQuery keeps Cartesian-product shape (separable fast path)
+        tx = [0.3, 0.7, 1.1]
+        ty = [0.1, 0.5]
+        g = itp(GriddedQuery((tx, ty)))
+        @test size(g) == (3, 2)
+        @test g[2, 1] ≈ itp([tx[2], ty[1]])
 
-    # GriddedQuery keeps Cartesian-product shape (separable fast path)
-    tx = [0.3, 0.7, 1.1]
-    ty = [0.1, 0.5]
-    g = itp(GriddedQuery((tx, ty)))
-    @test size(g) == (3, 2)
-    @test g[2, 1] ≈ itp([tx[2], ty[1]])
-
-    # 1-D vector query still returns a Vector
-    itp1 = linear_interp(x, sin.(x))
-    r1 = itp1([0.3, 0.7, 1.1])
-    @test r1 isa Vector
-    @test length(r1) == 3
-end
-
-# ------------------------------------------------------------
-# Phase 1 · Persistent N-D edge cases (deriv / extrap / view / precision)
-# ------------------------------------------------------------
-@testitem "query shape: persistent N-D edge cases" begin
-    x = collect(range(0.0, 2.0, 21))
-    y = collect(range(0.0, 1.0, 11))
-    data = [sin(xi) * cos(yj) for xi in x, yj in y]
-
-    qx12 = [0.3, 0.7, 1.1, 1.5, 1.9, 0.4, 0.8, 1.2, 1.6, 0.2, 0.6, 1.0]
-    qy12 = [0.1, 0.3, 0.5, 0.7, 0.9, 0.2, 0.4, 0.6, 0.8, 0.15, 0.35, 0.55]
-    pts_vec = [(qx12[k], qy12[k]) for k in eachindex(qx12)]
-    q_aos_mat = reshape(pts_vec, 3, 4)
-    qx_mat = reshape(qx12, 3, 4)
-    qy_mat = reshape(qy12, 3, 4)
+        # 1-D vector query still returns a Vector
+        itp1 = linear_interp(x, sin.(x))
+        r1 = itp1([0.3, 0.7, 1.1])
+        @test r1 isa Vector
+        @test length(r1) == 3
+    end
 
     # Extrap MODE is a build-time contract (call-time `extrap=` only accepts an
     # InBounds fast-path override), so build a NoExtrap default and a Clamp variant.
-    @testset "$name" for (name, ctor) in (("Linear", linear_interp), ("Cubic", cubic_interp))
+    @testset "edge cases — $name" for (name, ctor) in (("Linear", linear_interp), ("Cubic", cubic_interp))
         itp = ctor((x, y), data)                                  # default extrap = NoExtrap
         itp_clamp = ctor((x, y), data; extrap = ClampExtrap())
 
@@ -206,7 +175,6 @@ end
             @test size(r) == (3, 4)
             @test r == ref
         end
-
         @testset "NoExtrap validates whole batch BEFORE any write" begin
             q_bad = copy(pts_vec)
             q_bad[1] = (5.0, 0.5)                     # single OOB point
@@ -215,21 +183,18 @@ end
             @test_throws DomainError itp(out, q_bad_mat)
             @test all(==(-999.0), out)                # untouched — pre-scan threw first
         end
-
         @testset "ClampExtrap value-match with OOB point" begin
             q_mix = copy(pts_vec)
             q_mix[1] = (5.0, 0.5)                      # OOB x — clamped, not thrown
             q_mix_mat = reshape(q_mix, 3, 4)
             @test itp_clamp(q_mix_mat) == reshape(itp_clamp(q_mix), 3, 4)
         end
-
         @testset "noncontiguous view query preserves shape" begin
             qv = @view q_aos_mat[1:2, :]              # 2×4 SubArray of points
             r = itp(qv)
             @test size(r) == (2, 4)
             @test r == reshape(itp(vec(collect(qv))), 2, 4)
         end
-
         @testset "mixed precision (Float32 SoA) preserves shape" begin
             qxf = Float32.(qx_mat)
             qyf = Float32.(qy_mat)
@@ -242,79 +207,9 @@ end
 end
 
 # ------------------------------------------------------------
-# Phase 1 · Allocation parity — shaped in-place is 0 B warm (matches vector lanes)
+# One-shot N-D: unified + dedicated cores + local/user-Hermite
 # ------------------------------------------------------------
-@testitem "query shape: persistent N-D allocation parity" setup = [AllocConstants] begin
-    # Function barrier: warmup then measure with every input as a TYPED argument, so a
-    # boxed-local tuple construction at the call site is not counted as interpolation
-    # allocation (the @allocated must see only the shaped in-place call itself).
-    measure(itp, out, q) = (itp(out, q); itp(out, q); @allocated itp(out, q))
-
-    x = collect(range(0.0, 2.0, 21))
-    y = collect(range(0.0, 1.0, 11))
-    data = [sin(xi) * cos(yj) for xi in x, yj in y]
-    itp = linear_interp((x, y), data)
-
-    qx12 = [0.3, 0.7, 1.1, 1.5, 1.9, 0.4, 0.8, 1.2, 1.6, 0.2, 0.6, 1.0]
-    qy12 = [0.1, 0.3, 0.5, 0.7, 0.9, 0.2, 0.4, 0.6, 0.8, 0.15, 0.35, 0.55]
-    pts_vec = [(qx12[k], qy12[k]) for k in eachindex(qx12)]
-    q_aos_mat = reshape(pts_vec, 3, 4)
-    soa_mat = (reshape(qx12, 3, 4), reshape(qy12, 3, 4))
-    soa_vec = (qx12, qy12)
-
-    out_mat = Matrix{Float64}(undef, 3, 4)
-    out_vec = Vector{Float64}(undef, 12)
-
-    # shaped in-place: 0 B warm (matrix AoS + matrix SoA)
-    @test measure(itp, out_mat, q_aos_mat) <= ND_ALLOC_THRESHOLD
-    @test measure(itp, out_mat, soa_mat) <= ND_ALLOC_THRESHOLD
-    # existing vector lanes unchanged: 0 B warm (regression pin — matches master)
-    @test measure(itp, out_vec, pts_vec) <= ND_ALLOC_THRESHOLD
-    @test measure(itp, out_vec, soa_vec) <= ND_ALLOC_THRESHOLD
-end
-
-# ============================================================
-# Phase 2 · One-shot N-D quadrant (unified + dedicated)
-# ============================================================
-
-@testitem "query shape: one-shot N-D unified (interp/interp!)" begin
-    x = collect(range(0.0, 2.0, 21))
-    y = collect(range(0.0, 1.0, 11))
-    data = [sin(xi) * cos(yj) for xi in x, yj in y]
-    m = (CubicInterp(), LinearInterp())          # heterogeneous method tuple
-
-    qx12 = [0.3, 0.7, 1.1, 1.5, 1.9, 0.4, 0.8, 1.2, 1.6, 0.2, 0.6, 1.0]
-    qy12 = [0.1, 0.3, 0.5, 0.7, 0.9, 0.2, 0.4, 0.6, 0.8, 0.15, 0.35, 0.55]
-    pts_vec = [(qx12[k], qy12[k]) for k in eachindex(qx12)]
-    q_aos_mat = reshape(pts_vec, 3, 4)
-    soa_mat = (reshape(qx12, 3, 4), reshape(qy12, 3, 4))
-
-    ref_aos = reshape(interp((x, y), data, pts_vec; method = m), 3, 4)
-    ref_soa = reshape(interp((x, y), data, (qx12, qy12); method = m), 3, 4)
-
-    @testset "allocating preserves shape" begin
-        r1 = interp((x, y), data, q_aos_mat; method = m)
-        @test r1 isa Matrix && size(r1) == (3, 4) && r1 == ref_aos
-        r2 = interp((x, y), data, soa_mat; method = m)
-        @test r2 isa Matrix && size(r2) == (3, 4) && r2 == ref_soa
-    end
-
-    @testset "in-place preserves shape" begin
-        out = Matrix{Float64}(undef, 3, 4)
-        @test interp!(out, (x, y), data, q_aos_mat; method = m) === out
-        @test out == ref_aos
-        out2 = Matrix{Float64}(undef, 3, 4)
-        interp!(out2, (x, y), data, soa_mat; method = m)
-        @test out2 == ref_soa
-    end
-
-    @testset "exact-size rejection (right length, wrong shape)" begin
-        @test_throws DimensionMismatch interp!(Vector{Float64}(undef, 12), (x, y), data, q_aos_mat; method = m)
-        @test_throws DimensionMismatch interp!(Vector{Float64}(undef, 12), (x, y), data, soa_mat; method = m)
-    end
-end
-
-@testitem "query shape: one-shot N-D dedicated core families" begin
+@testitem "query shape: one-shot N-D" begin
     x = collect(range(0.0, 2.0, 21))
     y = collect(range(0.0, 1.0, 11))
     data = [sin(xi) * cos(yj) for xi in x, yj in y]
@@ -325,15 +220,37 @@ end
     q_aos_mat = reshape(pts_vec, 3, 4)
     soa_mat = (reshape(qx12, 3, 4), reshape(qy12, 3, 4))
 
-    # (name, allocating_fn, inplace_fn) — cubic ND one-shot has no dedicated in-place
-    families = (
-        ("linear", linear_interp, linear_interp!),
-        ("constant", constant_interp, constant_interp!),
-        ("quadratic", quadratic_interp, quadratic_interp!),
-        ("cubic", cubic_interp, cubic_interp!),
-    )
+    @testset "unified (interp/interp!)" begin
+        m = (CubicInterp(), LinearInterp())          # heterogeneous method tuple
+        ref_aos = reshape(interp((x, y), data, pts_vec; method = m), 3, 4)
+        ref_soa = reshape(interp((x, y), data, (qx12, qy12); method = m), 3, 4)
 
-    @testset "$name" for (name, f, f!) in families
+        @testset "allocating preserves shape" begin
+            r1 = interp((x, y), data, q_aos_mat; method = m)
+            @test r1 isa Matrix && size(r1) == (3, 4) && r1 == ref_aos
+            r2 = interp((x, y), data, soa_mat; method = m)
+            @test r2 isa Matrix && size(r2) == (3, 4) && r2 == ref_soa
+        end
+        @testset "in-place preserves shape" begin
+            out = Matrix{Float64}(undef, 3, 4)
+            @test interp!(out, (x, y), data, q_aos_mat; method = m) === out
+            @test out == ref_aos
+            out2 = Matrix{Float64}(undef, 3, 4)
+            interp!(out2, (x, y), data, soa_mat; method = m)
+            @test out2 == ref_soa
+        end
+        @testset "exact-size rejection (right length, wrong shape)" begin
+            @test_throws DimensionMismatch interp!(Vector{Float64}(undef, 12), (x, y), data, q_aos_mat; method = m)
+            @test_throws DimensionMismatch interp!(Vector{Float64}(undef, 12), (x, y), data, soa_mat; method = m)
+        end
+    end
+
+    @testset "dedicated core family — $name" for (name, f, f!) in (
+            ("linear", linear_interp, linear_interp!),
+            ("constant", constant_interp, constant_interp!),
+            ("quadratic", quadratic_interp, quadratic_interp!),
+            ("cubic", cubic_interp, cubic_interp!),
+        )
         ref_aos = reshape(f((x, y), data, pts_vec), 3, 4)
         ref_soa = reshape(f((x, y), data, (qx12, qy12)), 3, 4)
 
@@ -343,7 +260,6 @@ end
             r2 = f((x, y), data, soa_mat)
             @test r2 isa Matrix && size(r2) == (3, 4) && r2 == ref_soa
         end
-
         if f! !== nothing
             @testset "in-place preserves shape" begin
                 out = Matrix{Float64}(undef, 3, 4)
@@ -353,26 +269,13 @@ end
                 f!(out2, (x, y), data, soa_mat)
                 @test out2 == ref_soa
             end
-
             @testset "exact-size rejection" begin
                 @test_throws DimensionMismatch f!(Vector{Float64}(undef, 12), (x, y), data, q_aos_mat)
             end
         end
     end
-end
 
-@testitem "query shape: one-shot N-D local-Hermite + user-Hermite" begin
-    x = collect(range(0.0, 2.0, 21))
-    y = collect(range(0.0, 1.0, 11))
-    data = [sin(xi) * cos(yj) for xi in x, yj in y]
-
-    qx12 = [0.3, 0.7, 1.1, 1.5, 1.9, 0.4, 0.8, 1.2, 1.6, 0.2, 0.6, 1.0]
-    qy12 = [0.1, 0.3, 0.5, 0.7, 0.9, 0.2, 0.4, 0.6, 0.8, 0.15, 0.35, 0.55]
-    pts_vec = [(qx12[k], qy12[k]) for k in eachindex(qx12)]
-    q_aos_mat = reshape(pts_vec, 3, 4)
-    soa_mat = (reshape(qx12, 3, 4), reshape(qy12, 3, 4))
-
-    @testset "$name (local-Hermite forwarder)" for (name, f, f!) in (
+    @testset "local-Hermite forwarder — $name" for (name, f, f!) in (
             ("pchip", pchip_interp, pchip_interp!),
             ("cardinal", cardinal_interp, cardinal_interp!),
             ("akima", akima_interp, akima_interp!),
@@ -415,44 +318,14 @@ end
     end
 end
 
-@testitem "query shape: one-shot N-D allocation parity" setup = [AllocConstants] begin
-    # Function barriers (query passed as a typed arg — see Phase-1 alloc parity note).
-    meas_u(out, grids, data, q, m) = (interp!(out, grids, data, q; method = m); interp!(out, grids, data, q; method = m); @allocated interp!(out, grids, data, q; method = m))
-    meas_d(out, grids, data, q) = (linear_interp!(out, grids, data, q); linear_interp!(out, grids, data, q); @allocated linear_interp!(out, grids, data, q))
-
-    x = collect(range(0.0, 2.0, 21))
-    y = collect(range(0.0, 1.0, 11))
-    data = [sin(xi) * cos(yj) for xi in x, yj in y]
-    m = (CubicInterp(), LinearInterp())
-
-    qx12 = [0.3, 0.7, 1.1, 1.5, 1.9, 0.4, 0.8, 1.2, 1.6, 0.2, 0.6, 1.0]
-    qy12 = [0.1, 0.3, 0.5, 0.7, 0.9, 0.2, 0.4, 0.6, 0.8, 0.15, 0.35, 0.55]
-    pts_vec = [(qx12[k], qy12[k]) for k in eachindex(qx12)]
-    q_aos_mat = reshape(pts_vec, 3, 4)
-    soa_mat = (reshape(qx12, 3, 4), reshape(qy12, 3, 4))
-
-    out_mat = Matrix{Float64}(undef, 3, 4)
-    out_vec = Vector{Float64}(undef, 12)
-
-    # unified shaped in-place: 0 B warm (matrix AoS + matrix SoA); vector unchanged
-    @test meas_u(out_mat, (x, y), data, q_aos_mat, m) <= ND_ALLOC_THRESHOLD
-    @test meas_u(out_mat, (x, y), data, soa_mat, m) <= ND_ALLOC_THRESHOLD
-    @test meas_u(out_vec, (x, y), data, pts_vec, m) <= ND_ALLOC_THRESHOLD
-    # dedicated shaped in-place: 0 B warm; vector unchanged
-    @test meas_d(out_mat, (x, y), data, q_aos_mat) <= ND_ALLOC_THRESHOLD
-    @test meas_d(out_mat, (x, y), data, soa_mat) <= ND_ALLOC_THRESHOLD
-    @test meas_d(out_vec, (x, y), data, pts_vec) <= ND_ALLOC_THRESHOLD
-end
-
-# ============================================================
-# Phase 3 · Persistent 1-D quadrant + DerivativeView
-# ============================================================
+# ------------------------------------------------------------
+# Persistent 1-D: 8 families, allocating + in-place shape preservation
+# ------------------------------------------------------------
 # Reference = `map(itp, q)` (scalar eval per point, naturally shape-preserving).
 # Compared with `isclose` (ULP-tolerant): the batch and scalar kernels differ only
 # by FMA/muladd contraction, which is inline- and Julia/LLVM-version dependent, so
 # strict `==` flakes on some platforms (e.g. LTS). Shape/size is still pinned exactly.
-
-@testitem "query shape: persistent 1-D shape preservation" setup = [Basic] begin
+@testitem "query shape: persistent 1-D" setup = [Basic] begin
     x = collect(range(0.0, 2π, 25))
     y = sin.(x)
     dy = cos.(x)
@@ -461,18 +334,16 @@ end
     q_mat = reshape(q12, 3, 4)
     q_3d = reshape(collect(range(0.3, 6.0, 24)), 2, 3, 4)
 
-    families = (
-        ("linear", linear_interp(x, y)),
-        ("constant", constant_interp(x, y)),
-        ("quadratic", quadratic_interp(x, y)),
-        ("cubic", cubic_interp(x, y)),
-        ("pchip", pchip_interp(x, y)),
-        ("akima", akima_interp(x, y)),
-        ("cardinal", cardinal_interp(x, y)),
-        ("hermite", hermite_interp(x, y, dy)),
-    )
-
-    @testset "$name" for (name, itp) in families
+    @testset "$name" for (name, itp) in (
+            ("linear", linear_interp(x, y)),
+            ("constant", constant_interp(x, y)),
+            ("quadratic", quadratic_interp(x, y)),
+            ("cubic", cubic_interp(x, y)),
+            ("pchip", pchip_interp(x, y)),
+            ("akima", akima_interp(x, y)),
+            ("cardinal", cardinal_interp(x, y)),
+            ("hermite", hermite_interp(x, y, dy)),
+        )
         @testset "allocating Matrix / 3-D" begin
             r = itp(q_mat)
             @test r isa Matrix && size(r) == (3, 4)
@@ -481,24 +352,20 @@ end
             @test size(r3) == (2, 3, 4)
             @test isclose(r3, map(itp, q_3d))
         end
-
         @testset "in-place Matrix" begin
             out = Matrix{Float64}(undef, 3, 4)
             @test itp(out, q_mat) === out
             @test isclose(out, map(itp, q_mat))
         end
-
         @testset "noncontiguous view query" begin
             qv = @view q_mat[1:2, :]
             r = itp(qv)
             @test size(r) == (2, 4)
             @test isclose(r, map(itp, qv))
         end
-
         @testset "exact-size rejection" begin
             @test_throws DimensionMismatch itp(Vector{Float64}(undef, 12), q_mat)
         end
-
         @testset "N=1 SoA (q,) parity" begin
             @test itp((q_mat,)) == itp(q_mat)
             out = Matrix{Float64}(undef, 3, 4)
@@ -508,15 +375,16 @@ end
     end
 end
 
-@testitem "query shape: 1-D DerivativeView shaped" setup = [Basic] begin
-    x = collect(range(0.0, 2π, 25))
-    y = sin.(x)
-    itp = cubic_interp(x, y)
+# ------------------------------------------------------------
+# DerivativeView shaped in-place: 1-D (deriv1/2/3) + N-D mixed partial
+# ------------------------------------------------------------
+@testitem "query shape: DerivativeView shaped (1-D + N-D)" setup = [Basic] begin
+    @testset "1-D deriv$k preserves shape (allocating + in-place)" for k in 1:3
+        x = collect(range(0.0, 2π, 25))
+        y = sin.(x)
+        itp = cubic_interp(x, y)
+        q_mat = reshape(collect(range(0.3, 6.0, 12)), 3, 4)
 
-    q12 = collect(range(0.3, 6.0, 12))
-    q_mat = reshape(q12, 3, 4)
-
-    @testset "deriv$k preserves shape (allocating + in-place)" for k in 1:3
         dv = (deriv1, deriv2, deriv3)[k](itp)
         r = dv(q_mat)
         @test r isa Matrix && size(r) == (3, 4)
@@ -529,52 +397,66 @@ end
 
         @test_throws DimensionMismatch dv(Vector{Float64}(undef, 12), q_mat)
     end
+
+    @testset "N-D in-place shaped deriv" begin
+        x = collect(range(0.0, 2.0, 11))
+        y = collect(range(0.0, 1.0, 9))
+        data = [sin(a) * cos(b) for a in x, b in y]
+        dv = deriv_view(cubic_interp((x, y), data), (1, 0))   # ∂/∂x on a 2-D interpolant
+
+        qx = [0.3, 0.7, 1.1, 1.5, 1.9, 0.4]
+        qy = [0.1, 0.3, 0.5, 0.7, 0.9, 0.2]
+        pts = [(qx[k], qy[k]) for k in eachindex(qx)]
+        aos_mat = reshape(pts, 2, 3)
+        soa_mat = (reshape(qx, 2, 3), reshape(qy, 2, 3))
+
+        # The feature: in-place shaped ND deriv eval. The allocating and in-place
+        # paths forward to the same parent batch core, so results are bitwise
+        # identical (shape preservation, not a fresh computation) → `==`.
+        @testset "shaped in-place == allocating" for (q, shp) in
+            ((aos_mat, (2, 3)), (soa_mat, (2, 3)), (pts, (6,)), ((qx, qy), (6,)))
+            out = Array{Float64}(undef, shp)
+            @test dv(out, q) === out
+            @test size(dv(q)) == shp
+            @test out == dv(q)
+        end
+
+        # exact-size rejection: a length-6 vector sink for a 2x3 query must throw.
+        @test_throws DimensionMismatch dv(Vector{Float64}(undef, 6), aos_mat)
+
+        # The three ND-specialized in-place methods behind these calls exist SOLELY to
+        # satisfy `Aqua.test_ambiguities` — each tie-breaks the generic ND method against
+        # an all-ITP `(::AbstractArray,::Real)` / `(::AbstractVector,::AbstractVector{<:Real})`
+        # / `(::AbstractArray,::AbstractArray{<:Real})` form. A bare Real scalar/array is never
+        # a valid N-D point query, so they reject with ArgumentError rather than forward an
+        # ill-typed query; invoke directly for coverage (repo precedent:
+        # test_nd_utils_shared.jl "N=0 Aqua disambiguators").
+        @testset "Aqua tie-breaker guards reject non-point queries" begin
+            @test_throws ArgumentError dv(Matrix{Float64}(undef, 2, 2), 0.5)
+            @test_throws ArgumentError dv(Vector{Float64}(undef, 4), [0.1, 0.2, 0.3, 0.4])
+            @test_throws ArgumentError dv(Matrix{Float64}(undef, 2, 2), [0.1 0.2; 0.3 0.4])
+        end
+    end
 end
 
-@testitem "query shape: persistent 1-D allocation parity" setup = [AllocConstants] begin
-    measure(itp, out, q) = (itp(out, q); itp(out, q); @allocated itp(out, q))
-
-    x = collect(range(0.0, 2π, 25))
-    y = sin.(x)
-    itp = cubic_interp(x, y)
-
-    q12 = collect(range(0.3, 6.0, 12))
-    q_mat = reshape(q12, 3, 4)
-    qv = @view q_mat[1:2, :]
-
-    out_mat = Matrix{Float64}(undef, 3, 4)
-    out_view = Matrix{Float64}(undef, 2, 4)
-    out_vec = Vector{Float64}(undef, 12)
-
-    # shaped in-place: 0 B warm (dense Matrix + noncontiguous view)
-    @test measure(itp, out_mat, q_mat) <= ALLOC_THRESHOLD
-    @test measure(itp, out_view, qv) <= ALLOC_THRESHOLD
-    # existing vector lane unchanged: 0 B warm
-    @test measure(itp, out_vec, q12) <= ALLOC_THRESHOLD
-end
-
-# ============================================================
-# Phase 4 · One-shot 1-D core families (dedicated)
-# ============================================================
+# ------------------------------------------------------------
+# One-shot 1-D: core families + local-Hermite + unified
+# ------------------------------------------------------------
 # Reference = the vector one-shot path, reshaped.
-
-@testitem "query shape: one-shot 1-D core families" begin
+@testitem "query shape: one-shot 1-D" begin
     x = collect(range(0.0, 2π, 25))
     y = sin.(x)
     dy = cos.(x)
-
     q12 = collect(range(0.3, 6.0, 12))
     q_mat = reshape(q12, 3, 4)
 
-    families = (
-        ("linear", q -> linear_interp(x, y, q), (o, q) -> linear_interp!(o, x, y, q)),
-        ("constant", q -> constant_interp(x, y, q), (o, q) -> constant_interp!(o, x, y, q)),
-        ("quadratic", q -> quadratic_interp(x, y, q), (o, q) -> quadratic_interp!(o, x, y, q)),
-        ("cubic", q -> cubic_interp(x, y, q), (o, q) -> cubic_interp!(o, x, y, q)),
-        ("hermite", q -> hermite_interp(x, y, dy, q), (o, q) -> hermite_interp!(o, x, y, dy, q)),
-    )
-
-    @testset "$name" for (name, f, f!) in families
+    @testset "core family — $name" for (name, f, f!) in (
+            ("linear", q -> linear_interp(x, y, q), (o, q) -> linear_interp!(o, x, y, q)),
+            ("constant", q -> constant_interp(x, y, q), (o, q) -> constant_interp!(o, x, y, q)),
+            ("quadratic", q -> quadratic_interp(x, y, q), (o, q) -> quadratic_interp!(o, x, y, q)),
+            ("cubic", q -> cubic_interp(x, y, q), (o, q) -> cubic_interp!(o, x, y, q)),
+            ("hermite", q -> hermite_interp(x, y, dy, q), (o, q) -> hermite_interp!(o, x, y, dy, q)),
+        )
         ref = reshape(f(q12), 3, 4)
 
         @testset "allocating preserves shape" begin
@@ -582,48 +464,17 @@ end
             @test r isa Matrix && size(r) == (3, 4)
             @test r == ref
         end
-
         @testset "in-place preserves shape" begin
             o = Matrix{Float64}(undef, 3, 4)
             @test f!(o, q_mat) === o
             @test o == ref
         end
-
         @testset "exact-size rejection" begin
             @test_throws DimensionMismatch f!(Vector{Float64}(undef, 12), q_mat)
         end
     end
-end
 
-@testitem "query shape: one-shot 1-D allocation parity" setup = [AllocConstants] begin
-    mL(o, x, y, q) = (linear_interp!(o, x, y, q); linear_interp!(o, x, y, q); @allocated linear_interp!(o, x, y, q))
-    mC(o, x, y, q) = (cubic_interp!(o, x, y, q); cubic_interp!(o, x, y, q); @allocated cubic_interp!(o, x, y, q))
-
-    x = collect(range(0.0, 2π, 25))
-    y = sin.(x)
-    q12 = collect(range(0.3, 6.0, 12))
-    q_mat = reshape(q12, 3, 4)
-    om = Matrix{Float64}(undef, 3, 4)
-    ov = Vector{Float64}(undef, 12)
-
-    # shaped 1-D one-shot in-place: 0 B warm (matrix); vector lane unchanged
-    @test mL(om, x, y, q_mat) <= ALLOC_THRESHOLD
-    @test mL(ov, x, y, q12) <= ALLOC_THRESHOLD
-    @test mC(om, x, y, q_mat) <= ALLOC_THRESHOLD
-    @test mC(ov, x, y, q12) <= ALLOC_THRESHOLD
-end
-
-# ============================================================
-# Phase 5 · One-shot 1-D local-Hermite + unified interp + N=1 collapse
-# ============================================================
-
-@testitem "query shape: one-shot 1-D local-Hermite" begin
-    x = collect(range(0.0, 2π, 25))
-    y = sin.(x)
-    q12 = collect(range(0.3, 6.0, 12))
-    q_mat = reshape(q12, 3, 4)
-
-    @testset "$name" for (name, f, f!) in (
+    @testset "local-Hermite — $name" for (name, f, f!) in (
             ("pchip", (q) -> pchip_interp(x, y, q), (o, q) -> pchip_interp!(o, x, y, q)),
             ("cardinal", (q) -> cardinal_interp(x, y, q), (o, q) -> cardinal_interp!(o, x, y, q)),
             ("akima", (q) -> akima_interp(x, y, q), (o, q) -> akima_interp!(o, x, y, q)),
@@ -636,31 +487,29 @@ end
         @test o == ref
         @test_throws DimensionMismatch f!(Vector{Float64}(undef, 12), q_mat)
     end
+
+    @testset "unified interp/interp!" begin
+        m = CubicInterp()
+        ref = reshape(interp(x, y, q12; method = m), 3, 4)
+        r = interp(x, y, q_mat; method = m)
+        @test r isa Matrix && size(r) == (3, 4) && r == ref
+        o = Matrix{Float64}(undef, 3, 4)
+        @test interp!(o, x, y, q_mat; method = m) === o
+        @test o == ref
+        @test_throws DimensionMismatch interp!(Vector{Float64}(undef, 12), x, y, q_mat; method = m)
+    end
 end
 
-@testitem "query shape: unified interp/interp! 1-D" begin
+# ------------------------------------------------------------
+# N=1 tuple-grid collapse + empty / degenerate shaped queries
+# ------------------------------------------------------------
+@testitem "query shape: N=1 collapse + empty/degenerate" begin
     x = collect(range(0.0, 2π, 25))
     y = sin.(x)
     q12 = collect(range(0.3, 6.0, 12))
     q_mat = reshape(q12, 3, 4)
-    m = CubicInterp()
 
-    ref = reshape(interp(x, y, q12; method = m), 3, 4)
-    r = interp(x, y, q_mat; method = m)
-    @test r isa Matrix && size(r) == (3, 4) && r == ref
-    o = Matrix{Float64}(undef, 3, 4)
-    @test interp!(o, x, y, q_mat; method = m) === o
-    @test o == ref
-    @test_throws DimensionMismatch interp!(Vector{Float64}(undef, 12), x, y, q_mat; method = m)
-end
-
-@testitem "query shape: N=1 tuple-grid collapse (shaped)" begin
-    x = collect(range(0.0, 2π, 25))
-    y = sin.(x)
-    q12 = collect(range(0.3, 6.0, 12))
-    q_mat = reshape(q12, 3, 4)
-
-    @testset "$name" for (name, fn, fn!) in (
+    @testset "N=1 tuple-grid collapse — $name" for (name, fn, fn!) in (
             ("linear", linear_interp, linear_interp!),
             ("constant", constant_interp, constant_interp!),
             ("quadratic", quadratic_interp, quadratic_interp!),
@@ -675,32 +524,120 @@ end
         fn!(o, (x,), y, q_mat)
         @test o == native
     end
+
+    @testset "empty + degenerate shaped queries" begin
+        yb = collect(range(0.0, 1.0, 11))
+
+        # --- 1-D: empty matrix query → empty-shaped result ---
+        itp1 = cubic_interp(x, y)
+        qe = Matrix{Float64}(undef, 0, 3)
+        @test size(itp1(qe)) == (0, 3)
+        oe = Matrix{Float64}(undef, 0, 3)
+        @test itp1(oe, qe) === oe
+        @test itp1(Float64[]) == Float64[]                     # empty vector still a vector
+        @test_throws DimensionMismatch itp1(Matrix{Float64}(undef, 1, 3), qe)   # wrong-shape sink
+
+        # --- N-D: empty AoS matrix + empty SoA ---
+        data = [sin(a) * cos(b) for a in x, b in yb]
+        itp2 = linear_interp((x, yb), data)
+        q_aos_e = Matrix{NTuple{2, Float64}}(undef, 0, 2)
+        @test size(itp2(q_aos_e)) == (0, 2)
+        soa_e = (Matrix{Float64}(undef, 0, 2), Matrix{Float64}(undef, 0, 2))
+        @test size(itp2(soa_e)) == (0, 2)
+        oe2 = Matrix{Float64}(undef, 0, 2)
+        @test itp2(oe2, q_aos_e) === oe2
+    end
 end
 
-# ============================================================
-# Phase 6 · Empty / degenerate shaped queries (design §10.1)
-# ============================================================
-@testitem "query shape: empty + degenerate shaped queries" begin
-    x = collect(range(0.0, 2π, 25))
-    y = sin.(x)
-    yb = collect(range(0.0, 1.0, 11))
+# ------------------------------------------------------------
+# Allocation parity — shaped in-place is 0 B warm (matches vector lanes)
+# ------------------------------------------------------------
+@testitem "query shape: allocation parity (0 B warm)" setup = [AllocConstants] begin
+    # Function barriers kept at module scope (no captured/boxed locals): warmup
+    # then measure with every input as a TYPED argument, so a boxed-local tuple
+    # construction at the call site is not counted as interpolation allocation
+    # (the @allocated must see only the shaped in-place call itself).
+    measure(itp, out, q) = (itp(out, q); itp(out, q); @allocated itp(out, q))
+    meas_u(out, grids, data, q, m) = (interp!(out, grids, data, q; method = m); interp!(out, grids, data, q; method = m); @allocated interp!(out, grids, data, q; method = m))
+    meas_d(out, grids, data, q) = (linear_interp!(out, grids, data, q); linear_interp!(out, grids, data, q); @allocated linear_interp!(out, grids, data, q))
+    mL(o, x, y, q) = (linear_interp!(o, x, y, q); linear_interp!(o, x, y, q); @allocated linear_interp!(o, x, y, q))
+    mC(o, x, y, q) = (cubic_interp!(o, x, y, q); cubic_interp!(o, x, y, q); @allocated cubic_interp!(o, x, y, q))
 
-    # --- 1-D: empty matrix query → empty-shaped result ---
-    itp1 = cubic_interp(x, y)
-    qe = Matrix{Float64}(undef, 0, 3)
-    @test size(itp1(qe)) == (0, 3)
-    oe = Matrix{Float64}(undef, 0, 3)
-    @test itp1(oe, qe) === oe
-    @test itp1(Float64[]) == Float64[]                     # empty vector still a vector
-    @test_throws DimensionMismatch itp1(Matrix{Float64}(undef, 1, 3), qe)   # wrong-shape sink
+    @testset "persistent N-D" begin
+        x = collect(range(0.0, 2.0, 21))
+        y = collect(range(0.0, 1.0, 11))
+        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+        itp = linear_interp((x, y), data)
+        qx12 = [0.3, 0.7, 1.1, 1.5, 1.9, 0.4, 0.8, 1.2, 1.6, 0.2, 0.6, 1.0]
+        qy12 = [0.1, 0.3, 0.5, 0.7, 0.9, 0.2, 0.4, 0.6, 0.8, 0.15, 0.35, 0.55]
+        pts_vec = [(qx12[k], qy12[k]) for k in eachindex(qx12)]
+        q_aos_mat = reshape(pts_vec, 3, 4)
+        soa_mat = (reshape(qx12, 3, 4), reshape(qy12, 3, 4))
+        soa_vec = (qx12, qy12)
+        out_mat = Matrix{Float64}(undef, 3, 4)
+        out_vec = Vector{Float64}(undef, 12)
 
-    # --- N-D: empty AoS matrix + empty SoA ---
-    data = [sin(a) * cos(b) for a in x, b in yb]
-    itp2 = linear_interp((x, yb), data)
-    q_aos_e = Matrix{NTuple{2, Float64}}(undef, 0, 2)
-    @test size(itp2(q_aos_e)) == (0, 2)
-    soa_e = (Matrix{Float64}(undef, 0, 2), Matrix{Float64}(undef, 0, 2))
-    @test size(itp2(soa_e)) == (0, 2)
-    oe2 = Matrix{Float64}(undef, 0, 2)
-    @test itp2(oe2, q_aos_e) === oe2
+        # shaped in-place: 0 B warm (matrix AoS + matrix SoA)
+        @test measure(itp, out_mat, q_aos_mat) <= ND_ALLOC_THRESHOLD
+        @test measure(itp, out_mat, soa_mat) <= ND_ALLOC_THRESHOLD
+        # existing vector lanes unchanged: 0 B warm (regression pin — matches master)
+        @test measure(itp, out_vec, pts_vec) <= ND_ALLOC_THRESHOLD
+        @test measure(itp, out_vec, soa_vec) <= ND_ALLOC_THRESHOLD
+    end
+
+    @testset "one-shot N-D" begin
+        x = collect(range(0.0, 2.0, 21))
+        y = collect(range(0.0, 1.0, 11))
+        data = [sin(xi) * cos(yj) for xi in x, yj in y]
+        m = (CubicInterp(), LinearInterp())
+        qx12 = [0.3, 0.7, 1.1, 1.5, 1.9, 0.4, 0.8, 1.2, 1.6, 0.2, 0.6, 1.0]
+        qy12 = [0.1, 0.3, 0.5, 0.7, 0.9, 0.2, 0.4, 0.6, 0.8, 0.15, 0.35, 0.55]
+        pts_vec = [(qx12[k], qy12[k]) for k in eachindex(qx12)]
+        q_aos_mat = reshape(pts_vec, 3, 4)
+        soa_mat = (reshape(qx12, 3, 4), reshape(qy12, 3, 4))
+        out_mat = Matrix{Float64}(undef, 3, 4)
+        out_vec = Vector{Float64}(undef, 12)
+
+        # unified shaped in-place: 0 B warm (matrix AoS + matrix SoA); vector unchanged
+        @test meas_u(out_mat, (x, y), data, q_aos_mat, m) <= ND_ALLOC_THRESHOLD
+        @test meas_u(out_mat, (x, y), data, soa_mat, m) <= ND_ALLOC_THRESHOLD
+        @test meas_u(out_vec, (x, y), data, pts_vec, m) <= ND_ALLOC_THRESHOLD
+        # dedicated shaped in-place: 0 B warm; vector unchanged
+        @test meas_d(out_mat, (x, y), data, q_aos_mat) <= ND_ALLOC_THRESHOLD
+        @test meas_d(out_mat, (x, y), data, soa_mat) <= ND_ALLOC_THRESHOLD
+        @test meas_d(out_vec, (x, y), data, pts_vec) <= ND_ALLOC_THRESHOLD
+    end
+
+    @testset "persistent 1-D" begin
+        x = collect(range(0.0, 2π, 25))
+        y = sin.(x)
+        itp = cubic_interp(x, y)
+        q12 = collect(range(0.3, 6.0, 12))
+        q_mat = reshape(q12, 3, 4)
+        qv = @view q_mat[1:2, :]
+        out_mat = Matrix{Float64}(undef, 3, 4)
+        out_view = Matrix{Float64}(undef, 2, 4)
+        out_vec = Vector{Float64}(undef, 12)
+
+        # shaped in-place: 0 B warm (dense Matrix + noncontiguous view)
+        @test measure(itp, out_mat, q_mat) <= ALLOC_THRESHOLD
+        @test measure(itp, out_view, qv) <= ALLOC_THRESHOLD
+        # existing vector lane unchanged: 0 B warm
+        @test measure(itp, out_vec, q12) <= ALLOC_THRESHOLD
+    end
+
+    @testset "one-shot 1-D" begin
+        x = collect(range(0.0, 2π, 25))
+        y = sin.(x)
+        q12 = collect(range(0.3, 6.0, 12))
+        q_mat = reshape(q12, 3, 4)
+        om = Matrix{Float64}(undef, 3, 4)
+        ov = Vector{Float64}(undef, 12)
+
+        # shaped 1-D one-shot in-place: 0 B warm (matrix); vector lane unchanged
+        @test mL(om, x, y, q_mat) <= ALLOC_THRESHOLD
+        @test mL(ov, x, y, q12) <= ALLOC_THRESHOLD
+        @test mC(om, x, y, q_mat) <= ALLOC_THRESHOLD
+        @test mC(ov, x, y, q12) <= ALLOC_THRESHOLD
+    end
 end

--- a/test/test_query_shape_preservation.jl
+++ b/test/test_query_shape_preservation.jl
@@ -1,0 +1,274 @@
+# ============================================================
+# Query-Shape-Preserving Forward Evaluation
+# ============================================================
+#
+# Design: docs/design/query_shape_preserving_evaluation.md
+# Plan:   docs/design/PLAN_query_shape_preserving_batch_evaluation.md
+#
+# Contract: every batch forward-evaluation surface preserves the logical
+# `size` of its query container. A matrix query yields a matrix result; a
+# shaped SoA `(qx::Matrix, qy::Matrix)` yields a matrix; in-place calls
+# require the output to match `_query_size(queries)` exactly (not just length).
+#
+# Reference for correctness = the existing (tested) vector AoS/SoA path,
+# reshaped: `reshape(itp(vec_of_points), sz)`. This pins the new shaped
+# result against the flat path bit-for-bit.
+#
+# Phase 1 covers the query-shape protocol + the persistent N-D quadrant.
+
+# ------------------------------------------------------------
+# Phase 1 · Protocol: _query_size / _query_length / _query_extract / _query_eltype
+# ------------------------------------------------------------
+@testitem "query shape: protocol size/length/extract/eltype" begin
+    import FastInterpolations: _query_size, _query_length, _query_extract, _query_eltype
+
+    # --- AoS matrix of N-D points ---
+    pts12 = [(0.1 * k, 0.2 * k) for k in 1:12]
+    q_aos_mat = reshape(pts12, 3, 4)
+    q_aos_3d = reshape([(0.1 * k, 0.2 * k) for k in 1:12], 2, 2, 3)
+
+    @test _query_size(q_aos_mat) == (3, 4)
+    @test _query_size(q_aos_3d) == (2, 2, 3)
+    @test _query_length(q_aos_mat) == 12
+    @test _query_length(q_aos_mat) == prod(_query_size(q_aos_mat))     # length == prod(size)
+    # column-major linear extraction lands each point at its N-D slot
+    @test _query_extract(q_aos_mat, 5) == q_aos_mat[5]
+
+    # --- 1-D real matrix (each element one scalar coordinate) ---
+    q1 = reshape([0.1, 0.2, 0.3, 0.4], 2, 2)
+    @test _query_size(q1) == (2, 2)
+    @test _query_length(q1) == 4
+    @test _query_eltype(q1) == Float64
+
+    # --- shaped SoA: tuple of coordinate matrices ---
+    qx = [0.1 0.2; 0.3 0.4]
+    qy = [0.5 0.6; 0.7 0.8]
+    @test _query_size((qx, qy)) == (2, 2)
+    @test _query_length((qx, qy)) == 4
+    @test _query_extract((qx, qy), 3) == (qx[3], qy[3])               # column-major pairwise
+    @test _query_eltype((qx, qy)) == Float64
+
+    # --- Vector queries unchanged (regression pin) ---
+    v = [0.1, 0.2, 0.3]
+    @test _query_size(v) == (3,)
+    @test _query_size([(0.1, 0.2), (0.3, 0.4)]) == (2,)              # vector AoS stays flat
+    @test _query_size(([1.0, 2.0], [3.0, 4.0])) == (2,)             # vector SoA stays flat
+end
+
+# ------------------------------------------------------------
+# Phase 1 · Shaped SoA validation + ndims (mandatory correctness peers)
+# ------------------------------------------------------------
+@testitem "query shape: shaped SoA validation + ndims" begin
+    import FastInterpolations: _query_validate, _query_check_ndims
+
+    qx = [0.1 0.2; 0.3 0.4]
+    qy = [0.5 0.6; 0.7 0.8]
+
+    # matching-size SoA: validation is a no-op, ndims recognizes tuple length
+    @test _query_validate((qx, qy)) === nothing
+    @test _query_check_ndims((qx, qy), Val(2)) === nothing            # must NOT throw spurious ndims
+
+    # mismatched SIZE (equal length would not catch this) throws before evaluation
+    qy_bad = reshape([0.5, 0.6, 0.7, 0.8], 4, 1)                      # same length (4), different size
+    @test size(qx) != size(qy_bad)
+    @test length(qx) == length(qy_bad)
+    @test_throws DimensionMismatch _query_validate((qx, qy_bad))
+
+    # wrong axis count for the interpolation dimension still errors clearly
+    @test_throws DimensionMismatch _query_check_ndims((qx, qy), Val(3))
+end
+
+# ------------------------------------------------------------
+# Phase 1 · Persistent N-D shape preservation (allocating + in-place)
+# ------------------------------------------------------------
+@testitem "query shape: persistent N-D shape preservation" begin
+    x = collect(range(0.0, 2.0, 21))
+    y = collect(range(0.0, 1.0, 11))
+    data = [sin(xi) * cos(yj) for xi in x, yj in y]
+
+    # logical query points, 12 of them, laid out 3x4
+    qx12 = [0.3, 0.7, 1.1, 1.5, 1.9, 0.4, 0.8, 1.2, 1.6, 0.2, 0.6, 1.0]
+    qy12 = [0.1, 0.3, 0.5, 0.7, 0.9, 0.2, 0.4, 0.6, 0.8, 0.15, 0.35, 0.55]
+    pts_vec = [(qx12[k], qy12[k]) for k in eachindex(qx12)]
+
+    q_aos_mat = reshape(pts_vec, 3, 4)
+    qx_mat = reshape(qx12, 3, 4)
+    qy_mat = reshape(qy12, 3, 4)
+
+    configs = (
+        ("LinearInterpolantND", linear_interp((x, y), data)),
+        ("ConstantInterpolantND", constant_interp((x, y), data)),
+        ("QuadraticInterpolantND", quadratic_interp((x, y), data)),
+        ("CubicInterpolantND", cubic_interp((x, y), data)),
+        ("HeteroInterpolantND", interp((x, y), data; method = (CubicInterp(), LinearInterp()))),
+    )
+
+    @testset "$name" for (name, itp) in configs
+        # reference = existing vector path, reshaped
+        ref_aos = reshape(itp(pts_vec), 3, 4)
+        ref_soa = reshape(itp((qx12, qy12)), 3, 4)
+
+        @testset "allocating AoS matrix -> matrix" begin
+            r = itp(q_aos_mat)
+            @test r isa Matrix
+            @test size(r) == (3, 4)
+            @test r == ref_aos
+        end
+
+        @testset "allocating shaped SoA -> matrix" begin
+            r = itp((qx_mat, qy_mat))
+            @test r isa Matrix
+            @test size(r) == (3, 4)
+            @test r == ref_soa
+        end
+
+        @testset "in-place AoS matrix" begin
+            out = Matrix{Float64}(undef, 3, 4)
+            res = itp(out, q_aos_mat)
+            @test res === out
+            @test out == ref_aos
+        end
+
+        @testset "in-place shaped SoA" begin
+            out = Matrix{Float64}(undef, 3, 4)
+            res = itp(out, (qx_mat, qy_mat))
+            @test res === out
+            @test out == ref_soa
+        end
+
+        @testset "exact-size rejection (right length, wrong shape)" begin
+            # a length-12 vector output is NOT a valid sink for a 3x4 query
+            @test_throws DimensionMismatch itp(Vector{Float64}(undef, 12), q_aos_mat)
+            @test_throws DimensionMismatch itp(Vector{Float64}(undef, 12), (qx_mat, qy_mat))
+        end
+    end
+end
+
+# ------------------------------------------------------------
+# Phase 1 · Dispatch guards (regression pins — must stay green throughout)
+# ------------------------------------------------------------
+@testitem "query shape: dispatch guards" begin
+    import FastInterpolations: GriddedQuery
+
+    x = collect(range(0.0, 2.0, 21))
+    y = collect(range(0.0, 1.0, 11))
+    data = [sin(xi) * cos(yj) for xi in x, yj in y]
+    itp = linear_interp((x, y), data)
+
+    # N-D Vector{<:Real} of length N is ONE coordinate point, not a batch
+    p = itp([0.5, 0.5])
+    @test p isa Real
+    @test p ≈ itp(([0.5], [0.5]))[1]
+
+    # Vector{NTuple} is a vector batch -> Vector result
+    batch = itp([(0.3, 0.1), (0.7, 0.3)])
+    @test batch isa Vector
+    @test length(batch) == 2
+
+    # GriddedQuery keeps Cartesian-product shape (separable fast path)
+    tx = [0.3, 0.7, 1.1]
+    ty = [0.1, 0.5]
+    g = itp(GriddedQuery((tx, ty)))
+    @test size(g) == (3, 2)
+    @test g[2, 1] ≈ itp([tx[2], ty[1]])
+
+    # 1-D vector query still returns a Vector
+    itp1 = linear_interp(x, sin.(x))
+    r1 = itp1([0.3, 0.7, 1.1])
+    @test r1 isa Vector
+    @test length(r1) == 3
+end
+
+# ------------------------------------------------------------
+# Phase 1 · Persistent N-D edge cases (deriv / extrap / view / precision)
+# ------------------------------------------------------------
+@testitem "query shape: persistent N-D edge cases" begin
+    x = collect(range(0.0, 2.0, 21))
+    y = collect(range(0.0, 1.0, 11))
+    data = [sin(xi) * cos(yj) for xi in x, yj in y]
+
+    qx12 = [0.3, 0.7, 1.1, 1.5, 1.9, 0.4, 0.8, 1.2, 1.6, 0.2, 0.6, 1.0]
+    qy12 = [0.1, 0.3, 0.5, 0.7, 0.9, 0.2, 0.4, 0.6, 0.8, 0.15, 0.35, 0.55]
+    pts_vec = [(qx12[k], qy12[k]) for k in eachindex(qx12)]
+    q_aos_mat = reshape(pts_vec, 3, 4)
+    qx_mat = reshape(qx12, 3, 4)
+    qy_mat = reshape(qy12, 3, 4)
+
+    # Extrap MODE is a build-time contract (call-time `extrap=` only accepts an
+    # InBounds fast-path override), so build a NoExtrap default and a Clamp variant.
+    @testset "$name" for (name, ctor) in (("Linear", linear_interp), ("Cubic", cubic_interp))
+        itp = ctor((x, y), data)                                  # default extrap = NoExtrap
+        itp_clamp = ctor((x, y), data; extrap = ClampExtrap())
+
+        @testset "derivative preserves shape" begin
+            ref = reshape(itp((qx12, qy12); deriv = DerivOp(1, 0)), 3, 4)
+            r = itp((qx_mat, qy_mat); deriv = DerivOp(1, 0))
+            @test size(r) == (3, 4)
+            @test r == ref
+        end
+
+        @testset "NoExtrap validates whole batch BEFORE any write" begin
+            q_bad = copy(pts_vec)
+            q_bad[1] = (5.0, 0.5)                     # single OOB point
+            q_bad_mat = reshape(q_bad, 3, 4)
+            out = fill(-999.0, 3, 4)                  # sentinel
+            @test_throws DomainError itp(out, q_bad_mat)
+            @test all(==(-999.0), out)                # untouched — pre-scan threw first
+        end
+
+        @testset "ClampExtrap value-match with OOB point" begin
+            q_mix = copy(pts_vec)
+            q_mix[1] = (5.0, 0.5)                      # OOB x — clamped, not thrown
+            q_mix_mat = reshape(q_mix, 3, 4)
+            @test itp_clamp(q_mix_mat) == reshape(itp_clamp(q_mix), 3, 4)
+        end
+
+        @testset "noncontiguous view query preserves shape" begin
+            qv = @view q_aos_mat[1:2, :]              # 2×4 SubArray of points
+            r = itp(qv)
+            @test size(r) == (2, 4)
+            @test r == reshape(itp(vec(collect(qv))), 2, 4)
+        end
+
+        @testset "mixed precision (Float32 SoA) preserves shape" begin
+            qxf = Float32.(qx_mat)
+            qyf = Float32.(qy_mat)
+            r = itp((qxf, qyf))
+            @test size(r) == (3, 4)
+            # shaped-Float32 matches the Float32 VECTOR path exactly (same precision, reshaped)
+            @test r == reshape(itp((vec(qxf), vec(qyf))), 3, 4)
+        end
+    end
+end
+
+# ------------------------------------------------------------
+# Phase 1 · Allocation parity — shaped in-place is 0 B warm (matches vector lanes)
+# ------------------------------------------------------------
+@testitem "query shape: persistent N-D allocation parity" setup = [AllocConstants] begin
+    # Function barrier: warmup then measure with every input as a TYPED argument, so a
+    # boxed-local tuple construction at the call site is not counted as interpolation
+    # allocation (the @allocated must see only the shaped in-place call itself).
+    measure(itp, out, q) = (itp(out, q); itp(out, q); @allocated itp(out, q))
+
+    x = collect(range(0.0, 2.0, 21))
+    y = collect(range(0.0, 1.0, 11))
+    data = [sin(xi) * cos(yj) for xi in x, yj in y]
+    itp = linear_interp((x, y), data)
+
+    qx12 = [0.3, 0.7, 1.1, 1.5, 1.9, 0.4, 0.8, 1.2, 1.6, 0.2, 0.6, 1.0]
+    qy12 = [0.1, 0.3, 0.5, 0.7, 0.9, 0.2, 0.4, 0.6, 0.8, 0.15, 0.35, 0.55]
+    pts_vec = [(qx12[k], qy12[k]) for k in eachindex(qx12)]
+    q_aos_mat = reshape(pts_vec, 3, 4)
+    soa_mat = (reshape(qx12, 3, 4), reshape(qy12, 3, 4))
+    soa_vec = (qx12, qy12)
+
+    out_mat = Matrix{Float64}(undef, 3, 4)
+    out_vec = Vector{Float64}(undef, 12)
+
+    # shaped in-place: 0 B warm (matrix AoS + matrix SoA)
+    @test measure(itp, out_mat, q_aos_mat) <= ND_ALLOC_THRESHOLD
+    @test measure(itp, out_mat, soa_mat) <= ND_ALLOC_THRESHOLD
+    # existing vector lanes unchanged: 0 B warm (regression pin — matches master)
+    @test measure(itp, out_vec, pts_vec) <= ND_ALLOC_THRESHOLD
+    @test measure(itp, out_vec, soa_vec) <= ND_ALLOC_THRESHOLD
+end

--- a/test/test_query_shape_preservation.jl
+++ b/test/test_query_shape_preservation.jl
@@ -443,3 +443,108 @@ end
     @test meas_d(out_mat, (x, y), data, soa_mat) <= ND_ALLOC_THRESHOLD
     @test meas_d(out_vec, (x, y), data, pts_vec) <= ND_ALLOC_THRESHOLD
 end
+
+# ============================================================
+# Phase 3 · Persistent 1-D quadrant + DerivativeView
+# ============================================================
+# Reference = `map(itp, q)` (scalar eval per point, naturally shape-preserving).
+
+@testitem "query shape: persistent 1-D shape preservation" begin
+    x = collect(range(0.0, 2π, 25))
+    y = sin.(x)
+    dy = cos.(x)
+
+    q12 = collect(range(0.3, 6.0, 12))
+    q_mat = reshape(q12, 3, 4)
+    q_3d = reshape(collect(range(0.3, 6.0, 24)), 2, 3, 4)
+
+    families = (
+        ("linear", linear_interp(x, y)),
+        ("constant", constant_interp(x, y)),
+        ("quadratic", quadratic_interp(x, y)),
+        ("cubic", cubic_interp(x, y)),
+        ("pchip", pchip_interp(x, y)),
+        ("akima", akima_interp(x, y)),
+        ("cardinal", cardinal_interp(x, y)),
+        ("hermite", hermite_interp(x, y, dy)),
+    )
+
+    @testset "$name" for (name, itp) in families
+        @testset "allocating Matrix / 3-D" begin
+            r = itp(q_mat)
+            @test r isa Matrix && size(r) == (3, 4)
+            @test r == map(itp, q_mat)
+            r3 = itp(q_3d)
+            @test size(r3) == (2, 3, 4)
+            @test r3 == map(itp, q_3d)
+        end
+
+        @testset "in-place Matrix" begin
+            out = Matrix{Float64}(undef, 3, 4)
+            @test itp(out, q_mat) === out
+            @test out == map(itp, q_mat)
+        end
+
+        @testset "noncontiguous view query" begin
+            qv = @view q_mat[1:2, :]
+            r = itp(qv)
+            @test size(r) == (2, 4)
+            @test r == map(itp, qv)
+        end
+
+        @testset "exact-size rejection" begin
+            @test_throws DimensionMismatch itp(Vector{Float64}(undef, 12), q_mat)
+        end
+
+        @testset "N=1 SoA (q,) parity" begin
+            @test itp((q_mat,)) == itp(q_mat)
+            out = Matrix{Float64}(undef, 3, 4)
+            itp(out, (q_mat,))
+            @test out == itp(q_mat)
+        end
+    end
+end
+
+@testitem "query shape: 1-D DerivativeView shaped" begin
+    x = collect(range(0.0, 2π, 25))
+    y = sin.(x)
+    itp = cubic_interp(x, y)
+
+    q12 = collect(range(0.3, 6.0, 12))
+    q_mat = reshape(q12, 3, 4)
+
+    @testset "deriv$k preserves shape (allocating + in-place)" for k in 1:3
+        dv = (deriv1, deriv2, deriv3)[k](itp)
+        r = dv(q_mat)
+        @test r isa Matrix && size(r) == (3, 4)
+        @test r == map(dv, q_mat)
+
+        out = Matrix{Float64}(undef, 3, 4)
+        @test dv(out, q_mat) === out
+        @test out == map(dv, q_mat)
+
+        @test_throws DimensionMismatch dv(Vector{Float64}(undef, 12), q_mat)
+    end
+end
+
+@testitem "query shape: persistent 1-D allocation parity" setup = [AllocConstants] begin
+    measure(itp, out, q) = (itp(out, q); itp(out, q); @allocated itp(out, q))
+
+    x = collect(range(0.0, 2π, 25))
+    y = sin.(x)
+    itp = cubic_interp(x, y)
+
+    q12 = collect(range(0.3, 6.0, 12))
+    q_mat = reshape(q12, 3, 4)
+    qv = @view q_mat[1:2, :]
+
+    out_mat = Matrix{Float64}(undef, 3, 4)
+    out_view = Matrix{Float64}(undef, 2, 4)
+    out_vec = Vector{Float64}(undef, 12)
+
+    # shaped in-place: 0 B warm (dense Matrix + noncontiguous view)
+    @test measure(itp, out_mat, q_mat) <= ALLOC_THRESHOLD
+    @test measure(itp, out_view, qv) <= ALLOC_THRESHOLD
+    # existing vector lane unchanged: 0 B warm
+    @test measure(itp, out_vec, q12) <= ALLOC_THRESHOLD
+end

--- a/test/test_query_shape_preservation.jl
+++ b/test/test_query_shape_preservation.jl
@@ -448,8 +448,11 @@ end
 # Phase 3 · Persistent 1-D quadrant + DerivativeView
 # ============================================================
 # Reference = `map(itp, q)` (scalar eval per point, naturally shape-preserving).
+# Compared with `isclose` (ULP-tolerant): the batch and scalar kernels differ only
+# by FMA/muladd contraction, which is inline- and Julia/LLVM-version dependent, so
+# strict `==` flakes on some platforms (e.g. LTS). Shape/size is still pinned exactly.
 
-@testitem "query shape: persistent 1-D shape preservation" begin
+@testitem "query shape: persistent 1-D shape preservation" setup = [Basic] begin
     x = collect(range(0.0, 2π, 25))
     y = sin.(x)
     dy = cos.(x)
@@ -473,23 +476,23 @@ end
         @testset "allocating Matrix / 3-D" begin
             r = itp(q_mat)
             @test r isa Matrix && size(r) == (3, 4)
-            @test r == map(itp, q_mat)
+            @test isclose(r, map(itp, q_mat))
             r3 = itp(q_3d)
             @test size(r3) == (2, 3, 4)
-            @test r3 == map(itp, q_3d)
+            @test isclose(r3, map(itp, q_3d))
         end
 
         @testset "in-place Matrix" begin
             out = Matrix{Float64}(undef, 3, 4)
             @test itp(out, q_mat) === out
-            @test out == map(itp, q_mat)
+            @test isclose(out, map(itp, q_mat))
         end
 
         @testset "noncontiguous view query" begin
             qv = @view q_mat[1:2, :]
             r = itp(qv)
             @test size(r) == (2, 4)
-            @test r == map(itp, qv)
+            @test isclose(r, map(itp, qv))
         end
 
         @testset "exact-size rejection" begin
@@ -505,7 +508,7 @@ end
     end
 end
 
-@testitem "query shape: 1-D DerivativeView shaped" begin
+@testitem "query shape: 1-D DerivativeView shaped" setup = [Basic] begin
     x = collect(range(0.0, 2π, 25))
     y = sin.(x)
     itp = cubic_interp(x, y)
@@ -517,11 +520,12 @@ end
         dv = (deriv1, deriv2, deriv3)[k](itp)
         r = dv(q_mat)
         @test r isa Matrix && size(r) == (3, 4)
-        @test r == map(dv, q_mat)
+        # derivative kernels reassociate more than value kernels → wider ULP band
+        @test isclose(r, map(dv, q_mat); nulps = 4096)
 
         out = Matrix{Float64}(undef, 3, 4)
         @test dv(out, q_mat) === out
-        @test out == map(dv, q_mat)
+        @test isclose(out, map(dv, q_mat); nulps = 4096)
 
         @test_throws DimensionMismatch dv(Vector{Float64}(undef, 12), q_mat)
     end

--- a/test/test_query_shape_preservation.jl
+++ b/test/test_query_shape_preservation.jl
@@ -608,3 +608,67 @@ end
     @test mC(om, x, y, q_mat) <= ALLOC_THRESHOLD
     @test mC(ov, x, y, q12) <= ALLOC_THRESHOLD
 end
+
+# ============================================================
+# Phase 5 · One-shot 1-D local-Hermite + unified interp + N=1 collapse
+# ============================================================
+
+@testitem "query shape: one-shot 1-D local-Hermite" begin
+    x = collect(range(0.0, 2π, 25))
+    y = sin.(x)
+    q12 = collect(range(0.3, 6.0, 12))
+    q_mat = reshape(q12, 3, 4)
+
+    @testset "$name" for (name, f, f!) in (
+            ("pchip", (q) -> pchip_interp(x, y, q), (o, q) -> pchip_interp!(o, x, y, q)),
+            ("cardinal", (q) -> cardinal_interp(x, y, q), (o, q) -> cardinal_interp!(o, x, y, q)),
+            ("akima", (q) -> akima_interp(x, y, q), (o, q) -> akima_interp!(o, x, y, q)),
+        )
+        ref = reshape(f(q12), 3, 4)
+        r = f(q_mat)
+        @test r isa Matrix && size(r) == (3, 4) && r == ref
+        o = Matrix{Float64}(undef, 3, 4)
+        @test f!(o, q_mat) === o
+        @test o == ref
+        @test_throws DimensionMismatch f!(Vector{Float64}(undef, 12), q_mat)
+    end
+end
+
+@testitem "query shape: unified interp/interp! 1-D" begin
+    x = collect(range(0.0, 2π, 25))
+    y = sin.(x)
+    q12 = collect(range(0.3, 6.0, 12))
+    q_mat = reshape(q12, 3, 4)
+    m = CubicInterp()
+
+    ref = reshape(interp(x, y, q12; method = m), 3, 4)
+    r = interp(x, y, q_mat; method = m)
+    @test r isa Matrix && size(r) == (3, 4) && r == ref
+    o = Matrix{Float64}(undef, 3, 4)
+    @test interp!(o, x, y, q_mat; method = m) === o
+    @test o == ref
+    @test_throws DimensionMismatch interp!(Vector{Float64}(undef, 12), x, y, q_mat; method = m)
+end
+
+@testitem "query shape: N=1 tuple-grid collapse (shaped)" begin
+    x = collect(range(0.0, 2π, 25))
+    y = sin.(x)
+    q12 = collect(range(0.3, 6.0, 12))
+    q_mat = reshape(q12, 3, 4)
+
+    @testset "$name" for (name, fn, fn!) in (
+            ("linear", linear_interp, linear_interp!),
+            ("constant", constant_interp, constant_interp!),
+            ("quadratic", quadratic_interp, quadratic_interp!),
+            ("cubic", cubic_interp, cubic_interp!),
+            ("pchip", pchip_interp, pchip_interp!),
+        )
+        native = fn(x, y, q_mat)                      # bare-grid shaped 1-D
+        @test native isa Matrix && size(native) == (3, 4)
+        @test fn((x,), y, q_mat) == native            # tuple-grid collapse preserves shape
+        @test fn((x,), y, (q_mat,)) == native         # single-axis SoA collapse
+        o = Matrix{Float64}(undef, 3, 4)
+        fn!(o, (x,), y, q_mat)
+        @test o == native
+    end
+end

--- a/test/test_query_shape_preservation.jl
+++ b/test/test_query_shape_preservation.jl
@@ -272,3 +272,174 @@ end
     @test measure(itp, out_vec, pts_vec) <= ND_ALLOC_THRESHOLD
     @test measure(itp, out_vec, soa_vec) <= ND_ALLOC_THRESHOLD
 end
+
+# ============================================================
+# Phase 2 · One-shot N-D quadrant (unified + dedicated)
+# ============================================================
+
+@testitem "query shape: one-shot N-D unified (interp/interp!)" begin
+    x = collect(range(0.0, 2.0, 21))
+    y = collect(range(0.0, 1.0, 11))
+    data = [sin(xi) * cos(yj) for xi in x, yj in y]
+    m = (CubicInterp(), LinearInterp())          # heterogeneous method tuple
+
+    qx12 = [0.3, 0.7, 1.1, 1.5, 1.9, 0.4, 0.8, 1.2, 1.6, 0.2, 0.6, 1.0]
+    qy12 = [0.1, 0.3, 0.5, 0.7, 0.9, 0.2, 0.4, 0.6, 0.8, 0.15, 0.35, 0.55]
+    pts_vec = [(qx12[k], qy12[k]) for k in eachindex(qx12)]
+    q_aos_mat = reshape(pts_vec, 3, 4)
+    soa_mat = (reshape(qx12, 3, 4), reshape(qy12, 3, 4))
+
+    ref_aos = reshape(interp((x, y), data, pts_vec; method = m), 3, 4)
+    ref_soa = reshape(interp((x, y), data, (qx12, qy12); method = m), 3, 4)
+
+    @testset "allocating preserves shape" begin
+        r1 = interp((x, y), data, q_aos_mat; method = m)
+        @test r1 isa Matrix && size(r1) == (3, 4) && r1 == ref_aos
+        r2 = interp((x, y), data, soa_mat; method = m)
+        @test r2 isa Matrix && size(r2) == (3, 4) && r2 == ref_soa
+    end
+
+    @testset "in-place preserves shape" begin
+        out = Matrix{Float64}(undef, 3, 4)
+        @test interp!(out, (x, y), data, q_aos_mat; method = m) === out
+        @test out == ref_aos
+        out2 = Matrix{Float64}(undef, 3, 4)
+        interp!(out2, (x, y), data, soa_mat; method = m)
+        @test out2 == ref_soa
+    end
+
+    @testset "exact-size rejection (right length, wrong shape)" begin
+        @test_throws DimensionMismatch interp!(Vector{Float64}(undef, 12), (x, y), data, q_aos_mat; method = m)
+        @test_throws DimensionMismatch interp!(Vector{Float64}(undef, 12), (x, y), data, soa_mat; method = m)
+    end
+end
+
+@testitem "query shape: one-shot N-D dedicated core families" begin
+    x = collect(range(0.0, 2.0, 21))
+    y = collect(range(0.0, 1.0, 11))
+    data = [sin(xi) * cos(yj) for xi in x, yj in y]
+
+    qx12 = [0.3, 0.7, 1.1, 1.5, 1.9, 0.4, 0.8, 1.2, 1.6, 0.2, 0.6, 1.0]
+    qy12 = [0.1, 0.3, 0.5, 0.7, 0.9, 0.2, 0.4, 0.6, 0.8, 0.15, 0.35, 0.55]
+    pts_vec = [(qx12[k], qy12[k]) for k in eachindex(qx12)]
+    q_aos_mat = reshape(pts_vec, 3, 4)
+    soa_mat = (reshape(qx12, 3, 4), reshape(qy12, 3, 4))
+
+    # (name, allocating_fn, inplace_fn) — cubic ND one-shot has no dedicated in-place
+    families = (
+        ("linear", linear_interp, linear_interp!),
+        ("constant", constant_interp, constant_interp!),
+        ("quadratic", quadratic_interp, quadratic_interp!),
+        ("cubic", cubic_interp, cubic_interp!),
+    )
+
+    @testset "$name" for (name, f, f!) in families
+        ref_aos = reshape(f((x, y), data, pts_vec), 3, 4)
+        ref_soa = reshape(f((x, y), data, (qx12, qy12)), 3, 4)
+
+        @testset "allocating preserves shape" begin
+            r1 = f((x, y), data, q_aos_mat)
+            @test r1 isa Matrix && size(r1) == (3, 4) && r1 == ref_aos
+            r2 = f((x, y), data, soa_mat)
+            @test r2 isa Matrix && size(r2) == (3, 4) && r2 == ref_soa
+        end
+
+        if f! !== nothing
+            @testset "in-place preserves shape" begin
+                out = Matrix{Float64}(undef, 3, 4)
+                @test f!(out, (x, y), data, q_aos_mat) === out
+                @test out == ref_aos
+                out2 = Matrix{Float64}(undef, 3, 4)
+                f!(out2, (x, y), data, soa_mat)
+                @test out2 == ref_soa
+            end
+
+            @testset "exact-size rejection" begin
+                @test_throws DimensionMismatch f!(Vector{Float64}(undef, 12), (x, y), data, q_aos_mat)
+            end
+        end
+    end
+end
+
+@testitem "query shape: one-shot N-D local-Hermite + user-Hermite" begin
+    x = collect(range(0.0, 2.0, 21))
+    y = collect(range(0.0, 1.0, 11))
+    data = [sin(xi) * cos(yj) for xi in x, yj in y]
+
+    qx12 = [0.3, 0.7, 1.1, 1.5, 1.9, 0.4, 0.8, 1.2, 1.6, 0.2, 0.6, 1.0]
+    qy12 = [0.1, 0.3, 0.5, 0.7, 0.9, 0.2, 0.4, 0.6, 0.8, 0.15, 0.35, 0.55]
+    pts_vec = [(qx12[k], qy12[k]) for k in eachindex(qx12)]
+    q_aos_mat = reshape(pts_vec, 3, 4)
+    soa_mat = (reshape(qx12, 3, 4), reshape(qy12, 3, 4))
+
+    @testset "$name (local-Hermite forwarder)" for (name, f, f!) in (
+            ("pchip", pchip_interp, pchip_interp!),
+            ("cardinal", cardinal_interp, cardinal_interp!),
+            ("akima", akima_interp, akima_interp!),
+        )
+        ref_aos = reshape(f((x, y), data, pts_vec), 3, 4)
+        ref_soa = reshape(f((x, y), data, (qx12, qy12)), 3, 4)
+
+        r1 = f((x, y), data, q_aos_mat)
+        @test r1 isa Matrix && size(r1) == (3, 4) && r1 == ref_aos
+        @test f((x, y), data, soa_mat) == ref_soa
+
+        out = Matrix{Float64}(undef, 3, 4)
+        @test f!(out, (x, y), data, q_aos_mat) === out
+        @test out == ref_aos
+        out2 = Matrix{Float64}(undef, 3, 4)
+        f!(out2, (x, y), data, soa_mat)
+        @test out2 == ref_soa
+
+        @test_throws DimensionMismatch f!(Vector{Float64}(undef, 12), (x, y), data, q_aos_mat)
+    end
+
+    @testset "user-Hermite (explicit partials)" begin
+        dfdx = [cos(xi) * cos(yj) for xi in x, yj in y]
+        dfdy = [-sin(xi) * sin(yj) for xi in x, yj in y]
+        d2 = [-cos(xi) * sin(yj) for xi in x, yj in y]
+        p = HermitePartials((1, 0) => dfdx, (0, 1) => dfdy, (1, 1) => d2)
+
+        ref_aos = reshape(hermite_interp((x, y), data, p, pts_vec), 3, 4)
+        ref_soa = reshape(hermite_interp((x, y), data, p, (qx12, qy12)), 3, 4)
+
+        r1 = hermite_interp((x, y), data, p, q_aos_mat)
+        @test r1 isa Matrix && size(r1) == (3, 4) && r1 == ref_aos
+        @test hermite_interp((x, y), data, p, soa_mat) == ref_soa
+
+        out = Matrix{Float64}(undef, 3, 4)
+        @test hermite_interp!(out, (x, y), data, p, q_aos_mat) === out
+        @test out == ref_aos
+
+        @test_throws DimensionMismatch hermite_interp!(Vector{Float64}(undef, 12), (x, y), data, p, q_aos_mat)
+    end
+end
+
+@testitem "query shape: one-shot N-D allocation parity" setup = [AllocConstants] begin
+    # Function barriers (query passed as a typed arg — see Phase-1 alloc parity note).
+    meas_u(out, grids, data, q, m) = (interp!(out, grids, data, q; method = m); interp!(out, grids, data, q; method = m); @allocated interp!(out, grids, data, q; method = m))
+    meas_d(out, grids, data, q) = (linear_interp!(out, grids, data, q); linear_interp!(out, grids, data, q); @allocated linear_interp!(out, grids, data, q))
+
+    x = collect(range(0.0, 2.0, 21))
+    y = collect(range(0.0, 1.0, 11))
+    data = [sin(xi) * cos(yj) for xi in x, yj in y]
+    m = (CubicInterp(), LinearInterp())
+
+    qx12 = [0.3, 0.7, 1.1, 1.5, 1.9, 0.4, 0.8, 1.2, 1.6, 0.2, 0.6, 1.0]
+    qy12 = [0.1, 0.3, 0.5, 0.7, 0.9, 0.2, 0.4, 0.6, 0.8, 0.15, 0.35, 0.55]
+    pts_vec = [(qx12[k], qy12[k]) for k in eachindex(qx12)]
+    q_aos_mat = reshape(pts_vec, 3, 4)
+    soa_mat = (reshape(qx12, 3, 4), reshape(qy12, 3, 4))
+
+    out_mat = Matrix{Float64}(undef, 3, 4)
+    out_vec = Vector{Float64}(undef, 12)
+
+    # unified shaped in-place: 0 B warm (matrix AoS + matrix SoA); vector unchanged
+    @test meas_u(out_mat, (x, y), data, q_aos_mat, m) <= ND_ALLOC_THRESHOLD
+    @test meas_u(out_mat, (x, y), data, soa_mat, m) <= ND_ALLOC_THRESHOLD
+    @test meas_u(out_vec, (x, y), data, pts_vec, m) <= ND_ALLOC_THRESHOLD
+    # dedicated shaped in-place: 0 B warm; vector unchanged
+    @test meas_d(out_mat, (x, y), data, q_aos_mat) <= ND_ALLOC_THRESHOLD
+    @test meas_d(out_mat, (x, y), data, soa_mat) <= ND_ALLOC_THRESHOLD
+    @test meas_d(out_vec, (x, y), data, pts_vec) <= ND_ALLOC_THRESHOLD
+end


### PR DESCRIPTION
## Query-shape-preserving forward evaluation

Every batch forward-evaluation surface now preserves the logical `size` of its query container. A query that carries more than one dimension returns a dense `Array` of the same shape instead of a flattened `Vector`, and in-place calls require the output to match that shape exactly.

### Contract

- `itp(q::AbstractArray)` returns an `Array` with `size(q)` — `itp(q)[i,j] == itp(q[i,j])`.
- Shaped SoA `itp((qx::Matrix, qy::Matrix))` returns a `Matrix` (pairwise; requires `size(qx) == size(qy)`).
- In-place `itp(out, q)` requires `size(out) == size(q)` exactly — a length-matching vector sink for a matrix query now throws `DimensionMismatch` instead of silently flattening.
- Scalar and vector queries are unchanged; `GriddedQuery` keeps its Cartesian-product shape and separable fast path.

Coverage is the full grid of `(1-D / N-D) × (persistent / one-shot)`, allocating and in-place, dedicated family APIs (`linear_interp`, …, `pchip_interp`, `cardinal_interp`, `akima_interp`, user-Hermite) and the unified `interp` / `interp!`, plus `DerivativeView` and the N=1 tuple-grid collapse forwarders.

### Compatibility

Scalar/vector/`GriddedQuery` behavior is bit-identical. The one intentional change is for batch query containers that already carry more than one dimension (a matrix-of-points or a shaped SoA of matrices): these previously returned a flattened vector and now return a same-shape array. Callers that need the flat result can wrap the call: `vec(itp(q))`.

Out of scope (unchanged): Series interpolants, adjoint/AD construction, `GridIdx` reduced-dimension shape, custom/offset axes, and GPU execution.

### Implementation

The batch cores already write by logical query number (`output[k]`), so column-major linear indexing fills a shaped output for free — the numerical kernels are untouched. The change is a `_query_size` protocol extension plus `_alloc_query_output` / `_check_query_output_size` helpers, sink annotations widened `AbstractVector` → `AbstractArray`, and the removal of two `vec(output)` adapters. Hot-path domain/search/loop internals are widened annotation-only, so the vector path's codegen is compile-time-identical.

### Testing

- `test/test_query_shape_preservation.jl`: 19 testitems — protocol, all four quadrants, 8 families, both APIs, `DerivativeView`, N=1 collapse, dispatch guards, empty/degenerate shapes, and allocation parity.
- Aqua reports zero method ambiguities.
- Allocation: every shaped in-place lane is 0 B warm, matching the vector lane; existing vector allocation counts (`test_allocation.jl`) unchanged.
- Runtime: an A/B on the hot in-place paths (master `a1bed78e7` vs this branch, min-of-7) shows every path within ±5% measurement noise — 1d-linear −3.1%, 1d-cubic −1.2%, 1d-pchip +1.7%, nd-SoA −5.0%, nd-AoS −1.3% (four of five faster on this branch), consistent with the annotation-only widening being compile-time-identical. The CI benchmark (10% same-machine gate) is the final arbiter.

The design and a 6-phase TDD plan are under `docs/design/`.

### Remaining for CI

Full package + extension suites and the Julia 1.10 (LTS) run.
