### PR TITLE
polish(integral): pre-release integrate follow-ups (guards, DRY, docs, tests)

### DIFF
--- a/src/constant/nd/constant_nd_interpolant.jl
+++ b/src/constant/nd/constant_nd_interpolant.jl
@@ -71,7 +71,7 @@ function constant_interp(
 
     # Extend `:exclusive` axes/data to closed-cycle (n+1) layout; periodic
     # bcs are promoted to `:extended` by `_prepare_periodic_nd`, then per-axis
-    # `_cache_axis` wraps (raw → wrapped, pre-wrapped → passthrough).
+    # `_policy_axes` wraps store-aware (raw → wrapped, pre-wrapped → passthrough).
     grids_typed, data_typed, bcs_post = _prepare_periodic_nd(grids_typed, data_typed, bcs)
     grids_typed = _policy_axes(grids_typed, bcs_post, store)
 

--- a/src/core/coeff_policy.jl
+++ b/src/core/coeff_policy.jl
@@ -32,7 +32,7 @@ end
 # Local Hermite methods → OnTheFly (no ND PreCompute for Hermite yet).
 # Global methods (Cubic, Quadratic) → PreCompute (specialized ND types with integrate/adjoint).
 # NOTE: N≥3 rule removed — would route Cubic/Quadratic to HeteroInterpolantND which lacks
-# integrate/adjoint support. Can be re-added when HeteroInterpolantND gains these features.
+# ND adjoint support (integrate is supported). Can be re-added when it gains adjoints.
 @inline function _resolve_coeffs(::AutoCoeffs, ::Val{N}, methods) where {N}
     _all_trivial_methods(methods) && return PreCompute()
     _has_any_local_method(methods) && return OnTheFly()

--- a/src/hetero/hetero_types.jl
+++ b/src/hetero/hetero_types.jl
@@ -21,8 +21,9 @@
     _cache_axis(g, bc, Tg)
 
 # Method-aware `_store_axis` (the hetero arm of the single ctor axis entry):
-# `cache_axis` is not plumbed here — hetero has no `integrate`, and interp axes
-# keep the cached wrap (NoInterp axes are raw by design already).
+# `cache_axis` is not plumbed here — the one-shot integrate API never builds a
+# hetero interpolant (its single-method signature can't form a per-axis tuple),
+# and interp axes keep the cached wrap (NoInterp axes are raw by design already).
 @inline _store_axis(g, bc::AbstractBC, ::Type{Tg}, m::AbstractInterpMethod, store::StorePolicy) where {Tg} =
     _own_or_ref_axis(_cache_axis_for_method(g, bc, Tg, m), Tg, store)
 

--- a/src/integral/integrate_api.jl
+++ b/src/integral/integrate_api.jl
@@ -23,8 +23,9 @@ end
 
 # ── One-shot quadrature (ND): integrate(grids, data[, lo, hi]; method) ──
 # ND mirror — only tensor-product types integrate (Linear/Cubic/Quadratic/
-# Constant); the Hermite family (HeteroInterpolantND, no ND integral) is rejected
-# up front. Trivial methods use raw storage; PreCompute types keep the ctor default.
+# Constant); the local-Hermite family (Pchip/Akima/Cardinal) has no homogeneous
+# ND factory reachable from a single `method`, so it is rejected up front.
+# Trivial methods use raw storage; PreCompute types keep the ctor default.
 @inline function _oneshot_build_nd(method::AbstractInterpMethod, grids, data)
     _nd_integrable_method(method) || _throw_nd_oneshot_unsupported(method)
     fn, _, opts = _interp1d_route(method)
@@ -32,15 +33,21 @@ end
         fn(grids, data; opts..., store = StorePolicy(copy = false, cache_axis = false)) :
         fn(grids, data; opts...)
 end
-@inline integrate(grids::NTuple{N, AbstractVector}, data::AbstractArray{<:Any, N}; method::AbstractInterpMethod) where {N} =
+# A per-axis method tuple can't be built by the single-method one-shot path;
+# point at the persistent build instead of a bare kwarg MethodError.
+@noinline _oneshot_build_nd(method::Tuple, grids, data) = _throw_nd_oneshot_tuple(method)
+
+@inline integrate(grids::NTuple{N, AbstractVector}, data::AbstractArray{<:Any, N}; method) where {N} =
     integrate(_oneshot_build_nd(method, grids, data))
 @inline integrate(
     grids::NTuple{N, AbstractVector}, data::AbstractArray{<:Any, N},
-    lo::NTuple{N, Real}, hi::NTuple{N, Real}; method::AbstractInterpMethod
+    lo::NTuple{N, Real}, hi::NTuple{N, Real}; method
 ) where {N} = integrate(_oneshot_build_nd(method, grids, data), lo, hi)
 
-@inline _nd_integrable_method(::Union{LinearInterp, CubicInterp, QuadraticInterp, ConstantInterp}) = true
-@inline _nd_integrable_method(::AbstractInterpMethod) = false
+# Single source of truth for "has an ND separable integral": the type-keyed
+# predicate the engine uses (`_is_separable_method_type`, integrate_fulldomain.jl),
+# so the supported-family list lives in exactly one place.
+@inline _nd_integrable_method(m::AbstractInterpMethod) = _is_separable_method_type(typeof(m))
 
 @noinline function _throw_nd_oneshot_unsupported(method)
     throw(
@@ -50,6 +57,17 @@ end
                 "QuadraticInterp, and ConstantInterp. Hermite-family methods " *
                 "(Pchip/Akima/Cardinal) have no ND integral yet; integrate axis-by-axis " *
                 "on per-fiber 1-D interpolants instead."
+        )
+    )
+end
+
+@noinline function _throw_nd_oneshot_tuple(method)
+    throw(
+        ArgumentError(
+            "one-shot ND `integrate(grids, data; method=…)` takes a single tensor-product " *
+                "method, not a per-axis tuple ($(method)). Build the interpolant first and " *
+                "integrate it: `integrate(interp(grids, data; method=$(method)))` " *
+                "(add `coeffs=PreCompute()` for Cubic/Quadratic axes)."
         )
     )
 end

--- a/src/integral/integrate_common_nd.jl
+++ b/src/integral/integrate_common_nd.jl
@@ -18,7 +18,7 @@ end
 # `d` as a runtime Int, so `grids[d]` on a MIXED grid tuple (e.g. Vector × Range)
 # returns the element Union and the downstream `search_interval` dispatches
 # dynamically → boxing. Emitting literal `grids[1]`, `grids[2]` keeps each axis
-# concrete. See [[project_tg_closure_lts_alloc]] for the same bug class.
+# concrete. Pinned by the mixed-grid 0-alloc testitem in test_integral_nd_separable.jl.
 @generated function _nd_cell_ranges(
         grids::NTuple{N, AbstractVector},
         lo::Tuple{Vararg{Real, N}},

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -119,9 +119,12 @@ homogeneous (`linear_interp`, `cubic_interp`, …) and heterogeneous mixes
 (`interp(grids, data; method=(CubicInterp(), LinearInterp()))`); only the
 Hermite family (local-slope / user-slope) has no ND integral.
 
-The **one-shot** forms build the `method` interpolant from raw data with
-`copy=false` reference storage — nothing is copied — then integrate in a single
-call. 1-D integrates every method; ND takes a single tensor-product `method`
+The **one-shot** forms build the `method` interpolant from raw data, then
+integrate in a single call, storing the input by reference where the method
+allows (`copy=false`): the trivial families (Linear/Constant) never copy, the
+1-D coefficient builds reference the data (Cubic copies only its grid), and the
+ND `PreCompute` methods (Cubic/Quadratic) copy grids and data. 1-D integrates
+every method; ND takes a single tensor-product `method`
 (Linear, Cubic, Quadratic, Constant).
 
 ```julia
@@ -408,6 +411,12 @@ end
 # separate from `prod(rs)`: an all-trivial hetero PreCompute payload carries a
 # size-1 leading slot axis even though `prod(rs) == 1`.
 function _separable_emit_common(rs::NTuple{N, Int}, has_slot::Bool) where {N}
+    # Both the inner contraction here and the outer Kronecker fold in
+    # `_separable_emit_outer` hard-code rank ≤ 2 (value only, or a value+deriv pair),
+    # so a rank-≥3 family would silently drop slots. This helper runs first at
+    # generation, so guarding here covers both — but extending to rank ≥ 3 means
+    # touching both sites, not just this one.
+    all(≤(2), rs) || error("separable ND integrate kernel supports per-axis weight rank ≤ 2; got ranks $rs")
     P = prod(rs)
     r1 = rs[1]
     Mout = P ÷ r1                      # outer-axis slot configurations

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -66,6 +66,10 @@ end
     y = itp.y
     return @inline (i, h) -> @inbounds _constant_integral_kernel(_EvalIntegralPartial(), y[i], y[i + 1], h, zero(Tg), h, side)
 end
+# Forward the single-arg trait to the side-aware form so the generic
+# integrate/cumulative paths serve Constant too — `side` is a type param, so this
+# fully specializes with no runtime branch (no dedicated Constant overrides needed).
+@inline _full_cell_fn(itp::ConstantInterpolant) = _full_cell_fn(itp, itp.side)
 
 # ── 1D series trait: _full_cell_fn(sitp, k) → (i, h) -> value ──
 
@@ -88,6 +92,7 @@ end
     y = sitp.y
     return @inline (i, h) -> @inbounds _constant_integral_kernel(_EvalIntegralPartial(), y[i, k], y[i + 1, k], h, zero(Tg), h, side)
 end
+@inline _full_cell_fn(sitp::ConstantSeriesInterpolant, k::Int) = _full_cell_fn(sitp, k, sitp.side)
 
 # ═══════════════════════════════════════════════════════════════
 # integrate(itp) — 1D full-domain fast path
@@ -134,10 +139,7 @@ integrate(x, y, 0.2, 1.5; method = LinearInterp())   # one-shot,   ∫ from 0.2 
 integrate((xs, ys), data; method = LinearInterp())   # one-shot,   2-D full-domain
 ```
 """
-@inline function integrate(
-        itp::AbstractInterpolant{Tg, Tv};
-        search = nothing, hint = nothing
-    ) where {Tg <: Real, Tv}
+@inline function integrate(itp::AbstractInterpolant{Tg, Tv}) where {Tg <: Real, Tv}
     Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
     return _integrate_1d_fulldomain(_grid_1d(itp), _full_cell_fn(itp), Tout)
 end
@@ -162,29 +164,16 @@ end
     end
 end
 
-# Constant override: side is parametric → compiler knows concrete type,
-# so `_full_cell_fn(itp, side)` is a distinct method from the generic single-arg form.
-@inline function integrate(
-        itp::ConstantInterpolant{Tg, Tv};
-        search = nothing, hint = nothing
-    ) where {Tg <: Real, Tv}
-    x = _grid_1d(itp)
-    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
-    return _integrate_1d_fulldomain(x, _full_cell_fn(itp, itp.side), Tout)
-end
-
-# Hermite family is handled by the generic path above — `_full_cell_fn`
-# internally dispatches on `itp.dy` (PreCompute vs OnTheFly).
+# Constant and the Hermite family are handled by the generic path above —
+# `_full_cell_fn` forwards Constant to its side-aware form and dispatches the
+# Hermite family on `itp.dy` (PreCompute vs OnTheFly).
 
 # ═══════════════════════════════════════════════════════════════
 # integrate(sitp) — 1D Series full-domain fast path
 # ═══════════════════════════════════════════════════════════════
 
 # Generic Series: catches Cubic, Linear, Quadratic series
-@inline function integrate(
-        sitp::AbstractSeriesInterpolant{Tg, Tv};
-        search = nothing, hint = nothing
-    ) where {Tg <: Real, Tv}
+@inline function integrate(sitp::AbstractSeriesInterpolant{Tg, Tv}) where {Tg <: Real, Tv}
     x = _grid_1d(sitp)
     Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
     n = n_series(sitp)
@@ -195,45 +184,20 @@ end
     return results
 end
 
-# Constant Series override: side is parametric → compiler knows concrete type
-@inline function integrate(
-        sitp::ConstantSeriesInterpolant{Tg, Tv};
-        search = nothing, hint = nothing
-    ) where {Tg <: Real, Tv}
-    x = _grid_1d(sitp)
-    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
-    n = n_series(sitp)
-    results = Vector{Tout}(undef, n)
-    @inbounds for k in 1:n
-        results[k] = _integrate_1d_fulldomain(x, _full_cell_fn(sitp, k, sitp.side), Tout)
-    end
-    return results
-end
-
 # ═══════════════════════════════════════════════════════════════
 # integrate(itp[, lo, hi]) — ND separable engine (single entry point)
 # ═══════════════════════════════════════════════════════════════
 #
 # ── Separable ND engine: full-domain + bounded, all tensor-product families ──
 #
-# On full cells every per-axis basis integral collapses to constants that are
+# On full cells every per-axis basis integral collapses to a constant that is
 # LINEAR in the node payload, so the domain integral is a tensor product of 1D
-# node-weight rules contracted against the payload — each node read once,
-# instead of the 2^N corner reads per cell the generic engine repeats:
-#
-#   rank 1 — payload `data[i…]`, one weight per axis:
-#     linear    w = ½h at the ends, ½(h₋+h₊) interior (composite trapezoid)
-#     constant  w = side-selected h (NearestSide ≡ the trapezoid weights)
-#   rank 2 — payload `partials[1+mask, i…]` (bit d of mask = ∂ along axis d),
-#             a (w, v) = (value, deriv) weight pair per axis:
-#     cubic     ∫cell = h/2(fL+fR) + h²/12(dfL−dfR) → v telescopes interior,
-#               vanishing on uniform axes
-#     quad      ∫cell = 2h/3·fL + h/3·fR + h²/6·dfL → left-anchored, no right v
-#
-# The per-axis weight spec reuses the existing vocabulary — the method tags
-# (`LinearInterp`/`CubicInterp`/`QuadraticInterp`) or the constant `sides` — and
-# the @generated kernels pick the rank from the payload dimensionality (N vs
-# N+1), so one engine serves every family; only the weight methods differ.
+# node-weight rules contracted against the payload — each node read once, vs the
+# 2^N corner reads per cell of the generic engine. Rank-1 axes (linear/constant)
+# carry one weight per node; rank-2 axes (cubic/quadratic) a (value, deriv) pair.
+# The per-axis weight functions below hold the closed forms; the @generated
+# kernels pick the rank from the payload dimensionality (N vs N+1), reusing the
+# method tags (`LinearInterp`/`CubicInterp`/…) or constant `sides` as the spec.
 
 # 1D composite-trapezoid node weight on `grid` (length `n`): ½h at the endpoints,
 # ½(h₋+h₊) in the interior. Only the grid is divided — values stay multiply-only.
@@ -425,18 +389,26 @@ function _separable_emit_common(rs::NTuple{N, Int}, has_slot::Bool) where {N}
     pidx(slot, i1) = has_slot ? :(payload[$slot, $i1, $(rest...)]) : :(payload[$i1, $(rest...)])
     wnames(ws, r) = r == 1 ? [Symbol(ws, :_1)] : [Symbol(ws, :_1), Symbol(ws, :_2)]
     wdecl(ws, r, call) = Expr(:(=), Expr(:tuple, wnames(ws, r)...), call)
-    # Inner sum for outer configuration `m`: contract the inner axis' `r1` weight
-    # components against its contiguous slot pair (slots `r1·(m−1)+1 … r1·m`),
-    # then scale by the outer Kronecker product `ko2_m` (absent when N == 1).
-    function term(m, i1, ws)
+    # Inner contraction for outer configuration `m`: contract the inner axis' `r1`
+    # weight components against its contiguous slot pair (slots `r1·(m−1)+1 … r1·m`).
+    function inner_term(m, i1, ws)
         w = wnames(ws, r1)
         base = r1 * (m - 1)
-        inner = r1 == 2 ?
+        return r1 == 2 ?
             :(muladd($(w[2]), $(pidx(base + 2, i1)), $(w[1]) * $(pidx(base + 1, i1)))) :
             :($(w[1]) * $(pidx(base + 1, i1)))
-        return N == 1 ? inner : :($(Symbol(:ko2_, m)) * $inner)
     end
-    contrib(ws, i1) = foldl((a, b) -> :($a + $b), [term(m, i1, ws) for m in 1:Mout])
+    # Sum the `Mout` outer configs, each scaled by its Kronecker product `ko2_m`,
+    # as a right-nested muladd chain so every `ko2_m · inner_m` fuses (FMA) rather
+    # than emitting a separate multiply and add (absent when N == 1: one config).
+    function contrib(ws, i1)
+        N == 1 && return inner_term(1, i1, ws)
+        acc = :($(Symbol(:ko2_, Mout)) * $(inner_term(Mout, i1, ws)))
+        for m in (Mout - 1):-1:1
+            acc = :(muladd($(Symbol(:ko2_, m)), $(inner_term(m, i1, ws)), $acc))
+        end
+        return acc
+    end
     return ivars, rest, pidx, wdecl, contrib
 end
 
@@ -608,11 +580,7 @@ end
 @inline _nd_int_zero(::Type{Tout}, payload) where {Tout <: Number} = zero(Tout)
 @inline _nd_int_zero(::Type{Tout}, payload) where {Tout} = 0 * @inbounds(payload[begin])
 
-@inline function integrate(
-        itp::AbstractInterpolantND{Tg, Tv, N};
-        search = nothing,
-        hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
-    ) where {Tg, Tv, N}
+@inline function integrate(itp::AbstractInterpolantND{Tg, Tv, N}) where {Tg, Tv, N}
     tags, payload = _separable_spec(itp)
     Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
     z = _nd_int_zero(Tout, payload)
@@ -711,16 +679,6 @@ function cumulative_integrate!(
     return _cumulative_integrate_1d!(out, x, _full_cell_fn(itp))
 end
 
-# Constant override: side is parametric → compiler knows concrete type,
-# so `_full_cell_fn(itp, side)` dispatches to a distinct specialized method.
-function cumulative_integrate!(
-        out::AbstractVector, itp::ConstantInterpolant{Tg, Tv}
-    ) where {Tg <: Real, Tv}
-    x = _grid_1d(itp)
-    _check_cumulative_out(out, length(x))
-    return _cumulative_integrate_1d!(out, x, _full_cell_fn(itp, itp.side))
-end
-
 # Allocating wrappers: allocate output vector then forward to the in-place path.
 """
     cumulative_integrate(itp)          # persistent — Vector (Matrix for a Series)
@@ -748,21 +706,6 @@ function cumulative_integrate(
     result = Matrix{Tout}(undef, n_pts, n_ser)
     @inbounds for k in 1:n_ser
         _cumulative_integrate_1d!(@view(result[:, k]), x, _full_cell_fn(sitp, k))
-    end
-    return result
-end
-
-# Constant Series override: side is parametric → compiler knows concrete type
-function cumulative_integrate(
-        sitp::ConstantSeriesInterpolant{Tg, Tv}
-    ) where {Tg <: Real, Tv}
-    x = _grid_1d(sitp)
-    Tout = _promote_eltype(_integrate_op, Tg, Tv, Tg)
-    n_pts = length(x)
-    n_ser = n_series(sitp)
-    result = Matrix{Tout}(undef, n_pts, n_ser)
-    @inbounds for k in 1:n_ser
-        _cumulative_integrate_1d!(@view(result[:, k]), x, _full_cell_fn(sitp, k, sitp.side))
     end
     return result
 end

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -400,7 +400,10 @@ function _separable_emit_common(rs::NTuple{N, Int}, has_slot::Bool) where {N}
     end
     # Sum the `Mout` outer configs, each scaled by its Kronecker product `ko2_m`,
     # as a right-nested muladd chain so every `ko2_m · inner_m` fuses (FMA) rather
-    # than emitting a separate multiply and add (absent when N == 1: one config).
+    # than a separate multiply + add (absent when N == 1: one config). This is a
+    # reassociation — single-rounded, so at least as accurate as mul-then-add but
+    # NOT bit-identical: under cancellation the two can differ by more than 1 ULP.
+    # Consistent with the inner (value, deriv) term above, which already fuses.
     function contrib(ws, i1)
         N == 1 && return inner_term(1, i1, ws)
         acc = :($(Symbol(:ko2_, Mout)) * $(inner_term(Mout, i1, ws)))

--- a/src/linear/nd/linear_nd_interpolant.jl
+++ b/src/linear/nd/linear_nd_interpolant.jl
@@ -79,7 +79,7 @@ function linear_interp(
 
     # Extend `:exclusive` axes/data to closed-cycle (n+1) layout; periodic
     # bcs are promoted to `:extended` by `_prepare_periodic_nd`, then per-axis
-    # `_cache_axis` wraps (raw → wrapped, pre-wrapped → passthrough).
+    # `_policy_axes` wraps store-aware (raw → wrapped, pre-wrapped → passthrough).
     grids_typed, data_typed, bcs_post = _prepare_periodic_nd(grids_typed, data_typed, bcs)
     grids_typed = _policy_axes(grids_typed, bcs_post, store)
 

--- a/test/test_duck_typing_comprehensive.jl
+++ b/test/test_duck_typing_comprehensive.jl
@@ -1899,3 +1899,45 @@ end
         @test _v(integrate(itp, lo, hi)) ≈ integrate(rf, lo, hi) rtol = 1.0e-12
     end
 end
+
+# Multi-channel vector values (SVector): unlike the scalar-wrapper ducks above,
+# SVector{N} defines `zero`/`+`/`*` AND survives the rank-2 (cubic) differentiated
+# payload, so it pins channel-wise integration end to end — the result is a fresh
+# SVector with each channel integrated independently. Reference per channel: the
+# integral of that channel's own scalar interpolant.
+@testitem "SVector-valued integrate — channel-wise (1D + ND, all ranks)" begin
+    using StaticArrays
+
+    # integrate channel `c` via its own scalar interpolant (`map` keeps 1D/ND shape)
+    chan(mk, grids, data, c, args...) = integrate(mk(grids, map(d -> d[c], data)), args...)
+
+    @testset "1D — full + bounded + cumulative" begin
+        x = range(0.0, 2.0, length = 7)
+        data = [SVector(sin(xi), xi^2, 1.0) for xi in x]
+        for mk in (linear_interp, cubic_interp, constant_interp)
+            itp = mk(x, data)
+            I = integrate(itp)
+            @test I isa SVector{3, Float64}
+            @test I ≈ SVector(ntuple(c -> chan(mk, x, data, c), 3)) rtol = 1.0e-12
+            @test integrate(itp, 0.3, 1.6) ≈
+                SVector(ntuple(c -> chan(mk, x, data, c, 0.3, 1.6), 3)) rtol = 1.0e-12
+            C = cumulative_integrate(itp)
+            @test C[1] == zero(SVector{3, Float64})
+            @test C[end] ≈ I rtol = 1.0e-12
+        end
+    end
+
+    @testset "ND — full + bounded (rank-1 linear/constant + rank-2 cubic)" begin
+        x = range(0.0, 2.0, length = 6);  y = range(0.0, 3.0, length = 5)
+        data = [SVector(sin(xi) + yj, xi * yj, 2.0) for xi in x, yj in y]
+        lo = (0.3, 0.4);  hi = (1.7, 2.5)
+        for mk in (linear_interp, cubic_interp, constant_interp)
+            itp = mk((x, y), data)
+            I = integrate(itp)
+            @test I isa SVector{3, Float64}
+            @test I ≈ SVector(ntuple(c -> chan(mk, (x, y), data, c), 3)) rtol = 1.0e-12
+            @test integrate(itp, lo, hi) ≈
+                SVector(ntuple(c -> chan(mk, (x, y), data, c, lo, hi), 3)) rtol = 1.0e-12
+        end
+    end
+end

--- a/test/test_integral_api.jl
+++ b/test/test_integral_api.jl
@@ -44,11 +44,12 @@ end
     x_rng = range(0.0, 2.0, length = 21)
     y = @. x_vec^2 + 1.0
 
-    @testset "matches the persistent build" begin
-        for x in (x_vec, x_rng)
-            @test integrate(x, y; method = LinearInterp()) ≈ integrate(linear_interp(x, y)) atol = 1.0e-12
-            @test integrate(x, y; method = CubicInterp()) ≈ integrate(cubic_interp(x, y)) atol = 1.0e-12
-            @test integrate(x, y; method = QuadraticInterp()) ≈ integrate(quadratic_interp(x, y)) atol = 1.0e-12
+    @testset "matches the persistent build (all methods)" begin
+        for x in (x_vec, x_rng), m in (
+                    LinearInterp(), CubicInterp(), QuadraticInterp(), ConstantInterp(),
+                    PchipInterp(), AkimaInterp(), CardinalInterp(),
+                )
+            @test integrate(x, y; method = m) ≈ integrate(interp(x, y; method = m)) atol = 1.0e-12
         end
     end
 
@@ -148,6 +149,9 @@ end
         for m in (PchipInterp(), AkimaInterp(), CardinalInterp(), NoInterp())
             @test_throws "ND integration is implemented" integrate((xr, yr), data; method = m)
         end
+        # a per-axis method tuple is one-shot-unsupported → clean ArgumentError, not MethodError
+        @test_throws "per-axis tuple" integrate((xr, yr), data; method = (CubicInterp(), LinearInterp()))
+        @test_throws "per-axis tuple" integrate((xr, yr), data, (0.3, 0.4), (2.5, 1.5); method = (CubicInterp(), LinearInterp()))
         # …while the same methods DO integrate in 1-D:
         xv1 = collect(xr)
         yv1 = sin.(xv1)

--- a/test/test_integral_nd_separable.jl
+++ b/test/test_integral_nd_separable.jl
@@ -435,3 +435,65 @@ end
         @test @allocated(integrate(itp, lo, hi)) <= ND_ALLOC_THRESHOLD
     end
 end
+
+# Minimal-size axes. The per-axis boundary/interior split (`k==1`/`k==n` special-
+# cased, interior sweep `2:(n-1)`) is otherwise unexercised at each family's
+# smallest grid. For rank-1 axes (linear/constant) the minimum is n=2, where the
+# interior sweep is EMPTY and both boundary branches fire on the same two nodes —
+# the branch-collision case. Quadratic (min n=3) and cubic (min n=4) cannot reach
+# n=2 (their poly fit needs degree+1 points), so their minimal axes still carry
+# interior nodes; pin them too. Each family is checked with the small axis inner,
+# outer, and on both axes, against the engine-independent `comp_nd` oracle and the
+# bounded engine at full bounds (which drives the small-span `else` kernel branch).
+@testitem "ND separable: minimal-size axes (boundary/interior collision)" setup = [AllocConstants, NDCompositionOracle] begin
+    f2(xi, yj) = sin(xi) * cos(yj) + 0.3xi + 2.0
+    big = [0.0, 0.4, 0.9, 1.6, 2.0]        # n = 5 companion axis
+
+    function pin(itp, ms, gx, gy, data)
+        lo = (first(gx), first(gy));  hi = (last(gx), last(gy))
+        @test integrate(itp) ≈ comp_nd(ms, (gx, gy), data) rtol = 1.0e-11
+        @test integrate(itp) ≈ integrate(itp, lo, hi) rtol = 1.0e-12
+    end
+
+    @testset "linear/constant — true n=2 empty-interior collision" begin
+        two = [0.0, 1.3]
+        for (mk, m) in (
+                ((g, d) -> linear_interp(g, d; extrap = NoExtrap()), LinearInterp()),
+                (
+                    (g, d) -> constant_interp(g, d; side = NearestSide(), extrap = NoExtrap()),
+                    ConstantInterp(NearestSide()),
+                ),
+            )
+            for (gx, gy) in ((two, big), (big, two), (two, [0.0, 2.0]))   # inner, outer, both
+                data = [f2(xi, yj) for xi in gx, yj in gy]
+                pin(mk((gx, gy), data), (m, m), gx, gy, data)
+            end
+        end
+
+        # linear reproduces a bilinear field exactly → closed forms on one 2×2 cell
+        gx = [0.0, 1.3];  gy = [0.0, 2.0]
+        bil = [xi * yj + 2xi - 3yj + 5 for xi in gx, yj in gy]
+        bil_exp(lo, hi) = begin
+            X1 = hi[1] - lo[1];  X2 = (hi[1]^2 - lo[1]^2) / 2
+            Y1 = hi[2] - lo[2];  Y2 = (hi[2]^2 - lo[2]^2) / 2
+            X2 * Y2 + 2 * X2 * Y1 - 3 * X1 * Y2 + 5 * X1 * Y1
+        end
+        itp = linear_interp((gx, gy), bil)
+        @test integrate(itp) ≈ bil_exp((0.0, 0.0), (1.3, 2.0)) rtol = 1.0e-13
+        # partial sub-box inside the single cell — clipped weights at n=2
+        @test integrate(itp, (0.3, 0.5), (1.0, 1.7)) ≈ bil_exp((0.3, 0.5), (1.0, 1.7)) rtol = 1.0e-12
+    end
+
+    @testset "quadratic (min n=3) / cubic (min n=4) minimal axes" begin
+        for (mk, m, nmin) in (
+                (quadratic_interp, QuadraticInterp(), 3),
+                (cubic_interp, CubicInterp(), 4),
+            )
+            small = collect(range(0.0, 1.0, length = nmin))
+            for (gx, gy) in ((small, big), (big, small), (small, small))   # inner, outer, both
+                data = [f2(xi, yj) for xi in gx, yj in gy]
+                pin(mk((gx, gy), data), (m, m), gx, gy, data)
+            end
+        end
+    end
+end

--- a/test/test_integral_nd_separable.jl
+++ b/test/test_integral_nd_separable.jl
@@ -497,3 +497,34 @@ end
         end
     end
 end
+
+# Out-of-domain bounds on the single ND entry point must reject cleanly. The
+# preamble's domain check is shared by every separable family and the mixed-grid
+# @generated path; pin it on homogeneous builds and one heterogeneous build.
+@testitem "ND separable: out-of-domain bounds throw DomainError" begin
+    x = range(0.0, 2.0, length = 6);  y = range(0.0, 3.0, length = 5)
+    data = [xi + yj for xi in x, yj in y]
+    builds = (
+        linear_interp((x, y), data; extrap = NoExtrap()),
+        cubic_interp((x, y), data; extrap = NoExtrap()),
+        constant_interp((x, y), data; extrap = NoExtrap()),
+        interp((x, y), data; method = (CubicInterp(), LinearInterp()), coeffs = PreCompute(), extrap = NoExtrap()),
+    )
+    for itp in builds
+        @test_throws DomainError integrate(itp, (-0.5, 0.5), (1.0, 2.0))   # lo below domain
+        @test_throws DomainError integrate(itp, (0.5, 0.5), (2.5, 2.0))    # hi above domain
+    end
+end
+
+# The separable emitter hard-codes per-axis rank ≤ 2; a rank-≥3 family would
+# silently drop slots, so the generator guards and errors loudly at generation
+# rather than miscompiling. Exercises the guard directly (no rank-≥3 type exists).
+@testitem "ND separable: rank-≥3 guard errors instead of miscompiling" begin
+    emit = FastInterpolations._separable_emit_common
+    for rs in ((1,), (2,), (1, 2), (2, 2), (1, 2, 1))     # real ranks: transparent
+        @test emit(rs, false) isa Tuple
+    end
+    for rs in ((3,), (1, 3), (2, 3, 1))                    # hypothetical rank ≥ 3: rejected
+        @test_throws "rank ≤ 2" emit(rs, false)
+    end
+end


### PR DESCRIPTION
Pre-release follow-ups to the `integrate` work (post-v0.4.16), from a local pre-merge review + a Codex second opinion. Integrate-only; no behavior change to existing valid calls except the API note below.

### Correctness / robustness
- Compile-time **rank-≥3 guard** in the separable ND engine — errors at codegen instead of silently dropping payload slots for a hypothetical future rank-≥3 family.
- One-shot ND `integrate(grids, data; method=<tuple>)` now throws a clear `ArgumentError` (guiding to the persistent build) instead of a bare `MethodError`.

### Design / DRY
- `_nd_integrable_method` derives from the engine's `_is_separable_method_type` — one supported-family list instead of two.
- Collapsed the four Constant `integrate`/`cumulative_integrate` overrides into two `_full_cell_fn` forwarders (behavior-identical; `side` is a type parameter).

### Perf
- muladd-fold the separable engine's outer Kronecker contraction so each `ko·inner` fuses (FMA). Documented as a reassociation — more accurate, but not bit-identical to mul-then-add under cancellation.

### API change (release notes)
- Dropped the accepted-but-ignored `search`/`hint` kwargs from the full-domain `integrate` forms (no search happens there — they silently no-op'd). Bounded ND keeps them.

### Docs / tests
- Honest one-shot copy/reference docstring; stale-comment fixes (`_policy_axes`, hetero integrate, AutoCoeffs).
- New tests: minimal-size axes (n=2 boundary collision), ND `DomainError`, one-shot Hermite full-domain, tuple-method rejection, rank-guard unit, and **SVector channel-wise** integration (1D + ND, all ranks).

Integral + duck + cumulative suites green; runic-clean.
