### PR TITLE
fix(store): devirtualize ND factory axis maps — zero-alloc Range builds

### DIFF
--- a/docs/src/interpolation/integration.md
+++ b/docs/src/interpolation/integration.md
@@ -139,3 +139,12 @@ nothing #hide
 | `integrate(itp)` | Full-domain integration | Scalar (or Vector for Series) |
 | `integrate(x, y; method)` | One-shot full-domain integral from raw data | Scalar |
 | `cumulative_integrate(itp)` | Grid-aligned indefinite integrals | Vector (Scalar) / **Matrix** (Series) |
+---
+
+## API Reference
+
+```@docs
+integrate
+cumulative_integrate
+cumulative_integrate!
+```

--- a/src/constant/nd/constant_nd_adjoint_types.jl
+++ b/src/constant/nd/constant_nd_adjoint_types.jl
@@ -78,7 +78,7 @@ struct ConstantAdjointND{
             Tg, N, B <: NTuple{N, AbstractBC},
             EP <: Tuple{Vararg{AbstractExtrap, N}}, SD <: Tuple{Vararg{AbstractSide, N}}, Tq,
         }
-        grids_c = map((g, bc, T) -> _convert_copy(_cache_axis(g, bc, T), T), grids, bcs, ntuple(_ -> Tg, Val(N)))
+        grids_c = _convert_cache_axes(grids, bcs, Tg)
         return new{Tg, N, typeof(grids_c), B, EP, SD, Tq}(grids_c, bcs, extraps, sides, anchors, grid_size)
     end
 end

--- a/src/constant/nd/constant_nd_interpolant.jl
+++ b/src/constant/nd/constant_nd_interpolant.jl
@@ -73,7 +73,7 @@ function constant_interp(
     # bcs are promoted to `:extended` by `_prepare_periodic_nd`, then per-axis
     # `_cache_axis` wraps (raw → wrapped, pre-wrapped → passthrough).
     grids_typed, data_typed, bcs_post = _prepare_periodic_nd(grids_typed, data_typed, bcs)
-    grids_typed = map((g, bcp) -> _policy_axis(g, bcp, store), grids_typed, bcs_post)
+    grids_typed = _policy_axes(grids_typed, bcs_post, store)
 
     # Per-axis extrap: validate + auto-promote `WrapExtrap` on periodic axes.
     extrap_vals = _resolve_extrap(extrap, bcs, Val(N), Tv)

--- a/src/constant/nd/constant_nd_types.jl
+++ b/src/constant/nd/constant_nd_types.jl
@@ -72,7 +72,7 @@ struct ConstantInterpolantND{
             bcs::NTuple{N, AbstractBC} = ntuple(_ -> NoBC(), Val(N)),
             store::StorePolicy = StorePolicy()
         ) where {Tg, Tv, N}
-        grids_c = map((g, bc, T) -> _store_axis(g, bc, T, store), grids, bcs, ntuple(_ -> Tg, Val(N)))
+        grids_c = _store_axes(grids, bcs, Tg, store)
         data_c = _own_or_ref_data(data, store)
         return new{Tg, Tv, N, typeof(grids_c), typeof(extraps), typeof(sides), typeof(searches), typeof(data_c)}(
             grids_c, data_c, extraps, sides, searches

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1261,6 +1261,13 @@ end
     return :(($(exprs...),))
 end
 
+# Owned cached wrap (PreCompute/adjoint inner ctors): cache + `_convert_copy`
+# per axis. Closure-map forms of this are banned — see the store-policy lint.
+@generated function _convert_cache_axes(grids::NTuple{N, AbstractVector}, bcs, ::Type{Tg}) where {N, Tg}
+    exprs = [:(_convert_copy(_cache_axis(grids[$i], bcs[$i], Tg), Tg)) for i in 1:N]
+    return :(($(exprs...),))
+end
+
 # Width-typed reciprocal spans from search results (linear ND scalar one-shot).
 # Span-first via the width-first 5-arg `_get_inv_h` rows: raw axes difference in
 # their own eltype, convert the span once, divide at `Tg` — the reciprocal is

--- a/src/core/store_policy.jl
+++ b/src/core/store_policy.jl
@@ -125,6 +125,21 @@ struct StorePolicy{CopyGrid, CopyValues, CacheAxis} end
 @inline _policy_axis(x::AbstractVector, bc::AbstractBC, ::StorePolicy{CG, CV, false}) where {CG, CV} =
     _wrap_exclusive_raw(x, bc)
 
+# ND factory/ctor axis maps (@generated): closure-free unrolled per-axis calls.
+# `map((g, bc) -> _policy_axis(g, bc, store), …)` captures `store` (the inner-ctor
+# form also re-captures `Tg` through an ntuple closure); on Julia 1.12 codegen
+# leaves those per-axis calls dynamic for Range axes — runtime sparam computation
+# plus a boxed `_CachedRange` per axis. Unrolled direct calls devirtualize on
+# every version (same pattern as `_cache_axes_pooled` / `_resolve_axes`).
+@generated function _policy_axes(grids::NTuple{N, AbstractVector}, bcs, store::StorePolicy) where {N}
+    exprs = [:(_policy_axis(grids[$i], bcs[$i], store)) for i in 1:N]
+    return :(($(exprs...),))
+end
+@generated function _store_axes(grids::NTuple{N, AbstractVector}, bcs, ::Type{Tg}, store::StorePolicy) where {N, Tg}
+    exprs = [:(_store_axis(grids[$i], bcs[$i], Tg, store)) for i in 1:N]
+    return :(($(exprs...),))
+end
+
 # 1D values: copy → own (+ promote to `Tv`). Reference + matching eltype → alias.
 # Reference + eltype mismatch → copy fallback (keeps `Tv`, stays type-transparent).
 @inline _own_or_ref_values(y::AbstractVector, ::Type{Tv}, ::StorePolicy{CG, true, CA}) where {Tv, CG, CA} =

--- a/src/cubic/nd/cubic_nd_types.jl
+++ b/src/cubic/nd/cubic_nd_types.jl
@@ -105,7 +105,7 @@ struct CubicInterpolantND{
         # When the outer API has already wrapped + extended the grids, this
         # is just a per-axis `copy` of the wrapper (no buffer duplication
         # for Range-backed wrappers).
-        grids_c = map((g, bc, T) -> _convert_copy(_cache_axis(g, bc, T), T), grids, bcs, ntuple(_ -> Tg, Val(N)))
+        grids_c = _convert_cache_axes(grids, bcs, Tg)
         return new{Tg, Tv, N, NP1, typeof(grids_c), typeof(bcs), typeof(extraps), typeof(searches)}(
             grids_c, nodal_derivs, bcs, extraps, searches
         )

--- a/src/hermite/nd/hermite_nd_types.jl
+++ b/src/hermite/nd/hermite_nd_types.jl
@@ -108,7 +108,7 @@ struct CubicHermiteInterpolantND{
             searches::Tuple{Vararg{AbstractSearchPolicy, N}},
         ) where {Tg, Tv, N, NP1}
         NP1 == N + 1 || throw(ArgumentError("NP1 must equal N+1"))
-        grids_c = map((g, bc, T) -> _convert_copy(_cache_axis(g, bc, T), T), grids, bcs, ntuple(_ -> Tg, Val(N)))
+        grids_c = _convert_cache_axes(grids, bcs, Tg)
         return new{Tg, Tv, N, NP1, typeof(grids_c), typeof(bcs), typeof(extraps), typeof(searches)}(
             grids_c, nodal_derivs, bcs, extraps, searches,
         )

--- a/src/hetero/hetero_types.jl
+++ b/src/hetero/hetero_types.jl
@@ -26,6 +26,13 @@
 @inline _store_axis(g, bc::AbstractBC, ::Type{Tg}, m::AbstractInterpMethod, store::StorePolicy) where {Tg} =
     _own_or_ref_axis(_cache_axis_for_method(g, bc, Tg, m), Tg, store)
 
+# Method-aware unrolled map (hetero arm of `_store_axes` — see store_policy.jl
+# for why the closure-map form is avoided).
+@generated function _store_axes(grids::NTuple{N, AbstractVector}, bcs, methods, ::Type{Tg}, store::StorePolicy) where {N, Tg}
+    exprs = [:(_store_axis(grids[$i], bcs[$i], Tg, methods[$i], store)) for i in 1:N]
+    return :(($(exprs...),))
+end
+
 """
     HeteroInterpolantND{Tg, Tv, N, G, M, E, P, D} <: AbstractInterpolantND{Tg, Tv, N}
 
@@ -88,7 +95,7 @@ struct HeteroInterpolantND{
             store::StorePolicy = StorePolicy()
         ) where {Tg, N}
         Tv = eltype(data)
-        grids_c = map((g, bc, m, T) -> _store_axis(g, bc, T, m, store), grids, bcs, methods, ntuple(_ -> Tg, Val(N)))
+        grids_c = _store_axes(grids, bcs, methods, Tg, store)
         return new{Tg, Tv, N, typeof(grids_c), typeof(methods), typeof(extraps), typeof(searches), typeof(data)}(
             grids_c, data, methods, extraps, searches
         )

--- a/src/linear/nd/linear_nd_adjoint_types.jl
+++ b/src/linear/nd/linear_nd_adjoint_types.jl
@@ -96,7 +96,7 @@ struct LinearAdjointND{
             Tg, N, B <: NTuple{N, AbstractBC},
             EP <: Tuple{Vararg{AbstractExtrap, N}},
         }
-        grids_c = map((g, bc, T) -> _convert_copy(_cache_axis(g, bc, T), T), grids, bcs, ntuple(_ -> Tg, Val(N)))
+        grids_c = _convert_cache_axes(grids, bcs, Tg)
         return new{Tg, N, typeof(grids_c), B, EP}(grids_c, bcs, extraps, anchors, grid_size)
     end
 end

--- a/src/linear/nd/linear_nd_interpolant.jl
+++ b/src/linear/nd/linear_nd_interpolant.jl
@@ -81,7 +81,7 @@ function linear_interp(
     # bcs are promoted to `:extended` by `_prepare_periodic_nd`, then per-axis
     # `_cache_axis` wraps (raw → wrapped, pre-wrapped → passthrough).
     grids_typed, data_typed, bcs_post = _prepare_periodic_nd(grids_typed, data_typed, bcs)
-    grids_typed = map((g, bcp) -> _policy_axis(g, bcp, store), grids_typed, bcs_post)
+    grids_typed = _policy_axes(grids_typed, bcs_post, store)
 
     # Per-axis extrap: validate + auto-promote `WrapExtrap` on periodic axes.
     extrap_vals = _resolve_extrap(extrap, bcs, Val(N), Tv)

--- a/src/linear/nd/linear_nd_types.jl
+++ b/src/linear/nd/linear_nd_types.jl
@@ -92,7 +92,7 @@ struct LinearInterpolantND{
             bcs::NTuple{N, AbstractBC} = ntuple(_ -> NoBC(), Val(N)),
             store::StorePolicy = StorePolicy()
         ) where {Tg, Tv, N}
-        grids_c = map((g, bc, T) -> _store_axis(g, bc, T, store), grids, bcs, ntuple(_ -> Tg, Val(N)))
+        grids_c = _store_axes(grids, bcs, Tg, store)
         data_c = _own_or_ref_data(data, store)
         return new{Tg, Tv, N, typeof(grids_c), typeof(extraps), typeof(searches), typeof(data_c)}(
             grids_c, data_c, extraps, searches

--- a/src/quadratic/nd/quadratic_nd_adjoint_types.jl
+++ b/src/quadratic/nd/quadratic_nd_adjoint_types.jl
@@ -87,7 +87,7 @@ struct QuadraticAdjointND{
         ) where {
             Tg, N, BP <: NTuple{N, AbstractBC},
         }
-        grids_c = map((g, bc, T) -> _convert_copy(_cache_axis(g, bc, T), T), grids, bcs, ntuple(_ -> Tg, Val(N)))
+        grids_c = _convert_cache_axes(grids, bcs, Tg)
         return new{Tg, N, typeof(grids_c), BP}(grids_c, bcs, anchors, grid_size, mincurv_Cs)
     end
 end

--- a/src/quadratic/nd/quadratic_nd_types.jl
+++ b/src/quadratic/nd/quadratic_nd_types.jl
@@ -90,7 +90,7 @@ struct QuadraticInterpolantND{
             searches::Tuple{Vararg{AbstractSearchPolicy, N}}
         ) where {Tg, Tv, N, NP1}
         NP1 == N + 1 || throw(ArgumentError("NP1 must equal N+1"))
-        grids_c = map((g, bc, T) -> _convert_copy(_cache_axis(g, bc, T), T), grids, bcs, ntuple(_ -> Tg, Val(N)))
+        grids_c = _convert_cache_axes(grids, bcs, Tg)
         return new{Tg, Tv, N, NP1, typeof(grids_c), typeof(bcs), typeof(extraps), typeof(searches)}(
             grids_c, nodal_derivs, bcs, extraps, searches
         )

--- a/test/test_store_policy.jl
+++ b/test/test_store_policy.jl
@@ -491,6 +491,7 @@ end
 # Measured through function barriers (concrete args); the interpolant struct is
 # elided by escape analysis when consumed in the same call.
 @testitem "Store Policy - zero-alloc build contract (raw storage)" setup = [AllocConstants] begin
+    using FastInterpolations: _policy_axes, _store_axes, _cache_axis
     S_RAW = StorePolicy(copy = false, cache_axis = false)
 
     x_vec = collect(range(0.0, 1.0, length = 20))
@@ -535,4 +536,45 @@ end
             @test intN(g, D2, m) <= ND_ALLOC_THRESHOLD
         end
     end
+
+    # Unit pins for the @generated axis-map helpers — including the hetero arm,
+    # whose end-to-end build has inherent allocations and can't be pinned at 0.
+    # Range axes are the sensitive case: a helper regressing to dynamic dispatch
+    # heap-boxes the isbits `_CachedRange` return per axis.
+    @testset "unrolled axis-map helpers are zero-alloc (Range axes, all arms)" begin
+        g = (_cache_axis(x_rng, NoBC()), _cache_axis(range(0.0, 1.0, length = 14), NoBC()))
+        bcs = (NoBC(), NoBC())
+        ms = (LinearInterp(), ConstantInterp())
+        S_REF = StorePolicy(copy = false)
+        u3(g, b, s) = @allocated _policy_axes(g, b, s)
+        u4(g, b, s) = @allocated _store_axes(g, b, Float64, s)
+        u5(g, b, m, s) = @allocated _store_axes(g, b, m, Float64, s)
+        u3(g, bcs, S_RAW); u4(g, bcs, S_REF); u5(g, bcs, ms, S_REF)   # warmup
+        @test u3(g, bcs, S_RAW) <= ND_ALLOC_THRESHOLD
+        @test u4(g, bcs, S_REF) <= ND_ALLOC_THRESHOLD
+        @test u5(g, bcs, ms, S_REF) <= ND_ALLOC_THRESHOLD
+    end
+end
+
+# Source lint for the recurring alloc trap behind the contract above: a closure-
+# map over the axis-wrap family (`map((g, …) -> _policy_axis/_store_axis/
+# _cache_axis(…), tuple…)`) can leave per-axis calls dynamic — runtime sparam
+# computation plus a boxed `_CachedRange` per Range axis. Bare-function maps
+# (`map(_cache_axis, grids, bcs)`) are fine; closures must use the @generated
+# unrolled helpers (`_policy_axes` / `_store_axes` / `_convert_cache_axes`).
+@testitem "Store Policy - no closure-maps over axis-wrap helpers (lint)" begin
+    srcdir = joinpath(pkgdir(FastInterpolations), "src")
+    helper = r"(_policy_axis|_store_axis|_cache_axis)\("
+    offenders = String[]
+    for (root, _, files) in walkdir(srcdir), f in files
+        endswith(f, ".jl") || continue
+        p = joinpath(root, f)
+        for (i, ln) in enumerate(eachline(p))
+            code = strip(ln)
+            startswith(code, "#") && continue          # comments may cite the pattern
+            occursin("map(", code) && occursin("->", code) && occursin(helper, code) || continue
+            push!(offenders, string(relpath(p, srcdir), ":", i))
+        end
+    end
+    @test offenders == String[]
 end

--- a/test/test_store_policy.jl
+++ b/test/test_store_policy.jl
@@ -483,3 +483,56 @@ end
         @test itp(0.4, 0.6) ≈ itp_ref(0.4, 0.6) atol = 1.0e-12
     end
 end
+
+# Zero-allocation BUILD contract: with `copy=false, cache_axis=false` a trivial
+# (Linear/Constant) build wraps references only — on Julia ≥ 1.12 the whole
+# build+use call allocates nothing beyond the result, for BOTH grid kinds.
+# Range axes are stack-only `_CachedRange`s, so they must not heap-box either.
+# Measured through function barriers (concrete args); the interpolant struct is
+# elided by escape analysis when consumed in the same call.
+@testitem "Store Policy - zero-alloc build contract (raw storage)" setup = [AllocConstants] begin
+    S_RAW = StorePolicy(copy = false, cache_axis = false)
+
+    x_vec = collect(range(0.0, 1.0, length = 20))
+    x_rng = range(0.0, 1.0, length = 20)
+    y1 = sin.(x_vec)
+    Xv = collect(range(0.0, 1.0, length = 16));  Xr = range(0.0, 1.0, length = 16)
+    Yv = collect(range(0.0, 1.0, length = 14));  Yr = range(0.0, 1.0, length = 14)
+    D2 = [a + 2b for a in Xv, b in Yv]
+
+    # barriers: build+consume in one call so the struct itself is elided; every
+    # input (including the store) is a typed argument — a captured testitem-scope
+    # binding is a non-const global and its boxing would pollute the measurement.
+    fwd1(x, y, q, c, s) = @allocated (itp = c(x, y; store = s); itp(q))
+    fwdN(g, d, q, c, s) = @allocated (itp = c(g, d; store = s); itp(q...))
+    int1(x, y, m) = @allocated integrate(x, y; method = m)
+    intN(g, d, m) = @allocated integrate(g, d; method = m)
+
+    @testset "1D forward build+eval (Vector + Range)" begin
+        for c in (linear_interp, constant_interp), x in (x_vec, x_rng)
+            fwd1(x, y1, 0.5, c, S_RAW)                            # warmup
+            @test fwd1(x, y1, 0.5, c, S_RAW) <= ALLOC_THRESHOLD
+        end
+    end
+
+    @testset "ND forward build+eval (Vector + Range axes)" begin
+        for c in (linear_interp, constant_interp), g in ((Xv, Yv), (Xr, Yr))
+            fwdN(g, D2, (0.5, 0.5), c, S_RAW)                     # warmup
+            @test fwdN(g, D2, (0.5, 0.5), c, S_RAW) <= ND_ALLOC_THRESHOLD
+        end
+    end
+
+    @testset "1D one-shot integrate (Vector + Range)" begin
+        for m in (LinearInterp(), ConstantInterp()), x in (x_vec, x_rng)
+            int1(x, y1, m)                                        # warmup
+            @test int1(x, y1, m) <= ALLOC_THRESHOLD
+        end
+    end
+
+    @testset "ND one-shot integrate (Vector + Range axes)" begin
+        for m in (LinearInterp(), ConstantInterp()), g in ((Xv, Yv), (Xr, Yr))
+            intN(g, D2, m)                                        # warmup
+            @test intN(g, D2, m) <= ND_ALLOC_THRESHOLD
+        end
+    end
+end


### PR DESCRIPTION
## Summary

The cache_axis work (#194) routed per-axis wrap calls through closure-maps (`map((g, bc) -> _policy_axis(g, bc, store), …)` and the inner-ctor `_store_axis` form). On Julia 1.12, codegen leaves those per-axis calls dynamic for **Range axes**: runtime sparam computation plus a heap box of the isbits `_CachedRange` return — **416 B per 2-D build**, paid by every ND forward and one-shot-integrate build with Range axes since #194. Vector axes return heap pointers and stay clean, which is why the leak was Range-only. Eval was never affected — only the build.

## Fix

Replace the closure-maps with @generated unrolled helpers — `_policy_axes`, `_store_axes` (core + method-aware hetero arm), `_convert_cache_axes` — following the existing `_cache_axes_pooled` / `_resolve_axes` pattern. All 11 call sites converted: the 5 store-policy maps from #194 plus 6 legacy `_convert_copy(_cache_axis(…))` inner ctors carrying the same shape.

## Build allocation, `copy=false` (Julia 1.12, function-barrier measured)

| build path | Vector | Range (before) | Range (after) |
|---|---:|---:|---:|
| 1D forward / one-shot integrate | 0 B | 0 B | 0 B |
| ND forward build+eval | 0 B | **416 B** | **0 B** |
| ND one-shot integrate | 0 B | **416 B** | **0 B** |

## Tests — three-layer pin (TDD, red-first)

1. **Zero-alloc build contract** (committed red first): forward and one-shot integrate, 1D/ND × Vector/Range, `0 B` on Julia ≥ 1.12.
2. **Unit pins** for the @generated helpers on Range axes — covers the hetero arm, whose end-to-end build has inherent allocations and cannot be pinned at zero.
3. **Source lint**: closure-maps over the axis-wrap family are banned in `src/` (bare-function maps stay legal), so the pattern cannot silently return at any current or future call site. Red at introduction against the 6 legacy ctors, green after conversion.

Also carries a small docs rider: a canonical `@docs` block for `integrate` / `cumulative_integrate` so `makedocs` `checkdocs = :exports` passes.
