### PR TITLE
feat(integral): one-shot ND, bounded, and cumulative integration

### DIFF
--- a/src/integral/integrate_api.jl
+++ b/src/integral/integrate_api.jl
@@ -3,51 +3,48 @@
 @inline _grid_1d(itp::CubicSeriesInterpolant) = itp.cache.x
 @inline _grid_1d(itp::AbstractInterpolant) = itp.x
 
-# ── One-shot quadrature: integrate(x, y; method) ──
-# Full-domain integral of the `method` interpolant of `(x, y)`, routed like
-# `interp(x, y; method=…)` (same method tags; bc/side/tension forwarded). Built
-# with StorePolicy(copy=false, cache_axis=false) — nothing copied, no axis caches.
-@inline function integrate(
-        x::AbstractVector,
-        y::AbstractVector;
-        method::AbstractInterpMethod,
-    )
+# ── One-shot quadrature: integrate(x, y[, a, b]; method) ──
+# Build the `method` interpolant of `(x, y)` and integrate it — full-domain with
+# no bounds, or over `[a, b]` with them (the bounds just forward to the bounded
+# `integrate(itp, a, b)`). Routed like `interp(x, y; method=…)` and built with
+# StorePolicy(copy=false, cache_axis=false), so nothing is copied.
+@inline function _oneshot_build_1d(method::AbstractInterpMethod, x, y)
     fn, _, opts = _interp1d_route(method)
-    itp = fn(x, y; opts..., store = StorePolicy(copy = false, cache_axis = false))
-    return integrate(itp)
+    return fn(x, y; opts..., store = StorePolicy(copy = false, cache_axis = false))
 end
+@inline integrate(x::AbstractVector, y::AbstractVector; method::AbstractInterpMethod) =
+    integrate(_oneshot_build_1d(method, x, y))
+@inline integrate(x::AbstractVector, y::AbstractVector, a::Real, b::Real; method::AbstractInterpMethod) =
+    integrate(_oneshot_build_1d(method, x, y), a, b)
 
-# ── One-shot quadrature (ND): integrate(grids, data; method) ──
-# ND mirror of the 1-D form, but with a smaller supported set: ND full-domain
-# integration exists only for the specialized tensor-product types, whereas 1-D
-# integrates every method. A single `method` applied to every axis builds a
-# homogeneous specialized ND interpolant, then integrates it. Trivial methods
-# (linear/constant) use raw reference storage (0-copy, no axis caches); PreCompute
-# methods (cubic/quadratic) own their coefficient arrays, so `store` stays at the
-# ctor default. Hermite-family methods are rejected up front (see below).
-@inline function integrate(
-        grids::NTuple{N, AbstractVector},
-        data::AbstractArray{<:Any, N};
-        method::AbstractInterpMethod,
-    ) where {N}
+# ── One-shot quadrature (ND): integrate(grids, data[, lo, hi]; method) ──
+# ND mirror, full-domain or over the hyper-rectangle `[lo, hi]`. ND integration
+# exists only for the specialized tensor-product types (Linear/Cubic/Quadratic/
+# Constant) — the Hermite family collapses to a HeteroInterpolantND with no ND
+# integral and is rejected up front (unlike 1-D, which integrates every method).
+# Trivial methods use raw reference storage; PreCompute methods own their
+# coefficient arrays, so `store` stays at the ctor default.
+@inline function _oneshot_build_nd(method::AbstractInterpMethod, grids, data)
     _nd_integrable_method(method) || _throw_nd_oneshot_unsupported(method)
     fn, _, opts = _interp1d_route(method)
-    itp = _is_trivial_method(method) ?
+    return _is_trivial_method(method) ?
         fn(grids, data; opts..., store = StorePolicy(copy = false, cache_axis = false)) :
         fn(grids, data; opts...)
-    return integrate(itp)
 end
+@inline integrate(grids::NTuple{N, AbstractVector}, data::AbstractArray{<:Any, N}; method::AbstractInterpMethod) where {N} =
+    integrate(_oneshot_build_nd(method, grids, data))
+@inline integrate(
+    grids::NTuple{N, AbstractVector}, data::AbstractArray{<:Any, N},
+    lo::NTuple{N, Real}, hi::NTuple{N, Real}; method::AbstractInterpMethod
+) where {N} = integrate(_oneshot_build_nd(method, grids, data), lo, hi)
 
-# Which methods have a specialized ND type with a full-domain integral. Hermite
-# axes collapse to a HeteroInterpolantND (no ND integral), so they are excluded —
-# the one behavioral split from the 1-D one-shot, which integrates all methods.
 @inline _nd_integrable_method(::Union{LinearInterp, CubicInterp, QuadraticInterp, ConstantInterp}) = true
 @inline _nd_integrable_method(::AbstractInterpMethod) = false
 
 @noinline function _throw_nd_oneshot_unsupported(method)
     throw(
         ArgumentError(
-            "integrate(grids, data; method=$(nameof(typeof(method)))(…)) — ND full-domain " *
+            "integrate(grids, data[, lo, hi]; method=$(nameof(typeof(method)))(…)) — ND " *
                 "integration is implemented only for LinearInterp, CubicInterp, " *
                 "QuadraticInterp, and ConstantInterp. Hermite-family methods " *
                 "(Pchip/Akima/Cardinal) have no ND integral yet; integrate axis-by-axis " *

--- a/src/integral/integrate_api.jl
+++ b/src/integral/integrate_api.jl
@@ -4,10 +4,8 @@
 @inline _grid_1d(itp::AbstractInterpolant) = itp.x
 
 # ── One-shot quadrature: integrate(x, y[, a, b]; method) ──
-# Build the `method` interpolant of `(x, y)` and integrate it — full-domain with
-# no bounds, or over `[a, b]` with them (the bounds just forward to the bounded
-# `integrate(itp, a, b)`). Routed like `interp(x, y; method=…)` and built with
-# StorePolicy(copy=false, cache_axis=false), so nothing is copied.
+# Build the `method` interpolant of `(x, y)` with raw reference storage (nothing
+# copied) and integrate it — full-domain, or over `[a, b]` when bounds are given.
 @inline function _oneshot_build_1d(method::AbstractInterpMethod, x, y)
     fn, _, opts = _interp1d_route(method)
     return fn(x, y; opts..., store = StorePolicy(copy = false, cache_axis = false))
@@ -17,13 +15,16 @@ end
 @inline integrate(x::AbstractVector, y::AbstractVector, a::Real, b::Real; method::AbstractInterpMethod) =
     integrate(_oneshot_build_1d(method, x, y), a, b)
 
+# ── One-shot cumulative: cumulative_integrate(x, y; method) ──
+# Running-integral sibling of one-shot `integrate` (same raw-storage build);
+# `out[end]` == `integrate(x, y; method)`. 1-D only — ND is not defined here.
+@inline cumulative_integrate(x::AbstractVector, y::AbstractVector; method::AbstractInterpMethod) =
+    cumulative_integrate(_oneshot_build_1d(method, x, y))
+
 # ── One-shot quadrature (ND): integrate(grids, data[, lo, hi]; method) ──
-# ND mirror, full-domain or over the hyper-rectangle `[lo, hi]`. ND integration
-# exists only for the specialized tensor-product types (Linear/Cubic/Quadratic/
-# Constant) — the Hermite family collapses to a HeteroInterpolantND with no ND
-# integral and is rejected up front (unlike 1-D, which integrates every method).
-# Trivial methods use raw reference storage; PreCompute methods own their
-# coefficient arrays, so `store` stays at the ctor default.
+# ND mirror — only tensor-product types integrate (Linear/Cubic/Quadratic/
+# Constant); the Hermite family (HeteroInterpolantND, no ND integral) is rejected
+# up front. Trivial methods use raw storage; PreCompute types keep the ctor default.
 @inline function _oneshot_build_nd(method::AbstractInterpMethod, grids, data)
     _nd_integrable_method(method) || _throw_nd_oneshot_unsupported(method)
     fn, _, opts = _interp1d_route(method)

--- a/src/integral/integrate_api.jl
+++ b/src/integral/integrate_api.jl
@@ -17,6 +17,45 @@
     return integrate(itp)
 end
 
+# ── One-shot quadrature (ND): integrate(grids, data; method) ──
+# ND mirror of the 1-D form, but with a smaller supported set: ND full-domain
+# integration exists only for the specialized tensor-product types, whereas 1-D
+# integrates every method. A single `method` applied to every axis builds a
+# homogeneous specialized ND interpolant, then integrates it. Trivial methods
+# (linear/constant) use raw reference storage (0-copy, no axis caches); PreCompute
+# methods (cubic/quadratic) own their coefficient arrays, so `store` stays at the
+# ctor default. Hermite-family methods are rejected up front (see below).
+@inline function integrate(
+        grids::NTuple{N, AbstractVector},
+        data::AbstractArray{<:Any, N};
+        method::AbstractInterpMethod,
+    ) where {N}
+    _nd_integrable_method(method) || _throw_nd_oneshot_unsupported(method)
+    fn, _, opts = _interp1d_route(method)
+    itp = _is_trivial_method(method) ?
+        fn(grids, data; opts..., store = StorePolicy(copy = false, cache_axis = false)) :
+        fn(grids, data; opts...)
+    return integrate(itp)
+end
+
+# Which methods have a specialized ND type with a full-domain integral. Hermite
+# axes collapse to a HeteroInterpolantND (no ND integral), so they are excluded —
+# the one behavioral split from the 1-D one-shot, which integrates all methods.
+@inline _nd_integrable_method(::Union{LinearInterp, CubicInterp, QuadraticInterp, ConstantInterp}) = true
+@inline _nd_integrable_method(::AbstractInterpMethod) = false
+
+@noinline function _throw_nd_oneshot_unsupported(method)
+    throw(
+        ArgumentError(
+            "integrate(grids, data; method=$(nameof(typeof(method)))(…)) — ND full-domain " *
+                "integration is implemented only for LinearInterp, CubicInterp, " *
+                "QuadraticInterp, and ConstantInterp. Hermite-family methods " *
+                "(Pchip/Akima/Cardinal) have no ND integral yet; integrate axis-by-axis " *
+                "on per-fiber 1-D interpolants instead."
+        )
+    )
+end
+
 
 # ── Fallback stub (bounded 1D) ──
 function integrate(itp::AbstractInterpolant, x0::Real, x1::Real; search = nothing, hint = nothing)

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -97,6 +97,37 @@ end
 # single-arg form — Cubic, Linear, Quadratic, and the entire Hermite family
 # (PreCompute + OnTheFly via `_full_cell_fn`'s internal dispatch on `itp.dy`).
 # Constant has its own override below because its full-cell trait depends on `side`.
+"""
+    # persistent — integrate an interpolant you already built
+    integrate(itp)                          # full-domain
+    integrate(itp, a, b)                    # 1-D, over [a, b]
+    integrate(itp, lo::NTuple, hi::NTuple)  # ND, over the box [lo, hi]
+
+    # one-shot — build the `method` interpolant from raw data, then integrate
+    integrate(x, y; method)                 # 1-D full-domain
+    integrate(x, y, a, b; method)           # 1-D, over [a, b]
+    integrate(grids, data; method)          # ND full-domain
+    integrate(grids, data, lo, hi; method)  # ND, over the box [lo, hi]
+
+Definite integral of an interpolant.
+
+The **persistent** forms integrate an interpolant you built earlier.
+`integrate(itp)` covers the whole domain through a specialized search-free
+summation; the bounded forms integrate over `[a, b]` (1-D) or the
+hyper-rectangle `[lo, hi]` (ND).
+
+The **one-shot** forms build the `method` interpolant from raw data with
+`copy=false` reference storage — nothing is copied — then integrate in a single
+call. 1-D integrates every method; ND only the tensor-product types (Linear,
+Cubic, Quadratic, Constant), as the Hermite family has no ND integral.
+
+```julia
+integrate(cubic_interp(x, y))                        # persistent, full-domain
+integrate(x, y; method = CubicInterp())              # one-shot,   full-domain
+integrate(x, y, 0.2, 1.5; method = LinearInterp())   # one-shot,   ∫ from 0.2 to 1.5
+integrate((xs, ys), data; method = LinearInterp())   # one-shot,   2-D full-domain
+```
+"""
 @inline function integrate(
         itp::AbstractInterpolant{Tg, Tv};
         search = nothing, hint = nothing
@@ -301,6 +332,12 @@ end
 
 # Generic 1D: catches Cubic, Linear, Quadratic, and the entire Hermite family
 # (PreCompute + OnTheFly via `_full_cell_fn`'s trait dispatch on `itp.dy`).
+"""
+    cumulative_integrate!(out, itp) -> out
+
+In-place [`cumulative_integrate`](@ref): fills `out` with the running integral.
+`out` must satisfy `length(out) == length(grid)`.
+"""
 function cumulative_integrate!(
         out::AbstractVector, itp::AbstractInterpolant{Tg, Tv}
     ) where {Tg <: Real, Tv}
@@ -320,6 +357,15 @@ function cumulative_integrate!(
 end
 
 # Allocating wrappers: allocate output vector then forward to the in-place path.
+"""
+    cumulative_integrate(itp)          # persistent — Vector (Matrix for a Series)
+    cumulative_integrate(x, y; method) # one-shot   — build from raw data
+
+Running integral at every grid node: `out[i]` is the integral from the first
+node up to node `i`, so `out[1] == 0` and `out[end] == integrate(itp)`. The
+one-shot form builds the `method` interpolant (reference storage) first. 1-D
+only — ND cumulative integration has no unambiguous definition.
+"""
 function cumulative_integrate(itp::AbstractInterpolant{Tg, Tv}) where {Tg <: Real, Tv}
     Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
     out = Vector{Tout}(undef, length(_grid_1d(itp)))

--- a/test/test_integral_api.jl
+++ b/test/test_integral_api.jl
@@ -52,6 +52,19 @@ end
         end
     end
 
+    @testset "bounded integrate(x, y, a, b; method) — all methods, matches persistent" begin
+        for x in (x_vec, x_rng), m in (
+                    LinearInterp(), CubicInterp(), QuadraticInterp(), ConstantInterp(),
+                    PchipInterp(), AkimaInterp(), CardinalInterp(),
+                )
+            @test integrate(x, y, 0.3, 1.4; method = m) ≈
+                integrate(interp(x, y; method = m), 0.3, 1.4) rtol = 1.0e-12
+        end
+        # full-domain bounds reproduce the no-bounds one-shot
+        @test integrate(x_vec, y, 0.0, 2.0; method = CubicInterp()) ≈
+            integrate(x_vec, y; method = CubicInterp()) rtol = 1.0e-12
+    end
+
     @testset "method options forwarded" begin
         @test integrate(x_vec, y; method = ConstantInterp(side = LeftSide())) ≈
             integrate(constant_interp(x_vec, y; side = LeftSide())) atol = 1.0e-12
@@ -102,6 +115,20 @@ end
         @test integrate((x, y, z), data; method = LinearInterp()) ≈ ref rtol = 1.0e-12
     end
 
+    @testset "bounded integrate(grids, data, lo, hi; method) — matches persistent" begin
+        lo = (0.3, 0.4);  hi = (2.5, 1.5)
+        for (gx, gy) in ((xr, yr), (xv, yv))
+            data = [f(xi, yj) for xi in gx, yj in gy]
+            for m in (LinearInterp(), CubicInterp(), QuadraticInterp(), ConstantInterp())
+                @test integrate((gx, gy), data, lo, hi; method = m) ≈
+                    integrate(interp((gx, gy), data; method = m), lo, hi) rtol = 1.0e-12
+            end
+        end
+        # Hermite family rejected up front here too (same supported-method split)
+        data = [f(xi, yj) for xi in xr, yj in yr]
+        @test_throws "ND integration is implemented" integrate((xr, yr), data, lo, hi; method = AkimaInterp())
+    end
+
     @testset "trivial methods build with near-zero allocation" begin
         # Measured through a function barrier: a bare `@allocated` at test scope
         # boxes the captured globals and reports noise, not the API's real cost.
@@ -119,7 +146,7 @@ end
         # does not (they build a HeteroInterpolantND with no ND integral). Reject
         # them with a clear method-named error, not the internal Hetero message.
         for m in (PchipInterp(), AkimaInterp(), CardinalInterp(), NoInterp())
-            @test_throws "ND full-domain integration is implemented" integrate((xr, yr), data; method = m)
+            @test_throws "ND integration is implemented" integrate((xr, yr), data; method = m)
         end
         # …while the same methods DO integrate in 1-D:
         xv1 = collect(xr)

--- a/test/test_integral_api.jl
+++ b/test/test_integral_api.jl
@@ -71,3 +71,68 @@ end
         @test x_vec == xb && y == yb
     end
 end
+
+# ND one-shot quadrature: integrate(grids, data; method) — the ND mirror of the
+# 1-D form. A single method is applied to every axis, building a homogeneous
+# specialized ND interpolant; trivial methods (linear/constant) use raw reference
+# storage. Mixed/Hermite methods build a HeteroInterpolantND (integrate unsupported).
+@testitem "one-shot integrate(grids, data; method) — ND" setup = [AllocConstants] begin
+    xr = range(0.0, Float64(π), length = 20)
+    yr = range(0.0, 2.0, length = 16)
+    xv = collect(xr)
+    yv = collect(yr)
+    f(xi, yj) = sin(xi) * cos(yj)
+
+    @testset "matches the persistent build (2D, Range + Vector)" begin
+        for (gx, gy) in ((xr, yr), (xv, yv))
+            data = [f(xi, yj) for xi in gx, yj in gy]
+            for m in (LinearInterp(), CubicInterp(), QuadraticInterp(), ConstantInterp())
+                ref = integrate(interp((gx, gy), data; method = m))
+                @test integrate((gx, gy), data; method = m) ≈ ref rtol = 1.0e-12
+            end
+        end
+    end
+
+    @testset "3D linear parity" begin
+        x = range(0.0, 1.0, length = 9)
+        y = range(0.0, 2.0, length = 8)
+        z = range(0.0, 3.0, length = 7)
+        data = [xi + 2yj - zk for xi in x, yj in y, zk in z]
+        ref = integrate(linear_interp((x, y, z), data))
+        @test integrate((x, y, z), data; method = LinearInterp()) ≈ ref rtol = 1.0e-12
+    end
+
+    @testset "trivial methods build with near-zero allocation" begin
+        # Measured through a function barrier: a bare `@allocated` at test scope
+        # boxes the captured globals and reports noise, not the API's real cost.
+        data = [f(xi, yj) for xi in xv, yj in yv]
+        alloc_oneshot(g, d, m) = @allocated integrate(g, d; method = m)
+        alloc_oneshot((xv, yv), data, LinearInterp())          # warmup
+        @test alloc_oneshot((xv, yv), data, LinearInterp()) <= ND_ALLOC_THRESHOLD
+        @test alloc_oneshot((xv, yv), data, ConstantInterp()) <= ND_ALLOC_THRESHOLD
+    end
+
+    @testset "ND integrates fewer methods than 1D — reject the rest up front" begin
+        data = [f(xi, yj) for xi in xr, yj in yr]
+        @test_throws UndefKeywordError integrate((xr, yr), data)
+        # 1-D one-shot integrates the Hermite family (Pchip/Akima/Cardinal); ND
+        # does not (they build a HeteroInterpolantND with no ND integral). Reject
+        # them with a clear method-named error, not the internal Hetero message.
+        for m in (PchipInterp(), AkimaInterp(), CardinalInterp(), NoInterp())
+            @test_throws "ND full-domain integration is implemented" integrate((xr, yr), data; method = m)
+        end
+        # …while the same methods DO integrate in 1-D:
+        xv1 = collect(xr)
+        yv1 = sin.(xv1)
+        for m in (PchipInterp(), AkimaInterp(), CardinalInterp())
+            @test integrate(xv1, yv1; method = m) isa Real
+        end
+    end
+
+    @testset "inputs are not mutated" begin
+        data = [f(xi, yj) for xi in xv, yj in yv]
+        xb = copy(xv);  yb = copy(yv);  db = copy(data)
+        integrate((xv, yv), data; method = LinearInterp())
+        @test xv == xb && yv == yb && data == db
+    end
+end

--- a/test/test_integral_api.jl
+++ b/test/test_integral_api.jl
@@ -163,3 +163,45 @@ end
         @test xv == xb && yv == yb && data == db
     end
 end
+
+# One-shot cumulative: sibling of one-shot `integrate`, same raw-storage build.
+# 1-D only; every 1-D method works via the generic `cumulative_integrate(itp)`.
+@testitem "one-shot cumulative_integrate(x, y; method)" begin
+    x_vec = collect(range(0.0, 2.0, length = 21))
+    x_rng = range(0.0, 2.0, length = 21)
+    y = @. x_vec^2 + 1.0
+
+    @testset "matches the persistent build (all methods, Range + Vector)" begin
+        for x in (x_vec, x_rng), m in (
+                    LinearInterp(), CubicInterp(), QuadraticInterp(), ConstantInterp(),
+                    PchipInterp(), AkimaInterp(), CardinalInterp(),
+                )
+            @test cumulative_integrate(x, y; method = m) ≈
+                cumulative_integrate(interp(x, y; method = m)) rtol = 1.0e-12
+        end
+    end
+
+    @testset "last node equals the full integral; first is zero" begin
+        for m in (LinearInterp(), CubicInterp(), QuadraticInterp(), PchipInterp())
+            c = cumulative_integrate(x_vec, y; method = m)
+            @test length(c) == length(x_vec)
+            @test c[1] == 0
+            @test c[end] ≈ integrate(x_vec, y; method = m) rtol = 1.0e-12
+        end
+    end
+
+    @testset "method options forwarded" begin
+        @test cumulative_integrate(x_vec, y; method = ConstantInterp(side = LeftSide())) ≈
+            cumulative_integrate(constant_interp(x_vec, y; side = LeftSide())) rtol = 1.0e-12
+    end
+
+    @testset "contract: method is required" begin
+        @test_throws UndefKeywordError cumulative_integrate(x_vec, y)
+    end
+
+    @testset "inputs are not mutated" begin
+        xb = copy(x_vec);  yb = copy(y)
+        cumulative_integrate(x_vec, y; method = LinearInterp())
+        @test x_vec == xb && y == yb
+    end
+end


### PR DESCRIPTION
## Summary

Completes the one-shot integration API — build the interpolant and integrate it in a single call — extending the 1-D `integrate(x, y; method)` from #194 to ND, bounded ranges, and cumulative integration.

## What's new

```julia
integrate(grids, data; method)              # ND full-domain
integrate(x, y, a, b; method)               # 1-D bounded [a, b]
integrate(grids, data, lo, hi; method)      # ND bounded [lo, hi]
cumulative_integrate(x, y; method)          # 1-D running integral
```

All route through the same build helper as `interp(x, y; method=…)` and use raw reference storage (`copy=false`), so the input is never copied and trivial methods (Linear/Constant) fold the build in with zero allocation beyond the result.

## Method coverage: 1-D vs ND

1-D integrates every method — Linear, Cubic, Quadratic, Constant, and the Hermite family (Pchip/Akima/Cardinal). ND integrates only the tensor-product types (Linear/Cubic/Quadratic/Constant); Hermite methods build a `HeteroInterpolantND`, which has no ND integral, and are rejected up front with a clear method-named error instead of a confusing internal one. `cumulative_integrate` is 1-D only — ND cumulative integration has no unambiguous definition.

## Benchmark — one-shot vs manual persistent build

| operation | method | one-shot | persistent | one-shot alloc |
|-----------|--------|---------:|-----------:|---------------:|
| integrate 1D | Linear | 0.23 µs | 4.78 µs | 0 B |
| integrate 1D | Cubic | 6.39 µs | 7.16 µs | 16.1 KB |
| integrate 2D | Linear | 3.71 µs | 9.68 µs | 0 B |
| integrate 2D | Cubic | 68.3 µs | 68.3 µs | 133 KB |
| cumulative 1D | Linear | 1.25 µs | 5.77 µs | 8.06 KB |
| cumulative 1D | Cubic | 7.19 µs | 8.48 µs | 24.2 KB |

`persistent` is the naive one-liner `integrate(linear_interp(x, y))` / etc. using the default constructor, which copies its input defensively. For coefficient methods (Cubic) the one-shot matches it — the coefficient solve dominates and is the only allocation. For trivial methods (Linear/Constant) it is faster and allocation-free, because single-use integration does not need the defensive copy. Single machine, BenchmarkTools medians.

## Tests

Parity against the persistent build for every supported method across both grid kinds (Range/Vector), the `out[end] == integrate(x, y; method)` cumulative invariant, bounded ≡ full-domain at full bounds, zero-allocation (measured through a function barrier) for trivial methods, the 1-D/ND supported-method split, and no input mutation.
