### PR TITLE
Separable node-weight ND integration (single engine, all tensor-product families)

### DIFF
--- a/src/integral/integrate_api.jl
+++ b/src/integral/integrate_api.jl
@@ -310,17 +310,10 @@ end
 # ═══════════════════════════════════════════════════════════════
 # ND Integration
 # ═══════════════════════════════════════════════════════════════
-
-# ── Fallback stub (bounded ND) ──
-function integrate(
-        itp::AbstractInterpolantND{Tg, Tv, N},
-        lo::Tuple{Vararg{Real, N}},
-        hi::Tuple{Vararg{Real, N}};
-        search = nothing,
-        hint = nothing
-    ) where {Tg, Tv, N}
-    throw(ArgumentError("integrate(itp_nd, lo, hi) is not implemented for $(typeof(itp)) yet"))
-end
+#
+# The ND `integrate(itp)` / `integrate(itp, lo, hi)` entry points live in
+# integrate_fulldomain.jl — one separable engine for every tensor-product family
+# (homogeneous and heterogeneous). Only the shared output-type helper is here.
 
 @inline function _integrate_nd_output_type(
         ::Type{Tv}, ::Type{Tg},
@@ -329,116 +322,4 @@ end
     ) where {Tv, Tg, N}
     Tspan = promote_type(map(typeof, lo2)..., map(typeof, hi2)...)
     return _promote_eltype(_integrate_op, Tg, Tv, Tspan)
-end
-
-# ── CubicInterpolantND bounded ──
-
-@inline function integrate(
-        itp::CubicInterpolantND{Tg, Tv, N},
-        lo::Tuple{Vararg{Real, N}},
-        hi::Tuple{Vararg{Real, N}};
-        search = itp.searches,
-        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
-    ) where {Tg, Tv, N}
-    sign, lo2, hi2, idx_lo, idx_hi = _integrate_nd_preamble(
-        itp.grids, itp.extraps, lo, hi, search, hint
-    )
-    Tout = _integrate_nd_output_type(Tv, Tg, lo2, hi2)
-    _zero = Tout <: Number ? zero(Tout) : 0 * itp.nodal_derivs.partials[1]
-    sign == 0 && return _zero
-
-    total = _zero
-    for I in CartesianIndices(ntuple(d -> idx_lo[d]:idx_hi[d], Val(N)))
-        idx, hs, ulos, uhis = _nd_cell_geom(itp.grids, lo2, hi2, I, Val(N))
-        if all(d -> uhis[d] > ulos[d], 1:N)
-            inv_hs = ntuple(d -> @inbounds(_get_inv_h(itp.grids[d], idx[d])), Val(N))
-            total += convert(Tout, _integrate_nd_cubic_cell(itp.nodal_derivs.partials, idx, hs, inv_hs, ulos, uhis))
-        end
-    end
-    return sign * total
-end
-
-# ═══════════════════════════════════════════════════════════════
-# ND Linear Integration
-# ═══════════════════════════════════════════════════════════════
-
-@inline function integrate(
-        itp::LinearInterpolantND{Tg, Tv, N},
-        lo::Tuple{Vararg{Real, N}},
-        hi::Tuple{Vararg{Real, N}};
-        search = itp.searches,
-        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
-    ) where {Tg, Tv, N}
-    sign, lo2, hi2, idx_lo, idx_hi = _integrate_nd_preamble(
-        itp.grids, itp.extraps, lo, hi, search, hint
-    )
-    Tout = _integrate_nd_output_type(Tv, Tg, lo2, hi2)
-    _zero = Tout <: Number ? zero(Tout) : 0 * itp.data[1]
-    sign == 0 && return _zero
-
-    total = _zero
-    for I in CartesianIndices(ntuple(d -> idx_lo[d]:idx_hi[d], Val(N)))
-        idx, hs, ulos, uhis = _nd_cell_geom(itp.grids, lo2, hi2, I, Val(N))
-        if all(d -> uhis[d] > ulos[d], 1:N)
-            total += convert(Tout, _integrate_linear_nd_cell(itp.data, idx, hs, ulos, uhis))
-        end
-    end
-    return sign * total
-end
-
-# ═══════════════════════════════════════════════════════════════
-# ND Quadratic Integration
-# ═══════════════════════════════════════════════════════════════
-
-@inline function integrate(
-        itp::QuadraticInterpolantND{Tg, Tv, N},
-        lo::Tuple{Vararg{Real, N}},
-        hi::Tuple{Vararg{Real, N}};
-        search = itp.searches,
-        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
-    ) where {Tg, Tv, N}
-    sign, lo2, hi2, idx_lo, idx_hi = _integrate_nd_preamble(
-        itp.grids, itp.extraps, lo, hi, search, hint
-    )
-    Tout = _integrate_nd_output_type(Tv, Tg, lo2, hi2)
-    _zero = Tout <: Number ? zero(Tout) : 0 * itp.nodal_derivs.partials[1]
-    sign == 0 && return _zero
-
-    total = _zero
-    for I in CartesianIndices(ntuple(d -> idx_lo[d]:idx_hi[d], Val(N)))
-        idx, hs, ulos, uhis = _nd_cell_geom(itp.grids, lo2, hi2, I, Val(N))
-        if all(d -> uhis[d] > ulos[d], 1:N)
-            inv_hs = ntuple(d -> @inbounds(_get_inv_h(itp.grids[d], idx[d])), Val(N))
-            total += convert(Tout, _integrate_nd_quad_cell(itp.nodal_derivs.partials, idx, hs, inv_hs, ulos, uhis))
-        end
-    end
-    return sign * total
-end
-
-# ═══════════════════════════════════════════════════════════════
-# ND Constant Integration
-# ═══════════════════════════════════════════════════════════════
-
-@inline function integrate(
-        itp::ConstantInterpolantND{Tg, Tv, N},
-        lo::Tuple{Vararg{Real, N}},
-        hi::Tuple{Vararg{Real, N}};
-        search = itp.searches,
-        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
-    ) where {Tg, Tv, N}
-    sign, lo2, hi2, idx_lo, idx_hi = _integrate_nd_preamble(
-        itp.grids, itp.extraps, lo, hi, search, hint
-    )
-    Tout = _integrate_nd_output_type(Tv, Tg, lo2, hi2)
-    _zero = Tout <: Number ? zero(Tout) : 0 * itp.data[1]
-    sign == 0 && return _zero
-
-    total = _zero
-    for I in CartesianIndices(ntuple(d -> idx_lo[d]:idx_hi[d], Val(N)))
-        idx, hs, ulos, uhis = _nd_cell_geom(itp.grids, lo2, hi2, I, Val(N))
-        if all(d -> uhis[d] > ulos[d], 1:N)
-            total += convert(Tout, _integrate_constant_nd_cell(itp.data, idx, hs, ulos, uhis, itp.sides))
-        end
-    end
-    return sign * total
 end

--- a/src/integral/integrate_common_nd.jl
+++ b/src/integral/integrate_common_nd.jl
@@ -14,24 +14,31 @@ end
 # Uses 3-arg `search_interval(s, grid, q)` which dispatches correctly for raw
 # Range/Vector and wrapped grids alike — `_get_h` is read from the wrapped
 # axis directly when available.
-@inline function _nd_cell_ranges(
+# @generated per-axis unroll (not `ntuple(Val(N)) do d`): the `do` closure takes
+# `d` as a runtime Int, so `grids[d]` on a MIXED grid tuple (e.g. Vector × Range)
+# returns the element Union and the downstream `search_interval` dispatches
+# dynamically → boxing. Emitting literal `grids[1]`, `grids[2]` keeps each axis
+# concrete. See [[project_tg_closure_lts_alloc]] for the same bug class.
+@generated function _nd_cell_ranges(
         grids::NTuple{N, AbstractVector},
         lo::Tuple{Vararg{Real, N}},
         hi::Tuple{Vararg{Real, N}},
         search_tuple,
         hint
     ) where {N}
-    idx_lo = ntuple(Val(N)) do d
-        s = _resolve_search(grids[d], lo[d], search_tuple[d], isnothing(hint) ? nothing : hint[d])
-        i, _, _, _ = search_interval(s, grids[d], lo[d])
-        i
+    hd(d) = hint === Nothing ? :nothing : :(hint[$d])
+    lo_e = [:(_nd_cell_index(grids[$d], lo[$d], search_tuple[$d], $(hd(d)))) for d in 1:N]
+    hi_e = [:(_nd_cell_index(grids[$d], hi[$d], search_tuple[$d], $(hd(d)))) for d in 1:N]
+    return quote
+        Base.@_inline_meta
+        (($(lo_e...),), ($(hi_e...),))
     end
-    idx_hi = ntuple(Val(N)) do d
-        s = _resolve_search(grids[d], hi[d], search_tuple[d], isnothing(hint) ? nothing : hint[d])
-        i, _, _, _ = search_interval(s, grids[d], hi[d])
-        i
-    end
-    return idx_lo, idx_hi
+end
+
+@inline function _nd_cell_index(g, q, s, h)
+    searcher = _resolve_search(g, q, s, h)
+    i, _, _, _ = search_interval(searcher, g, q)
+    return i
 end
 
 # ND domain check for integration bounds.
@@ -49,35 +56,32 @@ end
     return nothing
 end
 
+# Per-axis domain checks, @generated so `grids[d]` stays concrete on mixed grid
+# tuples (a runtime-`d` loop leaks the element Union → dynamic dispatch → alloc,
+# same class as `_nd_cell_ranges`).
+@generated function _check_nd_bounds(grids, lo2, hi2, extraps, ::Val{N}) where {N}
+    checks = Expr[]
+    for d in 1:N
+        push!(checks, :(_check_nd_integrate_domain(grids[$d], lo2[$d], extraps[$d])))
+        push!(checks, :(_check_nd_integrate_domain(grids[$d], hi2[$d], extraps[$d])))
+    end
+    return quote
+        Base.@_inline_meta
+        @inbounds begin
+            $(checks...)
+        end
+        nothing
+    end
+end
+
 # Shared ND preamble: normalize bounds, domain checks, cell range computation.
 @inline function _integrate_nd_preamble(
         grids, extraps, lo::Tuple{Vararg{Real, N}}, hi::Tuple{Vararg{Real, N}},
         search, hint
     ) where {N}
     sign, lo2, hi2 = _normalize_bounds_nd(lo, hi)
-    @inbounds for d in 1:N
-        _check_nd_integrate_domain(grids[d], lo2[d], extraps[d])
-        _check_nd_integrate_domain(grids[d], hi2[d], extraps[d])
-    end
+    _check_nd_bounds(grids, lo2, hi2, extraps, Val(N))
     search_tuple = _resolve_search_nd(search, Val(N), lo)  # NTuple{N,Real} <: Tuple → BinarySearch/axis
     idx_lo, idx_hi = _nd_cell_ranges(grids, lo2, hi2, search_tuple, hint)
     return (sign, lo2, hi2, idx_lo, idx_hi)
-end
-
-# Per-cell geometry: indices, cell widths, and local integration bounds.
-# Uses the universal 2-arg `_get_h(grid, idx)` overloads (defined in
-# `cached_vector.jl` for `_CachedVector`/`AbstractRange`/`AbstractVector`,
-# `cached_range.jl` for `_CachedRange`, `periodic_axis.jl` for
-# `_ExclusivePeriodicAxis`) — works for raw and wrapped grids alike, so
-# all ND struct types (with or without spacings field) are supported.
-@inline function _nd_cell_geom(
-        grids, lo2, hi2, I::CartesianIndex{N}, ::Val{N}
-    ) where {N}
-    idx = ntuple(d -> I[d], Val(N))
-    hs = ntuple(d -> @inbounds(_get_h(grids[d], idx[d])), Val(N))
-    Ls = ntuple(d -> @inbounds(grids[d][idx[d]]), Val(N))
-    Rs = ntuple(d -> @inbounds(grids[d][idx[d] + 1]), Val(N))
-    ulos = ntuple(d -> max(lo2[d], Ls[d]) - Ls[d], Val(N))
-    uhis = ntuple(d -> min(hi2[d], Rs[d]) - Ls[d], Val(N))
-    return (idx, hs, ulos, uhis)
 end

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -290,13 +290,14 @@ end
     )
 end
 
-# ── Linear ND full-domain: separable composite-trapezoid path ──
+# ── Linear/Constant ND full-domain: separable node-weighted path ──
 #
-# A full-cell multilinear integral has both per-axis basis weights collapse to
-# h/2, so the whole domain integral is the tensor product of 1D composite-
-# trapezoid rules:  I = Σ_nodes (Π_d w_d(i_d))·data[i].  Iterating nodes (not
-# cells) reads each value once instead of the 2^N corner reads the generic
-# per-cell kernel repeats — an N-D generalization of the 1D telescoped path.
+# On full cells the per-axis basis weights collapse to constants (multilinear →
+# h/2 each end; constant → side-selected h), so the whole domain integral is a
+# tensor product of 1D node-weight rules:  I = Σ_nodes (Π_d w_d(i_d))·data[i].
+# Iterating nodes (not cells) reads each value once instead of the 2^N corner
+# reads the generic per-cell kernel repeats — an N-D generalization of the 1D
+# telescoped path.
 
 # 1D composite-trapezoid node weight on `grid` (length `n`): ½h at the endpoints,
 # ½(h₋+h₊) in the interior. Only the grid is divided — values stay multiply-only.
@@ -307,18 +308,29 @@ end
     return _nd_trap_weight_interior(grid, k)
 end
 
+# Per-axis weight provider: `nothing` = trapezoid (linear); a side = the constant
+# family's collapsed weights (NearestSide splits each cell at h/2 — identical to
+# the trapezoid rule; Left/Right put the whole h on the selected node).
+@inline _nd_node_weight(::Union{Nothing, NearestSide}, g, k::Int, n::Int) = _nd_trap_weight(g, k, n)
+@inline _nd_node_weight_interior(::Union{Nothing, NearestSide}, g, k::Int) = _nd_trap_weight_interior(g, k)
+@inline _nd_node_weight(::LeftSide, g, k::Int, n::Int) = k == n ? zero(_get_h(g, 1)) : _get_h(g, k)
+@inline _nd_node_weight_interior(::LeftSide, g, k::Int) = _get_h(g, k)
+@inline _nd_node_weight(::RightSide, g, k::Int, n::Int) = k == 1 ? zero(_get_h(g, 1)) : _get_h(g, k - 1)
+@inline _nd_node_weight_interior(::RightSide, g, k::Int) = _get_h(g, k - 1)
+
 # Nested reduction: outer axes hoist their weight product `wp`, the contiguous
 # inner axis peels its endpoints so the interior is a branch-free @simd loop.
-@generated function _integrate_linear_nd_fulldomain(
-        grids::NTuple{N, Any}, data::AbstractArray, ::Type{Tout}
+# `wspec` = per-axis weight provider tuple (see `_nd_node_weight`).
+@generated function _integrate_separable_nd_fulldomain(
+        wspec::NTuple{N, Any}, grids::NTuple{N, Any}, data::AbstractArray, ::Type{Tout}
     ) where {N, Tout}
     ivars = [Symbol(:i_, d) for d in 1:N]
     rest = ivars[2:N]
     inner = quote
-        s = _nd_trap_weight(g1, 1, n_1) * data[1, $(rest...)] +
-            _nd_trap_weight(g1, n_1, n_1) * data[n_1, $(rest...)]
+        s = _nd_node_weight(w1, g1, 1, n_1) * data[1, $(rest...)] +
+            _nd_node_weight(w1, g1, n_1, n_1) * data[n_1, $(rest...)]
         @simd for i_1 in 2:(n_1 - 1)
-            s += _nd_trap_weight_interior(g1, i_1) * data[i_1, $(rest...)]
+            s += _nd_node_weight_interior(w1, g1, i_1) * data[i_1, $(rest...)]
         end
         total += wp_2 * s
     end
@@ -326,8 +338,8 @@ end
     for d in 2:N
         id = ivars[d]
         nd = Symbol(:n_, d)
-        wexpr = d == N ? :(_nd_trap_weight(grids[$d], $id, $nd)) :
-            :(_nd_trap_weight(grids[$d], $id, $nd) * $(Symbol(:wp_, d + 1)))
+        wexpr = d == N ? :(_nd_node_weight(wspec[$d], grids[$d], $id, $nd)) :
+            :(_nd_node_weight(wspec[$d], grids[$d], $id, $nd) * $(Symbol(:wp_, d + 1)))
         body = quote
             for $id in 1:$nd
                 $(Symbol(:wp_, d)) = $wexpr
@@ -340,6 +352,7 @@ end
         Base.@_inline_meta
         $nassign
         g1 = grids[1]
+        w1 = wspec[1]
         total = zero(Tout)
         @inbounds begin
             $body
@@ -356,7 +369,18 @@ end
         hint = nothing
     ) where {Tg, Tv <: Number, N}
     Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
-    return _integrate_linear_nd_fulldomain(itp.grids, itp.data, Tout)
+    return _integrate_separable_nd_fulldomain(ntuple(_ -> nothing, Val(N)), itp.grids, itp.data, Tout)
+end
+
+# ConstantInterpolantND with numeric values: same separable engine, per-axis side
+# weights (mixed sides compose axis-wise). Duck values fall through to generic.
+@inline function integrate(
+        itp::ConstantInterpolantND{Tg, Tv, N};
+        search = nothing,
+        hint = nothing
+    ) where {Tg, Tv <: Number, N}
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
+    return _integrate_separable_nd_fulldomain(itp.sides, itp.grids, itp.data, Tout)
 end
 
 # Generic ND full-domain: catches all ND types

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -290,14 +290,26 @@ end
     )
 end
 
-# ── Linear/Constant ND full-domain: separable node-weighted path ──
+# ── Separable ND engine: full-domain + bounded, all tensor-product families ──
 #
-# On full cells the per-axis basis weights collapse to constants (multilinear →
-# h/2 each end; constant → side-selected h), so the whole domain integral is a
-# tensor product of 1D node-weight rules:  I = Σ_nodes (Π_d w_d(i_d))·data[i].
-# Iterating nodes (not cells) reads each value once instead of the 2^N corner
-# reads the generic per-cell kernel repeats — an N-D generalization of the 1D
-# telescoped path.
+# On full cells every per-axis basis integral collapses to constants that are
+# LINEAR in the node payload, so the domain integral is a tensor product of 1D
+# node-weight rules contracted against the payload — each node read once,
+# instead of the 2^N corner reads per cell the generic engine repeats:
+#
+#   rank 1 — payload `data[i…]`, one weight per axis:
+#     linear    w = ½h at the ends, ½(h₋+h₊) interior (composite trapezoid)
+#     constant  w = side-selected h (NearestSide ≡ the trapezoid weights)
+#   rank 2 — payload `partials[1+mask, i…]` (bit d of mask = ∂ along axis d),
+#             a (w, v) = (value, deriv) weight pair per axis:
+#     cubic     ∫cell = h/2(fL+fR) + h²/12(dfL−dfR) → v telescopes interior,
+#               vanishing on uniform axes
+#     quad      ∫cell = 2h/3·fL + h/3·fR + h²/6·dfL → left-anchored, no right v
+#
+# The per-axis weight spec reuses the existing vocabulary — the method tags
+# (`LinearInterp`/`CubicInterp`/`QuadraticInterp`) or the constant `sides` — and
+# the @generated kernels pick the rank from the payload dimensionality (N vs
+# N+1), so one engine serves every family; only the weight methods differ.
 
 # 1D composite-trapezoid node weight on `grid` (length `n`): ½h at the endpoints,
 # ½(h₋+h₊) in the interior. Only the grid is divided — values stay multiply-only.
@@ -308,100 +320,20 @@ end
     return _nd_trap_weight_interior(grid, k)
 end
 
-# Per-axis weight provider: `nothing` = trapezoid (linear); a side = the constant
-# family's collapsed weights (NearestSide splits each cell at h/2 — identical to
-# the trapezoid rule; Left/Right put the whole h on the selected node).
-@inline _nd_node_weight(::Union{Nothing, NearestSide}, g, k::Int, n::Int) = _nd_trap_weight(g, k, n)
-@inline _nd_node_weight_interior(::Union{Nothing, NearestSide}, g, k::Int) = _nd_trap_weight_interior(g, k)
-@inline _nd_node_weight(::LeftSide, g, k::Int, n::Int) = k == n ? zero(_get_h(g, 1)) : _get_h(g, k)
-@inline _nd_node_weight_interior(::LeftSide, g, k::Int) = _get_h(g, k)
-@inline _nd_node_weight(::RightSide, g, k::Int, n::Int) = k == 1 ? zero(_get_h(g, 1)) : _get_h(g, k - 1)
-@inline _nd_node_weight_interior(::RightSide, g, k::Int) = _get_h(g, k - 1)
+# ── Full-cell node weights: `_nd_node_weights(tag, g, k, n) -> NTuple{R}` ──
 
-# Nested reduction: outer axes hoist their weight product `wp`, the contiguous
-# inner axis peels its endpoints so the interior is a branch-free @simd loop.
-# `wspec` = per-axis weight provider tuple (see `_nd_node_weight`).
-@generated function _integrate_separable_nd_fulldomain(
-        wspec::NTuple{N, Any}, grids::NTuple{N, Any}, data::AbstractArray, ::Type{Tout}
-    ) where {N, Tout}
-    ivars = [Symbol(:i_, d) for d in 1:N]
-    rest = ivars[2:N]
-    inner = quote
-        s = _nd_node_weight(w1, g1, 1, n_1) * data[1, $(rest...)] +
-            _nd_node_weight(w1, g1, n_1, n_1) * data[n_1, $(rest...)]
-        @simd for i_1 in 2:(n_1 - 1)
-            s += _nd_node_weight_interior(w1, g1, i_1) * data[i_1, $(rest...)]
-        end
-        total += wp_2 * s
-    end
-    body = inner
-    for d in 2:N
-        id = ivars[d]
-        nd = Symbol(:n_, d)
-        wexpr = d == N ? :(_nd_node_weight(wspec[$d], grids[$d], $id, $nd)) :
-            :(_nd_node_weight(wspec[$d], grids[$d], $id, $nd) * $(Symbol(:wp_, d + 1)))
-        body = quote
-            for $id in 1:$nd
-                $(Symbol(:wp_, d)) = $wexpr
-                $body
-            end
-        end
-    end
-    nassign = Expr(:block, [:($(Symbol(:n_, d)) = size(data, $d)) for d in 1:N]...)
-    return quote
-        Base.@_inline_meta
-        $nassign
-        g1 = grids[1]
-        w1 = wspec[1]
-        total = zero(Tout)
-        @inbounds begin
-            $body
-        end
-        return total
-    end
-end
+@inline _nd_node_weights(::Union{LinearInterp, NearestSide}, g, k::Int, n::Int) =
+    (_nd_trap_weight(g, k, n),)
+@inline _nd_node_weights_interior(::Union{LinearInterp, NearestSide}, g, k::Int) =
+    (_nd_trap_weight_interior(g, k),)
+@inline _nd_node_weights(::LeftSide, g, k::Int, n::Int) =
+    (k == n ? zero(_get_h(g, 1)) : _get_h(g, k),)
+@inline _nd_node_weights_interior(::LeftSide, g, k::Int) = (_get_h(g, k),)
+@inline _nd_node_weights(::RightSide, g, k::Int, n::Int) =
+    (k == 1 ? zero(_get_h(g, 1)) : _get_h(g, k - 1),)
+@inline _nd_node_weights_interior(::RightSide, g, k::Int) = (_get_h(g, k - 1),)
 
-# LinearInterpolantND with numeric values: the separable path. Non-numeric (duck)
-# value types fall through to the generic per-cell method below.
-@inline function integrate(
-        itp::LinearInterpolantND{Tg, Tv, N};
-        search = nothing,
-        hint = nothing
-    ) where {Tg, Tv <: Number, N}
-    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
-    return _integrate_separable_nd_fulldomain(ntuple(_ -> nothing, Val(N)), itp.grids, itp.data, Tout)
-end
-
-# ConstantInterpolantND with numeric values: same separable engine, per-axis side
-# weights (mixed sides compose axis-wise). Duck values fall through to generic.
-@inline function integrate(
-        itp::ConstantInterpolantND{Tg, Tv, N};
-        search = nothing,
-        hint = nothing
-    ) where {Tg, Tv <: Number, N}
-    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
-    return _integrate_separable_nd_fulldomain(itp.sides, itp.grids, itp.data, Tout)
-end
-
-# ── Cubic/Quadratic ND full-domain: separable (value, deriv) pair path ──
-#
-# The full-cell collapse of the 1D kernels is linear in the payload — cubic
-# ∫cell = h/2(fL+fR) + h²/12(dfL−dfR), quadratic ∫cell = 2h/3·fL + h/3·fR +
-# h²/6·dfL — so the domain integral separates with per-axis (w, v) node-weight
-# PAIRS contracting the mixed-partials tensor (slot-first, bit d = ∂ along d):
-#
-#     I = Σ_node Σ_mask (Π_d bit_d(mask) ? v_d(i_d) : w_d(i_d)) · P[1+mask, node]
-#
-# Each node reads its contiguous 2^N-slot block once (vs the 4^N-ish payload
-# reads per cell of the per-cell engine). On uniform axes the cubic deriv
-# weight telescopes to zero in the interior.
-
-struct _CubicWV end
-struct _QuadWV end
-
-# cubic: w = composite trapezoid; v telescopes — (h_k² − h_{k−1}²)/12 interior,
-# ±h²/12 at the ends.
-@inline function _nd_node_wv(::_CubicWV, g, k::Int, n::Int)
+@inline function _nd_node_weights(::CubicInterp, g, k::Int, n::Int)
     if k == 1
         h1 = _get_h(g, 1)
         return (h1 / 2, h1 * h1 / 12)
@@ -409,16 +341,15 @@ struct _QuadWV end
         hm = _get_h(g, n - 1)
         return (hm / 2, -hm * hm / 12)
     end
-    return _nd_node_wv_interior(_CubicWV(), g, k)
+    return _nd_node_weights_interior(CubicInterp(), g, k)
 end
-@inline function _nd_node_wv_interior(::_CubicWV, g, k::Int)
+@inline function _nd_node_weights_interior(::CubicInterp, g, k::Int)
     hm = _get_h(g, k - 1)
     hk = _get_h(g, k)
     return ((hm + hk) / 2, (hk * hk - hm * hm) / 12)
 end
 
-# quadratic (left-anchored parabola): w is asymmetric, v has no right-end share.
-@inline function _nd_node_wv(::_QuadWV, g, k::Int, n::Int)
+@inline function _nd_node_weights(::QuadraticInterp, g, k::Int, n::Int)
     if k == 1
         h1 = _get_h(g, 1)
         return (2 * h1 / 3, h1 * h1 / 6)
@@ -426,127 +357,54 @@ end
         hm = _get_h(g, n - 1)
         return (hm / 3, zero(hm * hm))
     end
-    return _nd_node_wv_interior(_QuadWV(), g, k)
+    return _nd_node_weights_interior(QuadraticInterp(), g, k)
 end
-@inline function _nd_node_wv_interior(::_QuadWV, g, k::Int)
+@inline function _nd_node_weights_interior(::QuadraticInterp, g, k::Int)
     hm = _get_h(g, k - 1)
     hk = _get_h(g, k)
     return ((2 * hk + hm) / 3, hk * hk / 6)
 end
 
-# Nested pair reduction: outer axes hoist the Kronecker partial products of
-# their (w, v) pairs (axis 2 = fastest outer-mask bit, matching the slot
-# order), so the inner sweep is one contiguous slot-pair muladd per outer mask.
-@generated function _integrate_separable_pair_fulldomain(
-        p, grids::NTuple{N, Any}, partials::Array{Tv, NP1}, ::Type{Tout}
-    ) where {N, Tv, NP1, Tout}
-    NP1 == N + 1 || error("NP1 must equal N+1")
-    if N == 1
-        return quote
-            Base.@_inline_meta
-            g1 = grids[1]
-            n_1 = size(partials, 2)
-            total = zero(Tout)
-            @inbounds begin
-                (w1a, v1a) = _nd_node_wv(p, g1, 1, n_1)
-                (w1b, v1b) = _nd_node_wv(p, g1, n_1, n_1)
-                total += w1a * partials[1, 1] + v1a * partials[2, 1] +
-                    w1b * partials[1, n_1] + v1b * partials[2, n_1]
-                @simd for i_1 in 2:(n_1 - 1)
-                    (w1, v1) = _nd_node_wv_interior(p, g1, i_1)
-                    total += w1 * partials[1, i_1] + v1 * partials[2, i_1]
-                end
-            end
-            return total
-        end
-    end
-    M = 1 << (N - 1)
-    ivars = [Symbol(:i_, d) for d in 1:N]
-    rest = ivars[2:N]
-    ko(j) = Symbol(:ko, 2, :_, j)
-    contrib(w1s, v1s, i1expr) = foldl(
-        (a, b) -> :($a + $b),
-        [
-            :(
-                    $(ko(om)) * muladd(
-                        $v1s, partials[$(2om), $i1expr, $(rest...)],
-                        $w1s * partials[$(2om - 1), $i1expr, $(rest...)]
-                    )
-                ) for om in 1:M
-        ]
+# ── Partial-cell node shares: `_nd_cell_weights0/1(tag, u0, u1, h) -> NTuple{R}` ──
+# Share of ∫_{u0}^{u1} within one cell landing on the left (0) / right (1) node;
+# full cells reduce to the closed full-cell forms.
+
+@inline _nd_cell_weights0(::LinearInterp, u0, u1, h) = (_w0_int(u0, u1, h),)
+@inline _nd_cell_weights1(::LinearInterp, u0, u1, h) = (_w1_int(u0, u1, h),)
+@inline _nd_cell_weights0(s::AbstractSide, u0, u1, h) = (_cw0(u0, u1, h, s),)
+@inline _nd_cell_weights1(s::AbstractSide, u0, u1, h) = (_cw1(u0, u1, h, s),)
+
+# The ΔH antiderivatives carry Float64 coefficients, so the cubic pair converts
+# back to the promoted input precision (`oftype`) — same numerics as the generic
+# engine's per-cell `convert(Tout, …)`, keeping Float32 outputs Float32.
+@inline function _nd_cell_weights0(::CubicInterp, u0, u1, h)
+    t0 = u0 / h
+    t1 = u1 / h
+    return (
+        oftype(h * one(t1), h * (_IH00(t1) - _IH00(t0))),
+        oftype(h * h * one(t1), h * h * (_IH10(t1) - _IH10(t0))),
     )
-    inner = quote
-        (w1a, v1a) = _nd_node_wv(p, g1, 1, n_1)
-        (w1b, v1b) = _nd_node_wv(p, g1, n_1, n_1)
-        s = $(contrib(:w1a, :v1a, 1)) + $(contrib(:w1b, :v1b, :n_1))
-        @simd for i_1 in 2:(n_1 - 1)
-            (w1, v1) = _nd_node_wv_interior(p, g1, i_1)
-            s += $(contrib(:w1, :v1, :i_1))
-        end
-        total += s
-    end
-    body = inner
-    for d in 2:N
-        id = ivars[d]
-        nd = Symbol(:n_, d)
-        assigns = Expr[:(($(Symbol(:w_, d)), $(Symbol(:v_, d))) = _nd_node_wv(p, grids[$d], $id, $nd))]
-        if d == N
-            push!(assigns, :($(Symbol(:ko, d, :_, 1)) = $(Symbol(:w_, d))))
-            push!(assigns, :($(Symbol(:ko, d, :_, 2)) = $(Symbol(:v_, d))))
-        else
-            for j in 1:(1 << (N - d))
-                push!(assigns, :($(Symbol(:ko, d, :_, 2j - 1)) = $(Symbol(:w_, d)) * $(Symbol(:ko, d + 1, :_, j))))
-                push!(assigns, :($(Symbol(:ko, d, :_, 2j)) = $(Symbol(:v_, d)) * $(Symbol(:ko, d + 1, :_, j))))
-            end
-        end
-        body = quote
-            for $id in 1:$nd
-                $(assigns...)
-                $body
-            end
-        end
-    end
-    nassign = Expr(:block, [:($(Symbol(:n_, d)) = size(partials, $d + 1)) for d in 1:N]...)
-    return quote
-        Base.@_inline_meta
-        $nassign
-        g1 = grids[1]
-        total = zero(Tout)
-        @inbounds begin
-            $body
-        end
-        return total
-    end
+end
+@inline function _nd_cell_weights1(::CubicInterp, u0, u1, h)
+    t0 = u0 / h
+    t1 = u1 / h
+    return (
+        oftype(h * one(t1), h * (_IH01(t1) - _IH01(t0))),
+        oftype(h * h * one(t1), h * h * (_IH11(t1) - _IH11(t0))),
+    )
+end
+@inline function _nd_cell_weights0(::QuadraticInterp, u0, u1, h)
+    du = u1 - u0
+    D2 = du * (u1 + u0)
+    D3 = u1 * u1 * u1 - u0 * u0 * u0
+    return (du - D3 / (3 * h * h), D2 / 2 - D3 / (3 * h))
+end
+@inline function _nd_cell_weights1(::QuadraticInterp, u0, u1, h)
+    D3 = u1 * u1 * u1 - u0 * u0 * u0
+    return (D3 / (3 * h * h), zero(h * h))
 end
 
-# CubicInterpolantND / QuadraticInterpolantND with numeric values: the pair
-# path. Duck values fall through to the generic per-cell method below.
-@inline function integrate(
-        itp::CubicInterpolantND{Tg, Tv, N};
-        search = nothing,
-        hint = nothing
-    ) where {Tg, Tv <: Number, N}
-    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
-    return _integrate_separable_pair_fulldomain(_CubicWV(), itp.grids, itp.nodal_derivs.partials, Tout)
-end
-
-@inline function integrate(
-        itp::QuadraticInterpolantND{Tg, Tv, N};
-        search = nothing,
-        hint = nothing
-    ) where {Tg, Tv <: Number, N}
-    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
-    return _integrate_separable_pair_fulldomain(_QuadWV(), itp.grids, itp.nodal_derivs.partials, Tout)
-end
-
-# ── Bounded ND (linear/constant): separable clipped-composite path ──
-#
-# Separability holds on any axis-aligned box, not just the full domain: the
-# per-axis node weights become "clipped composites" — zero outside the covered
-# cells, the partial-cell integral weights at the two boundary cells, and the
-# full-cell weights in between — so the sum visits the node sub-box once with
-# no per-cell clip geometry. Bounds/sign/extrap semantics come from the shared
-# `_integrate_nd_preamble`, identical to the generic cell-wise engine.
+# ── Bounded per-axis machinery ──
 
 # Per-axis spec: covered cell range [ilo, ihi] plus the clipped local start
 # inside cell `ilo` (u0 ≥ 0) and clipped local end inside cell `ihi` (u1 ≤ h).
@@ -574,69 +432,162 @@ end
     return :(($(exprs...),))
 end
 
-# Partial-cell end-weight pair through the provider (`nothing` = linear basis,
-# a side = the constant selection weights) — full cells reduce to the closed forms.
-@inline _nd_cell_w0(::Nothing, u0, u1, h) = _w0_int(u0, u1, h)
-@inline _nd_cell_w1(::Nothing, u0, u1, h) = _w1_int(u0, u1, h)
-@inline _nd_cell_w0(s::AbstractSide, u0, u1, h) = _cw0(u0, u1, h, s)
-@inline _nd_cell_w1(s::AbstractSide, u0, u1, h) = _cw1(u0, u1, h, s)
-
-# Clipped composite node weight: right-end share of cell k−1 plus left-end share
-# of cell k, each clipped to the covered range. Only the ≤ 4 nodes touching the
-# two boundary cells differ from the full-domain weights.
-@inline function _nd_bounded_node_weight(w, spec::_BoundedAxisSpec, g, k::Int)
-    total = zero(spec.u0)
+# Clipped composite node weights: right-end share of cell k−1 plus left-end
+# share of cell k, each clipped to the covered range. Only the ≤ 4 nodes
+# touching the two boundary cells differ from the full-cell weights. The seed
+# is an empty-span cell share — typed zeros of the tag's weight tuple.
+@inline function _nd_bounded_node_weights(w, spec::_BoundedAxisSpec, g, k::Int)
+    acc = _nd_cell_weights0(w, spec.u0, spec.u0, _get_h(g, spec.ilo))
     c = k - 1
     if spec.ilo <= c <= spec.ihi
         h = _get_h(g, c)
-        total += _nd_cell_w1(w, c == spec.ilo ? spec.u0 : zero(h), c == spec.ihi ? spec.u1 : h, h)
+        acc = map(
+            +, acc,
+            _nd_cell_weights1(w, c == spec.ilo ? spec.u0 : zero(h), c == spec.ihi ? spec.u1 : h, h)
+        )
     end
     c = k
     if spec.ilo <= c <= spec.ihi
         h = _get_h(g, c)
-        total += _nd_cell_w0(w, c == spec.ilo ? spec.u0 : zero(h), c == spec.ihi ? spec.u1 : h, h)
+        acc = map(
+            +, acc,
+            _nd_cell_weights0(w, c == spec.ilo ? spec.u0 : zero(h), c == spec.ihi ? spec.u1 : h, h)
+        )
     end
-    return total
+    return acc
 end
 
-# Nested reduction over the node sub-box. Wide inner spans peel the four
-# boundary-cell nodes so the interior runs the branch-free full-cell weights
-# under @simd; narrow spans (≤ 2 cells) take the scalar clipped loop.
-@generated function _integrate_separable_nd_bounded(
-        wspec::NTuple{N, Any}, specs::NTuple{N, _BoundedAxisSpec},
-        grids::NTuple{N, Any}, data::AbstractArray, ::Type{Tout}
-    ) where {N, Tout}
+# ── The two @generated kernels (full-domain / bounded), rank-aware ──
+#
+# Emission per rank: rank 1 hoists the plain outer weight product `wp` and
+# multiplies once per inner sweep; rank 2 hoists the Kronecker partial products
+# of the (w, v) pairs (axis 2 = fastest mask bit, matching the slot order) and
+# folds each node's contiguous slot pair with one muladd per outer mask. The
+# inner axis peels its boundary nodes so the interior runs branch-free @simd.
+
+function _separable_emit_common(N::Int, R::Int)
     ivars = [Symbol(:i_, d) for d in 1:N]
     rest = ivars[2:N]
-    inner = quote
-        s = zero(Tout)
-        if ihi1 >= ilo1 + 2
-            s += _nd_bounded_node_weight(w1, spec1, g1, ilo1) * data[ilo1, $(rest...)] +
-                _nd_bounded_node_weight(w1, spec1, g1, ilo1 + 1) * data[ilo1 + 1, $(rest...)] +
-                _nd_bounded_node_weight(w1, spec1, g1, ihi1) * data[ihi1, $(rest...)] +
-                _nd_bounded_node_weight(w1, spec1, g1, ihi1 + 1) * data[ihi1 + 1, $(rest...)]
-            @simd for i_1 in (ilo1 + 2):(ihi1 - 1)
-                s += _nd_node_weight_interior(w1, g1, i_1) * data[i_1, $(rest...)]
-            end
-        else
-            for i_1 in ilo1:(ihi1 + 1)
-                s += _nd_bounded_node_weight(w1, spec1, g1, i_1) * data[i_1, $(rest...)]
-            end
-        end
-        total += wp_2 * s
-    end
-    body = inner
+    M = 1 << (N - 1)
+    pidx(slot, i1) = R == 1 ? :(payload[$i1, $(rest...)]) : :(payload[$slot, $i1, $(rest...)])
+    wnames(ws) = R == 1 ? [Symbol(ws, :_1)] : [Symbol(ws, :_1), Symbol(ws, :_2)]
+    wdecl(ws, call) = Expr(:(=), Expr(:tuple, wnames(ws)...), call)
+    contrib(ws, i1) = R == 1 ? :($(Symbol(ws, :_1)) * $(pidx(0, i1))) :
+        foldl(
+            (a, b) -> :($a + $b),
+            [
+                :(
+                    $(N == 1 ? 1 : Symbol(:ko2_, om)) * muladd(
+                        $(Symbol(ws, :_2)), $(pidx(2om, i1)),
+                        $(Symbol(ws, :_1)) * $(pidx(2om - 1, i1))
+                    )
+                ) for om in 1:M
+            ]
+        )
+    close_expr = N == 1 ? :(total += s) : R == 1 ? :(total += wp_2 * s) : :(total += s)
+    return ivars, rest, pidx, wdecl, contrib, close_expr
+end
+
+# Outer-axis loop wrapper: rank 1 chains the scalar product `wp_d`; rank 2
+# builds the Kronecker partial products `ko{d}_{j}` of the (w, v) pairs.
+function _separable_emit_outer(body, N::Int, R::Int, ivars, wcall::Function, ranges::Function)
     for d in 2:N
         id = ivars[d]
-        wexpr = d == N ? :(_nd_bounded_node_weight(wspec[$d], specs[$d], grids[$d], $id)) :
-            :(_nd_bounded_node_weight(wspec[$d], specs[$d], grids[$d], $id) * $(Symbol(:wp_, d + 1)))
+        assigns = Expr[]
+        if R == 1
+            wexpr = d == N ? :($(wcall(d))[1]) : :($(wcall(d))[1] * $(Symbol(:wp_, d + 1)))
+            push!(assigns, :($(Symbol(:wp_, d)) = $wexpr))
+        else
+            push!(assigns, Expr(:(=), Expr(:tuple, Symbol(:w_, d), Symbol(:v_, d)), wcall(d)))
+            if d == N
+                push!(assigns, :($(Symbol(:ko, d, :_, 1)) = $(Symbol(:w_, d))))
+                push!(assigns, :($(Symbol(:ko, d, :_, 2)) = $(Symbol(:v_, d))))
+            else
+                for j in 1:(1 << (N - d))
+                    push!(assigns, :($(Symbol(:ko, d, :_, 2j - 1)) = $(Symbol(:w_, d)) * $(Symbol(:ko, d + 1, :_, j))))
+                    push!(assigns, :($(Symbol(:ko, d, :_, 2j)) = $(Symbol(:v_, d)) * $(Symbol(:ko, d + 1, :_, j))))
+                end
+            end
+        end
         body = quote
-            for $id in specs[$d].ilo:(specs[$d].ihi + 1)
-                $(Symbol(:wp_, d)) = $wexpr
+            for $id in $(ranges(d))
+                $(assigns...)
                 $body
             end
         end
     end
+    return body
+end
+
+@generated function _integrate_separable_nd_fulldomain(
+        wspec::NTuple{N, Any}, grids::NTuple{N, Any},
+        payload::AbstractArray{Tv, NP}, ::Type{Tout}
+    ) where {N, Tv, NP, Tout}
+    R = NP - N + 1
+    R in (1, 2) || error("payload must have N or N+1 dimensions")
+    ivars, _, _, wdecl, contrib, close_expr = _separable_emit_common(N, R)
+    inner = quote
+        $(wdecl(:w1a, :(_nd_node_weights(w1, g1, 1, n_1))))
+        $(wdecl(:w1b, :(_nd_node_weights(w1, g1, n_1, n_1))))
+        s = $(contrib(:w1a, 1)) + $(contrib(:w1b, :n_1))
+        @simd for i_1 in 2:(n_1 - 1)
+            $(wdecl(:w1i, :(_nd_node_weights_interior(w1, g1, i_1))))
+            s += $(contrib(:w1i, :i_1))
+        end
+        $close_expr
+    end
+    body = _separable_emit_outer(
+        inner, N, R, ivars,
+        d -> :(_nd_node_weights(wspec[$d], grids[$d], $(ivars[d]), $(Symbol(:n_, d)))),
+        d -> :(1:$(Symbol(:n_, d)))
+    )
+    nassign = Expr(:block, [:($(Symbol(:n_, d)) = size(payload, $(d + R - 1))) for d in 1:N]...)
+    return quote
+        Base.@_inline_meta
+        $nassign
+        g1 = grids[1]
+        w1 = wspec[1]
+        total = zero(Tout)
+        @inbounds begin
+            $body
+        end
+        return total
+    end
+end
+
+@generated function _integrate_separable_nd_bounded(
+        wspec::NTuple{N, Any}, specs::NTuple{N, _BoundedAxisSpec},
+        grids::NTuple{N, Any}, payload::AbstractArray{Tv, NP}, ::Type{Tout}
+    ) where {N, Tv, NP, Tout}
+    R = NP - N + 1
+    R in (1, 2) || error("payload must have N or N+1 dimensions")
+    ivars, _, _, wdecl, contrib, close_expr = _separable_emit_common(N, R)
+    inner = quote
+        s = zero(Tout)
+        if ihi1 >= ilo1 + 2
+            $(wdecl(:w1a, :(_nd_bounded_node_weights(w1, spec1, g1, ilo1))))
+            $(wdecl(:w1b, :(_nd_bounded_node_weights(w1, spec1, g1, ilo1 + 1))))
+            $(wdecl(:w1c, :(_nd_bounded_node_weights(w1, spec1, g1, ihi1))))
+            $(wdecl(:w1d, :(_nd_bounded_node_weights(w1, spec1, g1, ihi1 + 1))))
+            s += $(contrib(:w1a, :ilo1)) + $(contrib(:w1b, :(ilo1 + 1))) +
+                $(contrib(:w1c, :ihi1)) + $(contrib(:w1d, :(ihi1 + 1)))
+            @simd for i_1 in (ilo1 + 2):(ihi1 - 1)
+                $(wdecl(:w1i, :(_nd_node_weights_interior(w1, g1, i_1))))
+                s += $(contrib(:w1i, :i_1))
+            end
+        else
+            for i_1 in ilo1:(ihi1 + 1)
+                $(wdecl(:w1x, :(_nd_bounded_node_weights(w1, spec1, g1, i_1))))
+                s += $(contrib(:w1x, :i_1))
+            end
+        end
+        $close_expr
+    end
+    body = _separable_emit_outer(
+        inner, N, R, ivars,
+        d -> :(_nd_bounded_node_weights(wspec[$d], specs[$d], grids[$d], $(ivars[d]))),
+        d -> :((specs[$d].ilo):(specs[$d].ihi + 1))
+    )
     return quote
         Base.@_inline_meta
         g1 = grids[1]
@@ -652,219 +603,61 @@ end
     end
 end
 
-# LinearInterpolantND bounded, numeric values: separable clipped path. Duck
-# values keep the generic per-cell method in integrate_api.jl.
+# ── Dispatches: numeric values take the separable engine; duck values fall
+# through to the generic per-cell methods. The weight spec per family is the
+# existing vocabulary: a method-tag tuple, or the constant `sides` as-is. ──
+
+@inline _separable_wspec(itp::LinearInterpolantND{Tg, Tv, N}) where {Tg, Tv, N} =
+    (ntuple(_ -> LinearInterp(), Val(N)), itp.data)
+@inline _separable_wspec(itp::ConstantInterpolantND{Tg, Tv, N}) where {Tg, Tv, N} =
+    (itp.sides, itp.data)
+@inline _separable_wspec(itp::CubicInterpolantND{Tg, Tv, N}) where {Tg, Tv, N} =
+    (ntuple(_ -> CubicInterp(), Val(N)), itp.nodal_derivs.partials)
+@inline _separable_wspec(itp::QuadraticInterpolantND{Tg, Tv, N}) where {Tg, Tv, N} =
+    (ntuple(_ -> QuadraticInterp(), Val(N)), itp.nodal_derivs.partials)
+
+const _SeparableND{Tg, Tv, N} = Union{
+    LinearInterpolantND{Tg, Tv, N}, ConstantInterpolantND{Tg, Tv, N},
+    CubicInterpolantND{Tg, Tv, N}, QuadraticInterpolantND{Tg, Tv, N},
+}
+
 @inline function integrate(
-        itp::LinearInterpolantND{Tg, Tv, N},
-        lo::Tuple{Vararg{Real, N}},
-        hi::Tuple{Vararg{Real, N}};
-        search = itp.searches,
-        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
+        itp::_SeparableND{Tg, Tv, N};
+        search = nothing,
+        hint = nothing
     ) where {Tg, Tv <: Number, N}
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
+    wspec, payload = _separable_wspec(itp)
+    return _integrate_separable_nd_fulldomain(wspec, itp.grids, payload, Tout)
+end
+
+# Bounded impl shared by the four thin dispatches below. The dispatches stay
+# per-type (not the `_SeparableND` union): the legacy per-cell bounded methods
+# in integrate_api.jl are per-type with unconstrained `Tv`, and a union-typed
+# `Tv <: Number` method would cross specificities with them (ambiguity); a
+# per-type `Tv <: Number` method is strictly more specific instead.
+@inline function _separable_bounded(itp, lo, hi, search, hint, ::Type{Tg}, ::Type{Tv}) where {Tg, Tv}
     sign, lo2, hi2, idx_lo, idx_hi = _integrate_nd_preamble(
         itp.grids, itp.extraps, lo, hi, search, hint
     )
     Tout = _integrate_nd_output_type(Tv, Tg, lo2, hi2)
     sign == 0 && return zero(Tout)
     specs = _nd_bounded_axis_specs(itp.grids, lo2, hi2, idx_lo, idx_hi)
-    total = _integrate_separable_nd_bounded(
-        ntuple(_ -> nothing, Val(N)), specs, itp.grids, itp.data, Tout
-    )
+    wspec, payload = _separable_wspec(itp)
+    total = _integrate_separable_nd_bounded(wspec, specs, itp.grids, payload, Tout)
     return sign * total
 end
 
-# ConstantInterpolantND bounded, numeric values: same path with side weights.
-@inline function integrate(
-        itp::ConstantInterpolantND{Tg, Tv, N},
-        lo::Tuple{Vararg{Real, N}},
-        hi::Tuple{Vararg{Real, N}};
-        search = itp.searches,
-        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
-    ) where {Tg, Tv <: Number, N}
-    sign, lo2, hi2, idx_lo, idx_hi = _integrate_nd_preamble(
-        itp.grids, itp.extraps, lo, hi, search, hint
-    )
-    Tout = _integrate_nd_output_type(Tv, Tg, lo2, hi2)
-    sign == 0 && return zero(Tout)
-    specs = _nd_bounded_axis_specs(itp.grids, lo2, hi2, idx_lo, idx_hi)
-    total = _integrate_separable_nd_bounded(itp.sides, specs, itp.grids, itp.data, Tout)
-    return sign * total
-end
-
-# ── Bounded ND (cubic/quadratic): separable clipped (value, deriv) pairs ──
-#
-# The clipped-composite structure extends to the pair payload: each boundary
-# cell contributes its partial-cell (value, deriv) end-weight pair — cubic via
-# the ΔH antiderivative deltas, quadratic via its closed form — and full cells
-# collapse to the full-domain pair weights.
-
-# Partial-cell end-weight pairs: node share of ∫_{u0}^{u1} within one cell.
-# The ΔH antiderivatives carry Float64 coefficients, so the cubic pair converts
-# back to the promoted input precision (`oftype`) — same numerics as the generic
-# engine's per-cell `convert(Tout, …)`, keeping Float32 outputs Float32.
-@inline function _nd_cell_wv0(::_CubicWV, u0, u1, h)
-    t0 = u0 / h
-    t1 = u1 / h
-    return (
-        oftype(h * one(t1), h * (_IH00(t1) - _IH00(t0))),
-        oftype(h * h * one(t1), h * h * (_IH10(t1) - _IH10(t0))),
-    )
-end
-@inline function _nd_cell_wv1(::_CubicWV, u0, u1, h)
-    t0 = u0 / h
-    t1 = u1 / h
-    return (
-        oftype(h * one(t1), h * (_IH01(t1) - _IH01(t0))),
-        oftype(h * h * one(t1), h * h * (_IH11(t1) - _IH11(t0))),
-    )
-end
-@inline function _nd_cell_wv0(::_QuadWV, u0, u1, h)
-    du = u1 - u0
-    D2 = du * (u1 + u0)
-    D3 = u1 * u1 * u1 - u0 * u0 * u0
-    return (du - D3 / (3 * h * h), D2 / 2 - D3 / (3 * h))
-end
-@inline function _nd_cell_wv1(::_QuadWV, u0, u1, h)
-    D3 = u1 * u1 * u1 - u0 * u0 * u0
-    return (D3 / (3 * h * h), zero(h * h))
-end
-
-# Clipped composite (w, v) node weight — the pair analog of
-# `_nd_bounded_node_weight`.
-@inline function _nd_bounded_node_wv(p, spec::_BoundedAxisSpec, g, k::Int)
-    w = zero(spec.u0)
-    v = zero(spec.u0 * spec.u0)
-    c = k - 1
-    if spec.ilo <= c <= spec.ihi
-        h = _get_h(g, c)
-        (wc, vc) = _nd_cell_wv1(p, c == spec.ilo ? spec.u0 : zero(h), c == spec.ihi ? spec.u1 : h, h)
-        w += wc
-        v += vc
+for T in (:LinearInterpolantND, :ConstantInterpolantND, :CubicInterpolantND, :QuadraticInterpolantND)
+    @eval @inline function integrate(
+            itp::$T{Tg, Tv, N},
+            lo::Tuple{Vararg{Real, N}},
+            hi::Tuple{Vararg{Real, N}};
+            search = itp.searches,
+            hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
+        ) where {Tg, Tv <: Number, N}
+        return _separable_bounded(itp, lo, hi, search, hint, Tg, Tv)
     end
-    c = k
-    if spec.ilo <= c <= spec.ihi
-        h = _get_h(g, c)
-        (wc, vc) = _nd_cell_wv0(p, c == spec.ilo ? spec.u0 : zero(h), c == spec.ihi ? spec.u1 : h, h)
-        w += wc
-        v += vc
-    end
-    return (w, v)
-end
-
-# Nested pair reduction over the node sub-box — the bounded analog of
-# `_integrate_separable_pair_fulldomain`, with the same boundary-node peel.
-@generated function _integrate_separable_pair_bounded(
-        p, specs::NTuple{N, _BoundedAxisSpec}, grids::NTuple{N, Any},
-        partials::Array{Tv, NP1}, ::Type{Tout}
-    ) where {N, Tv, NP1, Tout}
-    NP1 == N + 1 || error("NP1 must equal N+1")
-    M = 1 << (N - 1)
-    ivars = [Symbol(:i_, d) for d in 1:N]
-    rest = ivars[2:N]
-    ko(j) = Symbol(:ko, 2, :_, j)
-    contrib(w1s, v1s, i1expr) = foldl(
-        (a, b) -> :($a + $b),
-        [
-            :(
-                    $(M == 1 ? 1 : ko(om)) * muladd(
-                        $v1s, partials[$(2om), $i1expr, $(rest...)],
-                        $w1s * partials[$(2om - 1), $i1expr, $(rest...)]
-                    )
-                ) for om in 1:M
-        ]
-    )
-    inner = quote
-        s = zero(Tout)
-        if ihi1 >= ilo1 + 2
-            (w1a, v1a) = _nd_bounded_node_wv(p, spec1, g1, ilo1)
-            (w1b, v1b) = _nd_bounded_node_wv(p, spec1, g1, ilo1 + 1)
-            (w1c, v1c) = _nd_bounded_node_wv(p, spec1, g1, ihi1)
-            (w1d, v1d) = _nd_bounded_node_wv(p, spec1, g1, ihi1 + 1)
-            s += $(contrib(:w1a, :v1a, :ilo1)) + $(contrib(:w1b, :v1b, :(ilo1 + 1))) +
-                $(contrib(:w1c, :v1c, :ihi1)) + $(contrib(:w1d, :v1d, :(ihi1 + 1)))
-            @simd for i_1 in (ilo1 + 2):(ihi1 - 1)
-                (w1, v1) = _nd_node_wv_interior(p, g1, i_1)
-                s += $(contrib(:w1, :v1, :i_1))
-            end
-        else
-            for i_1 in ilo1:(ihi1 + 1)
-                (w1, v1) = _nd_bounded_node_wv(p, spec1, g1, i_1)
-                s += $(contrib(:w1, :v1, :i_1))
-            end
-        end
-        total += s
-    end
-    body = inner
-    for d in 2:N
-        id = ivars[d]
-        assigns = Expr[:(($(Symbol(:w_, d)), $(Symbol(:v_, d))) = _nd_bounded_node_wv(p, specs[$d], grids[$d], $id))]
-        if d == N
-            push!(assigns, :($(Symbol(:ko, d, :_, 1)) = $(Symbol(:w_, d))))
-            push!(assigns, :($(Symbol(:ko, d, :_, 2)) = $(Symbol(:v_, d))))
-        else
-            for j in 1:(1 << (N - d))
-                push!(assigns, :($(Symbol(:ko, d, :_, 2j - 1)) = $(Symbol(:w_, d)) * $(Symbol(:ko, d + 1, :_, j))))
-                push!(assigns, :($(Symbol(:ko, d, :_, 2j)) = $(Symbol(:v_, d)) * $(Symbol(:ko, d + 1, :_, j))))
-            end
-        end
-        body = quote
-            for $id in specs[$d].ilo:(specs[$d].ihi + 1)
-                $(assigns...)
-                $body
-            end
-        end
-    end
-    return quote
-        Base.@_inline_meta
-        g1 = grids[1]
-        spec1 = specs[1]
-        ilo1 = spec1.ilo
-        ihi1 = spec1.ihi
-        total = zero(Tout)
-        @inbounds begin
-            $body
-        end
-        return total
-    end
-end
-
-# CubicInterpolantND / QuadraticInterpolantND bounded, numeric values.
-@inline function integrate(
-        itp::CubicInterpolantND{Tg, Tv, N},
-        lo::Tuple{Vararg{Real, N}},
-        hi::Tuple{Vararg{Real, N}};
-        search = itp.searches,
-        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
-    ) where {Tg, Tv <: Number, N}
-    sign, lo2, hi2, idx_lo, idx_hi = _integrate_nd_preamble(
-        itp.grids, itp.extraps, lo, hi, search, hint
-    )
-    Tout = _integrate_nd_output_type(Tv, Tg, lo2, hi2)
-    sign == 0 && return zero(Tout)
-    specs = _nd_bounded_axis_specs(itp.grids, lo2, hi2, idx_lo, idx_hi)
-    total = _integrate_separable_pair_bounded(
-        _CubicWV(), specs, itp.grids, itp.nodal_derivs.partials, Tout
-    )
-    return sign * total
-end
-
-@inline function integrate(
-        itp::QuadraticInterpolantND{Tg, Tv, N},
-        lo::Tuple{Vararg{Real, N}},
-        hi::Tuple{Vararg{Real, N}};
-        search = itp.searches,
-        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
-    ) where {Tg, Tv <: Number, N}
-    sign, lo2, hi2, idx_lo, idx_hi = _integrate_nd_preamble(
-        itp.grids, itp.extraps, lo, hi, search, hint
-    )
-    Tout = _integrate_nd_output_type(Tv, Tg, lo2, hi2)
-    sign == 0 && return zero(Tout)
-    specs = _nd_bounded_axis_specs(itp.grids, lo2, hi2, idx_lo, idx_hi)
-    total = _integrate_separable_pair_bounded(
-        _QuadWV(), specs, itp.grids, itp.nodal_derivs.partials, Tout
-    )
-    return sign * total
 end
 
 # Generic ND full-domain: catches all ND types

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -383,6 +383,162 @@ end
     return _integrate_separable_nd_fulldomain(itp.sides, itp.grids, itp.data, Tout)
 end
 
+# ── Cubic/Quadratic ND full-domain: separable (value, deriv) pair path ──
+#
+# The full-cell collapse of the 1D kernels is linear in the payload — cubic
+# ∫cell = h/2(fL+fR) + h²/12(dfL−dfR), quadratic ∫cell = 2h/3·fL + h/3·fR +
+# h²/6·dfL — so the domain integral separates with per-axis (w, v) node-weight
+# PAIRS contracting the mixed-partials tensor (slot-first, bit d = ∂ along d):
+#
+#     I = Σ_node Σ_mask (Π_d bit_d(mask) ? v_d(i_d) : w_d(i_d)) · P[1+mask, node]
+#
+# Each node reads its contiguous 2^N-slot block once (vs the 4^N-ish payload
+# reads per cell of the per-cell engine). On uniform axes the cubic deriv
+# weight telescopes to zero in the interior.
+
+struct _CubicWV end
+struct _QuadWV end
+
+# cubic: w = composite trapezoid; v telescopes — (h_k² − h_{k−1}²)/12 interior,
+# ±h²/12 at the ends.
+@inline function _nd_node_wv(::_CubicWV, g, k::Int, n::Int)
+    if k == 1
+        h1 = _get_h(g, 1)
+        return (h1 / 2, h1 * h1 / 12)
+    elseif k == n
+        hm = _get_h(g, n - 1)
+        return (hm / 2, -hm * hm / 12)
+    end
+    return _nd_node_wv_interior(_CubicWV(), g, k)
+end
+@inline function _nd_node_wv_interior(::_CubicWV, g, k::Int)
+    hm = _get_h(g, k - 1)
+    hk = _get_h(g, k)
+    return ((hm + hk) / 2, (hk * hk - hm * hm) / 12)
+end
+
+# quadratic (left-anchored parabola): w is asymmetric, v has no right-end share.
+@inline function _nd_node_wv(::_QuadWV, g, k::Int, n::Int)
+    if k == 1
+        h1 = _get_h(g, 1)
+        return (2 * h1 / 3, h1 * h1 / 6)
+    elseif k == n
+        hm = _get_h(g, n - 1)
+        return (hm / 3, zero(hm * hm))
+    end
+    return _nd_node_wv_interior(_QuadWV(), g, k)
+end
+@inline function _nd_node_wv_interior(::_QuadWV, g, k::Int)
+    hm = _get_h(g, k - 1)
+    hk = _get_h(g, k)
+    return ((2 * hk + hm) / 3, hk * hk / 6)
+end
+
+# Nested pair reduction: outer axes hoist the Kronecker partial products of
+# their (w, v) pairs (axis 2 = fastest outer-mask bit, matching the slot
+# order), so the inner sweep is one contiguous slot-pair muladd per outer mask.
+@generated function _integrate_separable_pair_fulldomain(
+        p, grids::NTuple{N, Any}, partials::Array{Tv, NP1}, ::Type{Tout}
+    ) where {N, Tv, NP1, Tout}
+    NP1 == N + 1 || error("NP1 must equal N+1")
+    if N == 1
+        return quote
+            Base.@_inline_meta
+            g1 = grids[1]
+            n_1 = size(partials, 2)
+            total = zero(Tout)
+            @inbounds begin
+                (w1a, v1a) = _nd_node_wv(p, g1, 1, n_1)
+                (w1b, v1b) = _nd_node_wv(p, g1, n_1, n_1)
+                total += w1a * partials[1, 1] + v1a * partials[2, 1] +
+                    w1b * partials[1, n_1] + v1b * partials[2, n_1]
+                @simd for i_1 in 2:(n_1 - 1)
+                    (w1, v1) = _nd_node_wv_interior(p, g1, i_1)
+                    total += w1 * partials[1, i_1] + v1 * partials[2, i_1]
+                end
+            end
+            return total
+        end
+    end
+    M = 1 << (N - 1)
+    ivars = [Symbol(:i_, d) for d in 1:N]
+    rest = ivars[2:N]
+    ko(j) = Symbol(:ko, 2, :_, j)
+    contrib(w1s, v1s, i1expr) = foldl(
+        (a, b) -> :($a + $b),
+        [
+            :(
+                    $(ko(om)) * muladd(
+                        $v1s, partials[$(2om), $i1expr, $(rest...)],
+                        $w1s * partials[$(2om - 1), $i1expr, $(rest...)]
+                    )
+                ) for om in 1:M
+        ]
+    )
+    inner = quote
+        (w1a, v1a) = _nd_node_wv(p, g1, 1, n_1)
+        (w1b, v1b) = _nd_node_wv(p, g1, n_1, n_1)
+        s = $(contrib(:w1a, :v1a, 1)) + $(contrib(:w1b, :v1b, :n_1))
+        @simd for i_1 in 2:(n_1 - 1)
+            (w1, v1) = _nd_node_wv_interior(p, g1, i_1)
+            s += $(contrib(:w1, :v1, :i_1))
+        end
+        total += s
+    end
+    body = inner
+    for d in 2:N
+        id = ivars[d]
+        nd = Symbol(:n_, d)
+        assigns = Expr[:(($(Symbol(:w_, d)), $(Symbol(:v_, d))) = _nd_node_wv(p, grids[$d], $id, $nd))]
+        if d == N
+            push!(assigns, :($(Symbol(:ko, d, :_, 1)) = $(Symbol(:w_, d))))
+            push!(assigns, :($(Symbol(:ko, d, :_, 2)) = $(Symbol(:v_, d))))
+        else
+            for j in 1:(1 << (N - d))
+                push!(assigns, :($(Symbol(:ko, d, :_, 2j - 1)) = $(Symbol(:w_, d)) * $(Symbol(:ko, d + 1, :_, j))))
+                push!(assigns, :($(Symbol(:ko, d, :_, 2j)) = $(Symbol(:v_, d)) * $(Symbol(:ko, d + 1, :_, j))))
+            end
+        end
+        body = quote
+            for $id in 1:$nd
+                $(assigns...)
+                $body
+            end
+        end
+    end
+    nassign = Expr(:block, [:($(Symbol(:n_, d)) = size(partials, $d + 1)) for d in 1:N]...)
+    return quote
+        Base.@_inline_meta
+        $nassign
+        g1 = grids[1]
+        total = zero(Tout)
+        @inbounds begin
+            $body
+        end
+        return total
+    end
+end
+
+# CubicInterpolantND / QuadraticInterpolantND with numeric values: the pair
+# path. Duck values fall through to the generic per-cell method below.
+@inline function integrate(
+        itp::CubicInterpolantND{Tg, Tv, N};
+        search = nothing,
+        hint = nothing
+    ) where {Tg, Tv <: Number, N}
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
+    return _integrate_separable_pair_fulldomain(_CubicWV(), itp.grids, itp.nodal_derivs.partials, Tout)
+end
+
+@inline function integrate(
+        itp::QuadraticInterpolantND{Tg, Tv, N};
+        search = nothing,
+        hint = nothing
+    ) where {Tg, Tv <: Number, N}
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
+    return _integrate_separable_pair_fulldomain(_QuadWV(), itp.grids, itp.nodal_derivs.partials, Tout)
+end
+
 # ── Bounded ND (linear/constant): separable clipped-composite path ──
 #
 # Separability holds on any axis-aligned box, not just the full domain: the
@@ -532,6 +688,182 @@ end
     sign == 0 && return zero(Tout)
     specs = _nd_bounded_axis_specs(itp.grids, lo2, hi2, idx_lo, idx_hi)
     total = _integrate_separable_nd_bounded(itp.sides, specs, itp.grids, itp.data, Tout)
+    return sign * total
+end
+
+# ── Bounded ND (cubic/quadratic): separable clipped (value, deriv) pairs ──
+#
+# The clipped-composite structure extends to the pair payload: each boundary
+# cell contributes its partial-cell (value, deriv) end-weight pair — cubic via
+# the ΔH antiderivative deltas, quadratic via its closed form — and full cells
+# collapse to the full-domain pair weights.
+
+# Partial-cell end-weight pairs: node share of ∫_{u0}^{u1} within one cell.
+# The ΔH antiderivatives carry Float64 coefficients, so the cubic pair converts
+# back to the promoted input precision (`oftype`) — same numerics as the generic
+# engine's per-cell `convert(Tout, …)`, keeping Float32 outputs Float32.
+@inline function _nd_cell_wv0(::_CubicWV, u0, u1, h)
+    t0 = u0 / h
+    t1 = u1 / h
+    return (
+        oftype(h * one(t1), h * (_IH00(t1) - _IH00(t0))),
+        oftype(h * h * one(t1), h * h * (_IH10(t1) - _IH10(t0))),
+    )
+end
+@inline function _nd_cell_wv1(::_CubicWV, u0, u1, h)
+    t0 = u0 / h
+    t1 = u1 / h
+    return (
+        oftype(h * one(t1), h * (_IH01(t1) - _IH01(t0))),
+        oftype(h * h * one(t1), h * h * (_IH11(t1) - _IH11(t0))),
+    )
+end
+@inline function _nd_cell_wv0(::_QuadWV, u0, u1, h)
+    du = u1 - u0
+    D2 = du * (u1 + u0)
+    D3 = u1 * u1 * u1 - u0 * u0 * u0
+    return (du - D3 / (3 * h * h), D2 / 2 - D3 / (3 * h))
+end
+@inline function _nd_cell_wv1(::_QuadWV, u0, u1, h)
+    D3 = u1 * u1 * u1 - u0 * u0 * u0
+    return (D3 / (3 * h * h), zero(h * h))
+end
+
+# Clipped composite (w, v) node weight — the pair analog of
+# `_nd_bounded_node_weight`.
+@inline function _nd_bounded_node_wv(p, spec::_BoundedAxisSpec, g, k::Int)
+    w = zero(spec.u0)
+    v = zero(spec.u0 * spec.u0)
+    c = k - 1
+    if spec.ilo <= c <= spec.ihi
+        h = _get_h(g, c)
+        (wc, vc) = _nd_cell_wv1(p, c == spec.ilo ? spec.u0 : zero(h), c == spec.ihi ? spec.u1 : h, h)
+        w += wc
+        v += vc
+    end
+    c = k
+    if spec.ilo <= c <= spec.ihi
+        h = _get_h(g, c)
+        (wc, vc) = _nd_cell_wv0(p, c == spec.ilo ? spec.u0 : zero(h), c == spec.ihi ? spec.u1 : h, h)
+        w += wc
+        v += vc
+    end
+    return (w, v)
+end
+
+# Nested pair reduction over the node sub-box — the bounded analog of
+# `_integrate_separable_pair_fulldomain`, with the same boundary-node peel.
+@generated function _integrate_separable_pair_bounded(
+        p, specs::NTuple{N, _BoundedAxisSpec}, grids::NTuple{N, Any},
+        partials::Array{Tv, NP1}, ::Type{Tout}
+    ) where {N, Tv, NP1, Tout}
+    NP1 == N + 1 || error("NP1 must equal N+1")
+    M = 1 << (N - 1)
+    ivars = [Symbol(:i_, d) for d in 1:N]
+    rest = ivars[2:N]
+    ko(j) = Symbol(:ko, 2, :_, j)
+    contrib(w1s, v1s, i1expr) = foldl(
+        (a, b) -> :($a + $b),
+        [
+            :(
+                    $(M == 1 ? 1 : ko(om)) * muladd(
+                        $v1s, partials[$(2om), $i1expr, $(rest...)],
+                        $w1s * partials[$(2om - 1), $i1expr, $(rest...)]
+                    )
+                ) for om in 1:M
+        ]
+    )
+    inner = quote
+        s = zero(Tout)
+        if ihi1 >= ilo1 + 2
+            (w1a, v1a) = _nd_bounded_node_wv(p, spec1, g1, ilo1)
+            (w1b, v1b) = _nd_bounded_node_wv(p, spec1, g1, ilo1 + 1)
+            (w1c, v1c) = _nd_bounded_node_wv(p, spec1, g1, ihi1)
+            (w1d, v1d) = _nd_bounded_node_wv(p, spec1, g1, ihi1 + 1)
+            s += $(contrib(:w1a, :v1a, :ilo1)) + $(contrib(:w1b, :v1b, :(ilo1 + 1))) +
+                $(contrib(:w1c, :v1c, :ihi1)) + $(contrib(:w1d, :v1d, :(ihi1 + 1)))
+            @simd for i_1 in (ilo1 + 2):(ihi1 - 1)
+                (w1, v1) = _nd_node_wv_interior(p, g1, i_1)
+                s += $(contrib(:w1, :v1, :i_1))
+            end
+        else
+            for i_1 in ilo1:(ihi1 + 1)
+                (w1, v1) = _nd_bounded_node_wv(p, spec1, g1, i_1)
+                s += $(contrib(:w1, :v1, :i_1))
+            end
+        end
+        total += s
+    end
+    body = inner
+    for d in 2:N
+        id = ivars[d]
+        assigns = Expr[:(($(Symbol(:w_, d)), $(Symbol(:v_, d))) = _nd_bounded_node_wv(p, specs[$d], grids[$d], $id))]
+        if d == N
+            push!(assigns, :($(Symbol(:ko, d, :_, 1)) = $(Symbol(:w_, d))))
+            push!(assigns, :($(Symbol(:ko, d, :_, 2)) = $(Symbol(:v_, d))))
+        else
+            for j in 1:(1 << (N - d))
+                push!(assigns, :($(Symbol(:ko, d, :_, 2j - 1)) = $(Symbol(:w_, d)) * $(Symbol(:ko, d + 1, :_, j))))
+                push!(assigns, :($(Symbol(:ko, d, :_, 2j)) = $(Symbol(:v_, d)) * $(Symbol(:ko, d + 1, :_, j))))
+            end
+        end
+        body = quote
+            for $id in specs[$d].ilo:(specs[$d].ihi + 1)
+                $(assigns...)
+                $body
+            end
+        end
+    end
+    return quote
+        Base.@_inline_meta
+        g1 = grids[1]
+        spec1 = specs[1]
+        ilo1 = spec1.ilo
+        ihi1 = spec1.ihi
+        total = zero(Tout)
+        @inbounds begin
+            $body
+        end
+        return total
+    end
+end
+
+# CubicInterpolantND / QuadraticInterpolantND bounded, numeric values.
+@inline function integrate(
+        itp::CubicInterpolantND{Tg, Tv, N},
+        lo::Tuple{Vararg{Real, N}},
+        hi::Tuple{Vararg{Real, N}};
+        search = itp.searches,
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
+    ) where {Tg, Tv <: Number, N}
+    sign, lo2, hi2, idx_lo, idx_hi = _integrate_nd_preamble(
+        itp.grids, itp.extraps, lo, hi, search, hint
+    )
+    Tout = _integrate_nd_output_type(Tv, Tg, lo2, hi2)
+    sign == 0 && return zero(Tout)
+    specs = _nd_bounded_axis_specs(itp.grids, lo2, hi2, idx_lo, idx_hi)
+    total = _integrate_separable_pair_bounded(
+        _CubicWV(), specs, itp.grids, itp.nodal_derivs.partials, Tout
+    )
+    return sign * total
+end
+
+@inline function integrate(
+        itp::QuadraticInterpolantND{Tg, Tv, N},
+        lo::Tuple{Vararg{Real, N}},
+        hi::Tuple{Vararg{Real, N}};
+        search = itp.searches,
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
+    ) where {Tg, Tv <: Number, N}
+    sign, lo2, hi2, idx_lo, idx_hi = _integrate_nd_preamble(
+        itp.grids, itp.extraps, lo, hi, search, hint
+    )
+    Tout = _integrate_nd_output_type(Tv, Tg, lo2, hi2)
+    sign == 0 && return zero(Tout)
+    specs = _nd_bounded_axis_specs(itp.grids, lo2, hi2, idx_lo, idx_hi)
+    total = _integrate_separable_pair_bounded(
+        _QuadWV(), specs, itp.grids, itp.nodal_derivs.partials, Tout
+    )
     return sign * total
 end
 

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -114,12 +114,15 @@ Definite integral of an interpolant.
 The **persistent** forms integrate an interpolant you built earlier.
 `integrate(itp)` covers the whole domain through a specialized search-free
 summation; the bounded forms integrate over `[a, b]` (1-D) or the
-hyper-rectangle `[lo, hi]` (ND).
+hyper-rectangle `[lo, hi]` (ND). ND covers every tensor-product interpolant —
+homogeneous (`linear_interp`, `cubic_interp`, …) and heterogeneous mixes
+(`interp(grids, data; method=(CubicInterp(), LinearInterp()))`); only the
+Hermite family (local-slope / user-slope) has no ND integral.
 
 The **one-shot** forms build the `method` interpolant from raw data with
 `copy=false` reference storage — nothing is copied — then integrate in a single
-call. 1-D integrates every method; ND only the tensor-product types (Linear,
-Cubic, Quadratic, Constant), as the Hermite family has no ND integral.
+call. 1-D integrates every method; ND takes a single tensor-product `method`
+(Linear, Cubic, Quadratic, Constant).
 
 ```julia
 integrate(cubic_interp(x, y))                        # persistent, full-domain
@@ -205,91 +208,9 @@ end
 end
 
 # ═══════════════════════════════════════════════════════════════
-# integrate(itp) — ND full-domain fast path
+# integrate(itp[, lo, hi]) — ND separable engine (single entry point)
 # ═══════════════════════════════════════════════════════════════
-
-# ND per-type trait: _full_cell_integral_nd(itp, idx, hs)
-# Each calls the existing ND kernel with ulos = zeros, uhis = hs. Methods whose
-# kernel needs reciprocal spacings (cubic/quadratic hermite-form collapse) fetch
-# inv_hs themselves — mirrors 1D, where `_hermite_full_cell_fn` pulls `_get_inv_h`
-# inside the closure; linear/constant never pay for it (their kernels take no inv_hs).
-
-@inline function _full_cell_integral_nd(
-        itp::CubicInterpolantND{Tg, Tv, N}, idx, hs
-    ) where {Tg, Tv, N}
-    ulos = ntuple(d -> zero(Tg), Val(N))
-    inv_hs = ntuple(d -> @inbounds(_get_inv_h(itp.grids[d], idx[d])), Val(N))
-    return _integrate_nd_cubic_cell(itp.nodal_derivs.partials, idx, hs, inv_hs, ulos, hs)
-end
-
-@inline function _full_cell_integral_nd(
-        itp::LinearInterpolantND{Tg, Tv, N}, idx, hs
-    ) where {Tg, Tv, N}
-    ulos = ntuple(d -> zero(Tg), Val(N))
-    return _integrate_linear_nd_cell(itp.data, idx, hs, ulos, hs)
-end
-
-@inline function _full_cell_integral_nd(
-        itp::QuadraticInterpolantND{Tg, Tv, N}, idx, hs
-    ) where {Tg, Tv, N}
-    ulos = ntuple(d -> zero(Tg), Val(N))
-    inv_hs = ntuple(d -> @inbounds(_get_inv_h(itp.grids[d], idx[d])), Val(N))
-    return _integrate_nd_quad_cell(itp.nodal_derivs.partials, idx, hs, inv_hs, ulos, hs)
-end
-
-@inline function _full_cell_integral_nd(
-        itp::ConstantInterpolantND{Tg, Tv, N}, idx, hs
-    ) where {Tg, Tv, N}
-    ulos = ntuple(d -> zero(Tg), Val(N))
-    return _integrate_constant_nd_cell(itp.data, idx, hs, ulos, hs, itp.sides)
-end
-
-# Sample Tv value for duck-typing safe zero initialization
-@inline _nd_sample_value(itp::LinearInterpolantND) = @inbounds itp.data[1]
-@inline _nd_sample_value(itp::ConstantInterpolantND) = @inbounds itp.data[1]
-@inline _nd_sample_value(itp::CubicInterpolantND) = @inbounds itp.nodal_derivs.partials[1]
-@inline _nd_sample_value(itp::QuadraticInterpolantND) = @inbounds itp.nodal_derivs.partials[1]
-
-# HeteroInterpolantND: explicit not-implemented error. Beats the MethodError
-# the generic dispatch below would hit inside `_full_cell_integral_nd`, and
-# tells the user about the actual workaround (per-axis 1D integration, or
-# switching to a homogeneous specialized ND type).
-function integrate(
-        itp::HeteroInterpolantND;
-        search = nothing,
-        hint = nothing,
-    )
-    _throw_hetero_nd_integrate_unsupported(itp.methods)
-end
-
-# Bounded ND integrate never existed; add a HeteroInterpolantND-specific
-# overload too so `integrate(itp, a, b)` doesn't surface as a MethodError
-# asking the user about Real vs Tuple bound types. Must use `::Real, ::Real`
-# to win dispatch against the `(::AbstractInterpolant, ::Real, ::Real)`
-# fallback in integrate_api.jl (more specific first arg + equal specificity
-# on bounds).
-function integrate(
-        itp::HeteroInterpolantND, ::Real, ::Real;
-        search = nothing, hint = nothing,
-    )
-    _throw_hetero_nd_integrate_unsupported(itp.methods)
-end
-
-@noinline function _throw_hetero_nd_integrate_unsupported(methods)
-    throw(
-        ArgumentError(
-            "integrate is not yet implemented for HeteroInterpolantND " *
-                "(method tuple: $(methods)). ND tensor-product integration over " *
-                "mixed/Hermite axes is not yet supported. Workarounds: " *
-                "(1) use a homogeneous specialized ND type " *
-                "(`cubic_interp`, `quadratic_interp`, `linear_interp`, `constant_interp`) " *
-                "which do support `integrate`; " *
-                "(2) integrate axis-by-axis via 1D `integrate` calls on per-fiber " *
-                "1D interpolants."
-        )
-    )
-end
-
+#
 # ── Separable ND engine: full-domain + bounded, all tensor-product families ──
 #
 # On full cells every per-axis basis integral collapses to constants that are
@@ -333,6 +254,11 @@ end
     (k == 1 ? zero(_get_h(g, 1)) : _get_h(g, k - 1),)
 @inline _nd_node_weights_interior(::RightSide, g, k::Int) = (_get_h(g, k - 1),)
 
+# Constant axes carry the side in the `ConstantInterp` method tag, so the whole
+# engine speaks one vocabulary (method tags); the weight is the side's.
+@inline _nd_node_weights(m::ConstantInterp, g, k::Int, n::Int) = _nd_node_weights(m.side, g, k, n)
+@inline _nd_node_weights_interior(m::ConstantInterp, g, k::Int) = _nd_node_weights_interior(m.side, g, k)
+
 @inline function _nd_node_weights(::CubicInterp, g, k::Int, n::Int)
     if k == 1
         h1 = _get_h(g, 1)
@@ -373,6 +299,15 @@ end
 @inline _nd_cell_weights1(::LinearInterp, u0, u1, h) = (_w1_int(u0, u1, h),)
 @inline _nd_cell_weights0(s::AbstractSide, u0, u1, h) = (_cw0(u0, u1, h, s),)
 @inline _nd_cell_weights1(s::AbstractSide, u0, u1, h) = (_cw1(u0, u1, h, s),)
+@inline _nd_cell_weights0(m::ConstantInterp, u0, u1, h) = _nd_cell_weights0(m.side, u0, u1, h)
+@inline _nd_cell_weights1(m::ConstantInterp, u0, u1, h) = _nd_cell_weights1(m.side, u0, u1, h)
+
+# Per-axis weight rank (type-keyed for the @generated kernels; value-keyed for
+# the mixed-radix payload-storage checks): 1 = value-only axis (Linear/Constant),
+# 2 = (value, deriv) pair (Cubic/Quadratic). Matches `_deriv_size` in the hetero
+# build, so the slot layout the kernels index is exactly the stored layout.
+@inline _nd_weight_rank(::Type{<:Union{LinearInterp, ConstantInterp}}) = 1
+@inline _nd_weight_rank(::Type{<:Union{CubicInterp, QuadraticInterp}}) = 2
 
 # The ΔH antiderivatives carry Float64 coefficients, so the cubic pair converts
 # back to the promoted input precision (`oftype`) — same numerics as the generic
@@ -465,48 +400,57 @@ end
 # folds each node's contiguous slot pair with one muladd per outer mask. The
 # inner axis peels its boundary nodes so the interior runs branch-free @simd.
 
-function _separable_emit_common(N::Int, R::Int)
+# `rs[d] ∈ {1, 2}` — the per-axis weight rank: 1 for value-only axes
+# (Linear/Constant), 2 for the (value, deriv) pairs (Cubic/Quadratic). The
+# payload carries a leading slot dimension of size `prod(rs)` unless every axis
+# is rank 1 (a raw value array with no slot dimension). Slot layout is the same
+# mixed-radix convention `_HeteroPartials` uses: `stride_d = prod(rs[1:d-1])`,
+# so `slot = 1 + Σ_d off_d·stride_d` with the inner axis (d=1) varying fastest.
+function _separable_emit_common(rs::NTuple{N, Int}) where {N}
+    P = prod(rs)
+    r1 = rs[1]
+    Mout = P ÷ r1                      # outer-axis slot configurations
     ivars = [Symbol(:i_, d) for d in 1:N]
     rest = ivars[2:N]
-    M = 1 << (N - 1)
-    pidx(slot, i1) = R == 1 ? :(payload[$i1, $(rest...)]) : :(payload[$slot, $i1, $(rest...)])
-    wnames(ws) = R == 1 ? [Symbol(ws, :_1)] : [Symbol(ws, :_1), Symbol(ws, :_2)]
-    wdecl(ws, call) = Expr(:(=), Expr(:tuple, wnames(ws)...), call)
-    contrib(ws, i1) = R == 1 ? :($(Symbol(ws, :_1)) * $(pidx(0, i1))) :
-        foldl(
-            (a, b) -> :($a + $b),
-            [
-                :(
-                    $(N == 1 ? 1 : Symbol(:ko2_, om)) * muladd(
-                        $(Symbol(ws, :_2)), $(pidx(2om, i1)),
-                        $(Symbol(ws, :_1)) * $(pidx(2om - 1, i1))
-                    )
-                ) for om in 1:M
-            ]
-        )
-    close_expr = N == 1 ? :(total += s) : R == 1 ? :(total += wp_2 * s) : :(total += s)
-    return ivars, rest, pidx, wdecl, contrib, close_expr
+    pidx(slot, i1) = P == 1 ? :(payload[$i1, $(rest...)]) : :(payload[$slot, $i1, $(rest...)])
+    wnames(ws, r) = r == 1 ? [Symbol(ws, :_1)] : [Symbol(ws, :_1), Symbol(ws, :_2)]
+    wdecl(ws, r, call) = Expr(:(=), Expr(:tuple, wnames(ws, r)...), call)
+    # Inner sum for outer configuration `m`: contract the inner axis' `r1` weight
+    # components against its contiguous slot pair (slots `r1·(m−1)+1 … r1·m`),
+    # then scale by the outer Kronecker product `ko2_m` (absent when N == 1).
+    function term(m, i1, ws)
+        w = wnames(ws, r1)
+        base = r1 * (m - 1)
+        inner = r1 == 2 ?
+            :(muladd($(w[2]), $(pidx(base + 2, i1)), $(w[1]) * $(pidx(base + 1, i1)))) :
+            :($(w[1]) * $(pidx(base + 1, i1)))
+        return N == 1 ? inner : :($(Symbol(:ko2_, m)) * $inner)
+    end
+    contrib(ws, i1) = foldl((a, b) -> :($a + $b), [term(m, i1, ws) for m in 1:Mout])
+    return ivars, rest, pidx, wdecl, contrib
 end
 
-# Outer-axis loop wrapper: rank 1 chains the scalar product `wp_d`; rank 2
-# builds the Kronecker partial products `ko{d}_{j}` of the (w, v) pairs.
-function _separable_emit_outer(body, N::Int, R::Int, ivars, wcall::Function, ranges::Function)
+# Outer-axis loops (i_N outermost … i_2 just outside the inner sweep). Each level
+# folds axis d's rank-`rs[d]` weight components into the Kronecker partial
+# products `ko{d}_m` of the outer axes d…N (axis 2 = fastest index, matching the
+# slot order). Uniform `rs` reproduces the homogeneous scalar chain (all rank 1)
+# or the dense 2^N Kronecker chain (all rank 2) bit-for-bit.
+function _separable_emit_outer(body, rs::NTuple{N, Int}, ivars, wcall::Function, ranges::Function) where {N}
     for d in 2:N
         id = ivars[d]
-        assigns = Expr[]
-        if R == 1
-            wexpr = d == N ? :($(wcall(d))[1]) : :($(wcall(d))[1] * $(Symbol(:wp_, d + 1)))
-            push!(assigns, :($(Symbol(:wp_, d)) = $wexpr))
+        rd = rs[d]
+        wc(o) = Symbol(o == 0 ? :w_ : :v_, d)
+        assigns = Expr[Expr(:(=), Expr(:tuple, ntuple(o -> wc(o - 1), rd)...), wcall(d))]
+        if d == N
+            for o in 0:(rd - 1)
+                push!(assigns, :($(Symbol(:ko, d, :_, o + 1)) = $(wc(o))))
+            end
         else
-            push!(assigns, Expr(:(=), Expr(:tuple, Symbol(:w_, d), Symbol(:v_, d)), wcall(d)))
-            if d == N
-                push!(assigns, :($(Symbol(:ko, d, :_, 1)) = $(Symbol(:w_, d))))
-                push!(assigns, :($(Symbol(:ko, d, :_, 2)) = $(Symbol(:v_, d))))
-            else
-                for j in 1:(1 << (N - d))
-                    push!(assigns, :($(Symbol(:ko, d, :_, 2j - 1)) = $(Symbol(:w_, d)) * $(Symbol(:ko, d + 1, :_, j))))
-                    push!(assigns, :($(Symbol(:ko, d, :_, 2j)) = $(Symbol(:v_, d)) * $(Symbol(:ko, d + 1, :_, j))))
-                end
+            for mp in 1:prod(rs[(d + 1):N]), o in 0:(rd - 1)
+                push!(
+                    assigns,
+                    :($(Symbol(:ko, d, :_, o + rd * (mp - 1) + 1)) = $(wc(o)) * $(Symbol(:ko, d + 1, :_, mp))),
+                )
             end
         end
         body = quote
@@ -521,33 +465,35 @@ end
 
 @generated function _integrate_separable_nd_fulldomain(
         wspec::NTuple{N, Any}, grids::NTuple{N, Any},
-        payload::AbstractArray{Tv, NP}, ::Type{Tout}
+        payload::AbstractArray{Tv, NP}, ::Type{Tout}, z
     ) where {N, Tv, NP, Tout}
-    R = NP - N + 1
-    R in (1, 2) || error("payload must have N or N+1 dimensions")
-    ivars, _, _, wdecl, contrib, close_expr = _separable_emit_common(N, R)
+    rs = ntuple(d -> _nd_weight_rank(wspec.parameters[d]), N)
+    slotoff = prod(rs) > 1 ? 1 : 0
+    NP == N + slotoff || error("payload rank $NP inconsistent with weight spec $rs")
+    r1 = rs[1]
+    ivars, _, _, wdecl, contrib = _separable_emit_common(rs)
     inner = quote
-        $(wdecl(:w1a, :(_nd_node_weights(w1, g1, 1, n_1))))
-        $(wdecl(:w1b, :(_nd_node_weights(w1, g1, n_1, n_1))))
+        $(wdecl(:w1a, r1, :(_nd_node_weights(w1, g1, 1, n_1))))
+        $(wdecl(:w1b, r1, :(_nd_node_weights(w1, g1, n_1, n_1))))
         s = $(contrib(:w1a, 1)) + $(contrib(:w1b, :n_1))
         @simd for i_1 in 2:(n_1 - 1)
-            $(wdecl(:w1i, :(_nd_node_weights_interior(w1, g1, i_1))))
+            $(wdecl(:w1i, r1, :(_nd_node_weights_interior(w1, g1, i_1))))
             s += $(contrib(:w1i, :i_1))
         end
-        $close_expr
+        total += s
     end
     body = _separable_emit_outer(
-        inner, N, R, ivars,
+        inner, rs, ivars,
         d -> :(_nd_node_weights(wspec[$d], grids[$d], $(ivars[d]), $(Symbol(:n_, d)))),
         d -> :(1:$(Symbol(:n_, d)))
     )
-    nassign = Expr(:block, [:($(Symbol(:n_, d)) = size(payload, $(d + R - 1))) for d in 1:N]...)
+    nassign = Expr(:block, [:($(Symbol(:n_, d)) = size(payload, $(d + slotoff))) for d in 1:N]...)
     return quote
         Base.@_inline_meta
         $nassign
         g1 = grids[1]
         w1 = wspec[1]
-        total = zero(Tout)
+        total = z
         @inbounds begin
             $body
         end
@@ -557,34 +503,36 @@ end
 
 @generated function _integrate_separable_nd_bounded(
         wspec::NTuple{N, Any}, specs::NTuple{N, _BoundedAxisSpec},
-        grids::NTuple{N, Any}, payload::AbstractArray{Tv, NP}, ::Type{Tout}
+        grids::NTuple{N, Any}, payload::AbstractArray{Tv, NP}, ::Type{Tout}, z
     ) where {N, Tv, NP, Tout}
-    R = NP - N + 1
-    R in (1, 2) || error("payload must have N or N+1 dimensions")
-    ivars, _, _, wdecl, contrib, close_expr = _separable_emit_common(N, R)
+    rs = ntuple(d -> _nd_weight_rank(wspec.parameters[d]), N)
+    slotoff = prod(rs) > 1 ? 1 : 0
+    NP == N + slotoff || error("payload rank $NP inconsistent with weight spec $rs")
+    r1 = rs[1]
+    ivars, _, _, wdecl, contrib = _separable_emit_common(rs)
     inner = quote
-        s = zero(Tout)
+        s = z
         if ihi1 >= ilo1 + 2
-            $(wdecl(:w1a, :(_nd_bounded_node_weights(w1, spec1, g1, ilo1))))
-            $(wdecl(:w1b, :(_nd_bounded_node_weights(w1, spec1, g1, ilo1 + 1))))
-            $(wdecl(:w1c, :(_nd_bounded_node_weights(w1, spec1, g1, ihi1))))
-            $(wdecl(:w1d, :(_nd_bounded_node_weights(w1, spec1, g1, ihi1 + 1))))
+            $(wdecl(:w1a, r1, :(_nd_bounded_node_weights(w1, spec1, g1, ilo1))))
+            $(wdecl(:w1b, r1, :(_nd_bounded_node_weights(w1, spec1, g1, ilo1 + 1))))
+            $(wdecl(:w1c, r1, :(_nd_bounded_node_weights(w1, spec1, g1, ihi1))))
+            $(wdecl(:w1d, r1, :(_nd_bounded_node_weights(w1, spec1, g1, ihi1 + 1))))
             s += $(contrib(:w1a, :ilo1)) + $(contrib(:w1b, :(ilo1 + 1))) +
                 $(contrib(:w1c, :ihi1)) + $(contrib(:w1d, :(ihi1 + 1)))
             @simd for i_1 in (ilo1 + 2):(ihi1 - 1)
-                $(wdecl(:w1i, :(_nd_node_weights_interior(w1, g1, i_1))))
+                $(wdecl(:w1i, r1, :(_nd_node_weights_interior(w1, g1, i_1))))
                 s += $(contrib(:w1i, :i_1))
             end
         else
             for i_1 in ilo1:(ihi1 + 1)
-                $(wdecl(:w1x, :(_nd_bounded_node_weights(w1, spec1, g1, i_1))))
+                $(wdecl(:w1x, r1, :(_nd_bounded_node_weights(w1, spec1, g1, i_1))))
                 s += $(contrib(:w1x, :i_1))
             end
         end
-        $close_expr
+        total += s
     end
     body = _separable_emit_outer(
-        inner, N, R, ivars,
+        inner, rs, ivars,
         d -> :(_nd_bounded_node_weights(wspec[$d], specs[$d], grids[$d], $(ivars[d]))),
         d -> :((specs[$d].ilo):(specs[$d].ihi + 1))
     )
@@ -595,7 +543,7 @@ end
         spec1 = specs[1]
         ilo1 = spec1.ilo
         ihi1 = spec1.ihi
-        total = zero(Tout)
+        total = z
         @inbounds begin
             $body
         end
@@ -603,78 +551,115 @@ end
     end
 end
 
-# ── Dispatches: numeric values take the separable engine; duck values fall
-# through to the generic per-cell methods. The weight spec per family is the
-# existing vocabulary: a method-tag tuple, or the constant `sides` as-is. ──
+# ── Single entry point. Every tensor-product ND interpolant — homogeneous or
+# heterogeneous, numeric or duck-typed — routes through the separable engine.
+# `_separable_spec(itp)` returns `(per-axis method-tag tuple, payload)` in the
+# existing vocabulary (the method tuple the build already carries), or throws a
+# clear error for the non-tensor families (local-Hermite / user-slope Hermite /
+# NoInterp) that have no separable node-weight rule. ──
 
-@inline _separable_wspec(itp::LinearInterpolantND{Tg, Tv, N}) where {Tg, Tv, N} =
-    (ntuple(_ -> LinearInterp(), Val(N)), itp.data)
-@inline _separable_wspec(itp::ConstantInterpolantND{Tg, Tv, N}) where {Tg, Tv, N} =
-    (itp.sides, itp.data)
-@inline _separable_wspec(itp::CubicInterpolantND{Tg, Tv, N}) where {Tg, Tv, N} =
-    (ntuple(_ -> CubicInterp(), Val(N)), itp.nodal_derivs.partials)
-@inline _separable_wspec(itp::QuadraticInterpolantND{Tg, Tv, N}) where {Tg, Tv, N} =
-    (ntuple(_ -> QuadraticInterp(), Val(N)), itp.nodal_derivs.partials)
+@inline _separable_spec(itp::LinearInterpolantND{Tg, Tv, N}) where {Tg, Tv, N} =
+    (_method_tuple(LinearInterp(), Val(N)), itp.data)
+@inline _separable_spec(itp::ConstantInterpolantND{Tg, Tv, N}) where {Tg, Tv, N} =
+    (map(ConstantInterp, itp.sides), itp.data)
+@inline _separable_spec(itp::CubicInterpolantND{Tg, Tv, N}) where {Tg, Tv, N} =
+    (_method_tuple(CubicInterp(), Val(N)), itp.nodal_derivs.partials)
+@inline _separable_spec(itp::QuadraticInterpolantND{Tg, Tv, N}) where {Tg, Tv, N} =
+    (_method_tuple(QuadraticInterp(), Val(N)), itp.nodal_derivs.partials)
 
-const _SeparableND{Tg, Tv, N} = Union{
-    LinearInterpolantND{Tg, Tv, N}, ConstantInterpolantND{Tg, Tv, N},
-    CubicInterpolantND{Tg, Tv, N}, QuadraticInterpolantND{Tg, Tv, N},
-}
-
-@inline function integrate(
-        itp::_SeparableND{Tg, Tv, N};
-        search = nothing,
-        hint = nothing
-    ) where {Tg, Tv <: Number, N}
-    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
-    wspec, payload = _separable_wspec(itp)
-    return _integrate_separable_nd_fulldomain(wspec, itp.grids, payload, Tout)
-end
-
-# Bounded impl shared by the four thin dispatches below. The dispatches stay
-# per-type (not the `_SeparableND` union): the legacy per-cell bounded methods
-# in integrate_api.jl are per-type with unconstrained `Tv`, and a union-typed
-# `Tv <: Number` method would cross specificities with them (ambiguity); a
-# per-type `Tv <: Number` method is strictly more specific instead.
-@inline function _separable_bounded(itp, lo, hi, search, hint, ::Type{Tg}, ::Type{Tv}) where {Tg, Tv}
-    sign, lo2, hi2, idx_lo, idx_hi = _integrate_nd_preamble(
-        itp.grids, itp.extraps, lo, hi, search, hint
-    )
-    Tout = _integrate_nd_output_type(Tv, Tg, lo2, hi2)
-    sign == 0 && return zero(Tout)
-    specs = _nd_bounded_axis_specs(itp.grids, lo2, hi2, idx_lo, idx_hi)
-    wspec, payload = _separable_wspec(itp)
-    total = _integrate_separable_nd_bounded(wspec, specs, itp.grids, payload, Tout)
-    return sign * total
-end
-
-for T in (:LinearInterpolantND, :ConstantInterpolantND, :CubicInterpolantND, :QuadraticInterpolantND)
-    @eval @inline function integrate(
-            itp::$T{Tg, Tv, N},
-            lo::Tuple{Vararg{Real, N}},
-            hi::Tuple{Vararg{Real, N}};
-            search = itp.searches,
-            hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
-        ) where {Tg, Tv <: Number, N}
-        return _separable_bounded(itp, lo, hi, search, hint, Tg, Tv)
+# HeteroInterpolantND: the stored per-axis methods ARE the weight-tag tuple; the
+# payload is the mixed-radix partials (PreCompute) or the raw data (OnTheFly /
+# all-trivial). @generated so the separability + storage gate is a compile-time
+# branch — no runtime method scan, no boxing.
+@generated function _separable_spec(
+        itp::HeteroInterpolantND{Tg, Tv, N, G, M, E, P, D}
+    ) where {Tg, Tv, N, G, M, E, P, D}
+    ms = (M.parameters...,)
+    all(_is_separable_method_type, ms) || return :(_throw_nd_integrate_unsupported(itp))
+    if D <: _HeteroPartials
+        return :((itp.methods, itp.data.partials))
+    elseif any(t -> _nd_weight_rank(t) == 2, ms)
+        return :(_throw_hetero_precompute_required(itp.methods))
+    else
+        return :((itp.methods, itp.data))
     end
 end
 
-# Generic ND full-domain: catches all ND types
+# Non-tensor ND families (CubicHermiteInterpolantND, and any future type): clean
+# error instead of a MethodError deep in the kernel.
+@inline _separable_spec(itp::AbstractInterpolantND) = _throw_nd_integrate_unsupported(itp)
+
+@inline _is_separable_method_type(
+    ::Type{<:Union{LinearInterp, ConstantInterp, CubicInterp, QuadraticInterp}}
+) = true
+@inline _is_separable_method_type(::Type{<:AbstractInterpMethod}) = false
+
+# Duck-safe integral zero: `zero(Tout)` for numbers, `0 * sample` otherwise.
+@inline _nd_int_zero(::Type{Tout}, payload) where {Tout <: Number} = zero(Tout)
+@inline _nd_int_zero(::Type{Tout}, payload) where {Tout} = 0 * @inbounds(payload[begin])
+
 @inline function integrate(
         itp::AbstractInterpolantND{Tg, Tv, N};
         search = nothing,
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
+    tags, payload = _separable_spec(itp)
     Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
-    total = Tout <: Number ? zero(Tout) : 0 * _nd_sample_value(itp)
-    cell_ranges = ntuple(d -> 1:(length(itp.grids[d]) - 1), Val(N))
-    for I in CartesianIndices(cell_ranges)
-        idx = ntuple(d -> I[d], Val(N))
-        hs = ntuple(d -> @inbounds(_get_h(itp.grids[d], idx[d])), Val(N))
-        total += _full_cell_integral_nd(itp, idx, hs)
-    end
-    return total
+    z = _nd_int_zero(Tout, payload)
+    return _integrate_separable_nd_fulldomain(tags, itp.grids, payload, Tout, z)
+end
+
+@inline function integrate(
+        itp::AbstractInterpolantND{Tg, Tv, N},
+        lo::Tuple{Vararg{Real, N}},
+        hi::Tuple{Vararg{Real, N}};
+        search = itp.searches,
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
+    ) where {Tg, Tv, N}
+    tags, payload = _separable_spec(itp)
+    sign, lo2, hi2, idx_lo, idx_hi = _integrate_nd_preamble(
+        itp.grids, itp.extraps, lo, hi, search, hint
+    )
+    Tout = _integrate_nd_output_type(Tv, Tg, lo2, hi2)
+    z = _nd_int_zero(Tout, payload)
+    sign == 0 && return z
+    specs = _nd_bounded_axis_specs(itp.grids, lo2, hi2, idx_lo, idx_hi)
+    total = _integrate_separable_nd_bounded(tags, specs, itp.grids, payload, Tout, z)
+    return sign * total
+end
+
+# Real bounds on an ND interpolant → point at the tuple form (otherwise the 1D
+# `(::AbstractInterpolant, ::Real, ::Real)` stub fires with a 1D-flavoured message).
+@inline function integrate(::AbstractInterpolantND, ::Real, ::Real; search = nothing, hint = nothing)
+    throw(
+        ArgumentError(
+            "ND `integrate` needs tuple bounds — pass lo/hi as `NTuple{N,Real}`, " *
+                "e.g. `integrate(itp, (a1, a2), (b1, b2))`."
+        )
+    )
+end
+
+@noinline function _throw_nd_integrate_unsupported(itp)
+    throw(
+        ArgumentError(
+            "integrate is not implemented for $(nameof(typeof(itp))). ND tensor-product " *
+                "integration is defined for Linear/Cubic/Quadratic/Constant axes (homogeneous " *
+                "or heterogeneous). Local-Hermite (Pchip/Cardinal/Akima), user-slope Hermite, " *
+                "and NoInterp axes have no separable node-weight rule — integrate axis-by-axis " *
+                "via 1D `integrate` on per-fiber 1D interpolants instead."
+        )
+    )
+end
+
+@noinline function _throw_hetero_precompute_required(methods)
+    throw(
+        ArgumentError(
+            "integrate over a HeteroInterpolantND with a derivative axis (Cubic/Quadratic) " *
+                "requires precomputed partials: rebuild with `coeffs=PreCompute()` " *
+                "(method tuple: $(methods)). The OnTheFly build stores only raw data, " *
+                "which has no derivative slots."
+        )
+    )
 end
 
 # ═══════════════════════════════════════════════════════════════

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -290,6 +290,75 @@ end
     )
 end
 
+# ── Linear ND full-domain: separable composite-trapezoid path ──
+#
+# A full-cell multilinear integral has both per-axis basis weights collapse to
+# h/2, so the whole domain integral is the tensor product of 1D composite-
+# trapezoid rules:  I = Σ_nodes (Π_d w_d(i_d))·data[i].  Iterating nodes (not
+# cells) reads each value once instead of the 2^N corner reads the generic
+# per-cell kernel repeats — an N-D generalization of the 1D telescoped path.
+
+# 1D composite-trapezoid node weight on `grid` (length `n`): ½h at the endpoints,
+# ½(h₋+h₊) in the interior. Only the grid is divided — values stay multiply-only.
+@inline _nd_trap_weight_interior(grid, k::Int) = (_get_h(grid, k - 1) + _get_h(grid, k)) / 2
+@inline function _nd_trap_weight(grid, k::Int, n::Int)
+    k == 1 && return _get_h(grid, 1) / 2
+    k == n && return _get_h(grid, n - 1) / 2
+    return _nd_trap_weight_interior(grid, k)
+end
+
+# Nested reduction: outer axes hoist their weight product `wp`, the contiguous
+# inner axis peels its endpoints so the interior is a branch-free @simd loop.
+@generated function _integrate_linear_nd_fulldomain(
+        grids::NTuple{N, Any}, data::AbstractArray, ::Type{Tout}
+    ) where {N, Tout}
+    ivars = [Symbol(:i_, d) for d in 1:N]
+    rest = ivars[2:N]
+    inner = quote
+        s = _nd_trap_weight(g1, 1, n_1) * data[1, $(rest...)] +
+            _nd_trap_weight(g1, n_1, n_1) * data[n_1, $(rest...)]
+        @simd for i_1 in 2:(n_1 - 1)
+            s += _nd_trap_weight_interior(g1, i_1) * data[i_1, $(rest...)]
+        end
+        total += wp_2 * s
+    end
+    body = inner
+    for d in 2:N
+        id = ivars[d]
+        nd = Symbol(:n_, d)
+        wexpr = d == N ? :(_nd_trap_weight(grids[$d], $id, $nd)) :
+            :(_nd_trap_weight(grids[$d], $id, $nd) * $(Symbol(:wp_, d + 1)))
+        body = quote
+            for $id in 1:$nd
+                $(Symbol(:wp_, d)) = $wexpr
+                $body
+            end
+        end
+    end
+    nassign = Expr(:block, [:($(Symbol(:n_, d)) = size(data, $d)) for d in 1:N]...)
+    return quote
+        Base.@_inline_meta
+        $nassign
+        g1 = grids[1]
+        total = zero(Tout)
+        @inbounds begin
+            $body
+        end
+        return total
+    end
+end
+
+# LinearInterpolantND with numeric values: the separable path. Non-numeric (duck)
+# value types fall through to the generic per-cell method below.
+@inline function integrate(
+        itp::LinearInterpolantND{Tg, Tv, N};
+        search = nothing,
+        hint = nothing
+    ) where {Tg, Tv <: Number, N}
+    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
+    return _integrate_linear_nd_fulldomain(itp.grids, itp.data, Tout)
+end
+
 # Generic ND full-domain: catches all ND types
 @inline function integrate(
         itp::AbstractInterpolantND{Tg, Tv, N};

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -383,6 +383,158 @@ end
     return _integrate_separable_nd_fulldomain(itp.sides, itp.grids, itp.data, Tout)
 end
 
+# ── Bounded ND (linear/constant): separable clipped-composite path ──
+#
+# Separability holds on any axis-aligned box, not just the full domain: the
+# per-axis node weights become "clipped composites" — zero outside the covered
+# cells, the partial-cell integral weights at the two boundary cells, and the
+# full-cell weights in between — so the sum visits the node sub-box once with
+# no per-cell clip geometry. Bounds/sign/extrap semantics come from the shared
+# `_integrate_nd_preamble`, identical to the generic cell-wise engine.
+
+# Per-axis spec: covered cell range [ilo, ihi] plus the clipped local start
+# inside cell `ilo` (u0 ≥ 0) and clipped local end inside cell `ihi` (u1 ≤ h).
+struct _BoundedAxisSpec{T}
+    ilo::Int
+    ihi::Int
+    u0::T
+    u1::T
+end
+
+@generated function _nd_bounded_axis_specs(
+        grids::NTuple{N, Any}, lo2, hi2, idx_lo, idx_hi
+    ) where {N}
+    exprs = [
+        quote
+                let g = grids[$d], il = idx_lo[$d], ih = idx_hi[$d]
+                    xLl = @inbounds g[il]
+                    xLh = @inbounds g[ih]
+                    xRh = @inbounds g[ih + 1]
+                    u0, u1 = promote(max(lo2[$d], xLl) - xLl, min(hi2[$d], xRh) - xLh)
+                    _BoundedAxisSpec(il, ih, u0, u1)
+            end
+            end for d in 1:N
+    ]
+    return :(($(exprs...),))
+end
+
+# Partial-cell end-weight pair through the provider (`nothing` = linear basis,
+# a side = the constant selection weights) — full cells reduce to the closed forms.
+@inline _nd_cell_w0(::Nothing, u0, u1, h) = _w0_int(u0, u1, h)
+@inline _nd_cell_w1(::Nothing, u0, u1, h) = _w1_int(u0, u1, h)
+@inline _nd_cell_w0(s::AbstractSide, u0, u1, h) = _cw0(u0, u1, h, s)
+@inline _nd_cell_w1(s::AbstractSide, u0, u1, h) = _cw1(u0, u1, h, s)
+
+# Clipped composite node weight: right-end share of cell k−1 plus left-end share
+# of cell k, each clipped to the covered range. Only the ≤ 4 nodes touching the
+# two boundary cells differ from the full-domain weights.
+@inline function _nd_bounded_node_weight(w, spec::_BoundedAxisSpec, g, k::Int)
+    total = zero(spec.u0)
+    c = k - 1
+    if spec.ilo <= c <= spec.ihi
+        h = _get_h(g, c)
+        total += _nd_cell_w1(w, c == spec.ilo ? spec.u0 : zero(h), c == spec.ihi ? spec.u1 : h, h)
+    end
+    c = k
+    if spec.ilo <= c <= spec.ihi
+        h = _get_h(g, c)
+        total += _nd_cell_w0(w, c == spec.ilo ? spec.u0 : zero(h), c == spec.ihi ? spec.u1 : h, h)
+    end
+    return total
+end
+
+# Nested reduction over the node sub-box. Wide inner spans peel the four
+# boundary-cell nodes so the interior runs the branch-free full-cell weights
+# under @simd; narrow spans (≤ 2 cells) take the scalar clipped loop.
+@generated function _integrate_separable_nd_bounded(
+        wspec::NTuple{N, Any}, specs::NTuple{N, _BoundedAxisSpec},
+        grids::NTuple{N, Any}, data::AbstractArray, ::Type{Tout}
+    ) where {N, Tout}
+    ivars = [Symbol(:i_, d) for d in 1:N]
+    rest = ivars[2:N]
+    inner = quote
+        s = zero(Tout)
+        if ihi1 >= ilo1 + 2
+            s += _nd_bounded_node_weight(w1, spec1, g1, ilo1) * data[ilo1, $(rest...)] +
+                _nd_bounded_node_weight(w1, spec1, g1, ilo1 + 1) * data[ilo1 + 1, $(rest...)] +
+                _nd_bounded_node_weight(w1, spec1, g1, ihi1) * data[ihi1, $(rest...)] +
+                _nd_bounded_node_weight(w1, spec1, g1, ihi1 + 1) * data[ihi1 + 1, $(rest...)]
+            @simd for i_1 in (ilo1 + 2):(ihi1 - 1)
+                s += _nd_node_weight_interior(w1, g1, i_1) * data[i_1, $(rest...)]
+            end
+        else
+            for i_1 in ilo1:(ihi1 + 1)
+                s += _nd_bounded_node_weight(w1, spec1, g1, i_1) * data[i_1, $(rest...)]
+            end
+        end
+        total += wp_2 * s
+    end
+    body = inner
+    for d in 2:N
+        id = ivars[d]
+        wexpr = d == N ? :(_nd_bounded_node_weight(wspec[$d], specs[$d], grids[$d], $id)) :
+            :(_nd_bounded_node_weight(wspec[$d], specs[$d], grids[$d], $id) * $(Symbol(:wp_, d + 1)))
+        body = quote
+            for $id in specs[$d].ilo:(specs[$d].ihi + 1)
+                $(Symbol(:wp_, d)) = $wexpr
+                $body
+            end
+        end
+    end
+    return quote
+        Base.@_inline_meta
+        g1 = grids[1]
+        w1 = wspec[1]
+        spec1 = specs[1]
+        ilo1 = spec1.ilo
+        ihi1 = spec1.ihi
+        total = zero(Tout)
+        @inbounds begin
+            $body
+        end
+        return total
+    end
+end
+
+# LinearInterpolantND bounded, numeric values: separable clipped path. Duck
+# values keep the generic per-cell method in integrate_api.jl.
+@inline function integrate(
+        itp::LinearInterpolantND{Tg, Tv, N},
+        lo::Tuple{Vararg{Real, N}},
+        hi::Tuple{Vararg{Real, N}};
+        search = itp.searches,
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
+    ) where {Tg, Tv <: Number, N}
+    sign, lo2, hi2, idx_lo, idx_hi = _integrate_nd_preamble(
+        itp.grids, itp.extraps, lo, hi, search, hint
+    )
+    Tout = _integrate_nd_output_type(Tv, Tg, lo2, hi2)
+    sign == 0 && return zero(Tout)
+    specs = _nd_bounded_axis_specs(itp.grids, lo2, hi2, idx_lo, idx_hi)
+    total = _integrate_separable_nd_bounded(
+        ntuple(_ -> nothing, Val(N)), specs, itp.grids, itp.data, Tout
+    )
+    return sign * total
+end
+
+# ConstantInterpolantND bounded, numeric values: same path with side weights.
+@inline function integrate(
+        itp::ConstantInterpolantND{Tg, Tv, N},
+        lo::Tuple{Vararg{Real, N}},
+        hi::Tuple{Vararg{Real, N}};
+        search = itp.searches,
+        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
+    ) where {Tg, Tv <: Number, N}
+    sign, lo2, hi2, idx_lo, idx_hi = _integrate_nd_preamble(
+        itp.grids, itp.extraps, lo, hi, search, hint
+    )
+    Tout = _integrate_nd_output_type(Tv, Tg, lo2, hi2)
+    sign == 0 && return zero(Tout)
+    specs = _nd_bounded_axis_specs(itp.grids, lo2, hi2, idx_lo, idx_hi)
+    total = _integrate_separable_nd_bounded(itp.sides, specs, itp.grids, itp.data, Tout)
+    return sign * total
+end
+
 # Generic ND full-domain: catches all ND types
 @inline function integrate(
         itp::AbstractInterpolantND{Tg, Tv, N};

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -401,18 +401,19 @@ end
 # inner axis peels its boundary nodes so the interior runs branch-free @simd.
 
 # `rs[d] ∈ {1, 2}` — the per-axis weight rank: 1 for value-only axes
-# (Linear/Constant), 2 for the (value, deriv) pairs (Cubic/Quadratic). The
-# payload carries a leading slot dimension of size `prod(rs)` unless every axis
-# is rank 1 (a raw value array with no slot dimension). Slot layout is the same
-# mixed-radix convention `_HeteroPartials` uses: `stride_d = prod(rs[1:d-1])`,
-# so `slot = 1 + Σ_d off_d·stride_d` with the inner axis (d=1) varying fastest.
-function _separable_emit_common(rs::NTuple{N, Int}) where {N}
+# (Linear/Constant), 2 for the (value, deriv) pairs (Cubic/Quadratic). Slot
+# layout is the mixed-radix convention `_HeteroPartials` uses: `stride_d =
+# prod(rs[1:d-1])`, so `slot = 1 + Σ_d off_d·stride_d` with the inner axis (d=1)
+# varying fastest. `has_slot` (payload rank N+1 vs N) is a *storage* fact, kept
+# separate from `prod(rs)`: an all-trivial hetero PreCompute payload carries a
+# size-1 leading slot axis even though `prod(rs) == 1`.
+function _separable_emit_common(rs::NTuple{N, Int}, has_slot::Bool) where {N}
     P = prod(rs)
     r1 = rs[1]
     Mout = P ÷ r1                      # outer-axis slot configurations
     ivars = [Symbol(:i_, d) for d in 1:N]
     rest = ivars[2:N]
-    pidx(slot, i1) = P == 1 ? :(payload[$i1, $(rest...)]) : :(payload[$slot, $i1, $(rest...)])
+    pidx(slot, i1) = has_slot ? :(payload[$slot, $i1, $(rest...)]) : :(payload[$i1, $(rest...)])
     wnames(ws, r) = r == 1 ? [Symbol(ws, :_1)] : [Symbol(ws, :_1), Symbol(ws, :_2)]
     wdecl(ws, r, call) = Expr(:(=), Expr(:tuple, wnames(ws, r)...), call)
     # Inner sum for outer configuration `m`: contract the inner axis' `r1` weight
@@ -468,10 +469,10 @@ end
         payload::AbstractArray{Tv, NP}, ::Type{Tout}, z
     ) where {N, Tv, NP, Tout}
     rs = ntuple(d -> _nd_weight_rank(wspec.parameters[d]), N)
-    slotoff = prod(rs) > 1 ? 1 : 0
-    NP == N + slotoff || error("payload rank $NP inconsistent with weight spec $rs")
+    slotoff = NP - N          # 0 = raw N-d value array, 1 = leading slot axis
+    slotoff in (0, 1) || error("payload rank $NP inconsistent with N=$N")
     r1 = rs[1]
-    ivars, _, _, wdecl, contrib = _separable_emit_common(rs)
+    ivars, _, _, wdecl, contrib = _separable_emit_common(rs, slotoff == 1)
     inner = quote
         $(wdecl(:w1a, r1, :(_nd_node_weights(w1, g1, 1, n_1))))
         $(wdecl(:w1b, r1, :(_nd_node_weights(w1, g1, n_1, n_1))))
@@ -506,10 +507,10 @@ end
         grids::NTuple{N, Any}, payload::AbstractArray{Tv, NP}, ::Type{Tout}, z
     ) where {N, Tv, NP, Tout}
     rs = ntuple(d -> _nd_weight_rank(wspec.parameters[d]), N)
-    slotoff = prod(rs) > 1 ? 1 : 0
-    NP == N + slotoff || error("payload rank $NP inconsistent with weight spec $rs")
+    slotoff = NP - N          # 0 = raw N-d value array, 1 = leading slot axis
+    slotoff in (0, 1) || error("payload rank $NP inconsistent with N=$N")
     r1 = rs[1]
-    ivars, _, _, wdecl, contrib = _separable_emit_common(rs)
+    ivars, _, _, wdecl, contrib = _separable_emit_common(rs, slotoff == 1)
     inner = quote
         s = z
         if ihi1 >= ilo1 + 2

--- a/src/integral/integrate_kernels.jl
+++ b/src/integral/integrate_kernels.jl
@@ -161,92 +161,15 @@ end
     return h * muladd(h, inner, outer)
 end
 
-# @generated tensor-product cell integral kernel for ND cubic.
-# Mirrors _eval_nd_cell but replaces _hermite_kernel_1d with
-# _hermite_integral_kernel_1d for each dimension collapse stage.
-@inline @generated function _integrate_nd_cubic_cell(
-        partials::Array{Tv, NP1},
-        indices::NTuple{N, Int},
-        hs::NTuple{N, Tg},
-        inv_hs::NTuple{N, Tg},
-        ulos::NTuple{N, <:Real},
-        uhis::NTuple{N, <:Real}
-    ) where {Tv, Tg, N, NP1}
-    NP1 == N + 1 || error("NP1 must equal N+1")
-
-    stmts = Expr[]
-
-    # Unpack tuples
-    for (prefix, source) in [
-            ("idx_", :indices), ("h_", :hs), ("inv_h_", :inv_hs),
-            ("ulo_", :ulos), ("uhi_", :uhis),
-        ]
-        syms = ntuple(d -> Symbol(prefix, d), N)
-        lhs = Expr(:tuple, syms...)
-        push!(stmts, :($lhs = $source))
-    end
-
-    # Collapse each dimension via integral kernel
-    for stage in 1:N
-        num_corners = 1 << (N - stage)
-        num_derivs = 1 << (N - stage)
-
-        for corner in 0:(num_corners - 1)
-            for deriv in 0:(num_derivs - 1)
-                out_var = _varname(stage, corner, deriv)
-
-                if stage == 1
-                    function make_partial_access(c_dim1::Int, d_dim1::Int)
-                        corner_full = c_dim1 | (corner << 1)
-                        deriv_full = d_dim1 | (deriv << 1)
-                        p_idx = _partial_index(deriv_full)
-                        offsets = _corner_offset_expr(corner_full, N)
-                        idx_exprs = [:($(Symbol("idx_", d)) + $(offsets[d])) for d in 1:N]
-                        return :(partials[$p_idx, $(idx_exprs...)])
-                    end
-
-                    fL = make_partial_access(0, 0)
-                    fR = make_partial_access(1, 0)
-                    dfL = make_partial_access(0, 1)
-                    dfR = make_partial_access(1, 1)
-                else
-                    prev_stage = stage - 1
-                    fL = _varname(prev_stage, 0 | (corner << 1), 0 | (deriv << 1))
-                    fR = _varname(prev_stage, 1 | (corner << 1), 0 | (deriv << 1))
-                    dfL = _varname(prev_stage, 0 | (corner << 1), 1 | (deriv << 1))
-                    dfR = _varname(prev_stage, 1 | (corner << 1), 1 | (deriv << 1))
-                end
-
-                h = Symbol("h_", stage)
-                inv_h = Symbol("inv_h_", stage)
-                ulo = Symbol("ulo_", stage)
-                uhi = Symbol("uhi_", stage)
-
-                kernel_call = :(_hermite_integral_kernel_1d($fL, $fR, $dfL, $dfR, $h, $inv_h, $ulo, $uhi))
-                push!(stmts, :($out_var = $kernel_call))
-            end
-        end
-    end
-
-    final_var = _varname(N, 0, 0)
-    push!(stmts, :(return $final_var))
-
-    return quote
-        Base.@_inline_meta
-        @inbounds begin
-            $(stmts...)
-        end
-    end
-end
-
 # ═══════════════════════════════════════════════════════════════
-# ND Linear integration kernel
-#
+# Partial-cell 1D weight helpers (consumed by the separable ND engine's bounded
+# node weights in integrate_fulldomain.jl). The 2^N per-cell ND kernels these
+# once fed were retired with the generic engine.
+# ═══════════════════════════════════════════════════════════════
+
 # Multilinear basis weights integrated over [u0, u1]:
 #   w₀(u0,u1,h) = ∫(1 - u/h) du = (u1-u0) - (u1²-u0²)/(2h)
 #   w₁(u0,u1,h) = ∫(u/h) du     = (u1²-u0²)/(2h)
-# ═══════════════════════════════════════════════════════════════
-
 # Factored form: u1²-u0² = (u1-u0)(u1+u0), then muladd to avoid explicit squaring.
 @inline function _w0_int(u0, u1, h)
     du = u1 - u0
@@ -258,167 +181,12 @@ end
     return du * (u1 + u0) / (2h)
 end
 
-@inline @generated function _integrate_linear_nd_cell(
-        data::AbstractArray{Tv, N},
-        idx::NTuple{N, Int},
-        hs::NTuple{N},
-        ulo::NTuple{N},
-        uhi::NTuple{N}
-    ) where {Tv, N}
-    nc = 1 << N
-    terms = Expr[]
-    for c in 0:(nc - 1)
-        bits = ntuple(d -> (c >> (d - 1)) & 1, N)
-        idx_parts = [:(idx[$d] + $(bits[d])) for d in 1:N]
-        ws = [
-            bits[d] == 0 ?
-                :(_w0_int(ulo[$d], uhi[$d], hs[$d])) :
-                :(_w1_int(ulo[$d], uhi[$d], hs[$d])) for d in 1:N
-        ]
-        w = foldl((a, b) -> :($a * $b), ws)
-        push!(terms, :(@inbounds data[$(idx_parts...)] * $w))
-    end
-    sum_expr = foldl((a, b) -> :($a + $b), terms)
-    return quote
-        Base.@_inline_meta
-        @inbounds $sum_expr
-    end
-end
-
-# ═══════════════════════════════════════════════════════════════
-# ND Quadratic integration kernel
-#
-# 1D quadratic: S(u) = a·u² + dfL·u + fL
-#   where a = ((fR-fL)/h - dfL)/h = (s - dfL)·inv_h
-# Integral: ∫_{u0}^{u1} S(u) du = a/3·(u1³-u0³) + dfL/2·(u1²-u0²) + fL·(u1-u0)
-# ═══════════════════════════════════════════════════════════════
-
-# Horner form: F(u) = u · @evalpoly(u, fL, dfL/2, a/3)
-@inline function _quadratic_integral_kernel_nd(fL::Tv, fR, dfL, h::Tg, inv_h::Tinv, u0, u1) where {Tg, Tinv, Tv}
-    # `Tg` = grid type (from `h`); `inv_h::Tinv` is its reciprocal (`inv(Int)::Float`, so
-    # `Tinv` ≠ `Tg` on Int grids). Witness the coeff field through the grid `Tg` (the
-    # `_coeff_op` convention — `inv(h)` floats Int grids), matching `_hermite_kernel_1d`.
-    s = _fielddiff(_promote_eltype(_coeff_op, Tg, Tv), fR, fL) * inv_h
-    a_3 = (s - dfL) * (inv_h * inv(oftype(h, 3)))  # a/3
-    d_2 = inv(oftype(h, 2)) * dfL   # Tg * Tv
-    return u1 * @evalpoly(u1, fL, d_2, a_3) -
-        u0 * @evalpoly(u0, fL, d_2, a_3)
-end
-
-# @generated tensor-product cell integral for quadratic ND
-# Mirrors _eval_nd_quad_cell but replaces point-eval with integral kernel.
-# Reads 3 values per dimension (fL, fR, dfL — no dfR).
-@inline @generated function _integrate_nd_quad_cell(
-        partials::Array{Tv, NP1},
-        indices::NTuple{N, Int},
-        hs::NTuple{N, Tg},
-        inv_hs::NTuple{N, Tg},
-        ulos::NTuple{N, <:Real},
-        uhis::NTuple{N, <:Real}
-    ) where {Tv, Tg, N, NP1}
-    NP1 == N + 1 || error("NP1 must equal N+1")
-
-    stmts = Expr[]
-
-    for (prefix, source) in [
-            ("idx_", :indices), ("h_", :hs), ("inv_h_", :inv_hs),
-            ("ulo_", :ulos), ("uhi_", :uhis),
-        ]
-        syms = ntuple(d -> Symbol(prefix, d), N)
-        lhs = Expr(:tuple, syms...)
-        push!(stmts, :($lhs = $source))
-    end
-
-    for stage in 1:N
-        num_corners = 1 << (N - stage)
-        num_derivs = 1 << (N - stage)
-
-        for corner in 0:(num_corners - 1)
-            for deriv in 0:(num_derivs - 1)
-                out_var = _varname(stage, corner, deriv)
-
-                if stage == 1
-                    function make_partial_access_qi(c_dim1::Int, d_dim1::Int)
-                        corner_full = c_dim1 | (corner << 1)
-                        deriv_full = d_dim1 | (deriv << 1)
-                        p_idx = _partial_index(deriv_full)
-                        offsets = _corner_offset_expr(corner_full, N)
-                        idx_exprs = [:($(Symbol("idx_", d)) + $(offsets[d])) for d in 1:N]
-                        return :(partials[$p_idx, $(idx_exprs...)])
-                    end
-
-                    fL = make_partial_access_qi(0, 0)
-                    fR = make_partial_access_qi(1, 0)
-                    dfL = make_partial_access_qi(0, 1)
-                else
-                    prev_stage = stage - 1
-                    fL = _varname(prev_stage, 0 | (corner << 1), 0 | (deriv << 1))
-                    fR = _varname(prev_stage, 1 | (corner << 1), 0 | (deriv << 1))
-                    dfL = _varname(prev_stage, 0 | (corner << 1), 1 | (deriv << 1))
-                end
-
-                h = Symbol("h_", stage)
-                inv_h = Symbol("inv_h_", stage)
-                ulo = Symbol("ulo_", stage)
-                uhi = Symbol("uhi_", stage)
-
-                kernel_call = :(_quadratic_integral_kernel_nd($fL, $fR, $dfL, $h, $inv_h, $ulo, $uhi))
-                push!(stmts, :($out_var = $kernel_call))
-            end
-        end
-    end
-
-    final_var = _varname(N, 0, 0)
-    push!(stmts, :(return $final_var))
-
-    return quote
-        Base.@_inline_meta
-        @inbounds begin
-            $(stmts...)
-        end
-    end
-end
-
-# ═══════════════════════════════════════════════════════════════
-# ND Constant integration kernel
-#
-# Per-axis weight functions for side-dependent integration:
-#   LeftSide    → all weight to left corner
-#   RightSide   → all weight to right corner
-#   NearestSide → split at midpoint h/2
-# ═══════════════════════════════════════════════════════════════
-
+# Constant side-dependent partial-cell weights:
+#   LeftSide → all weight to left corner; RightSide → right corner;
+#   NearestSide → split at midpoint h/2.
 @inline _cw0(u0, u1, h, ::LeftSide) = u1 - u0
 @inline _cw1(u0, u1, h, ::LeftSide) = zero(u1 - u0)
 @inline _cw0(u0, u1, h, ::RightSide) = zero(u1 - u0)
 @inline _cw1(u0, u1, h, ::RightSide) = u1 - u0
 @inline _cw0(u0, u1, h, ::NearestSide) = max(zero(u0), min(u1, h / 2) - u0)
 @inline _cw1(u0, u1, h, ::NearestSide) = max(zero(u0), u1 - max(u0, h / 2))
-
-@inline @generated function _integrate_constant_nd_cell(
-        data::AbstractArray{Tv, N},
-        idx::NTuple{N, Int},
-        hs::NTuple{N},
-        ulo::NTuple{N},
-        uhi::NTuple{N},
-        sides::Tuple{Vararg{AbstractSide, N}}
-    ) where {Tv, N}
-    nc = 1 << N
-    terms = Expr[]
-    for c in 0:(nc - 1)
-        bits = ntuple(d -> (c >> (d - 1)) & 1, N)
-        idx_parts = [:(idx[$d] + $(bits[d])) for d in 1:N]
-        ws = [
-            bits[d] == 0 ?
-                :(_cw0(ulo[$d], uhi[$d], hs[$d], sides[$d])) :
-                :(_cw1(ulo[$d], uhi[$d], hs[$d], sides[$d])) for d in 1:N
-        ]
-        w = foldl((a, b) -> :($a * $b), ws)
-        push!(terms, :(@inbounds data[$(idx_parts...)] * $w))
-    end
-    sum_expr = foldl((a, b) -> :($a + $b), terms)
-    return quote
-        Base.@_inline_meta
-        @inbounds $sum_expr
-    end
-end

--- a/test/runtests_parallel.jl
+++ b/test/runtests_parallel.jl
@@ -239,12 +239,20 @@ function scan_file(path)
                     push!(names, ex.args[3])
                 end
             elseif mname === Symbol("@testsnippet")
+                # Match `begin`/`end` as WHOLE WORDS, not substrings: on Julia 1.10
+                # `Meta.parse` folds a following comment into this expr's span, so
+                # `chunk` can carry trailing prose. A plain `findlast("end", …)`
+                # then latches onto the "end" inside a word like "indep-end-ent"
+                # and truncates the body (the module closes early, its shim escapes
+                # to top level → "Test files must only include @testitem/@testsetup").
                 chunk = src[pos:stop]
-                b = findfirst("begin", chunk)
-                e = findlast("end", chunk)
-                if b !== nothing && e !== nothing
+                bs = collect(eachmatch(r"\bbegin\b", chunk))
+                es = collect(eachmatch(r"\bend\b", chunk))
+                if !isempty(bs) && !isempty(es)
                     name = string(ex.args[3])
-                    body = strip(chunk[nextind(chunk, last(b)):prevind(chunk, first(e))])
+                    bstop = bs[1].offset + ncodeunits(bs[1].match)   # first char after `begin`
+                    estart = es[end].offset                          # first char of the last `end`
+                    body = strip(chunk[bstop:prevind(chunk, estart)])
                     push!(snips, (name, String(body)))
                 end
             end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -42,6 +42,37 @@ end
     end
 end
 
+# Per-fiber 1D-composition oracle for ND tensor-product `integrate`. Independent
+# of the ND separable engine: it integrates the inner axis per outer node with a
+# freshly built 1D interpolant of the matching method, then integrates the outer
+# 1D interpolant of those node integrals. Exact for tensor products (integration
+# is linear and the ND antiderivative factorizes), so it validates the whole ND
+# engine — weights, slot contraction, mixed radix — without sharing its code.
+# `ms` is the per-axis method tuple; homogeneous callers pass `(m, m[, m])`.
+@testsnippet NDCompositionOracle begin
+    const FIO = FastInterpolations
+    _ob1d(::FIO.LinearInterp, x, v) = linear_interp(x, v)
+    _ob1d(::FIO.CubicInterp, x, v) = cubic_interp(x, v)
+    _ob1d(::FIO.QuadraticInterp, x, v) = quadratic_interp(x, v)
+    _ob1d(m::FIO.ConstantInterp, x, v) = constant_interp(x, v; side = m.side)
+
+    comp_nd(ms::Tuple{Any}, grids, A) = integrate(_ob1d(ms[1], grids[1], A))
+    comp_nd(ms::Tuple{Any}, grids, A, lo, hi) =
+        integrate(_ob1d(ms[1], grids[1], A), lo[1], hi[1])
+    function comp_nd(ms, grids, A)
+        x = grids[1]
+        inner = grids[2:end]
+        vals = [comp_nd(Base.tail(ms), inner, selectdim(A, 1, i)) for i in eachindex(x)]
+        return integrate(_ob1d(ms[1], x, vals))
+    end
+    function comp_nd(ms, grids, A, lo, hi)
+        x = grids[1]
+        inner = grids[2:end]
+        vals = [comp_nd(Base.tail(ms), inner, selectdim(A, 1, i), Base.tail(lo), Base.tail(hi)) for i in eachindex(x)]
+        return integrate(_ob1d(ms[1], x, vals), lo[1], hi[1])
+    end
+end
+
 # DuckFloat5 type + shared 1D/2D fixtures for the duck-typing comprehensive
 # tests (test_duck_typing_comprehensive.jl). Extracted as a snippet so the
 # testitem split inside that file can reuse the same setup without copy-paste.

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -61,13 +61,13 @@ end
         integrate(_ob1d(ms[1], grids[1], A), lo[1], hi[1])
     function comp_nd(ms, grids, A)
         x = grids[1]
-        inner = grids[2:end]
+        inner = Base.tail(grids)
         vals = [comp_nd(Base.tail(ms), inner, selectdim(A, 1, i)) for i in eachindex(x)]
         return integrate(_ob1d(ms[1], x, vals))
     end
     function comp_nd(ms, grids, A, lo, hi)
         x = grids[1]
-        inner = grids[2:end]
+        inner = Base.tail(grids)
         vals = [comp_nd(Base.tail(ms), inner, selectdim(A, 1, i), Base.tail(lo), Base.tail(hi)) for i in eachindex(x)]
         return integrate(_ob1d(ms[1], x, vals), lo[1], hi[1])
     end

--- a/test/test_duck_typing_comprehensive.jl
+++ b/test/test_duck_typing_comprehensive.jl
@@ -1864,3 +1864,38 @@ end
         end
     end
 end
+
+# ND duck integrate exercises the separable engine's non-Number zero init
+# (`_nd_int_zero` → `0 * sample`) — the path the retired generic per-cell engine
+# used to serve. Rank-1 families (Linear/Constant) build without differentiating
+# the duck payload, so they're the clean pin for the ND value contract.
+@testitem "duck ND integrate — separable engine (full + bounded)" begin
+    struct NdDuck
+        v::Float64
+    end
+    Base.:+(a::NdDuck, b::NdDuck) = NdDuck(a.v + b.v)
+    Base.:-(a::NdDuck, b::NdDuck) = NdDuck(a.v - b.v)
+    Base.:*(a::Real, b::NdDuck) = NdDuck(a * b.v)
+    Base.:*(a::NdDuck, b::Real) = NdDuck(a.v * b)
+    Base.zero(::Type{NdDuck}) = NdDuck(0.0)
+    _v(d::NdDuck) = d.v
+
+    x = [0.0, 0.5, 1.3, 2.0, 3.0]           # Vector × Range → also mixed-grid path
+    y = range(0.0, 2.0, length = 6)
+    dat = [NdDuck(sin(xi) + 2yj) for xi in x, yj in y]
+    ref = [d.v for d in dat]
+    lo = (0.3, 0.4);  hi = (2.6, 1.7)
+
+    @testset "linear ND (rank-1 payload)" begin
+        itp = linear_interp((x, y), dat);  rf = linear_interp((x, y), ref)
+        @test integrate(itp) isa NdDuck
+        @test _v(integrate(itp)) ≈ integrate(rf) rtol = 1.0e-12
+        @test _v(integrate(itp, lo, hi)) ≈ integrate(rf, lo, hi) rtol = 1.0e-12
+    end
+
+    @testset "constant ND (rank-1, side weights)" begin
+        itp = constant_interp((x, y), dat);  rf = constant_interp((x, y), ref)
+        @test _v(integrate(itp)) ≈ integrate(rf) rtol = 1.0e-12
+        @test _v(integrate(itp, lo, hi)) ≈ integrate(rf, lo, hi) rtol = 1.0e-12
+    end
+end

--- a/test/test_finite_eltype_no_wrap.jl
+++ b/test/test_finite_eltype_no_wrap.jl
@@ -247,10 +247,10 @@ end
     @test FI._cubic_integral_kernel(FI._EvalIntegralPartial(), 0.0, 0.0, 200.0, 50.0, 1.0, 0.0, 1.0) === 125.0
     @test FI._cubic_integral_kernel(FI._EvalIntegralCell(), 0.0, 0.0, 200.0, 220.0, 1.0) === 210.0
 
-    # ── quadratic ND kernel: (fR - fL) wrap ─────────────────────────────────────
-    # _quadratic_integral_kernel_nd: s = (fR - fL) * inv_h; with dfL=0, u0=0, u1=1
-    @test FI._quadratic_integral_kernel_nd(UInt8(200), UInt8(50), 0.0, 1.0, 1.0, 0.0, 1.0) ≈
-        FI._quadratic_integral_kernel_nd(200.0, 50.0, 0.0, 1.0, 1.0, 0.0, 1.0)
+    # Quadratic ND no longer has a raw-corner kernel: the separable engine
+    # multiplies each node value by a grid-typed (Float) weight before summing,
+    # so a finite-eltype quadratic payload widens and never modular-wraps. Pinned
+    # end-to-end by the N0f8/Gray carrier tests below.
 end
 
 @testitem "build-overflow: periodic seams" begin

--- a/test/test_hermite_nd_graceful_errors.jl
+++ b/test/test_hermite_nd_graceful_errors.jl
@@ -61,6 +61,9 @@
     end
 
     @testset "integrate(HeteroInterpolantND) — full-domain" begin
+        # Local-Hermite axes have no separable node-weight rule → the single ND
+        # entry point rejects them with a clear message pointing at the 1D
+        # axis-by-axis workaround.
         itp = interp((x, y), data; method = (PchipInterp(), CardinalInterp()))
         err = try
             integrate(itp)
@@ -69,21 +72,21 @@
             e
         end
         @test err isa ArgumentError
-        @test occursin("not yet implemented for HeteroInterpolantND", err.msg)
-        @test occursin("tensor-product integration", err.msg)
-        @test occursin("cubic_interp", err.msg)  # suggests homogeneous workaround
+        @test occursin("not implemented for HeteroInterpolantND", err.msg)
+        @test occursin("tensor-product", err.msg)
+        @test occursin("axis-by-axis", err.msg)  # suggests the 1D workaround
     end
 
-    @testset "integrate(HeteroInterpolantND, a, b) — bounded" begin
+    @testset "integrate(HeteroInterpolantND, lo, hi) — bounded" begin
         itp = interp((x, y), data; method = (CubicInterp(), AkimaInterp()))
         err = try
-            integrate(itp, 0.1, 0.9)
+            integrate(itp, (0.1, 0.1), (0.9, 0.9))
             nothing
         catch e
             e
         end
         @test err isa ArgumentError
-        @test occursin("not yet implemented for HeteroInterpolantND", err.msg)
+        @test occursin("not implemented for HeteroInterpolantND", err.msg)
     end
 
     @testset "integrate(pure Cubic ND) — regression guard" begin

--- a/test/test_integral_nd_hetero.jl
+++ b/test/test_integral_nd_hetero.jl
@@ -1,0 +1,187 @@
+# ═══════════════════════════════════════════════════════════════════════
+# Hetero ND integrate — mixed per-axis methods through the separable engine
+#
+# The separable node-weight engine keys on per-axis method tags, so mixed
+# tensor-product axes (Linear/Cubic/Quadratic/Constant) integrate exactly like
+# their homogeneous counterparts. Oracle: the engine-independent per-fiber 1D
+# composition (`comp_nd` in the NDCompositionOracle snippet).
+# ═══════════════════════════════════════════════════════════════════════
+
+@testitem "hetero ND integrate: mixed full-domain vs 1D composition" setup = [Basic, NDCompositionOracle] begin
+    x = [0.0, 0.3, 0.7, 1.1, 1.8, 2.0]
+    y = range(0.0, 3.0, length = 9)
+    A = [sin(xi) * cos(yj) + 0.5 * xi for xi in x, yj in y]
+
+    @testset "PreCompute mixes (rank-1 × rank-2, rank-2 × rank-2)" begin
+        for ms in (
+                (CubicInterp(), LinearInterp()),
+                (LinearInterp(), CubicInterp()),
+                (QuadraticInterp(), LinearInterp()),
+                (LinearInterp(), QuadraticInterp()),
+                (CubicInterp(), QuadraticInterp()),
+            )
+            itp = interp((x, y), A; method = ms, coeffs = PreCompute())
+            @test itp isa FI.HeteroInterpolantND
+            @test integrate(itp) ≈ comp_nd(ms, (x, y), A) rtol = 1.0e-11
+        end
+    end
+
+    @testset "Range × Range grids" begin
+        xr = range(0.0, 2.0, length = 13)
+        Ar = [sin(xi) * cos(yj) for xi in xr, yj in y]
+        ms = (CubicInterp(), LinearInterp())
+        itp = interp((xr, y), Ar; method = ms, coeffs = PreCompute())
+        @test integrate(itp) ≈ comp_nd(ms, (xr, y), Ar) rtol = 1.0e-11
+    end
+
+    @testset "OnTheFly rank-1 mixes (raw data payload)" begin
+        ms = (LinearInterp(), ConstantInterp(side = LeftSide()))
+        itp = interp((x, y), A; method = ms, coeffs = OnTheFly())
+        @test itp isa FI.HeteroInterpolantND
+        @test integrate(itp) ≈ comp_nd(ms, (x, y), A) rtol = 1.0e-12
+
+        # NearestSide constant weights ≡ composite trapezoid ≡ linear weights
+        itp_n = interp((x, y), A; method = (LinearInterp(), ConstantInterp()), coeffs = OnTheFly())
+        itp_l = interp((x, y), A; method = (LinearInterp(), LinearInterp()), coeffs = OnTheFly())
+        @test integrate(itp_n) ≈ integrate(itp_l) rtol = 1.0e-14
+    end
+
+    @testset "all-linear hetero == homogeneous linear" begin
+        itp_h = interp((x, y), A; method = (LinearInterp(), LinearInterp()), coeffs = OnTheFly())
+        itp_l = linear_interp((x, y), A)
+        @test integrate(itp_h) ≈ integrate(itp_l) rtol = 1.0e-14
+    end
+
+    @testset "periodic linear axis (closed-domain storage)" begin
+        xp = range(0.0, 2π, length = 17)
+        P = [sin(xi) * (1.0 + 0.3 * yj) for xi in xp, yj in y]   # P[end,:] == P[1,:]
+        itp_h = interp(
+            (xp, y), P;
+            method = (LinearInterp(bc = PeriodicBC()), LinearInterp()), coeffs = OnTheFly()
+        )
+        itp_l = linear_interp((xp, y), P; bc = (PeriodicBC(), NoBC()))
+        @test integrate(itp_h) ≈ integrate(itp_l) rtol = 1.0e-13
+    end
+
+    @testset "3D Linear × Cubic × Quadratic" begin
+        y3 = range(0.0, 1.5, length = 7)
+        z = [0.0, 0.35, 0.8, 1.0]
+        B = [cos(xi) + yj * zk + 0.2 * zk^2 for xi in x, yj in y3, zk in z]
+        ms = (LinearInterp(), CubicInterp(), QuadraticInterp())
+        itp = interp((x, y3, z), B; method = ms, coeffs = PreCompute())
+        @test itp isa FI.HeteroInterpolantND
+        @test integrate(itp) ≈ comp_nd(ms, (x, y3, z), B) rtol = 1.0e-10
+    end
+end
+
+@testitem "hetero ND integrate: mixed bounded boxes" setup = [Basic, NDCompositionOracle] begin
+    x = [0.0, 0.3, 0.7, 1.1, 1.8, 2.0]
+    y = range(0.0, 3.0, length = 9)
+    A = [sin(xi) * cos(yj) + 0.5 * xi for xi in x, yj in y]
+
+    @testset "box sweep vs composition oracle" begin
+        for ms in ((CubicInterp(), LinearInterp()), (CubicInterp(), QuadraticInterp()))
+            itp = interp((x, y), A; method = ms, coeffs = PreCompute())
+            for (lo, hi) in (
+                    ((0.2, 0.4), (1.5, 2.6)),            # interior, non-node cuts
+                    ((x[2], y[3]), (x[4], y[6])),        # node-aligned
+                    ((first(x), first(y)), (last(x), last(y))),  # box == domain
+                )
+                @test integrate(itp, lo, hi) ≈ comp_nd(ms, (x, y), A, lo, hi) rtol = 1.0e-11
+            end
+            lo = (first(x), first(y))
+            hi = (last(x), last(y))
+            @test integrate(itp, lo, hi) ≈ integrate(itp) rtol = 1.0e-12
+        end
+    end
+
+    @testset "axis additivity at a non-node cut" begin
+        ms = (CubicInterp(), LinearInterp())
+        itp = interp((x, y), A; method = ms, coeffs = PreCompute())
+        lo = (0.1, 0.3)
+        hi = (1.9, 2.7)
+        xc = 0.95
+        left = integrate(itp, lo, (xc, hi[2]))
+        right = integrate(itp, (xc, lo[2]), hi)
+        @test left + right ≈ integrate(itp, lo, hi) rtol = 1.0e-11
+    end
+
+    @testset "orientation sign" begin
+        ms = (CubicInterp(), LinearInterp())
+        itp = interp((x, y), A; method = ms, coeffs = PreCompute())
+        lo = (0.2, 0.4)
+        hi = (1.5, 2.6)
+        ref = integrate(itp, lo, hi)
+        @test integrate(itp, (hi[1], lo[2]), (lo[1], hi[2])) ≈ -ref rtol = 1.0e-11
+        @test integrate(itp, hi, lo) ≈ ref rtol = 1.0e-11
+    end
+
+    @testset "OnTheFly rank-1 bounded" begin
+        ms = (LinearInterp(), ConstantInterp(side = LeftSide()))
+        itp = interp((x, y), A; method = ms, coeffs = OnTheFly())
+        lo = (0.2, 0.4)
+        hi = (1.5, 2.6)
+        @test integrate(itp, lo, hi) ≈ comp_nd(ms, (x, y), A, lo, hi) rtol = 1.0e-12
+    end
+end
+
+@testitem "hetero ND integrate: gates and error messages" begin
+    const FI = FastInterpolations
+    x = [0.0, 0.3, 0.7, 1.1, 1.8, 2.0]
+    y = range(0.0, 3.0, length = 9)
+    A = [sin(xi) * cos(yj) for xi in x, yj in y]
+
+    @testset "OnTheFly with a derivative axis needs PreCompute" begin
+        itp = interp((x, y), A; method = (CubicInterp(), LinearInterp()), coeffs = OnTheFly())
+        @test_throws "PreCompute" integrate(itp)
+        @test_throws "PreCompute" integrate(itp, (0.2, 0.4), (1.5, 2.6))
+    end
+
+    @testset "local-Hermite axes stay unsupported" begin
+        itp = interp((x, y), A; method = (PchipInterp(), LinearInterp()))
+        @test_throws ArgumentError integrate(itp)
+        @test_throws ArgumentError integrate(itp, (0.2, 0.4), (1.5, 2.6))
+    end
+
+    @testset "NoInterp axes stay unsupported" begin
+        itp = interp((x, y), A; method = (LinearInterp(), NoInterp()))
+        @test_throws ArgumentError integrate(itp)
+    end
+
+    @testset "ND with Real bounds points at tuple form" begin
+        lin = linear_interp((x, y), A)
+        @test_throws "tuple" integrate(lin, 0.1, 0.5)
+    end
+
+    @testset "CubicHermiteInterpolantND: clean not-implemented (not MethodError)" begin
+        dfdx = [cos(xi) * cos(yj) for xi in x, yj in y]
+        dfdy = [-sin(xi) * sin(yj) for xi in x, yj in y]
+        d2 = [-cos(xi) * sin(yj) for xi in x, yj in y]
+        p = HermitePartials((1, 0) => dfdx, (0, 1) => dfdy, (1, 1) => d2)
+        itp = hermite_interp((x, y), A, p)
+        @test_throws ArgumentError integrate(itp)
+        @test_throws ArgumentError integrate(itp, (0.2, 0.4), (1.5, 2.6))
+    end
+end
+
+@testitem "hetero ND integrate: zero allocation" setup = [AllocConstants] begin
+    x = collect(range(0.0, 2.0, length = 24))
+    y = range(0.0, 3.0, length = 20)
+    A = [sin(xi) * cos(yj) for xi in x, yj in y]
+    itp2 = interp((x, y), A; method = (CubicInterp(), LinearInterp()), coeffs = PreCompute())
+
+    z = range(0.0, 1.0, length = 10)
+    B = [cos(xi) + yj * zk for xi in x, yj in y, zk in z]
+    itp3 = interp((x, y, z), B; method = (LinearInterp(), CubicInterp(), QuadraticInterp()), coeffs = PreCompute())
+
+    lo2 = (0.2, 0.4)
+    hi2 = (1.7, 2.6)
+    lo3 = (0.2, 0.4, 0.1)
+    hi3 = (1.7, 2.6, 0.9)
+    integrate(itp2);  integrate(itp3)                    # warmup
+    integrate(itp2, lo2, hi2);  integrate(itp3, lo3, hi3)
+    @test @allocated(integrate(itp2)) <= ND_ALLOC_THRESHOLD
+    @test @allocated(integrate(itp3)) <= ND_ALLOC_THRESHOLD
+    @test @allocated(integrate(itp2, lo2, hi2)) <= ND_ALLOC_THRESHOLD
+    @test @allocated(integrate(itp3, lo3, hi3)) <= ND_ALLOC_THRESHOLD
+end

--- a/test/test_integral_nd_hetero.jl
+++ b/test/test_integral_nd_hetero.jl
@@ -12,8 +12,16 @@
     y = range(0.0, 3.0, length = 9)
     A = [sin(xi) * cos(yj) + 0.5 * xi for xi in x, yj in y]
 
-    @testset "PreCompute mixes (rank-1 × rank-2, rank-2 × rank-2)" begin
+    @testset "PreCompute mixes (rank-1×rank-1, rank-1×rank-2, rank-2×rank-2)" begin
+        # Only genuinely-mixed method TYPES build a HeteroInterpolantND — `interp`
+        # collapses same-method tuples (Linear×Linear, Const×Const) to the
+        # homogeneous ND type. The rank-1×rank-1 mix (Linear×Constant) is the key
+        # case: all-trivial PreCompute carries a SIZE-1 leading slot axis (payload
+        # rank N+1 with prod(rs)==1), so the kernel must key "has slot" off the
+        # payload rank, not prod(rs).
         for ms in (
+                (LinearInterp(), ConstantInterp()),                 # rank-1 × rank-1
+                (ConstantInterp(side = LeftSide()), LinearInterp()),  # rank-1 × rank-1, other order
                 (CubicInterp(), LinearInterp()),
                 (LinearInterp(), CubicInterp()),
                 (QuadraticInterp(), LinearInterp()),
@@ -22,6 +30,17 @@
             )
             itp = interp((x, y), A; method = ms, coeffs = PreCompute())
             @test itp isa FI.HeteroInterpolantND
+            @test integrate(itp) ≈ comp_nd(ms, (x, y), A) rtol = 1.0e-11
+            @test integrate(itp, (0.2, 0.4), (1.7, 2.6)) ≈ comp_nd(ms, (x, y), A, (0.2, 0.4), (1.7, 2.6)) rtol = 1.0e-11
+        end
+    end
+
+    @testset "same-method PreCompute collapses to homogeneous (still integrates)" begin
+        # Contract check: (Linear,Linear)/(Const,Const) route to the specialized
+        # homogeneous type, not Hetero — value must still match composition.
+        for ms in ((LinearInterp(), LinearInterp()), (ConstantInterp(side = LeftSide()), ConstantInterp(side = LeftSide())))
+            itp = interp((x, y), A; method = ms, coeffs = PreCompute())
+            @test !(itp isa FI.HeteroInterpolantND)
             @test integrate(itp) ≈ comp_nd(ms, (x, y), A) rtol = 1.0e-11
         end
     end

--- a/test/test_integral_nd_separable.jl
+++ b/test/test_integral_nd_separable.jl
@@ -303,14 +303,13 @@ end
 # the (value, derivative) payload — cubic h/2(fL+fR) + h²/12(dfL−dfR), quadratic
 # 2h/3·fL + h/3·fR + h²/6·dfL — so the domain integral separates with per-axis
 # (w, v) node-weight PAIRS contracting the mixed-partials tensor. Oracles: the
-# generic per-cell engine (forced via invoke) and the bounded engine at full
-# bounds (still cell-wise for these families → independent of the new path).
-@testitem "ND cubic/quad separable: engine parity (Range + Vector, 2D/3D)" setup = [AllocConstants] begin
+# engine-independent per-fiber 1D composition (`comp_nd`) and the bounded engine
+# at full bounds.
+@testitem "ND cubic/quad separable: engine parity (Range + Vector, 2D/3D)" setup = [AllocConstants, NDCompositionOracle] begin
     nonuni(a, b, n) = a .+ (b - a) .* ((x -> (x .- x[1]) ./ (x[end] - x[1]))([u + 0.15 * sinpi(u) for u in range(0, 1; length = n)]))
-    generic_nd(itp) = invoke(integrate, Tuple{FastInterpolations.AbstractInterpolantND}, itp)
 
     @testset "2D parity (both engines)" begin
-        for mk in (cubic_interp, quadratic_interp)
+        for (mk, m) in ((cubic_interp, CubicInterp()), (quadratic_interp, QuadraticInterp()))
             for (gx, gy) in (
                     (range(0.0, 2.0, length = 17), range(0.0, 3.0, length = 13)),
                     (nonuni(0.0, 2.0, 17), nonuni(0.0, 3.0, 13)),
@@ -318,19 +317,19 @@ end
                 data = [sin(xi) * cos(yj) + 0.3xi for xi in gx, yj in gy]
                 itp = mk((gx, gy), data)
                 lo = (first(gx), first(gy));  hi = (last(gx), last(gy))
-                @test integrate(itp) ≈ generic_nd(itp) rtol = 1.0e-12
+                @test integrate(itp) ≈ comp_nd((m, m), (gx, gy), data) rtol = 1.0e-12
                 @test integrate(itp) ≈ integrate(itp, lo, hi) rtol = 1.0e-12
             end
         end
     end
 
     @testset "3D parity (both engines)" begin
-        for mk in (cubic_interp, quadratic_interp)
+        for (mk, m) in ((cubic_interp, CubicInterp()), (quadratic_interp, QuadraticInterp()))
             x = nonuni(0.0, 1.0, 9);  y = nonuni(0.0, 2.0, 8);  z = nonuni(0.0, 3.0, 7)
             data = [sin(xi) + yj * zk - 0.2zk^2 for xi in x, yj in y, zk in z]
             itp = mk((x, y, z), data)
             lo = (first(x), first(y), first(z));  hi = (last(x), last(y), last(z))
-            @test integrate(itp) ≈ generic_nd(itp) rtol = 1.0e-12
+            @test integrate(itp) ≈ comp_nd((m, m, m), (x, y, z), data) rtol = 1.0e-12
             @test integrate(itp) ≈ integrate(itp, lo, hi) rtol = 1.0e-12
         end
     end
@@ -360,19 +359,14 @@ end
 # Cubic/Quadratic bounded: the clipped-composite structure extends to the pair
 # payload — per-axis (w, v) node weights built from the partial-cell integrals
 # (cubic via the ΔH antiderivatives, quadratic via its closed form), full cells
-# collapsing to the full-domain pair weights. Oracles: the generic cell-wise
-# bounded engine (invoke-forced), box == domain vs the full-domain path, axis
-# additivity, and orientation sign.
-@testitem "ND cubic/quad bounded separable: engine parity + oracles" setup = [AllocConstants] begin
+# collapsing to the full-domain pair weights. Oracles: the engine-independent
+# per-fiber 1D composition (`comp_nd`), box == domain vs the full-domain path,
+# axis additivity, and orientation sign.
+@testitem "ND cubic/quad bounded separable: engine parity + oracles" setup = [AllocConstants, NDCompositionOracle] begin
     nonuni(a, b, n) = a .+ (b - a) .* ((x -> (x .- x[1]) ./ (x[end] - x[1]))([u + 0.15 * sinpi(u) for u in range(0, 1; length = n)]))
-    const FI = FastInterpolations
-    gen2(itp, lo, hi, ::Type{T}) where {T} =
-        invoke(integrate, Tuple{T{Tg, Tv, 2} where {Tg, Tv}, NTuple{2, Real}, NTuple{2, Real}}, itp, lo, hi)
-    gen3(itp, lo, hi, ::Type{T}) where {T} =
-        invoke(integrate, Tuple{T{Tg, Tv, 3} where {Tg, Tv}, NTuple{3, Real}, NTuple{3, Real}}, itp, lo, hi)
 
-    @testset "2D parity vs generic bounded (Range + Vector, box sweep)" begin
-        for (mk, T) in ((cubic_interp, FI.CubicInterpolantND), (quadratic_interp, FI.QuadraticInterpolantND))
+    @testset "2D parity vs composition oracle (Range + Vector, box sweep)" begin
+        for (mk, m) in ((cubic_interp, CubicInterp()), (quadratic_interp, QuadraticInterp()))
             for (gx, gy) in (
                     (range(0.0, 2.0, length = 17), range(0.0, 3.0, length = 13)),
                     (nonuni(0.0, 2.0, 17), nonuni(0.0, 3.0, 13)),
@@ -385,7 +379,7 @@ end
                         ((0.31, 0.55), (0.65, 1.15)),   # few cells
                         ((0.05, 0.1), (0.11, 0.2)),     # sub-/single-cell
                     )
-                    @test integrate(itp, lo, hi) ≈ gen2(itp, lo, hi, T) rtol = 1.0e-11
+                    @test integrate(itp, lo, hi) ≈ comp_nd((m, m), (gx, gy), data, lo, hi) rtol = 1.0e-11
                 end
                 @test integrate(itp, (0.0, 0.0), (2.0, 3.0)) ≈ integrate(itp) rtol = 1.0e-12
             end
@@ -395,10 +389,10 @@ end
     @testset "3D parity + additivity + sign" begin
         x = nonuni(0.0, 1.0, 9);  y = nonuni(0.0, 2.0, 8);  z = nonuni(0.0, 3.0, 7)
         data = [sin(xi) + yj * zk - 0.2zk^2 for xi in x, yj in y, zk in z]
-        for (mk, T) in ((cubic_interp, FI.CubicInterpolantND), (quadratic_interp, FI.QuadraticInterpolantND))
+        for (mk, m) in ((cubic_interp, CubicInterp()), (quadratic_interp, QuadraticInterp()))
             itp = mk((x, y, z), data)
             lo = (0.12, 0.3, 0.4);  hi = (0.85, 1.7, 2.6)
-            @test integrate(itp, lo, hi) ≈ gen3(itp, lo, hi, T) rtol = 1.0e-11
+            @test integrate(itp, lo, hi) ≈ comp_nd((m, m, m), (x, y, z), data, lo, hi) rtol = 1.0e-11
             c = 0.5
             @test integrate(itp, lo, hi) ≈
                 integrate(itp, lo, (c, hi[2], hi[3])) + integrate(itp, (c, lo[2], lo[3]), hi) rtol = 1.0e-11
@@ -418,5 +412,26 @@ end
             @test @allocated(integrate(itp_r, lo, hi)) <= ND_ALLOC_THRESHOLD
             @test @allocated(integrate(itp_v, lo, hi)) <= ND_ALLOC_THRESHOLD
         end
+    end
+end
+
+# Bounded ND over MIXED grid types (Vector × Range): the `_nd_cell_ranges`
+# preamble must stay 0-alloc — the `do`-closure form leaked the element Union of
+# a mixed grid tuple into a dynamic `search_interval` dispatch (fixed via the
+# @generated per-axis unroll). Covers every tensor-product family + one hetero.
+@testitem "ND bounded: mixed grid types 0-alloc (all families)" setup = [AllocConstants] begin
+    xv = collect(range(0.0, 2.0, length = 20));  yr = range(0.0, 3.0, length = 16)
+    data = [sin(xi) * cos(yj) for xi in xv, yj in yr]
+    lo = (0.2, 0.4);  hi = (1.8, 2.7)
+    builds = (
+        linear_interp((xv, yr), data),
+        constant_interp((xv, yr), data),
+        cubic_interp((xv, yr), data),
+        quadratic_interp((xv, yr), data),
+        interp((xv, yr), data; method = (CubicInterp(), LinearInterp()), coeffs = PreCompute()),
+    )
+    for itp in builds
+        integrate(itp, lo, hi)   # warmup
+        @test @allocated(integrate(itp, lo, hi)) <= ND_ALLOC_THRESHOLD
     end
 end

--- a/test/test_integral_nd_separable.jl
+++ b/test/test_integral_nd_separable.jl
@@ -198,3 +198,103 @@ end
         end
     end
 end
+
+# Bounded ND (linear/constant): separability holds on any axis-aligned box —
+# per-axis weights become "clipped composites" (zero outside the cell range,
+# partial `_w0_int`/`_w1_int`-style weights at the two boundary cells, full
+# weights inside), so the sum visits only the node sub-box. These tests pin the
+# bounded semantics through engine-independent oracles before the path lands:
+# analytic exact fields, box == domain ≡ full-domain, axis additivity, sign.
+@testitem "ND bounded separable: oracles (linear + constant)" setup = [AllocConstants] begin
+    bilin_expected(lo, hi) = begin
+        X1 = hi[1] - lo[1];  X2 = (hi[1]^2 - lo[1]^2) / 2
+        Y1 = hi[2] - lo[2];  Y2 = (hi[2]^2 - lo[2]^2) / 2
+        X2 * Y2 + 2 * X2 * Y1 - 3 * X1 * Y2 + 5 * X1 * Y1
+    end
+    mk2d(x, y) = [xi * yj + 2xi - 3yj + 5 for xi in x, yj in y]
+
+    xv = [0.0, 0.3, 0.7, 1.1, 1.8, 2.0]
+    yv = [0.0, 0.5, 1.2, 2.0, 3.0]
+    xr = range(0.0, 2.0, length = 6)
+    yr = range(0.0, 3.0, length = 5)
+
+    @testset "linear 2D analytic sub-boxes (Range + Vector)" begin
+        for (gx, gy) in ((xr, yr), (xv, yv))
+            itp = linear_interp((gx, gy), mk2d(gx, gy); extrap = NoExtrap())
+            for (lo, hi) in (
+                    ((0.25, 0.4), (1.65, 2.6)),     # interior, cuts cells mid-way
+                    ((0.0, 0.0), (2.0, 3.0)),       # box == domain
+                    ((0.31, 0.55), (0.65, 1.15)),   # within few cells
+                    ((0.72, 1.25), (1.05, 1.95)),   # single-cell box on both axes (vector grid)
+                )
+                @test integrate(itp, lo, hi) ≈ bilin_expected(lo, hi) rtol = 1.0e-12
+            end
+            # box == domain matches the full-domain separable path
+            @test integrate(itp, (0.0, 0.0), (2.0, 3.0)) ≈ integrate(itp) rtol = 1.0e-12
+        end
+    end
+
+    @testset "linear 3D analytic sub-box + additivity" begin
+        z = [0.0, 0.35, 0.8, 1.0]
+        aff_expected(lo, hi) = begin
+            X1 = hi[1] - lo[1];  X2 = (hi[1]^2 - lo[1]^2) / 2
+            Y1 = hi[2] - lo[2];  Y2 = (hi[2]^2 - lo[2]^2) / 2
+            Z1 = hi[3] - lo[3];  Z2 = (hi[3]^2 - lo[3]^2) / 2
+            2 * X2 * Y1 * Z1 + 3 * X1 * Y2 * Z1 - X1 * Y1 * Z2 + 4 * X1 * Y1 * Z1
+        end
+        data = [2xi + 3yj - zk + 4 for xi in xv, yj in yv, zk in z]
+        itp = linear_interp((xv, yv, z), data; extrap = NoExtrap())
+        lo = (0.15, 0.4, 0.1);  hi = (1.7, 2.55, 0.9)
+        @test integrate(itp, lo, hi) ≈ aff_expected(lo, hi) rtol = 1.0e-12
+        # additivity along axis 1 at a non-node cut
+        c = 0.95
+        @test integrate(itp, lo, hi) ≈
+            integrate(itp, lo, (c, hi[2], hi[3])) + integrate(itp, (c, lo[2], lo[3]), hi) rtol = 1.0e-12
+    end
+
+    @testset "per-axis orientation sign; degenerate box is zero" begin
+        itp = linear_interp((xv, yv), mk2d(xv, yv))
+        lo = (0.25, 0.4);  hi = (1.65, 2.6)
+        # one reversed axis → −1; both reversed → (−1)² = +1
+        @test integrate(itp, (hi[1], lo[2]), (lo[1], hi[2])) ≈ -integrate(itp, lo, hi) rtol = 1.0e-12
+        @test integrate(itp, hi, lo) ≈ integrate(itp, lo, hi) rtol = 1.0e-12
+        @test integrate(itp, (0.5, 0.4), (0.5, 2.6)) == 0
+    end
+
+    @testset "constant: box-volume identity + additivity (all sides, mixed)" begin
+        ones2d = fill(1.0, length(xv), length(yv))
+        for side in (
+                NearestSide(), LeftSide(), RightSide(),
+                (LeftSide(), NearestSide()),
+            )
+            itp = constant_interp((xv, yv), ones2d; side = side)
+            lo = (0.2, 0.45);  hi = (1.75, 2.7)
+            # unit data integrates to the box volume regardless of side
+            @test integrate(itp, lo, hi) ≈ (hi[1] - lo[1]) * (hi[2] - lo[2]) rtol = 1.0e-12
+        end
+        data = [sin(xi) + cos(yj) for xi in xv, yj in yv]
+        for side in (NearestSide(), LeftSide(), RightSide())
+            itp = constant_interp((xv, yv), data; side = side)
+            lo = (0.2, 0.45);  hi = (1.75, 2.7)
+            c = 1.0                                     # non-node cut
+            @test integrate(itp, lo, hi) ≈
+                integrate(itp, lo, (c, hi[2])) + integrate(itp, (c, lo[2]), hi) rtol = 1.0e-12
+            @test integrate(itp, (first(xv), first(yv)), (last(xv), last(yv))) ≈
+                integrate(itp) rtol = 1.0e-12
+        end
+    end
+
+    @testset "zero allocation (Range + Vector)" begin
+        xr2 = range(0.0, 2.0, length = 20);  yr2 = range(0.0, 3.0, length = 16)
+        data = [sin(xi) * cos(yj) for xi in xr2, yj in yr2]
+        lo = (0.2, 0.4);  hi = (1.8, 2.7)
+        for itp in (
+                linear_interp((xr2, yr2), data),
+                linear_interp((collect(xr2), collect(yr2)), data),
+                constant_interp((xr2, yr2), data; side = NearestSide()),
+            )
+            integrate(itp, lo, hi)   # warmup
+            @test @allocated(integrate(itp, lo, hi)) <= ND_ALLOC_THRESHOLD
+        end
+    end
+end

--- a/test/test_integral_nd_separable.jl
+++ b/test/test_integral_nd_separable.jl
@@ -113,3 +113,88 @@ end
         @test Float64(integrate(itpN)) ≈ integrate(itpF) rtol = 1.0e-9
     end
 end
+
+# Constant ND full-domain: the per-axis side weights also collapse on full cells
+# (Left → h at the left node, Right → h at the right node, Nearest → ½h each),
+# so the domain integral is a separable side-weighted Riemann sum. Oracle 1 is
+# an explicit cell-sum reference implementation (independent of both engines);
+# oracle 2 is the generic bounded engine at full bounds. NearestSide weights
+# equal the linear composite-trapezoid weights, giving a third cross-family pin.
+@testitem "ND constant separable: cell-sum + bounded parity (all sides)" setup = [AllocConstants] begin
+    # reference: I = Σ_cells Σ_{s∈{0,1}^N} Π_d wpair(side_d, h_d(c_d))[s_d+1] · data[c+s]
+    wpair(::LeftSide, h) = (h, zero(h))
+    wpair(::RightSide, h) = (zero(h), h)
+    wpair(::NearestSide, h) = (h / 2, h / 2)
+    function brute(grids, data, sides)
+        N = length(grids)
+        total = 0.0
+        for c in CartesianIndices(ntuple(d -> 1:(length(grids[d]) - 1), N))
+            for s in CartesianIndices(ntuple(_ -> 0:1, N))
+                w = 1.0
+                for d in 1:N
+                    h = Float64(grids[d][c[d] + 1] - grids[d][c[d]])
+                    w *= wpair(sides[d], h)[s[d] + 1]
+                end
+                total += w * Float64(data[c + s])
+            end
+        end
+        return total
+    end
+
+    xv = [0.0, 0.3, 0.7, 1.1, 1.8, 2.0]
+    yv = [0.0, 0.5, 1.2, 2.0, 3.0]
+    xr = range(0.0, 2.0, length = 6)
+    yr = range(0.0, 3.0, length = 5)
+
+    @testset "2D all side combos — Range + Vector" begin
+        for (gx, gy) in ((xr, yr), (xv, yv))
+            data = [sin(xi) + cos(yj) for xi in gx, yj in gy]
+            lo = (first(gx), first(gy));  hi = (last(gx), last(gy))
+            for sx in (LeftSide(), RightSide(), NearestSide()),
+                    sy in (LeftSide(), RightSide(), NearestSide())
+
+                itp = constant_interp((gx, gy), data; side = (sx, sy), extrap = NoExtrap())
+                @test integrate(itp) ≈ brute((gx, gy), data, (sx, sy)) rtol = 1.0e-12
+                @test integrate(itp) ≈ integrate(itp, lo, hi) rtol = 1.0e-12
+            end
+        end
+    end
+
+    @testset "3D mixed sides — Vector (non-uniform)" begin
+        zv = [0.0, 0.35, 0.8, 1.0]
+        data = [xi + 2yj - zk for xi in xv, yj in yv, zk in zv]
+        sides = (LeftSide(), NearestSide(), RightSide())
+        itp = constant_interp((xv, yv, zv), data; side = sides, extrap = NoExtrap())
+        lo = (first(xv), first(yv), first(zv));  hi = (last(xv), last(yv), last(zv))
+        @test integrate(itp) ≈ brute((xv, yv, zv), data, sides) rtol = 1.0e-12
+        @test integrate(itp) ≈ integrate(itp, lo, hi) rtol = 1.0e-12
+    end
+
+    @testset "NearestSide ≡ linear composite trapezoid (full domain)" begin
+        for (gx, gy) in ((xr, yr), (xv, yv))
+            data = [xi^2 + yj for xi in gx, yj in gy]
+            itp_c = constant_interp((gx, gy), data; side = NearestSide())
+            itp_l = linear_interp((gx, gy), data)
+            @test integrate(itp_c) ≈ integrate(itp_l) rtol = 1.0e-12
+        end
+    end
+
+    @testset "Int data promotes to Float output" begin
+        di = [xi + yj for xi in 1:4, yj in 1:3]
+        itp = constant_interp((collect(1.0:4.0), collect(1.0:3.0)), di; side = NearestSide())
+        @test integrate(itp) isa AbstractFloat
+        @test integrate(itp) ≈ brute((1.0:4.0, 1.0:3.0), di, (NearestSide(), NearestSide())) rtol = 1.0e-12
+    end
+
+    @testset "zero allocation (Range + Vector, homogeneous + mixed sides)" begin
+        xr2 = range(0.0, 2.0, length = 20);  yr2 = range(0.0, 3.0, length = 16)
+        data = [sin(xi) * cos(yj) for xi in xr2, yj in yr2]
+        for sides in ((NearestSide(), NearestSide()), (LeftSide(), RightSide()))
+            itp_r = constant_interp((xr2, yr2), data; side = sides)
+            itp_v = constant_interp((collect(xr2), collect(yr2)), data; side = sides)
+            integrate(itp_r);  integrate(itp_v)   # warmup
+            @test @allocated(integrate(itp_r)) <= ND_ALLOC_THRESHOLD
+            @test @allocated(integrate(itp_v)) <= ND_ALLOC_THRESHOLD
+        end
+    end
+end

--- a/test/test_integral_nd_separable.jl
+++ b/test/test_integral_nd_separable.jl
@@ -1,0 +1,115 @@
+# ═══════════════════════════════════════════════════════════════════════
+# ND linear full-domain integrate — separable composite-trapezoid path
+#
+# The full-domain integral of a multilinear interpolant factorizes into a
+# tensor product of 1D composite-trapezoid rules:
+#
+#     I = Σ_nodes (Π_d w_d(i_d)) · data[i],   w_d = ½h at ends, ½(h₋+h₊) interior
+#
+# so every node is read once (vs 2^N corner reads per cell in the generic
+# per-cell kernel). This suite pins that path against two independent oracles
+# — the analytic integral of a multilinear-exact integrand, and the generic
+# bounded engine `integrate(itp, lo, hi)` — on Range and Vector grids, 2D/3D.
+# ═══════════════════════════════════════════════════════════════════════
+
+@testitem "ND linear separable: analytic + bounded parity" setup = [AllocConstants] begin
+    # 2D bilinear f(x,y) = xy + 2x − 3y + 5 (reproduced exactly by bilinear itp)
+    bilin_expected(lo, hi) = begin
+        X1 = hi[1] - lo[1];  X2 = (hi[1]^2 - lo[1]^2) / 2
+        Y1 = hi[2] - lo[2];  Y2 = (hi[2]^2 - lo[2]^2) / 2
+        X2 * Y2 + 2 * X2 * Y1 - 3 * X1 * Y2 + 5 * X1 * Y1
+    end
+    mk2d(x, y) = [xi * yj + 2xi - 3yj + 5 for xi in x, yj in y]
+
+    @testset "2D bilinear — Range grid" begin
+        x = range(0.0, 2.0, length = 21)
+        y = range(0.0, 3.0, length = 17)
+        itp = linear_interp((x, y), mk2d(x, y); extrap = NoExtrap())
+        lo = (first(x), first(y));  hi = (last(x), last(y))
+        @test integrate(itp) ≈ bilin_expected(lo, hi) rtol = 1.0e-12
+        @test integrate(itp) ≈ integrate(itp, lo, hi) rtol = 1.0e-12
+    end
+
+    @testset "2D bilinear — Vector grid (non-uniform)" begin
+        x = [0.0, 0.3, 0.7, 1.1, 1.8, 2.0]
+        y = [0.0, 0.5, 1.2, 2.0, 3.0]
+        itp = linear_interp((x, y), mk2d(x, y); extrap = NoExtrap())
+        lo = (first(x), first(y));  hi = (last(x), last(y))
+        @test integrate(itp) ≈ bilin_expected(lo, hi) rtol = 1.0e-12   # bilinear exact on non-uniform
+        @test integrate(itp) ≈ integrate(itp, lo, hi) rtol = 1.0e-12
+    end
+
+    # 3D affine f = 2x + 3y − z + 4
+    aff_expected(lo, hi) = begin
+        X1 = hi[1] - lo[1];  X2 = (hi[1]^2 - lo[1]^2) / 2
+        Y1 = hi[2] - lo[2];  Y2 = (hi[2]^2 - lo[2]^2) / 2
+        Z1 = hi[3] - lo[3];  Z2 = (hi[3]^2 - lo[3]^2) / 2
+        2 * X2 * Y1 * Z1 + 3 * X1 * Y2 * Z1 - X1 * Y1 * Z2 + 4 * X1 * Y1 * Z1
+    end
+    mk3d(x, y, z) = [2xi + 3yj - zk + 4 for xi in x, yj in y, zk in z]
+
+    @testset "3D affine — Range grid" begin
+        x = range(0.0, 2.0, length = 11)
+        y = range(0.0, 3.0, length = 13)
+        z = range(0.0, 1.0, length = 9)
+        itp = linear_interp((x, y, z), mk3d(x, y, z); extrap = NoExtrap())
+        lo = (first(x), first(y), first(z));  hi = (last(x), last(y), last(z))
+        @test integrate(itp) ≈ aff_expected(lo, hi) rtol = 1.0e-12
+        @test integrate(itp) ≈ integrate(itp, lo, hi) rtol = 1.0e-12
+    end
+
+    @testset "3D affine — Vector grid (non-uniform)" begin
+        x = [0.0, 0.4, 0.9, 1.5, 2.0]
+        y = [0.0, 0.6, 1.3, 2.1, 3.0]
+        z = [0.0, 0.35, 0.8, 1.0]
+        itp = linear_interp((x, y, z), mk3d(x, y, z); extrap = NoExtrap())
+        lo = (first(x), first(y), first(z));  hi = (last(x), last(y), last(z))
+        @test integrate(itp) ≈ aff_expected(lo, hi) rtol = 1.0e-12
+        @test integrate(itp) ≈ integrate(itp, lo, hi) rtol = 1.0e-12
+    end
+
+    @testset "3D smooth field — Vector parity vs bounded oracle" begin
+        x = [0.0, 0.4, 0.9, 1.5, 2.0]
+        y = [0.0, 0.6, 1.3, 2.1, 3.0]
+        z = [0.0, 0.35, 0.8, 1.0]
+        data = [sin(xi) * cos(yj) + zk^2 for xi in x, yj in y, zk in z]  # not exact, oracle = bounded
+        itp = linear_interp((x, y, z), data; extrap = NoExtrap())
+        lo = (first(x), first(y), first(z));  hi = (last(x), last(y), last(z))
+        @test integrate(itp) ≈ integrate(itp, lo, hi) rtol = 1.0e-12
+    end
+
+    @testset "Range and Vector grids agree (same nodes)" begin
+        xr = range(0.0, 2.0, length = 15);  yr = range(-1.0, 1.0, length = 11)
+        data = [sin(xi) + cos(yj) for xi in xr, yj in yr]
+        itp_r = linear_interp((xr, yr), data; extrap = NoExtrap())
+        itp_v = linear_interp((collect(xr), collect(yr)), data; extrap = NoExtrap())
+        @test integrate(itp_r) ≈ integrate(itp_v) rtol = 1.0e-13
+    end
+
+    @testset "zero allocation (Range + Vector)" begin
+        xr = range(0.0, 2.0, length = 20);  yr = range(0.0, 3.0, length = 16)
+        data = [sin(xi) * cos(yj) for xi in xr, yj in yr]
+        itp_r = linear_interp((xr, yr), data)
+        itp_v = linear_interp((collect(xr), collect(yr)), data)
+        integrate(itp_r);  integrate(itp_v)   # warmup
+        @test @allocated(integrate(itp_r)) <= ND_ALLOC_THRESHOLD
+        @test @allocated(integrate(itp_v)) <= ND_ALLOC_THRESHOLD
+    end
+end
+
+# The separable path multiplies each value by a grid-typed (Float) weight before
+# summing, so fixed-point carriers widen and never modular-wrap — the ND analog
+# of the 1D endpoint-wrap contract.
+@testitem "ND linear separable: N0f8 carrier no-wrap" begin
+    using FixedPointNumbers
+
+    x = 0.0:0.25:1.0
+    y = 0.0:0.5:1.0
+    dataN = N0f8.([0.8 0.4 0.8; 0.4 0.4 0.4; 0.8 0.4 0.8; 0.4 0.8 0.4; 0.8 0.4 0.8])
+    dataF = Float64.(dataN)
+    for gx in (x, collect(x)), gy in (y, collect(y))
+        itpN = linear_interp((gx, gy), dataN; extrap = NoExtrap())
+        itpF = linear_interp((gx, gy), dataF; extrap = NoExtrap())
+        @test Float64(integrate(itpN)) ≈ integrate(itpF) rtol = 1.0e-9
+    end
+end

--- a/test/test_integral_nd_separable.jl
+++ b/test/test_integral_nd_separable.jl
@@ -298,3 +298,125 @@ end
         end
     end
 end
+
+# Cubic/Quadratic ND full-domain: the per-axis full-cell collapse is linear in
+# the (value, derivative) payload — cubic h/2(fL+fR) + h²/12(dfL−dfR), quadratic
+# 2h/3·fL + h/3·fR + h²/6·dfL — so the domain integral separates with per-axis
+# (w, v) node-weight PAIRS contracting the mixed-partials tensor. Oracles: the
+# generic per-cell engine (forced via invoke) and the bounded engine at full
+# bounds (still cell-wise for these families → independent of the new path).
+@testitem "ND cubic/quad separable: engine parity (Range + Vector, 2D/3D)" setup = [AllocConstants] begin
+    nonuni(a, b, n) = a .+ (b - a) .* ((x -> (x .- x[1]) ./ (x[end] - x[1]))([u + 0.15 * sinpi(u) for u in range(0, 1; length = n)]))
+    generic_nd(itp) = invoke(integrate, Tuple{FastInterpolations.AbstractInterpolantND}, itp)
+
+    @testset "2D parity (both engines)" begin
+        for mk in (cubic_interp, quadratic_interp)
+            for (gx, gy) in (
+                    (range(0.0, 2.0, length = 17), range(0.0, 3.0, length = 13)),
+                    (nonuni(0.0, 2.0, 17), nonuni(0.0, 3.0, 13)),
+                )
+                data = [sin(xi) * cos(yj) + 0.3xi for xi in gx, yj in gy]
+                itp = mk((gx, gy), data)
+                lo = (first(gx), first(gy));  hi = (last(gx), last(gy))
+                @test integrate(itp) ≈ generic_nd(itp) rtol = 1.0e-12
+                @test integrate(itp) ≈ integrate(itp, lo, hi) rtol = 1.0e-12
+            end
+        end
+    end
+
+    @testset "3D parity (both engines)" begin
+        for mk in (cubic_interp, quadratic_interp)
+            x = nonuni(0.0, 1.0, 9);  y = nonuni(0.0, 2.0, 8);  z = nonuni(0.0, 3.0, 7)
+            data = [sin(xi) + yj * zk - 0.2zk^2 for xi in x, yj in y, zk in z]
+            itp = mk((x, y, z), data)
+            lo = (first(x), first(y), first(z));  hi = (last(x), last(y), last(z))
+            @test integrate(itp) ≈ generic_nd(itp) rtol = 1.0e-12
+            @test integrate(itp) ≈ integrate(itp, lo, hi) rtol = 1.0e-12
+        end
+    end
+
+    @testset "Range and Vector grids agree (same nodes)" begin
+        xr = range(0.0, 2.0, length = 15);  yr = range(-1.0, 1.0, length = 11)
+        data = [sin(xi) + cos(yj) for xi in xr, yj in yr]
+        for mk in (cubic_interp, quadratic_interp)
+            @test integrate(mk((xr, yr), data)) ≈
+                integrate(mk((collect(xr), collect(yr)), data)) rtol = 1.0e-11
+        end
+    end
+
+    @testset "zero allocation (Range + Vector)" begin
+        xr = range(0.0, 2.0, length = 20);  yr = range(0.0, 3.0, length = 16)
+        data = [sin(xi) * cos(yj) for xi in xr, yj in yr]
+        for mk in (cubic_interp, quadratic_interp)
+            itp_r = mk((xr, yr), data)
+            itp_v = mk((collect(xr), collect(yr)), data)
+            integrate(itp_r);  integrate(itp_v)   # warmup
+            @test @allocated(integrate(itp_r)) <= ND_ALLOC_THRESHOLD
+            @test @allocated(integrate(itp_v)) <= ND_ALLOC_THRESHOLD
+        end
+    end
+end
+
+# Cubic/Quadratic bounded: the clipped-composite structure extends to the pair
+# payload — per-axis (w, v) node weights built from the partial-cell integrals
+# (cubic via the ΔH antiderivatives, quadratic via its closed form), full cells
+# collapsing to the full-domain pair weights. Oracles: the generic cell-wise
+# bounded engine (invoke-forced), box == domain vs the full-domain path, axis
+# additivity, and orientation sign.
+@testitem "ND cubic/quad bounded separable: engine parity + oracles" setup = [AllocConstants] begin
+    nonuni(a, b, n) = a .+ (b - a) .* ((x -> (x .- x[1]) ./ (x[end] - x[1]))([u + 0.15 * sinpi(u) for u in range(0, 1; length = n)]))
+    const FI = FastInterpolations
+    gen2(itp, lo, hi, ::Type{T}) where {T} =
+        invoke(integrate, Tuple{T{Tg, Tv, 2} where {Tg, Tv}, NTuple{2, Real}, NTuple{2, Real}}, itp, lo, hi)
+    gen3(itp, lo, hi, ::Type{T}) where {T} =
+        invoke(integrate, Tuple{T{Tg, Tv, 3} where {Tg, Tv}, NTuple{3, Real}, NTuple{3, Real}}, itp, lo, hi)
+
+    @testset "2D parity vs generic bounded (Range + Vector, box sweep)" begin
+        for (mk, T) in ((cubic_interp, FI.CubicInterpolantND), (quadratic_interp, FI.QuadraticInterpolantND))
+            for (gx, gy) in (
+                    (range(0.0, 2.0, length = 17), range(0.0, 3.0, length = 13)),
+                    (nonuni(0.0, 2.0, 17), nonuni(0.0, 3.0, 13)),
+                )
+                data = [sin(xi) * cos(yj) + 0.3xi for xi in gx, yj in gy]
+                itp = mk((gx, gy), data)
+                for (lo, hi) in (
+                        ((0.25, 0.4), (1.65, 2.6)),     # interior, cells cut mid-way
+                        ((0.0, 0.0), (2.0, 3.0)),       # box == domain
+                        ((0.31, 0.55), (0.65, 1.15)),   # few cells
+                        ((0.05, 0.1), (0.11, 0.2)),     # sub-/single-cell
+                    )
+                    @test integrate(itp, lo, hi) ≈ gen2(itp, lo, hi, T) rtol = 1.0e-11
+                end
+                @test integrate(itp, (0.0, 0.0), (2.0, 3.0)) ≈ integrate(itp) rtol = 1.0e-12
+            end
+        end
+    end
+
+    @testset "3D parity + additivity + sign" begin
+        x = nonuni(0.0, 1.0, 9);  y = nonuni(0.0, 2.0, 8);  z = nonuni(0.0, 3.0, 7)
+        data = [sin(xi) + yj * zk - 0.2zk^2 for xi in x, yj in y, zk in z]
+        for (mk, T) in ((cubic_interp, FI.CubicInterpolantND), (quadratic_interp, FI.QuadraticInterpolantND))
+            itp = mk((x, y, z), data)
+            lo = (0.12, 0.3, 0.4);  hi = (0.85, 1.7, 2.6)
+            @test integrate(itp, lo, hi) ≈ gen3(itp, lo, hi, T) rtol = 1.0e-11
+            c = 0.5
+            @test integrate(itp, lo, hi) ≈
+                integrate(itp, lo, (c, hi[2], hi[3])) + integrate(itp, (c, lo[2], lo[3]), hi) rtol = 1.0e-11
+            @test integrate(itp, (hi[1], lo[2], lo[3]), (lo[1], hi[2], hi[3])) ≈
+                -integrate(itp, lo, hi) rtol = 1.0e-11
+        end
+    end
+
+    @testset "zero allocation (Range + Vector)" begin
+        xr = range(0.0, 2.0, length = 20);  yr = range(0.0, 3.0, length = 16)
+        data = [sin(xi) * cos(yj) for xi in xr, yj in yr]
+        lo = (0.2, 0.4);  hi = (1.8, 2.7)
+        for mk in (cubic_interp, quadratic_interp)
+            itp_r = mk((xr, yr), data)
+            itp_v = mk((collect(xr), collect(yr)), data)
+            integrate(itp_r, lo, hi);  integrate(itp_v, lo, hi)   # warmup
+            @test @allocated(integrate(itp_r, lo, hi)) <= ND_ALLOC_THRESHOLD
+            @test @allocated(integrate(itp_v, lo, hi)) <= ND_ALLOC_THRESHOLD
+        end
+    end
+end


### PR DESCRIPTION
## Summary

Replaces the per-cell `2^N` ND `integrate` engine with a **separable node-weight** engine. On a full cell every per-axis basis integral collapses to a constant that is linear in the node payload, so the domain integral factorizes into a tensor product of 1-D node-weight rules — each node is read once instead of the `2^N` corner reads per cell the old engine repeated. The same clipped-composite weights extend the factorization to any axis-aligned box for the bounded form.

## What changed

- **One entry point.** `integrate(itp)` (full-domain) and `integrate(itp, lo, hi)` (bounded box) dispatch on `AbstractInterpolantND` and serve every tensor-product family — homogeneous *and* heterogeneous, numeric *and* duck-typed. A compile-time gate rejects the non-tensor families (local/user-slope Hermite, `NoInterp`) with a clear error instead of a `MethodError` deep in the kernel.
- **Heterogeneous ND integrate is now supported**, e.g. `integrate(interp(grids, data; method = (CubicInterp(), LinearInterp()), coeffs = PreCompute()))`, keyed on the interpolant's stored per-axis methods.
- **Two `@generated` kernels** parametrized by per-axis rank `rs[d] ∈ {1, 2}` cover all families and both storage layouts; uniform `rs` reproduces the homogeneous codegen exactly, so specialized types are unchanged.
- Deletes the generic per-cell engine, the four ND cell kernels, `_nd_cell_geom`, and the legacy per-type bounded methods; the per-axis weight tags reuse the existing method vocabulary (`_method_tuple`, `itp.methods`).
- Fixes a latent mixed-grid (`Vector × Range`) bounded allocation in the search preamble (a runtime-index closure leaked the element `Union` into a dynamic dispatch).

## Benchmark

Previous per-cell engine → separable, across 2-D `256²` and 3-D `40³` grids (Range + Vector). Every case is bit-identical to the old engine and allocation-free.

| family | full-domain | bounded box |
|--------|:---:|:---:|
| linear | 4.5–12.0× | 3.2–23.7× |
| constant | 4.2–11.6× | 3.5–21.8× |
| cubic | 2.5–7.8× | 2.9–9.8× |
| quadratic | 3.7–10.4× | 3.0–8.8× |

Heterogeneous combinations scale with the number of derivative slots and stay allocation-free (e.g. `Quad × Cubic` matches `Cubic × Cubic` within ~10%).

## Tests

Value correctness is pinned against engine-independent oracles (analytic integrals, an explicit cell-sum reference, and per-fiber 1-D composition), plus zero-allocation and output-type-promotion contracts, duck-typed ND values, and the heterogeneous / gate / mixed-grid paths.
