### PR TITLE
refac: unit-native Thomas/solver core — strip-twin paths deleted, duck cache banking

### DIFF
--- a/src/constant/constant_kernels.jl
+++ b/src/constant/constant_kernels.jl
@@ -65,16 +65,11 @@ dL may be Real, Unitful.Quantity, or ForwardDiff.Dual — its carrier propagates
     return selected * one(dL)
 end
 
-# N-th derivative of a degree-0 (constant) interpolant is zero for N ≥ 1, but lives in
-# `[value]/[grid]ᴺ` space. The unit scale comes from the GRID spacing `h`
-# (`_deriv_oneunit(h, op)`), matching the OOB branch and the ND grid⁻ᴺ pins — a
-# query in different (compatible) units must not change the return type at the
-# domain boundary. `* one(dL)` retains the query carrier (Dual partials shape),
-# and `0 * y_left` keeps the zero, duck-typing, and NaN propagation. The zero
-# VALUE is unchanged; its eltype is `typeof(y / gridᴺ)` — for an all-Int Real
-# grid that floats to Float64 (Int/Int → Float), which is the dimensionally
-# correct derivative type, NOT a Real-path regression (`Constant` keeps the
-# primal Int; only the derivative floats).
+# N-th derivative of degree-0 is zero for N ≥ 1, in `[value]/[grid]ᴺ` space.
+# The unit scale comes from the GRID spacing (`_deriv_oneunit(h, op)`, matching
+# the OOB branch) so query units can't flip the return type at the boundary;
+# `* one(dL)` keeps the query carrier, `0 * y_left` keeps zero/duck/NaN
+# semantics. Int grids float the derivative (Int/Int → Float) — correct, not a regression.
 """
     _constant_kernel(::EvalDeriv1, y_left, y_right, h, dL, side)
 

--- a/src/constant/constant_kernels.jl
+++ b/src/constant/constant_kernels.jl
@@ -66,20 +66,22 @@ dL may be Real, Unitful.Quantity, or ForwardDiff.Dual — its carrier propagates
 end
 
 # N-th derivative of a degree-0 (constant) interpolant is zero for N ≥ 1, but lives in
-# `[value]/[grid]ᴺ` space: the `inv(oneunit(dL))ᴺ` factor carries the grid⁻ᴺ units so a
-# unit-grid deriv batch's buffer (`_deriv_eltype`) accepts the value (else DimensionError),
-# while `0 * y_left` keeps the zero, duck-typing, and NaN propagation. The zero VALUE is
-# unchanged; its eltype is `typeof(y / gridᴺ)` — for an all-Int Real grid that floats to
-# Float64 (Int/Int → Float), which is the dimensionally correct derivative type, NOT a
-# Real-path regression (`Constant` keeps the primal Int; only the derivative floats). A
-# literal exponent stays type-stable for Unitful.
+# `[value]/[grid]ᴺ` space. The unit scale comes from the GRID spacing `h`
+# (`_deriv_oneunit(h, op)`), matching the OOB branch and the ND grid⁻ᴺ pins — a
+# query in different (compatible) units must not change the return type at the
+# domain boundary. `* one(dL)` retains the query carrier (Dual partials shape),
+# and `0 * y_left` keeps the zero, duck-typing, and NaN propagation. The zero
+# VALUE is unchanged; its eltype is `typeof(y / gridᴺ)` — for an all-Int Real
+# grid that floats to Float64 (Int/Int → Float), which is the dimensionally
+# correct derivative type, NOT a Real-path regression (`Constant` keeps the
+# primal Int; only the derivative floats).
 """
     _constant_kernel(::EvalDeriv1, y_left, y_right, h, dL, side)
 
 First derivative of constant interpolation — zero, in `value/grid` units.
 """
-@inline function _constant_kernel(::EvalDeriv1, y_left::Tv, ::Tv, ::Tg, dL::Td, ::AbstractSide) where {Tv, Tg, Td}
-    return 0 * y_left * inv(oneunit(dL))
+@inline function _constant_kernel(::EvalDeriv1, y_left::Tv, ::Tv, h::Tg, dL::Td, ::AbstractSide) where {Tv, Tg, Td}
+    return 0 * y_left * _deriv_oneunit(h, DerivOp(1)) * one(dL)
 end
 
 """
@@ -87,8 +89,8 @@ end
 
 Second derivative of constant interpolation — zero, in `value/grid²` units.
 """
-@inline function _constant_kernel(::EvalDeriv2, y_left::Tv, ::Tv, ::Tg, dL::Td, ::AbstractSide) where {Tv, Tg, Td}
-    return 0 * y_left * inv(oneunit(dL))^2
+@inline function _constant_kernel(::EvalDeriv2, y_left::Tv, ::Tv, h::Tg, dL::Td, ::AbstractSide) where {Tv, Tg, Td}
+    return 0 * y_left * _deriv_oneunit(h, DerivOp(2)) * one(dL)
 end
 
 """
@@ -96,15 +98,15 @@ end
 
 Third derivative of constant interpolation — zero, in `value/grid³` units.
 """
-@inline function _constant_kernel(::EvalDeriv3, y_left::Tv, ::Tv, ::Tg, dL::Td, ::AbstractSide) where {Tv, Tg, Td}
-    return 0 * y_left * inv(oneunit(dL))^3
+@inline function _constant_kernel(::EvalDeriv3, y_left::Tv, ::Tv, h::Tg, dL::Td, ::AbstractSide) where {Tv, Tg, Td}
+    return 0 * y_left * _deriv_oneunit(h, DerivOp(3)) * one(dL)
 end
 
-# Generic fallback (N ≥ 4): `Base.literal_pow` keeps `inv(oneunit(dL))ᴺ` type-stable for
-# unit grids even when N is a type parameter (a plain `^N` there infers an abstract unit).
+# Generic fallback (N ≥ 4): `_deriv_oneunit` uses `Base.literal_pow` so the grid⁻ᴺ
+# factor stays type-stable for unit grids even when N is a type parameter.
 """Generic fallback: N-th derivative of degree-0 (constant) is zero for N ≥ 1."""
-@inline function _constant_kernel(::DerivOp{N}, y_left::Tv, ::Tv, ::Tg, dL::Td, ::AbstractSide) where {N, Tv, Tg, Td}
-    return 0 * y_left * Base.literal_pow(^, inv(oneunit(dL)), Val(N))
+@inline function _constant_kernel(::DerivOp{N}, y_left::Tv, ::Tv, h::Tg, dL::Td, ::AbstractSide) where {N, Tv, Tg, Td}
+    return 0 * y_left * _deriv_oneunit(h, DerivOp(N)) * one(dL)
 end
 
 # ========================================

--- a/src/constant/nd/constant_nd_eval.jl
+++ b/src/constant/nd/constant_nd_eval.jl
@@ -86,19 +86,15 @@ end
     ::NTuple{N, EvalValue}, ::Val{N}
 ) where {N} = _constant_nd_kernel(data, intervals, hs, sides, q_eval, Ls)
 
-# `* 0` zeros the value (NaN-preserving); the per-axis `_constant_nd_deriv_scale` then
+# `* 0` zeros the value (NaN-preserving); the per-axis `_nd_deriv_scale` then
 # carries the grid⁻ᴺ units so the result lives in `value/∏ gridᵈ^{orderᵈ}` space — else a
 # same-unit deriv batch's concrete buffer rejects the value-unit zero (DimensionError).
+# `hs[d]` carries axis d's grid unit — the canonical `_nd_deriv_scale` fold
+# lands the zero in `value/∏ gridᵈ^{orderᵈ}` space.
 @inline _constant_nd_evaluate(
     data, intervals, hs, sides, q_eval, Ls,
     ops::NTuple{N, AbstractEvalOp}, ::Val{N}
-) where {N} = _constant_nd_kernel(data, intervals, hs, sides, q_eval, Ls) * 0 * _constant_nd_deriv_scale(hs, ops)
-
-# Per-axis grid⁻ᴺ unit scale, folded across the axes. The single-axis factor is
-# the shared `_deriv_oneunit` (core/utils.jl); `hs[d]` carries axis d's grid unit.
-@inline _constant_nd_deriv_scale(::Tuple{}, ::Tuple{}) = true
-@inline _constant_nd_deriv_scale(hs::Tuple, ops::Tuple) =
-    _deriv_oneunit(first(hs), first(ops)) * _constant_nd_deriv_scale(Base.tail(hs), Base.tail(ops))
+) where {N} = _constant_nd_kernel(data, intervals, hs, sides, q_eval, Ls) * 0 * _nd_deriv_scale(hs, ops)
 
 # ========================================
 # Derivative Check

--- a/src/core/bc_types.jl
+++ b/src/core/bc_types.jl
@@ -674,6 +674,26 @@ function _normalize_bc_array(
     return [_normalize_bc(bc) for bc in bcs]
 end
 
+# Sample-based (grid, value) variant for the SOLVE side: zero-BC payloads land
+# in their true derivative spaces (see the 3-arg `_normalize_bc`).
+function _normalize_bc_array(
+        bcs::AbstractVector{<:AbstractBC},
+        x1, y1,
+        n_series::Int
+    )
+    length(bcs) == n_series || throw(
+        DimensionMismatch(
+            "BC array length $(length(bcs)) does not match n_series $n_series"
+        )
+    )
+    for (i, bc) in enumerate(bcs)
+        _is_periodic_bc(bc) && _throw_periodic_in_bc_array(i)
+    end
+    return [_normalize_bc(bc, x1, y1) for bc in bcs]
+end
+@inline _normalize_bc_array(bcs::AbstractVector{<:BCPair}, x1, y1, n_series::Int) =
+    _normalize_bc_array(bcs, typeof(y1), n_series)
+
 
 # ========================================
 # BC Type Predicates

--- a/src/core/bc_types.jl
+++ b/src/core/bc_types.jl
@@ -562,6 +562,33 @@ Note: PeriodicBC is handled separately via `_is_periodic_bc()` check before
     (z = 0 * _coeff_op2(oneunit(first(x)), first(y)); BCPair(Deriv2(z), Deriv2(z)))
 @inline _normalize_bc(::ZeroSlopeBC, x::AbstractArray, y::AbstractArray) =
     (z = 0 * _coeff_op(oneunit(first(x)), first(y)); BCPair(Deriv1(z), Deriv1(z)))
+# BCPair (grid-aware): rehydrate STRUCTURAL Real payloads. Cache-then-values
+# builds (`cubic_interp(cache, y)`) and structural BCPairs carry `Deriv2(0.0)`
+# placeholders; zero is the one Real with no unit ambiguity, so it promotes
+# into its derivative space [Y/Xⁿ]. A NONZERO Real payload beside unit-carrying
+# spaces has no inferable unit → actionable error. Embeddable value carriers
+# (Complex/Dual y) keep the verbatim late-convert path.
+@inline _normalize_bc(bc::BCPair, x::AbstractArray, y::AbstractArray) =
+    BCPair(_rehydrate_pointbc(bc.left, x, y), _rehydrate_pointbc(bc.right, x, y))
+@inline _rehydrate_pointbc(bc::Deriv1, x, y) =
+    Deriv1(_payload_val(bc.val, oneunit(first(y)) * _deriv_oneunit(oneunit(first(x)), DerivOp(1))))
+@inline _rehydrate_pointbc(bc::Deriv2, x, y) =
+    Deriv2(_payload_val(bc.val, oneunit(first(y)) * _deriv_oneunit(oneunit(first(x)), DerivOp(2))))
+@inline _rehydrate_pointbc(bc::Deriv3, x, y) =
+    Deriv3(_payload_val(bc.val, oneunit(first(y)) * _deriv_oneunit(oneunit(first(x)), DerivOp(3))))
+@inline _rehydrate_pointbc(bc::PointBC, _x, _y) = bc              # PolyFit{D}: payload-free
+@inline _payload_val(v::Real, pw::Real) = v                       # Real solve: verbatim
+@inline function _payload_val(v::Real, pw)
+    one(pw) * v isa typeof(pw) && return v                        # Complex/Dual y: late-convert
+    iszero(v) && return 0 * pw                                    # structural zero → payload space
+    throw(
+        ArgumentError(
+            "unitless BC payload `$v` with unit-carrying data — pass the payload " *
+                "in its derivative space, e.g. `Deriv2(κ)` with `κ::Quantity` in [value]/[grid]²"
+        )
+    )
+end
+@inline _payload_val(v, pw) = v                                   # typed payload: RHS rules own the space
 # Shape-only fallback: other BC types carry user payloads verbatim.
 @inline _normalize_bc(bc::AbstractBC, _x::AbstractArray, _y::AbstractArray) = _normalize_bc(bc)
 @inline _normalize_bc(bc::BCPair) = bc

--- a/src/core/bc_types.jl
+++ b/src/core/bc_types.jl
@@ -550,25 +550,20 @@ Note: PeriodicBC is handled separately via `_is_periodic_bc()` check before
 # Needed when data type (e.g. MyDuck) doesn't support convert(MyDuck, Float64).
 @inline _normalize_bc(::ZeroCurvBC, sample) = (z = 0 * sample; BCPair(Deriv2(z), Deriv2(z)))
 @inline _normalize_bc(::ZeroSlopeBC, sample) = (z = 0 * sample; BCPair(Deriv1(z), Deriv1(z)))
-# Grid-aware duck-safe zeros (`(grid, value)` sample order): Deriv2/Deriv1
-# payload spaces are [Y/X²]/[Y/X] — a value-space zero (`0 * y`) would make the
-# RHS rule `bc.val * oneunit(Tg)` dimensionally wrong on unit grids. The zero
-# is a `0 *` value-witness (no `zero(::Type)`/`convert` — duck contract);
-# `oneunit(x1)` (never `x1`) keeps it finite for grids starting at 0.
-@inline _normalize_bc(::ZeroCurvBC, x1, y1) =
-    (z = 0 * _coeff_op2(oneunit(x1), y1); BCPair(Deriv2(z), Deriv2(z)))
-@inline _normalize_bc(::ZeroSlopeBC, x1, y1) =
-    (z = 0 * _coeff_op(oneunit(x1), y1); BCPair(Deriv1(z), Deriv1(z)))
+# Grid-aware duck-safe zeros — THE solve-side normalize (`(grid, value)` array
+# order): Deriv2/Deriv1 payload spaces are [Y/X²]/[Y/X] — a value-space zero
+# (`0 * y`) would make the RHS rule `bc.val * oneunit(Tg)` dimensionally wrong
+# on unit grids. The zero is a `0 *` value-witness (no `zero(::Type)`/`convert`
+# — duck-Tv contract); `oneunit(first(x))` (never `first(x)`) keeps it finite
+# for grids starting at 0. Samples are read INSIDE the zero-BC arms only —
+# shape-only BCs never touch the arrays (a caller-side `first(x)` costs a box
+# on some kwarg paths, so keep the reads here).
+@inline _normalize_bc(::ZeroCurvBC, x::AbstractArray, y::AbstractArray) =
+    (z = 0 * _coeff_op2(oneunit(first(x)), first(y)); BCPair(Deriv2(z), Deriv2(z)))
+@inline _normalize_bc(::ZeroSlopeBC, x::AbstractArray, y::AbstractArray) =
+    (z = 0 * _coeff_op(oneunit(first(x)), first(y)); BCPair(Deriv1(z), Deriv1(z)))
 # Shape-only fallback: other BC types carry user payloads verbatim.
-@inline _normalize_bc(bc::AbstractBC, _x1, _y1) = _normalize_bc(bc)
-
-# Vector-sample form for hot one-shot paths: grid/value samples are read ONLY
-# on the arms that need them (zero-BCs) — shape-only BCs never touch the
-# arrays, keeping the Real 0-alloc contract (a `first(x)` in the caller costs
-# a box on some kwarg paths).
-@inline _normalize_bc_solve(bc::AbstractBC, _x, _y) = _normalize_bc(bc)
-@inline _normalize_bc_solve(bc::ZeroCurvBC, x, y) = _normalize_bc(bc, first(x), first(y))
-@inline _normalize_bc_solve(bc::ZeroSlopeBC, x, y) = _normalize_bc(bc, first(x), first(y))
+@inline _normalize_bc(bc::AbstractBC, _x::AbstractArray, _y::AbstractArray) = _normalize_bc(bc)
 @inline _normalize_bc(bc::BCPair) = bc
 @inline _normalize_bc(bc::PointBC) = BCPair(bc, bc)
 @inline _normalize_bc(bc::NoBC) = bc
@@ -682,11 +677,11 @@ function _normalize_bc_array(
     return [_normalize_bc(bc) for bc in bcs]
 end
 
-# Sample-based (grid, value) variant for the SOLVE side: zero-BC payloads land
-# in their true derivative spaces (see the 3-arg `_normalize_bc`).
+# Grid-aware (grid, value) variant for the SOLVE side: zero-BC payloads land
+# in their true derivative spaces (see the array 3-arg `_normalize_bc`).
 function _normalize_bc_array(
         bcs::AbstractVector{<:AbstractBC},
-        x1, y1,
+        x::AbstractArray, y::AbstractArray,
         n_series::Int
     )
     length(bcs) == n_series || throw(
@@ -697,10 +692,10 @@ function _normalize_bc_array(
     for (i, bc) in enumerate(bcs)
         _is_periodic_bc(bc) && _throw_periodic_in_bc_array(i)
     end
-    return [_normalize_bc(bc, x1, y1) for bc in bcs]
+    return [_normalize_bc(bc, x, y) for bc in bcs]
 end
-@inline _normalize_bc_array(bcs::AbstractVector{<:BCPair}, x1, y1, n_series::Int) =
-    _normalize_bc_array(bcs, typeof(y1), n_series)
+@inline _normalize_bc_array(bcs::AbstractVector{<:BCPair}, ::AbstractArray, y::AbstractArray, n_series::Int) =
+    _normalize_bc_array(bcs, eltype(y), n_series)
 
 
 # ========================================

--- a/src/core/bc_types.jl
+++ b/src/core/bc_types.jl
@@ -561,6 +561,14 @@ Note: PeriodicBC is handled separately via `_is_periodic_bc()` check before
     (z = 0 * _coeff_op(oneunit(x1), y1); BCPair(Deriv1(z), Deriv1(z)))
 # Shape-only fallback: other BC types carry user payloads verbatim.
 @inline _normalize_bc(bc::AbstractBC, _x1, _y1) = _normalize_bc(bc)
+
+# Vector-sample form for hot one-shot paths: grid/value samples are read ONLY
+# on the arms that need them (zero-BCs) — shape-only BCs never touch the
+# arrays, keeping the Real 0-alloc contract (a `first(x)` in the caller costs
+# a box on some kwarg paths).
+@inline _normalize_bc_solve(bc::AbstractBC, _x, _y) = _normalize_bc(bc)
+@inline _normalize_bc_solve(bc::ZeroCurvBC, x, y) = _normalize_bc(bc, first(x), first(y))
+@inline _normalize_bc_solve(bc::ZeroSlopeBC, x, y) = _normalize_bc(bc, first(x), first(y))
 @inline _normalize_bc(bc::BCPair) = bc
 @inline _normalize_bc(bc::PointBC) = BCPair(bc, bc)
 @inline _normalize_bc(bc::NoBC) = bc

--- a/src/core/bc_types.jl
+++ b/src/core/bc_types.jl
@@ -562,12 +562,9 @@ Note: PeriodicBC is handled separately via `_is_periodic_bc()` check before
     (z = 0 * _coeff_op2(oneunit(first(x)), first(y)); BCPair(Deriv2(z), Deriv2(z)))
 @inline _normalize_bc(::ZeroSlopeBC, x::AbstractArray, y::AbstractArray) =
     (z = 0 * _coeff_op(oneunit(first(x)), first(y)); BCPair(Deriv1(z), Deriv1(z)))
-# BCPair (grid-aware): rehydrate STRUCTURAL Real payloads. Cache-then-values
-# builds (`cubic_interp(cache, y)`) and structural BCPairs carry `Deriv2(0.0)`
-# placeholders; zero is the one Real with no unit ambiguity, so it promotes
-# into its derivative space [Y/Xⁿ]. A NONZERO Real payload beside unit-carrying
-# spaces has no inferable unit → actionable error. Embeddable value carriers
-# (Complex/Dual y) keep the verbatim late-convert path.
+# BCPair (grid-aware): rehydrate structural Real payloads. Zero is the one
+# Real with no unit ambiguity → promote into [Y/Xⁿ]; a nonzero Real beside
+# unit spaces errors; Complex/Dual carriers and typed payloads pass verbatim.
 @inline _normalize_bc(bc::BCPair, x::AbstractArray, y::AbstractArray) =
     BCPair(_rehydrate_pointbc(bc.left, x, y), _rehydrate_pointbc(bc.right, x, y))
 @inline _rehydrate_pointbc(bc::Deriv1, x, y) =

--- a/src/core/bc_types.jl
+++ b/src/core/bc_types.jl
@@ -565,19 +565,22 @@ Note: PeriodicBC is handled separately via `_is_periodic_bc()` check before
 # BCPair (grid-aware): rehydrate structural Real payloads. Zero is the one
 # Real with no unit ambiguity → promote into [Y/Xⁿ]; a nonzero Real beside
 # unit spaces errors; Complex/Dual carriers and typed payloads pass verbatim.
+# Typed payloads short-circuit BEFORE the witness — the [Y/Xⁿ] witness is a
+# `first(y)` value-product (mirrors the zero-BC arms above); `one`/`oneunit`
+# are not duck-Tv contract ops, so they must never run on duck data.
 @inline _normalize_bc(bc::BCPair, x::AbstractArray, y::AbstractArray) =
     BCPair(_rehydrate_pointbc(bc.left, x, y), _rehydrate_pointbc(bc.right, x, y))
-@inline _rehydrate_pointbc(bc::Deriv1, x, y) =
-    Deriv1(_payload_val(bc.val, oneunit(first(y)) * _deriv_oneunit(oneunit(first(x)), DerivOp(1))))
-@inline _rehydrate_pointbc(bc::Deriv2, x, y) =
-    Deriv2(_payload_val(bc.val, oneunit(first(y)) * _deriv_oneunit(oneunit(first(x)), DerivOp(2))))
-@inline _rehydrate_pointbc(bc::Deriv3, x, y) =
-    Deriv3(_payload_val(bc.val, oneunit(first(y)) * _deriv_oneunit(oneunit(first(x)), DerivOp(3))))
+@inline _rehydrate_pointbc(bc::Deriv1, x, y) = Deriv1(_rehydrate_payload(bc.val, x, y, DerivOp(1)))
+@inline _rehydrate_pointbc(bc::Deriv2, x, y) = Deriv2(_rehydrate_payload(bc.val, x, y, DerivOp(2)))
+@inline _rehydrate_pointbc(bc::Deriv3, x, y) = Deriv3(_rehydrate_payload(bc.val, x, y, DerivOp(3)))
 @inline _rehydrate_pointbc(bc::PointBC, _x, _y) = bc              # PolyFit{D}: payload-free
+@inline _rehydrate_payload(v, _x, _y, ::DerivOp) = v              # typed payload: RHS rules own the space
+@inline _rehydrate_payload(v::Real, x, y, n::DerivOp) =
+    _payload_val(v, first(y) * _deriv_oneunit(first(x), n))
 @inline _payload_val(v::Real, pw::Real) = v                       # Real solve: verbatim
 @inline function _payload_val(v::Real, pw)
-    one(pw) * v isa typeof(pw) && return v                        # Complex/Dual y: late-convert
     iszero(v) && return 0 * pw                                    # structural zero → payload space
+    one(pw) * v isa typeof(pw) && return v                        # Complex/Dual y: embeds verbatim
     throw(
         ArgumentError(
             "unitless BC payload `$v` with unit-carrying data — pass the payload " *
@@ -585,7 +588,6 @@ Note: PeriodicBC is handled separately via `_is_periodic_bc()` check before
         )
     )
 end
-@inline _payload_val(v, pw) = v                                   # typed payload: RHS rules own the space
 # Shape-only fallback: other BC types carry user payloads verbatim.
 @inline _normalize_bc(bc::AbstractBC, _x::AbstractArray, _y::AbstractArray) = _normalize_bc(bc)
 @inline _normalize_bc(bc::BCPair) = bc

--- a/src/core/bc_types.jl
+++ b/src/core/bc_types.jl
@@ -550,6 +550,17 @@ Note: PeriodicBC is handled separately via `_is_periodic_bc()` check before
 # Needed when data type (e.g. MyDuck) doesn't support convert(MyDuck, Float64).
 @inline _normalize_bc(::ZeroCurvBC, sample) = (z = 0 * sample; BCPair(Deriv2(z), Deriv2(z)))
 @inline _normalize_bc(::ZeroSlopeBC, sample) = (z = 0 * sample; BCPair(Deriv1(z), Deriv1(z)))
+# Grid-aware duck-safe zeros (`(grid, value)` sample order): Deriv2/Deriv1
+# payload spaces are [Y/X²]/[Y/X] — a value-space zero (`0 * y`) would make the
+# RHS rule `bc.val * oneunit(Tg)` dimensionally wrong on unit grids. The zero
+# is a `0 *` value-witness (no `zero(::Type)`/`convert` — duck contract);
+# `oneunit(x1)` (never `x1`) keeps it finite for grids starting at 0.
+@inline _normalize_bc(::ZeroCurvBC, x1, y1) =
+    (z = 0 * _coeff_op2(oneunit(x1), y1); BCPair(Deriv2(z), Deriv2(z)))
+@inline _normalize_bc(::ZeroSlopeBC, x1, y1) =
+    (z = 0 * _coeff_op(oneunit(x1), y1); BCPair(Deriv1(z), Deriv1(z)))
+# Shape-only fallback: other BC types carry user payloads verbatim.
+@inline _normalize_bc(bc::AbstractBC, _x1, _y1) = _normalize_bc(bc)
 @inline _normalize_bc(bc::BCPair) = bc
 @inline _normalize_bc(bc::PointBC) = BCPair(bc, bc)
 @inline _normalize_bc(bc::NoBC) = bc

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -140,7 +140,7 @@ end
 # units); `DerivOp{0}` is the identity. ND folds the single-axis helper across axes.
 @inline _deriv_eltype(::Type{Tr}, ::Type{Tg}, ::DerivOp{0}) where {Tr, Tg} = Tr
 @inline _deriv_eltype(::Type{Tr}, ::Type{Tg}, ::DerivOp{N}) where {Tr, Tg, N} =
-    _deriv_eltype(_promote_eltype(_deriv1_op, Tr, Tg), Tg, DerivOp{N - 1}())
+    _deriv_eltype(_promote_eltype(_deriv1_op, Tg, Tr), Tg, DerivOp{N - 1}())
 @inline _deriv_eltype_nd(::Type{Tr}, ::Tuple{}, ::Tuple{}) where {Tr} = Tr
 @inline _deriv_eltype_nd(::Type{Tr}, grids::Tuple, ops::Tuple) where {Tr} =
     _deriv_eltype_nd(_deriv_eltype(Tr, eltype(first(grids)), first(ops)), Base.tail(grids), Base.tail(ops))

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -135,13 +135,19 @@ end
     return _promote_extrap_val(fill_val, qe)
 end
 
-# Per-axis inverse-coordinate-unit product for a FillExtrap OOB derivative zero: scales the
-# value-space zero into value/∏gridᵈ space (units only — the value stays 0/NaN). A scalar op
-# broadcasts to every axis. `true` (dimensionless) on Real grids, so no runtime cost there.
+# CANONICAL per-axis grid⁻ᵒʳᵈᵉʳ scale fold: ∏ᵈ `_deriv_oneunit(samples[d], ops[d])`.
+# `samples[d]` is any grid-space value for axis d (`oneunit` is taken inside the
+# single-axis factor). `true` (dimensionless) on Real grids — folds to no-op.
+# Every ND derivative-zero scale routes through THIS fold — do not respell it.
+@inline _nd_deriv_scale(::Tuple{}, ::Tuple{}) = true
+@inline _nd_deriv_scale(samples::Tuple, ops::Tuple) =
+    _deriv_oneunit(first(samples), first(ops)) * _nd_deriv_scale(Base.tail(samples), Base.tail(ops))
+
+# FillExtrap OOB form: axis samples from the grid eltypes; a scalar op
+# broadcasts to every axis.
 @inline _nd_fill_deriv_scale(grids::Tuple, op::AbstractEvalOp) = _nd_fill_deriv_scale(grids, map(_ -> op, grids))
-@inline _nd_fill_deriv_scale(::Tuple{}, ::Tuple{}) = true
 @inline _nd_fill_deriv_scale(grids::Tuple, ops::Tuple) =
-    _deriv_oneunit(oneunit(eltype(first(grids))), first(ops)) * _nd_fill_deriv_scale(Base.tail(grids), Base.tail(ops))
+    _nd_deriv_scale(map(g -> oneunit(eltype(g)), grids), ops)
 
 # Extract fill_value from the first FillExtrap in extraps tuple.
 # Only called on OOB cold path (guarded by _is_fill_oob).

--- a/src/core/polyfit_kernels.jl
+++ b/src/core/polyfit_kernels.jl
@@ -172,27 +172,30 @@ end
 end
 
 # ----------------------------------------
-# Mixed-type _compute_deriv1 for Complex value support
-# f::NTuple{N,Tv} values (can be Complex)
-# inv_h::Tg inverse grid spacing (always real)
-# Returns Tc = _promote_eltype(_coeff_op, Tg, Tv)
+# Mixed-type _compute_deriv1 (Complex / unit / narrow value support)
+# f::NTuple{N,Tv} values; inv_h::Tg is the INVERSE spacing (1/X space).
+# The stencil lift target is the VALUE-space field (`_value_space_eltype`:
+# wrap-free for narrow eltypes, ratio-shaped so 1/X in the width slot still
+# cancels) — feeding `Tg` (= 1/X) into a spacing-shaped witness like
+# `_coeff_op` mints h·y-typed garbage on unit grids. The trailing `* inv_h`
+# lands the result in coefficient space [Y/X].
 # ----------------------------------------
 
 # PolyFit{1} (LinearFit) - 2 points, O(h) - Mixed type
 @inline function _compute_deriv1(::PolyFit{1}, ::LeftSide, f::NTuple{2, Tv}, inv_h::Tg) where {Tv, Tg}
-    Tc = _promote_eltype(_coeff_op, Tg, Tv)
+    Tc = _value_space_eltype(Tg, Tv)
     return _fielddiff(Tc, f[2], f[1]) * inv_h
 end
 
 @inline function _compute_deriv1(::PolyFit{1}, ::RightSide, f::NTuple{2, Tv}, inv_h::Tg) where {Tv, Tg}
-    Tc = _promote_eltype(_coeff_op, Tg, Tv)
+    Tc = _value_space_eltype(Tg, Tv)
     return _fielddiff(Tc, f[2], f[1]) * inv_h
 end
 
 # PolyFit{2} (QuadraticFit) - 3 points, O(h²) - Mixed type
 @inline function _compute_deriv1(::PolyFit{2}, ::LeftSide, f::NTuple{3, Tv}, inv_h::Tg) where {Tv, Tg}
     # Coefficients: -(3, -4, 1) / 2
-    Tc = _promote_eltype(_coeff_op, Tg, Tv)
+    Tc = _value_space_eltype(Tg, Tv)
     fp = _convert_stencil(Tc, f)
     coeff = -inv_h / 2
     return muladd(3, fp[1], muladd(-4, fp[2], fp[3])) * coeff
@@ -200,7 +203,7 @@ end
 
 @inline function _compute_deriv1(::PolyFit{2}, ::RightSide, f::NTuple{3, Tv}, inv_h::Tg) where {Tv, Tg}
     # Coefficients: (1, -4, 3) / 2
-    Tc = _promote_eltype(_coeff_op, Tg, Tv)
+    Tc = _value_space_eltype(Tg, Tv)
     fp = _convert_stencil(Tc, f)
     coeff = inv_h / 2
     return muladd(1, fp[1], muladd(-4, fp[2], 3 * fp[3])) * coeff
@@ -209,7 +212,7 @@ end
 # PolyFit{3} (CubicFit) - 4 points, O(h³) - Mixed type
 @inline function _compute_deriv1(::PolyFit{3}, ::LeftSide, f::NTuple{4, Tv}, inv_h::Tg) where {Tv, Tg}
     # Coefficients: (-11, 18, -9, 2) / 6
-    Tc = _promote_eltype(_coeff_op, Tg, Tv)
+    Tc = _value_space_eltype(Tg, Tv)
     fp = _convert_stencil(Tc, f)
     coeff = inv_h / 6
     return muladd(-11, fp[1], muladd(18, fp[2], muladd(-9, fp[3], 2 * fp[4]))) * coeff
@@ -217,7 +220,7 @@ end
 
 @inline function _compute_deriv1(::PolyFit{3}, ::RightSide, f::NTuple{4, Tv}, inv_h::Tg) where {Tv, Tg}
     # Coefficients: (-2, 9, -18, 11) / 6
-    Tc = _promote_eltype(_coeff_op, Tg, Tv)
+    Tc = _value_space_eltype(Tg, Tv)
     fp = _convert_stencil(Tc, f)
     coeff = inv_h / 6
     return muladd(-2, fp[1], muladd(9, fp[2], muladd(-18, fp[3], 11 * fp[4]))) * coeff

--- a/src/core/polyfit_kernels.jl
+++ b/src/core/polyfit_kernels.jl
@@ -247,11 +247,9 @@ end
     return s
 end
 
-# Generic D > 3, mixed carriers (unit grids / Complex / narrow values). The
-# barycentric intermediates are unit-heterogeneous (β ∈ X^(1-N)), so compute the
-# coefficients on the EXACT dimensionless reference nodes t = 0..D (the uniform
-# stencil in units of h) with the carrier of `one(inv_h)`; each `cᵢ·inv_h` then
-# lands the weighted sum in coefficient space [Y/X].
+# Generic D > 3, mixed carriers: barycentric intermediates are unit-
+# heterogeneous (β ∈ X^(1-N)), so compute coefficients on the dimensionless
+# reference nodes t = 0..D and land each `cᵢ·inv_h` term in [Y/X].
 @inline function _compute_deriv1_refnodes(
         pf::PolyFit{D}, side::AbstractSide, f::NTuple{N}, inv_h
     ) where {D, N}
@@ -355,10 +353,8 @@ end
         _compute_deriv1_coeffs!(c, β, pf, side, x)
         return ntuple(i -> @inbounds(c[i]), Val(N))
     else
-        # Unit-carrying x (type-folded branch): the β workspace is
-        # unit-heterogeneous (X^(1-N)), so run the same kernels on the EXACT
-        # dimensionless reparameterization t = (xᵢ−x₁)·inv(x₂−x₁); the chain
-        # rule dP/dx = (dP/dt)·(dt/dx) restores every coefficient to [1/X].
+        # Unit-carrying x: same kernels on the exact reparameterization
+        # t = (xᵢ−x₁)·inv(x₂−x₁); dP/dx = (dP/dt)·(dt/dx) restores [1/X].
         inv_href = inv(x[2] - x[1])
         t = ntuple(i -> (x[i] - x[1]) * inv_href, Val(N))
         ct = _compute_deriv1_coeffs(pf, side, t)

--- a/src/core/polyfit_kernels.jl
+++ b/src/core/polyfit_kernels.jl
@@ -231,6 +231,8 @@ end
 @inline @with_pool pool function _compute_deriv1(
         pf::PolyFit{D}, side::AbstractSide, f::NTuple{N, T}, inv_h::T
     ) where {D, N, T}
+    # Unit-carrying T (type-folded branch): delegate to the reference-node body.
+    T === typeof(one(inv_h)) || return _compute_deriv1_refnodes(pf, side, f, inv_h)
     # Compute coefficients on reference grid t = 0, 1, ..., D
     coeffs = acquire!(pool, T, N)
     β = acquire!(pool, T, N)
@@ -244,6 +246,26 @@ end
     end
     return s
 end
+
+# Generic D > 3, mixed carriers (unit grids / Complex / narrow values). The
+# barycentric intermediates are unit-heterogeneous (β ∈ X^(1-N)), so compute the
+# coefficients on the EXACT dimensionless reference nodes t = 0..D (the uniform
+# stencil in units of h) with the carrier of `one(inv_h)`; each `cᵢ·inv_h` then
+# lands the weighted sum in coefficient space [Y/X].
+@inline function _compute_deriv1_refnodes(
+        pf::PolyFit{D}, side::AbstractSide, f::NTuple{N}, inv_h
+    ) where {D, N}
+    T1 = typeof(one(inv_h))
+    ct = _compute_deriv1_coeffs(pf, side, ntuple(i -> T1(i - 1), Val(N)))
+    s = 0 * (f[1] * inv_h)
+    @inbounds for i in 1:N
+        s = muladd(ct[i] * inv_h, f[i], s)
+    end
+    return s
+end
+
+@inline _compute_deriv1(pf::PolyFit{D}, side::AbstractSide, f::NTuple{N, Tv}, inv_h::Tg) where {D, N, Tv, Tg} =
+    _compute_deriv1_refnodes(pf, side, f, inv_h)
 
 
 # ----------------------------------------
@@ -327,10 +349,21 @@ end
 @inline @with_pool pool function _compute_deriv1_coeffs(
         pf::PolyFit{D}, side::Union{LeftSide, RightSide}, x::NTuple{N, T}
     ) where {D, N, T}
-    c = acquire!(pool, T, N)
-    β = acquire!(pool, T, N)
-    _compute_deriv1_coeffs!(c, β, pf, side, x)
-    return ntuple(i -> @inbounds(c[i]), Val(N))
+    if T === typeof(one(x[1]))
+        c = acquire!(pool, T, N)
+        β = acquire!(pool, T, N)
+        _compute_deriv1_coeffs!(c, β, pf, side, x)
+        return ntuple(i -> @inbounds(c[i]), Val(N))
+    else
+        # Unit-carrying x (type-folded branch): the β workspace is
+        # unit-heterogeneous (X^(1-N)), so run the same kernels on the EXACT
+        # dimensionless reparameterization t = (xᵢ−x₁)·inv(x₂−x₁); the chain
+        # rule dP/dx = (dP/dt)·(dt/dx) restores every coefficient to [1/X].
+        inv_href = inv(x[2] - x[1])
+        t = ntuple(i -> (x[i] - x[1]) * inv_href, Val(N))
+        ct = _compute_deriv1_coeffs(pf, side, t)
+        return ntuple(i -> ct[i] * inv_href, Val(N))
+    end
 end
 
 

--- a/src/core/thomas_lu_solver.jl
+++ b/src/core/thomas_lu_solver.jl
@@ -1,22 +1,14 @@
 # ========================================
 # Thomas Algorithm LU Solver
 # ========================================
-# Generic Thomas algorithm (TDMA) solvers for tridiagonal systems.
-# These work with any diagonally-dominant tridiagonal LU factorization.
+# TDMA solvers for diagonally-dominant tridiagonal systems (cubic spline
+# builds, batch ND).
 #
-# Currently used by:
-# - Cubic spline system solvers (periodic + derivative BC)
-# - Batch ND interpolation (SIMD-optimized vectorized solver)
-#
-# Unit spaces: the matrix entries carry the grid unit `X`, but the
-# factorization does not stay in that space — `l` is dimensionless and
-# `inv_d` lives in `1/X`, and a solve maps a `B`-space RHS to a `B/X`-space
-# result. The storage is therefore per-field typed and the solve writes into a
-# caller-provided output; overwriting an `X`-typed buffer with those values is
-# exactly the write a unit-carrying axis cannot represent. For `Real` grids
-# every space collapses to the same element type and the loops below are
-# op-for-op identical to the historic in-place implementation (bit-identical
-# results — pinned by test_thomas_lu_solver.jl).
+# Unit spaces: matrix entries carry the grid unit `X`, but `l` is
+# dimensionless, `inv_d` is `1/X`, and a solve maps a `B`-space RHS to `B/X` —
+# so storage is per-field typed and solves write to a caller output. Real
+# grids collapse every space to one eltype; the loops are op-for-op the
+# historic in-place implementation (bit-identity pinned in tests).
 
 # ========================================
 # ThomasFactorization Type
@@ -25,30 +17,13 @@
 """
     ThomasFactorization{Vl, Vu, Vd}
 
-Lightweight LU factorization for tridiagonal matrices using the Thomas
-algorithm. Zero-allocation alternative to `LinearAlgebra.LU` for
-diagonally-dominant systems.
-
-# Fields (one unit space per field)
-- `dl::Vl`: L multipliers (n-1) — dimensionless (`dl_in[i] * inv_d[i]`)
-- `du::Vu`: U super-diagonal (n-1) — grid space `X`, captured by reference
-  from the assembly input, unchanged
+Thomas LU factorization, one unit space per field:
+- `dl::Vl`: L multipliers (n-1) — dimensionless
+- `du::Vu`: U super-diagonal (n-1) — grid space `X`, by reference, unchanged
 - `inv_d::Vd`: inverse U diagonal (n) — `1/X`
 
-For `Real` grids all three are plain `Vector{T}` — same layout the old
-single-`T` struct had.
-
-# Thread Safety
-Immutable after construction. Safe for concurrent reads from multiple tasks.
-
-# Example
-```julia
-dl = rand(n - 1); d = 4.0 .+ rand(n); du = rand(n - 1)
-thomas = thomas_factorize(dl, d, du)   # inputs read-only
-x = similar(b)
-_ldiv_tridiagonal_nopiv!(x, b, thomas) # b consumed as forward-sweep scratch
-_ldiv_tridiagonal_nopiv!(b, b, thomas) # alias form ≡ historic in-place solve
-```
+Real grids: all three are `Vector{T}` (old single-`T` layout). Immutable —
+safe for concurrent reads.
 """
 struct ThomasFactorization{Vl <: AbstractVector, Vu <: AbstractVector, Vd <: AbstractVector}
     dl::Vl     # L multipliers (dimensionless)
@@ -63,28 +38,14 @@ end
 """
     thomas_factorize(dl, d, du) -> ThomasFactorization
 
-One-pass Thomas factorization. Inputs are **read-only**; `l` and `inv_d` are
-allocated with witness-computed element types (`_thomas_l_op`, `_inv_op`) so a
-unit-carrying axis factorizes natively. `du` is captured by reference.
+One-pass Thomas factorization. **Inputs are donated — do not reuse after the
+call.** Storage per witness space (`_thomas_storage`):
+- witness eltype == input eltype (Real/Dual): donated `dl`/`d` ARE the
+  `l`/`inv_d` storage — old in-place layout, zero allocation.
+- differs (unit axis): fresh witness-typed outputs, inputs untouched.
 
-# Algorithm (Thomas/TDMA)
-For i = 1 to n:
-    inv_d[i] = 1/d[i]
-    if i < n:
-        l[i] = dl[i] * inv_d[i]            # L multiplier (dimensionless)
-        d'[i+1] = d[i+1] - l[i] * du[i]    # U diagonal update (grid space)
-
-The loop is op-for-op the historic in-place factorization — `Real` results
-are bit-identical; only the destination of the two unit-changing writes moved
-(they used to overwrite the `X`-typed inputs).
-
-# Safety
-Assumes the matrix is **diagonally dominant** (no pivoting). For general
-matrices use `LinearAlgebra.lu`.
-
-# Performance
-O(n) single pass; allocates the two output vectors (build-time only — the
-factorization is cached, never rebuilt on the eval hot path).
+`du` is captured by reference either way. Assumes diagonal dominance (no
+pivoting).
 """
 function thomas_factorize(
         dl::AbstractVector, d::AbstractVector, du::AbstractVector
@@ -92,16 +53,19 @@ function thomas_factorize(
     Tg = eltype(d)
     Tl = _promote_eltype(_thomas_l_op, Tg, Tg)
     Tinv = _promote_eltype(_inv_op, Tg)
+    l = _thomas_storage(dl, Tl)
+    inv_d = _thomas_storage(d, Tinv)
     n = length(d)
-    l = Vector{Tl}(undef, n - 1)
-    inv_d = Vector{Tinv}(undef, n)
 
     @inbounds begin
         # First diagonal element: compute inverse
         inv_d_val = inv(d[1])
         inv_d[1] = inv_d_val
 
-        # Forward elimination with simultaneous inverse computation
+        # Forward elimination with simultaneous inverse computation.
+        # Alias-safe for the reuse arm: dl[i] / d[i+1] are read before
+        # l[i] / inv_d[i+1] overwrite those slots — op-for-op the historic
+        # in-place loop.
         for i in 1:(n - 1)
             # L factor: l_i = dl[i] / d'_i (use pre-computed inverse)
             l_val = dl[i] * inv_d_val
@@ -119,6 +83,14 @@ function thomas_factorize(
     return ThomasFactorization(l, du, inv_d)
 end
 
+# Storage selector for `thomas_factorize` outputs: reuse the donated input when
+# the witness space equals its eltype (Real/Dual — old in-place layout, zero
+# allocation); allocate fresh when the spaces differ (unit grids). Dispatch,
+# not a runtime branch — folds at specialization time.
+@inline _thomas_storage(v::AbstractVector{T}, ::Type{T}) where {T} = v
+@inline _thomas_storage(v::AbstractVector, ::Type{T}) where {T} =
+    Vector{T}(undef, length(v))
+
 # ========================================
 # Scalar Thomas Solver - ThomasFactorization (Primary)
 # ========================================
@@ -126,27 +98,12 @@ end
 """
     _ldiv_tridiagonal_nopiv!(x, b, thomas::ThomasFactorization) -> x
 
-Fast Thomas solve of `Ax = b` using the pre-computed factorization.
+Thomas solve of `Ax = b`. `x` is the output in `[b]/X` space; `b` is
+**consumed as scratch** by the forward sweep (L is dimensionless, so that
+sweep stays in b's space).
 
-# Arguments
-- `x::AbstractVector`: output, in `[b]/X` space (caller allocates with the
-  witness eltype; for `Real` grids that is `eltype(b)`)
-- `b::AbstractVector`: RHS — **consumed as scratch** by the forward sweep
-  (L is dimensionless, so the sweep stays in b's space)
-- `thomas`: factorization from [`thomas_factorize`](@ref)
-
-# Aliasing
-`x === b` is allowed and degenerates to the historic in-place solve
-bit-for-bit (`b[i]` is read before `x[i]` is written; `x[i+1]` reads are the
-intended already-substituted values). Partially-overlapping *distinct* arrays
-are not supported.
-
-# Algorithm
-1. Forward elimination (in place on `b`): `b[i+1] -= l[i] * b[i]`
-2. Backward substitution (into `x`): `x[i] = (b[i] - du[i] * x[i+1]) * inv_d[i]`
-
-# Performance
-O(n), zero allocations, `muladd`-fused.
+Aliasing: `x === b` is allowed — it degenerates to the historic in-place
+solve bit-for-bit. Partially-overlapping *distinct* arrays are not.
 """
 @inline function _ldiv_tridiagonal_nopiv!(
         x::AbstractVector,
@@ -180,18 +137,10 @@ end
 """
     _ldiv_tridiagonal_transpose!(x, b, thomas::ThomasFactorization) -> x
 
-Solve `Aᵀx = b` using the same `ThomasFactorization` as the forward solve.
-
-Given `A = L·U` with L unit lower bidiagonal (dl) and U upper bidiagonal
-(du, inv_d), `Aᵀ = Uᵀ·Lᵀ` is solved in two sweeps:
-
-1. **Uᵀ forward sweep** (writes `x`, reads `b`):
-   `x[1] = b[1] * inv_d[1]`; `x[i] = (b[i] - du[i-1] * x[i-1]) * inv_d[i]`
-2. **Lᵀ backward sweep** (in place on `x`): `x[i] -= dl[i] * x[i+1]`
-
-`b` is read-only here (unlike the non-transpose solve). Output space is
-`[b]/X`. `x === b` is allowed and matches the historic in-place solve
-bit-for-bit; partially-overlapping distinct arrays are not supported.
+Solve `Aᵀx = b` (`Aᵀ = Uᵀ·Lᵀ`): Uᵀ sweep writes `x` from `b`, then Lᵀ sweep
+in place on `x`. Output space `[b]/X`; **`b` is read-only here** (unlike the
+non-transpose solve). `x === b` allowed (bit-identical to the historic
+in-place solve); partial overlap is not.
 """
 @inline function _ldiv_tridiagonal_transpose!(
         x::AbstractVector,
@@ -234,27 +183,11 @@ end
 """
     _ldiv_along_dim!(z::AbstractMatrix, thomas::ThomasFactorization, Val{2}) -> z
 
-Batch Thomas solver for 2D matrix using `ThomasFactorization`.
-
-Each row `z[i, :]` is an independent RHS vector. Solves all rows simultaneously
-using SIMD vectorization along the contiguous axis 1.
-
-**Real-only in-place contract**: the RHS is overwritten with the solution, so
-the two spaces must share one element type — the signature pins `eltype(z)`
-to the factorization eltype. Unit-carrying ND builds never reach this path
-(the ND PreCompute boundary refuses them).
-
-# Memory Layout (column-major)
-```
-z[n_batch, n_sys] where:
-  axis 1 (n_batch): contiguous in memory → SIMD inner loop
-  axis 2 (n_sys):   tridiagonal system dimension
-```
-
-# Performance
-- O(n_batch × n_sys) operations
-- SIMD vectorization on axis 1 (contiguous)
-- Zero allocations
+Batch solve: each row `z[i, :]` is an independent RHS; SIMD over the
+contiguous axis 1. **Real-only in-place contract** — the RHS is overwritten
+with the solution, so the signature pins `eltype(z)` to the factorization
+eltype (unit-carrying ND builds never reach this path; the ND PreCompute
+boundary refuses them).
 """
 @inline function _ldiv_along_dim!(
         z::AbstractMatrix{T},

--- a/src/core/thomas_lu_solver.jl
+++ b/src/core/thomas_lu_solver.jl
@@ -8,54 +8,52 @@
 # - Cubic spline system solvers (periodic + derivative BC)
 # - Batch ND interpolation (SIMD-optimized vectorized solver)
 #
-# Design: ThomasFactorization stores dl, du, inv_d for zero-allocation hot loops.
+# Unit spaces: the matrix entries carry the grid unit `X`, but the
+# factorization does not stay in that space — `l` is dimensionless and
+# `inv_d` lives in `1/X`, and a solve maps a `B`-space RHS to a `B/X`-space
+# result. The storage is therefore per-field typed and the solve writes into a
+# caller-provided output; overwriting an `X`-typed buffer with those values is
+# exactly the write a unit-carrying axis cannot represent. For `Real` grids
+# every space collapses to the same element type and the loops below are
+# op-for-op identical to the historic in-place implementation (bit-identical
+# results — pinned by test_thomas_lu_solver.jl).
 
 # ========================================
 # ThomasFactorization Type
 # ========================================
 
 """
-    ThomasFactorization{T<:AbstractFloat, V<:AbstractVector{T}}
+    ThomasFactorization{Vl, Vu, Vd}
 
-Lightweight LU factorization for tridiagonal matrices using Thomas algorithm.
-Zero-allocation alternative to `LinearAlgebra.LU` for diagonally-dominant systems.
+Lightweight LU factorization for tridiagonal matrices using the Thomas
+algorithm. Zero-allocation alternative to `LinearAlgebra.LU` for
+diagonally-dominant systems.
 
-# Fields
-- `dl::V`: Lower diagonal - L multipliers after factorization (n-1 elements)
-- `du::V`: Upper diagonal - unchanged from input (n-1 elements)
-- `inv_d::V`: Inverse U diagonal - 1/d[i] for fast back-substitution (n elements)
+# Fields (one unit space per field)
+- `dl::Vl`: L multipliers (n-1) — dimensionless (`dl_in[i] * inv_d[i]`)
+- `du::Vu`: U super-diagonal (n-1) — grid space `X`, captured by reference
+  from the assembly input, unchanged
+- `inv_d::Vd`: inverse U diagonal (n) — `1/X`
 
-# Memory Layout
-For n×n tridiagonal system:
-- `dl`: n-1 elements (L multipliers)
-- `du`: n-1 elements (U super-diagonal, unchanged)
-- `inv_d`: n elements (1/U diagonal for backward substitution)
-
-Total: 3n-2 elements. Compared to `LinearAlgebra.LU` which stores dl, d, du, ipiv, info.
+For `Real` grids all three are plain `Vector{T}` — same layout the old
+single-`T` struct had.
 
 # Thread Safety
 Immutable after construction. Safe for concurrent reads from multiple tasks.
 
 # Example
 ```julia
-# Allocate persistent arrays (NOT from pool!)
-dl = Vector{Float64}(undef, n-1)
-d = Vector{Float64}(undef, n)
-du = Vector{Float64}(undef, n-1)
-
-# Fill with tridiagonal entries...
-
-# One-pass factorization: d becomes inv_d
-thomas = thomas_factorize!(dl, d, du)
-
-# Solve Ax = b in-place
-_ldiv_tridiagonal_nopiv!(b, thomas)
+dl = rand(n - 1); d = 4.0 .+ rand(n); du = rand(n - 1)
+thomas = thomas_factorize(dl, d, du)   # inputs read-only
+x = similar(b)
+_ldiv_tridiagonal_nopiv!(x, b, thomas) # b consumed as forward-sweep scratch
+_ldiv_tridiagonal_nopiv!(b, b, thomas) # alias form ≡ historic in-place solve
 ```
 """
-struct ThomasFactorization{T, V <: AbstractVector{T}}
-    dl::V     # Lower diagonal (L multipliers after factorization)
-    du::V     # Upper diagonal (unchanged from input)
-    inv_d::V  # Inverse of U diagonal (1/d[i])
+struct ThomasFactorization{Vl <: AbstractVector, Vu <: AbstractVector, Vd <: AbstractVector}
+    dl::Vl     # L multipliers (dimensionless)
+    du::Vu     # Upper diagonal (unchanged input, grid space)
+    inv_d::Vd  # Inverse of U diagonal (1/grid space)
 end
 
 # ========================================
@@ -63,72 +61,62 @@ end
 # ========================================
 
 """
-    thomas_factorize!(dl, d, du) -> ThomasFactorization
+    thomas_factorize(dl, d, du) -> ThomasFactorization
 
-In-place Thomas algorithm factorization. Computes L, U, and inv_d in ONE PASS.
-
-# Arguments
-- `dl::AbstractVector{T}`: Lower diagonal (n-1), modified in-place to store L multipliers
-- `d::AbstractVector{T}`: Main diagonal (n), modified in-place to store 1/U diagonal (inv_d)
-- `du::AbstractVector{T}`: Upper diagonal (n-1), unchanged
-
-# Returns
-`ThomasFactorization(dl, du, d)` where `d` now contains `inv_d`.
+One-pass Thomas factorization. Inputs are **read-only**; `l` and `inv_d` are
+allocated with witness-computed element types (`_thomas_l_op`, `_inv_op`) so a
+unit-carrying axis factorizes natively. `du` is captured by reference.
 
 # Algorithm (Thomas/TDMA)
 For i = 1 to n:
     inv_d[i] = 1/d[i]
     if i < n:
-        l[i] = dl[i] * inv_d[i]           # L multiplier
-        d[i+1] = d[i+1] - l[i] * du[i]    # U diagonal update
+        l[i] = dl[i] * inv_d[i]            # L multiplier (dimensionless)
+        d'[i+1] = d[i+1] - l[i] * du[i]    # U diagonal update (grid space)
+
+The loop is op-for-op the historic in-place factorization — `Real` results
+are bit-identical; only the destination of the two unit-changing writes moved
+(they used to overwrite the `X`-typed inputs).
 
 # Safety
-This function assumes the matrix is **diagonally dominant** (no pivoting required).
-For non-diagonally-dominant matrices, use `LinearAlgebra.lu` with pivoting.
+Assumes the matrix is **diagonally dominant** (no pivoting). For general
+matrices use `LinearAlgebra.lu`.
 
 # Performance
-- O(n) time and space
-- Zero allocations (modifies inputs in-place)
-- Single pass through data (cache-friendly)
-
-# Example
-```julia
-n = 100
-dl = rand(n-1)
-d = 4.0 .+ rand(n)  # Diagonally dominant
-du = rand(n-1)
-
-thomas = thomas_factorize!(dl, d, du)
-# dl now contains L multipliers
-# d now contains inv_d (aliased as thomas.inv_d)
-```
+O(n) single pass; allocates the two output vectors (build-time only — the
+factorization is cached, never rebuilt on the eval hot path).
 """
-function thomas_factorize!(
-        dl::V, d::V, du::V
-    ) where {T, V <: AbstractVector{T}}
+function thomas_factorize(
+        dl::AbstractVector, d::AbstractVector, du::AbstractVector
+    )
+    Tg = eltype(d)
+    Tl = _promote_eltype(_thomas_l_op, Tg, Tg)
+    Tinv = _promote_eltype(_inv_op, Tg)
     n = length(d)
+    l = Vector{Tl}(undef, n - 1)
+    inv_d = Vector{Tinv}(undef, n)
 
     @inbounds begin
         # First diagonal element: compute inverse
         inv_d_val = inv(d[1])
-        d[1] = inv_d_val
+        inv_d[1] = inv_d_val
 
         # Forward elimination with simultaneous inverse computation
         for i in 1:(n - 1)
-            # L factor: l_i = dl[i] / d_i (use pre-computed inverse)
+            # L factor: l_i = dl[i] / d'_i (use pre-computed inverse)
             l_val = dl[i] * inv_d_val
-            dl[i] = l_val
+            l[i] = l_val
 
-            # U diagonal update: d_{i+1} = d_{i+1} - l_i * du[i]
+            # U diagonal update: d'_{i+1} = d[i+1] - l_i * du[i]
             d_next = d[i + 1] - l_val * du[i]
 
             # Compute inverse for next step and final storage
             inv_d_val = inv(d_next)
-            d[i + 1] = inv_d_val
+            inv_d[i + 1] = inv_d_val
         end
     end
 
-    return ThomasFactorization(dl, du, d)
+    return ThomasFactorization(l, du, inv_d)
 end
 
 # ========================================
@@ -136,33 +124,35 @@ end
 # ========================================
 
 """
-    _ldiv_tridiagonal_nopiv!(b, thomas::ThomasFactorization) -> b
+    _ldiv_tridiagonal_nopiv!(x, b, thomas::ThomasFactorization) -> x
 
-Fast Thomas algorithm solver using `ThomasFactorization`.
-
-Solves `Ax = b` in-place where `A = L*U` is the pre-computed factorization.
-
-# Type Parameters
-- `Tg<:AbstractFloat`: Grid type (Thomas factorization type)
-- `Tv`: Value type for RHS (unconstrained)
+Fast Thomas solve of `Ax = b` using the pre-computed factorization.
 
 # Arguments
-- `b::AbstractVector{Tv}`: RHS vector (modified in-place to hold solution)
-- `thomas::ThomasFactorization{Tg,V}`: Pre-computed factorization with dl, du, inv_d
+- `x::AbstractVector`: output, in `[b]/X` space (caller allocates with the
+  witness eltype; for `Real` grids that is `eltype(b)`)
+- `b::AbstractVector`: RHS — **consumed as scratch** by the forward sweep
+  (L is dimensionless, so the sweep stays in b's space)
+- `thomas`: factorization from [`thomas_factorize`](@ref)
+
+# Aliasing
+`x === b` is allowed and degenerates to the historic in-place solve
+bit-for-bit (`b[i]` is read before `x[i]` is written; `x[i+1]` reads are the
+intended already-substituted values). Partially-overlapping *distinct* arrays
+are not supported.
 
 # Algorithm
-1. **Forward elimination**: `b[i+1] -= L[i] * b[i]` for i = 1:n-1
-2. **Backward substitution**: `b[i] = (b[i] - U[i] * b[i+1]) * inv_d[i]` for i = n:-1:1
+1. Forward elimination (in place on `b`): `b[i+1] -= l[i] * b[i]`
+2. Backward substitution (into `x`): `x[i] = (b[i] - du[i] * x[i+1]) * inv_d[i]`
 
 # Performance
-- O(n) time complexity
-- Zero allocations in hot path
-- Uses `muladd` for fused multiply-add when available
+O(n), zero allocations, `muladd`-fused.
 """
 @inline function _ldiv_tridiagonal_nopiv!(
-        b::AbstractVector{Tv},
-        thomas::ThomasFactorization{Tg, V},
-    ) where {Tg, Tv, V <: AbstractVector{Tg}}
+        x::AbstractVector,
+        b::AbstractVector,
+        thomas::ThomasFactorization,
+    )
     dl = thomas.dl
     du = thomas.du
     inv_d = thomas.inv_d
@@ -175,12 +165,12 @@ Solves `Ax = b` in-place where `A = L*U` is the pre-computed factorization.
     end
 
     # Backward substitution
-    @inbounds b[n] *= inv_d[n]
+    @inbounds x[n] = b[n] * inv_d[n]
     @inbounds for i in (n - 1):-1:1
-        b[i] = muladd(-du[i], b[i + 1], b[i]) * inv_d[i]
+        x[i] = muladd(-du[i], x[i + 1], b[i]) * inv_d[i]
     end
 
-    return b
+    return x
 end
 
 # ========================================
@@ -188,24 +178,26 @@ end
 # ========================================
 
 """
-    _ldiv_tridiagonal_transpose!(b, thomas::ThomasFactorization) -> b
+    _ldiv_tridiagonal_transpose!(x, b, thomas::ThomasFactorization) -> x
 
-Solve `Aᵀx = b` in-place using the same `ThomasFactorization` as the forward solve.
+Solve `Aᵀx = b` using the same `ThomasFactorization` as the forward solve.
 
-Given `A = L·U` where L is unit lower bidiagonal (dl) and U is upper bidiagonal (du, inv_d),
-the transpose `Aᵀ = Uᵀ·Lᵀ` is solved in two steps:
+Given `A = L·U` with L unit lower bidiagonal (dl) and U upper bidiagonal
+(du, inv_d), `Aᵀ = Uᵀ·Lᵀ` is solved in two sweeps:
 
-1. **Uᵀ forward sweep**: `b[1] *= inv_d[1]`; `b[i] = (b[i] - du[i-1]*b[i-1]) * inv_d[i]`
-2. **Lᵀ backward sweep**: `b[i] -= dl[i] * b[i+1]`
+1. **Uᵀ forward sweep** (writes `x`, reads `b`):
+   `x[1] = b[1] * inv_d[1]`; `x[i] = (b[i] - du[i-1] * x[i-1]) * inv_d[i]`
+2. **Lᵀ backward sweep** (in place on `x`): `x[i] -= dl[i] * x[i+1]`
 
-When `A` is symmetric (e.g. Deriv1/PolyFit BCs), this produces identical results
-to `_ldiv_tridiagonal_nopiv!`. For asymmetric `A` (Deriv2/Deriv3 BCs), this is the
-correct transpose solve needed by the cubic adjoint operator.
+`b` is read-only here (unlike the non-transpose solve). Output space is
+`[b]/X`. `x === b` is allowed and matches the historic in-place solve
+bit-for-bit; partially-overlapping distinct arrays are not supported.
 """
 @inline function _ldiv_tridiagonal_transpose!(
-        b::AbstractVector{Tv},
-        thomas::ThomasFactorization{Tg, V},
-    ) where {Tg, Tv, V <: AbstractVector{Tg}}
+        x::AbstractVector,
+        b::AbstractVector,
+        thomas::ThomasFactorization,
+    )
     dl = thomas.dl
     du = thomas.du
     inv_d = thomas.inv_d
@@ -213,17 +205,17 @@ correct transpose solve needed by the cubic adjoint operator.
     n = length(inv_d)
 
     # Step 1: Uᵀ forward sweep (lower bidiagonal with du as sub-diagonal)
-    @inbounds b[1] *= inv_d[1]
+    @inbounds x[1] = b[1] * inv_d[1]
     @inbounds for i in 2:n
-        b[i] = muladd(-du[i - 1], b[i - 1], b[i]) * inv_d[i]
+        x[i] = muladd(-du[i - 1], x[i - 1], b[i]) * inv_d[i]
     end
 
     # Step 2: Lᵀ backward sweep (upper bidiagonal with dl as super-diagonal)
     @inbounds for i in (n - 1):-1:1
-        b[i] = muladd(-dl[i], b[i + 1], b[i])
+        x[i] = muladd(-dl[i], x[i + 1], x[i])
     end
 
-    return b
+    return x
 end
 
 # ========================================
@@ -247,6 +239,11 @@ Batch Thomas solver for 2D matrix using `ThomasFactorization`.
 Each row `z[i, :]` is an independent RHS vector. Solves all rows simultaneously
 using SIMD vectorization along the contiguous axis 1.
 
+**Real-only in-place contract**: the RHS is overwritten with the solution, so
+the two spaces must share one element type — the signature pins `eltype(z)`
+to the factorization eltype. Unit-carrying ND builds never reach this path
+(the ND PreCompute boundary refuses them).
+
 # Memory Layout (column-major)
 ```
 z[n_batch, n_sys] where:
@@ -261,9 +258,11 @@ z[n_batch, n_sys] where:
 """
 @inline function _ldiv_along_dim!(
         z::AbstractMatrix{T},
-        thomas::ThomasFactorization{T, V},
+        thomas::ThomasFactorization{
+            <:AbstractVector{T}, <:AbstractVector{T}, <:AbstractVector{T},
+        },
         ::Val{2},
-    ) where {T, V <: AbstractVector{T}}
+    ) where {T}
     dl = thomas.dl
     du = thomas.du
     inv_d = thomas.inv_d

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -602,15 +602,25 @@ ForwardDiff support is added via:
 # GridIdx <: Real: _extract_primal(g::GridIdx) returns g (identity fallback).
 
 """
+    _grid_bankable(::Type{Tg}) -> Bool
+
+Whether grid eltype `Tg` may participate in the autocache pool. Contract: the
+pool is keyed by linear `isequal` scans (never `hash`), so `isequal(a, b)` on
+two grids must imply interchangeable factorizations. ForwardDiff Duals compare
+primal AND partials (safe); Unitful compares across unit rescale, but banks
+are segregated by exact eltype so cross-unit hits cannot occur. A type whose
+`isequal` ignores factorization-relevant state must opt out with a `false`
+method (none known today — escape hatch).
+"""
+@inline _grid_bankable(::Type{Tg}) where {Tg} = true
+
+"""
     _effective_autocache(autocache, Tg) -> Bool
 
-Disable autocache for non-standard grid types (e.g. ForwardDiff.Dual).
-Enabled for `_PromotableValue` types (AbstractFloat, Integer, Rational) which
-have stable grid identity (cache hit rate > 0). Dual grids are ephemeral
-(created fresh each AD call), so autocache is disabled for them.
-Resolves at specialization time — zero runtime cost on the Float hot path.
+Resolve the user's `autocache` flag against `_grid_bankable(Tg)`.
+Folds at specialization time — zero runtime cost on the Float hot path.
 """
-@inline _effective_autocache(ac::Bool, ::Type{Tg}) where {Tg} = ac & (Tg <: _PromotableValue)
+@inline _effective_autocache(ac::Bool, ::Type{Tg}) where {Tg} = ac & _grid_bankable(Tg)
 # Arithmetic then auto-promotes GridIdx → g.val via promote_rule.
 
 """

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -253,10 +253,15 @@ end
 # Unitful inverse units and duck carriers.
 @inline _inv_op(h) = inv(h)
 
+# `_thomas_l_op` (2-arg, both grid-space): Thomas L-multiplier eltype —
+# `dl[i]*inv(d)` cancels the axis unit (dimensionless float for unit grids,
+# `Tg` for Real). Drives `thomas_factorize`'s `l` output allocation.
+@inline _thomas_l_op(h::Tg, d::Tg2) where {Tg, Tg2} = h * inv(d)
+
 # `_deriv1_op` (2-arg): ONE order of differentiation — output type `r` scaled by a single
 # `inv(h)`. dⁿf/dxⁿ ∈ `[value]/[grid]ⁿ` is this folded n times (`_deriv_eltype`); one
 # `inv(h)` per order — never `h^-n` (type-unstable for units) — keeps every step concrete.
-@inline _deriv1_op(r::Tr, h::Tg) where {Tr, Tg} = r * inv(h)
+@inline _deriv1_op(h::Tg, r::Tr) where {Tg, Tr} = r * inv(h)
 
 # Grid-precision DIMENSIONLESS constant `1/n` (kernel coefficients like 1/24):
 # `Tg(n)` would demand a unit for unit-carrying grids — `one(Tg)` keeps the

--- a/src/cubic/cubic_adjoint.jl
+++ b/src/cubic/cubic_adjoint.jl
@@ -146,7 +146,7 @@ end
     _scatter_eval_adjoint!(f_bar, z_bar, adj.anchors, y_bar, deriv)
 
     # Step 2: Transpose solve — A⁻ᵀz̄ → r̄ (result in z_bar)
-    _ldiv_tridiagonal_transpose!(z_bar, adj.cache.thomas)
+    _ldiv_tridiagonal_transpose!(z_bar, z_bar, adj.cache.thomas)
 
     # Step 3: RHS adjoint — f̄ += Rᵀr̄
     # Compute polyfit stencil coefficients on the fly (O(D), grid-only)
@@ -553,7 +553,7 @@ end
     fill!(q_t, zero(Tg))
     @inbounds q_t[1] = one(Tg)
     @inbounds q_t[n] = one(Tg)
-    _ldiv_tridiagonal_transpose!(q_t, adj.cache.thomas)
+    _ldiv_tridiagonal_transpose!(q_t, q_t, adj.cache.thomas)
 
     _adjoint_periodic_solve!(z_bar, adj.cache, q_t, n)
 
@@ -585,7 +585,7 @@ function _adjoint_periodic_solve!(
     ) where {Tv, Tg, X, F}
 
     # Transpose Thomas solve on z_bar[1:n]
-    _ldiv_tridiagonal_transpose!(z_bar, cache.thomas)
+    _ldiv_tridiagonal_transpose!(z_bar, z_bar, cache.thomas)
 
     # Sherman-Morrison correction with q_t = A'^{-T} u
     α = Tv(_get_h(cache.x, n))

--- a/src/cubic/cubic_cache_pool.jl
+++ b/src/cubic/cubic_cache_pool.jl
@@ -108,8 +108,8 @@ end
 Cache entry for periodic BC (uses PeriodicData).
 
 # Type Parameters
-- `T`: grid eltype (constructed for `T <: AbstractFloat` only until the
-  Sherman-Morrison `q` witness lands — see `_get_periodic_bank`)
+- `T`: bankable grid eltype; the Sherman-Morrison `q` lives in the `_inv_op`
+  space (`Vector{T}` for Real, `[1/X]` for unit grids)
 - `X`: Grid type (Vector{T} or StepRangeLen)
 - `E`: Endpoint variant (`:inclusive`, `:exclusive`, or `:extended`) — encoded
   so the bank registry holds *separate* banks per variant. The cache content
@@ -126,7 +126,7 @@ Cache entry for periodic BC (uses PeriodicData).
 # Mutation Safety
 See `CacheEntry` documentation for details on mutation safety pattern.
 """
-mutable struct PeriodicCacheEntry{T, X <: AbstractVector{T}, E, C <: CubicSplineCache{T, <:AbstractVector{T}, <:ThomasFactorization, <:PeriodicBC, Vector{T}}} <: AbstractCacheEntry{T, X}
+mutable struct PeriodicCacheEntry{T, X <: AbstractVector{T}, E, C <: CubicSplineCache{T, <:AbstractVector{T}, <:ThomasFactorization, <:PeriodicBC, <:AbstractVector}} <: AbstractCacheEntry{T, X}
     id::UInt
     x::X
     cache::C
@@ -399,13 +399,12 @@ that were promoted from `:exclusive` at build time.
 Without partitioning on `C`, a cache built from `check=false` BC would fail to
 fit into a bank typed for `check=true`.
 """
-# NOTE: periodic banks stay `T <: AbstractFloat` until the Sherman-Morrison
-# `q` witness lands (unit periodic builds are guarded in `_build_periodic_cache`).
-@inline function _get_periodic_bank(::Type{X}, ::Val{E}, ::Val{C}) where {T <: AbstractFloat, X <: AbstractVector{T}, E, C}
+@inline function _get_periodic_bank(::Type{X}, ::Val{E}, ::Val{C}) where {T, X <: AbstractVector{T}, E, C}
     Xc = _cached_axis_type(X, T, Val(E))
     # `E` ∈ {:inclusive, :exclusive, :extended} — each gets its own bank.
+    # PeriodicBC's period param carries the grid unit; `q` is `_inv_op`-typed.
     bc = PeriodicBC{E, T, C}
-    Cc = CubicSplineCache{T, Xc, _bank_factorization_type(T), bc, Vector{T}}
+    Cc = CubicSplineCache{T, Xc, _bank_factorization_type(T), bc, Vector{_promote_eltype(_inv_op, T)}}
     EntryType = PeriodicCacheEntry{T, X, E, Cc}
     return _get_bank(_PERIODIC_REGISTRY, CacheBank{EntryType})
 end
@@ -519,7 +518,7 @@ end
 # (not optional `Nothing`) because cache content is BC-form-dependent: cycle
 # length, period, and seam-cell width all differ between `:inclusive` and
 # `:exclusive`. The entry's E type-param matches `bc`'s E by dispatch.
-@inline function _build_cache(::Type{<:PeriodicCacheEntry{T, X, E}}, x::AbstractVector{T}, bc::PeriodicBC{E}) where {T <: AbstractFloat, X, E}
+@inline function _build_cache(::Type{<:PeriodicCacheEntry{T, X, E}}, x::AbstractVector{T}, bc::PeriodicBC{E}) where {T, X, E}
     return _build_periodic_cache(x, bc)
 end
 
@@ -882,10 +881,29 @@ end
     return _lookup_or_insert!(bank, x, bc)
 end
 
-# Duck-typed grids (Dual, etc.): build fresh, no caching.
-@inline function _get_periodic_cache_impl(x::AbstractVector, bc::PeriodicBC)
-    return _build_periodic_cache(_to_float(x, _cache_float_type(eltype(x))), bc)
+# Duck-typed grids (unit-carrying, Dual, …): same trait-gated exact-eltype
+# banking as the derivative pool.
+@inline function _get_periodic_cache_impl(x::AbstractVector{T}, bc::PeriodicBC) where {T}
+    if _grid_bankable(T)
+        bank = _get_periodic_bank(Vector{T}, bc)
+        return _lookup_or_insert!(bank, x, bc)
+    else
+        return _build_periodic_cache(_to_float(x, _cache_float_type(T)), bc)
+    end
 end
+
+@inline function _get_periodic_cache_impl(x::_CachedRange{T, Tinv}, bc::PeriodicBC) where {T, Tinv}
+    if _grid_bankable(T)
+        bank = _get_periodic_bank(typeof(x), bc)
+        return _lookup_or_insert!(bank, x, bc)
+    else
+        return _build_periodic_cache(_to_float(x, _cache_float_type(T)), bc)
+    end
+end
+
+# Duck raw ranges: normalize to the wrapped axis first (defensive).
+@inline _get_periodic_cache_impl(x::AbstractRange{T}, bc::PeriodicBC) where {T} =
+    _get_periodic_cache_impl(_resolve_axis(x), bc)
 
 # ---- Explicit target float `Tg` (data-aware bank) ----
 # Same contract as the derivative impl: Integer/Rational route to `Vector{Tg}`;

--- a/src/cubic/cubic_cache_pool.jl
+++ b/src/cubic/cubic_cache_pool.jl
@@ -40,8 +40,12 @@ Abstract type for cache entries. Subtypes must have:
 - `id::UInt` - object identity for fast lookup
 - `x::X` - grid data for equality check
 - `cache` - CubicSplineCache instance
+
+`T` is any bankable grid eltype (`_grid_bankable`): Real floats, unit
+quantities, Duals. Lookup is a linear `isequal` scan — never `hash` (Unitful
+and ForwardDiff both bend the isequal/hash contract, in opposite directions).
 """
-abstract type AbstractCacheEntry{T <: AbstractFloat, X <: AbstractVector{T}} end
+abstract type AbstractCacheEntry{T, X <: AbstractVector{T}} end
 
 # Banked axis type for an already-normalized cache grid: `_CachedRange{T}` (tag preserved)
 # or `Vector{T}`. Raw ranges are `_to_float`-converted upstream, so they never reach here;
@@ -60,17 +64,27 @@ abstract type AbstractCacheEntry{T <: AbstractFloat, X <: AbstractVector{T}} end
     return _ExclusivePeriodicAxis{T, Inner, T}
 end
 
+# Bank-side factorization type — SAME witnesses as `thomas_factorize` (single
+# source of truth): `l` in `_thomas_l_op` space (dimensionless for units),
+# `du` grid space by reference, `inv_d` in `_inv_op` space. Real grids
+# degenerate to the historic `{Vector{T}, Vector{T}, Vector{T}}`.
+@inline _bank_factorization_type(::Type{T}) where {T} = ThomasFactorization{
+    Vector{_promote_eltype(_thomas_l_op, T, T)}, Vector{T},
+    Vector{_promote_eltype(_inv_op, T)},
+}
+
 """
     CacheEntry{T, L, R, X, S}
 
 Cache entry for derivative BC (uses BCPair).
 
 # Type Parameters
-- `T`: Float type (Float32 or Float64)
+- `T`: bankable grid eltype (Real float, unit quantity, Dual, …)
 - `L`: Left boundary condition type (Deriv1{T} or Deriv2{T})
 - `R`: Right boundary condition type (Deriv1{T} or Deriv2{T})
-- `X`: Grid type (Vector{T} or StepRangeLen)
-- `C`: Concrete `CubicSplineCache` parametrization
+- `X`: Grid type (Vector{T} or wrapped range)
+- `C`: Concrete `CubicSplineCache` parametrization (factorization from
+  `_bank_factorization_type` — witness-typed, Real-degenerate)
 
 # Fields
 - `id::UInt`: objectid of the ORIGINAL input x (hint for fast lookup)
@@ -82,7 +96,7 @@ The `x` field stores a snapshot (copy) for Vector inputs, preventing external
 mutation from corrupting the cache. Lookup verifies `isequal(entry.x, input_x)`
 even on objectid match to detect in-place mutation.
 """
-mutable struct CacheEntry{T <: AbstractFloat, L <: PointBC, R <: PointBC, X <: AbstractVector{T}, C <: CubicSplineCache{T, <:AbstractVector{T}, ThomasFactorization{Vector{T}, Vector{T}, Vector{T}}, BCPair{L, R}, Nothing}} <: AbstractCacheEntry{T, X}
+mutable struct CacheEntry{T, L <: PointBC, R <: PointBC, X <: AbstractVector{T}, C <: CubicSplineCache{T, <:AbstractVector{T}, <:ThomasFactorization, BCPair{L, R}, Nothing}} <: AbstractCacheEntry{T, X}
     id::UInt
     x::X                                  # user-input snapshot (Vector / Range)
     cache::C                              # concrete cache type — preserves wrapped-axis X for inference
@@ -94,7 +108,8 @@ end
 Cache entry for periodic BC (uses PeriodicData).
 
 # Type Parameters
-- `T`: Float type (Float32 or Float64)
+- `T`: grid eltype (constructed for `T <: AbstractFloat` only until the
+  Sherman-Morrison `q` witness lands — see `_get_periodic_bank`)
 - `X`: Grid type (Vector{T} or StepRangeLen)
 - `E`: Endpoint variant (`:inclusive`, `:exclusive`, or `:extended`) — encoded
   so the bank registry holds *separate* banks per variant. The cache content
@@ -111,7 +126,7 @@ Cache entry for periodic BC (uses PeriodicData).
 # Mutation Safety
 See `CacheEntry` documentation for details on mutation safety pattern.
 """
-mutable struct PeriodicCacheEntry{T <: AbstractFloat, X <: AbstractVector{T}, E, C <: CubicSplineCache{T, <:AbstractVector{T}, ThomasFactorization{Vector{T}, Vector{T}, Vector{T}}, <:PeriodicBC, Vector{T}}} <: AbstractCacheEntry{T, X}
+mutable struct PeriodicCacheEntry{T, X <: AbstractVector{T}, E, C <: CubicSplineCache{T, <:AbstractVector{T}, <:ThomasFactorization, <:PeriodicBC, Vector{T}}} <: AbstractCacheEntry{T, X}
     id::UInt
     x::X
     cache::C
@@ -360,9 +375,9 @@ Get or create a derivative BC cache bank for the given (T, L, R, X, S) combinati
 Type-Free design: L, R are PointBC subtypes without type parameter constraint.
 Accepts Type{X} to avoid needing an instance (eliminates collect() for views).
 """
-@inline function _get_derivative_bank(::Type{X}, ::BCPair{L, R}) where {T <: AbstractFloat, L <: PointBC, R <: PointBC, X <: AbstractVector{T}}
+@inline function _get_derivative_bank(::Type{X}, ::BCPair{L, R}) where {T, L <: PointBC, R <: PointBC, X <: AbstractVector{T}}
     Xc = _cached_axis_type(X, T)
-    Cc = CubicSplineCache{T, Xc, ThomasFactorization{Vector{T}, Vector{T}, Vector{T}}, BCPair{L, R}, Nothing}
+    Cc = CubicSplineCache{T, Xc, _bank_factorization_type(T), BCPair{L, R}, Nothing}
     EntryType = CacheEntry{T, L, R, X, Cc}
     return _get_bank(_DERIVATIVE_REGISTRY, CacheBank{EntryType})
 end
@@ -384,11 +399,13 @@ that were promoted from `:exclusive` at build time.
 Without partitioning on `C`, a cache built from `check=false` BC would fail to
 fit into a bank typed for `check=true`.
 """
+# NOTE: periodic banks stay `T <: AbstractFloat` until the Sherman-Morrison
+# `q` witness lands (unit periodic builds are guarded in `_build_periodic_cache`).
 @inline function _get_periodic_bank(::Type{X}, ::Val{E}, ::Val{C}) where {T <: AbstractFloat, X <: AbstractVector{T}, E, C}
     Xc = _cached_axis_type(X, T, Val(E))
     # `E` ∈ {:inclusive, :exclusive, :extended} — each gets its own bank.
     bc = PeriodicBC{E, T, C}
-    Cc = CubicSplineCache{T, Xc, ThomasFactorization{Vector{T}, Vector{T}, Vector{T}}, bc, Vector{T}}
+    Cc = CubicSplineCache{T, Xc, _bank_factorization_type(T), bc, Vector{T}}
     EntryType = PeriodicCacheEntry{T, X, E, Cc}
     return _get_bank(_PERIODIC_REGISTRY, CacheBank{EntryType})
 end
@@ -488,7 +505,7 @@ end
 # Build cache for derivative BC entry
 # Accepts AbstractVector (not x::X) so views can be passed directly;
 # CubicSplineCache inner constructor handles copy() → Vector.
-@inline function _build_cache(::Type{<:CacheEntry{T, L, R}}, x::AbstractVector{T}, bc::BCPair{L, R}) where {T <: AbstractFloat, L <: PointBC, R <: PointBC}
+@inline function _build_cache(::Type{<:CacheEntry{T, L, R}}, x::AbstractVector{T}, bc::BCPair{L, R}) where {T, L <: PointBC, R <: PointBC}
     return _build_derivative_bc_cache(x, bc.left, bc.right)
 end
 
@@ -785,12 +802,35 @@ end
     return _lookup_or_insert!(bank, x, bc_pair)
 end
 
-# Duck-typed grids (Dual, etc.): build fresh, no caching.
-# These are ephemeral — cache hit rate ≈ 0%.
-@inline function _get_derivative_cache_impl(x::AbstractVector, bc_pair::BCPair{L, R}) where {L <: PointBC, R <: PointBC}
-    FT = _cache_float_type(eltype(x))
-    return _build_derivative_bc_cache(_to_float(x, FT), bc_pair.left, bc_pair.right)
+# Duck-typed grids (unit-carrying, Dual, …): bank under the EXACT eltype when
+# `_grid_bankable` (type-folded branch); otherwise build fresh. Exact keying is
+# what makes Unitful safe here — cross-unit isequal-hits cannot happen when cm
+# and m grids live in different (type-keyed) banks.
+@inline function _get_derivative_cache_impl(x::AbstractVector{T}, bc_pair::BCPair{L, R}) where {T, L <: PointBC, R <: PointBC}
+    if _grid_bankable(T)
+        bank = _get_derivative_bank(Vector{T}, bc_pair)
+        return _lookup_or_insert!(bank, x, bc_pair)
+    else
+        return _build_derivative_bc_cache(_to_float(x, _cache_float_type(T)), bc_pair.left, bc_pair.right)
+    end
 end
+
+# Duck `_CachedRange` (unit Range axes: Tinv ≠ T): bank on the concrete wrapper
+# type — `copy` of an isbits range is the range itself, so the entry snapshot
+# stays type-exact and objectid is content-deterministic.
+@inline function _get_derivative_cache_impl(x::_CachedRange{T, Tinv}, bc_pair::BCPair{L, R}) where {T, Tinv, L <: PointBC, R <: PointBC}
+    if _grid_bankable(T)
+        bank = _get_derivative_bank(typeof(x), bc_pair)
+        return _lookup_or_insert!(bank, x, bc_pair)
+    else
+        return _build_derivative_bc_cache(_to_float(x, _cache_float_type(T)), bc_pair.left, bc_pair.right)
+    end
+end
+
+# Duck raw ranges: normalize to the wrapped axis first (defensive — the public
+# path resolves axes before reaching the impl).
+@inline _get_derivative_cache_impl(x::AbstractRange{T}, bc_pair::BCPair{L, R}) where {T, L <: PointBC, R <: PointBC} =
+    _get_derivative_cache_impl(_resolve_axis(x), bc_pair)
 
 # ---- Explicit target float `Tg` (data-aware bank) ----
 # Integer/Rational grids route to the `Vector{Tg}` bank (value-matched) instead

--- a/src/cubic/cubic_cache_pool.jl
+++ b/src/cubic/cubic_cache_pool.jl
@@ -82,7 +82,7 @@ The `x` field stores a snapshot (copy) for Vector inputs, preventing external
 mutation from corrupting the cache. Lookup verifies `isequal(entry.x, input_x)`
 even on objectid match to detect in-place mutation.
 """
-mutable struct CacheEntry{T <: AbstractFloat, L <: PointBC, R <: PointBC, X <: AbstractVector{T}, C <: CubicSplineCache{T, <:AbstractVector{T}, ThomasFactorization{T, Vector{T}}, BCPair{L, R}}} <: AbstractCacheEntry{T, X}
+mutable struct CacheEntry{T <: AbstractFloat, L <: PointBC, R <: PointBC, X <: AbstractVector{T}, C <: CubicSplineCache{T, <:AbstractVector{T}, ThomasFactorization{Vector{T}, Vector{T}, Vector{T}}, BCPair{L, R}, Nothing}} <: AbstractCacheEntry{T, X}
     id::UInt
     x::X                                  # user-input snapshot (Vector / Range)
     cache::C                              # concrete cache type — preserves wrapped-axis X for inference
@@ -111,7 +111,7 @@ Cache entry for periodic BC (uses PeriodicData).
 # Mutation Safety
 See `CacheEntry` documentation for details on mutation safety pattern.
 """
-mutable struct PeriodicCacheEntry{T <: AbstractFloat, X <: AbstractVector{T}, E, C <: CubicSplineCache{T, <:AbstractVector{T}, ThomasFactorization{T, Vector{T}}, <:PeriodicBC}} <: AbstractCacheEntry{T, X}
+mutable struct PeriodicCacheEntry{T <: AbstractFloat, X <: AbstractVector{T}, E, C <: CubicSplineCache{T, <:AbstractVector{T}, ThomasFactorization{Vector{T}, Vector{T}, Vector{T}}, <:PeriodicBC, Vector{T}}} <: AbstractCacheEntry{T, X}
     id::UInt
     x::X
     cache::C
@@ -362,7 +362,7 @@ Accepts Type{X} to avoid needing an instance (eliminates collect() for views).
 """
 @inline function _get_derivative_bank(::Type{X}, ::BCPair{L, R}) where {T <: AbstractFloat, L <: PointBC, R <: PointBC, X <: AbstractVector{T}}
     Xc = _cached_axis_type(X, T)
-    Cc = CubicSplineCache{T, Xc, ThomasFactorization{T, Vector{T}}, BCPair{L, R}}
+    Cc = CubicSplineCache{T, Xc, ThomasFactorization{Vector{T}, Vector{T}, Vector{T}}, BCPair{L, R}, Nothing}
     EntryType = CacheEntry{T, L, R, X, Cc}
     return _get_bank(_DERIVATIVE_REGISTRY, CacheBank{EntryType})
 end
@@ -388,7 +388,7 @@ fit into a bank typed for `check=true`.
     Xc = _cached_axis_type(X, T, Val(E))
     # `E` ∈ {:inclusive, :exclusive, :extended} — each gets its own bank.
     bc = PeriodicBC{E, T, C}
-    Cc = CubicSplineCache{T, Xc, ThomasFactorization{T, Vector{T}}, bc}
+    Cc = CubicSplineCache{T, Xc, ThomasFactorization{Vector{T}, Vector{T}, Vector{T}}, bc, Vector{T}}
     EntryType = PeriodicCacheEntry{T, X, E, Cc}
     return _get_bank(_PERIODIC_REGISTRY, CacheBank{EntryType})
 end

--- a/src/cubic/cubic_interpolant.jl
+++ b/src/cubic/cubic_interpolant.jl
@@ -220,8 +220,7 @@ so the pool memory can be safely reused after this function returns.
     ) where {Tg, Tv, P <: AbstractSearchPolicy}
     Tz = _promote_eltype(_coeff_op2, eltype(cache.x), Tv)
     tmp_z = acquire!(pool, Tz, length(y))
-    # Rehydrate structural placeholder payloads (the cache stores value-free
-    # zeros — no values existed at cache-build time; see `_normalize_bc(BCPair,…)`).
+    # Rehydrate structural placeholder payloads (cache stores value-free zeros).
     bc_solve = cache.bc isa PeriodicBC ? cache.bc : _normalize_bc(cache.bc, cache.x, y)
     _solve_system!(tmp_z, cache, y, bc_solve)
 

--- a/src/cubic/cubic_interpolant.jl
+++ b/src/cubic/cubic_interpolant.jl
@@ -175,7 +175,9 @@ val = itp(0.5)  # returns ComplexF64
     end
 end
 
-# Unified entry: handles all grid types including duck-typed (Dual).
+# Unified entry: ONE native path for every grid eltype (Real, Dual,
+# unit-carrying). BC payloads travel verbatim — the solver's RHS rules promote
+# them in place (H9: never pre-convert into value space).
 function cubic_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv};
@@ -186,67 +188,9 @@ function cubic_interp(
         store::StorePolicy = StorePolicy()
     ) where {Tg <: Number, Tv, P <: AbstractSearchPolicy}
     _check_grid_orderable(Tg)
-    Tg_f = _promote_grid_float(Tg, Tv)
-    # Non-Real (unit-carrying) grids: strip→solve→reattach (type-level branch folds).
-    Tg_f <: Real ||
-        return _cubic_interp_units(x, y, bc, extrap, autocache, search, store)
-    xc = _store_grid(x, Tg_f)
-    Tv_out = _value_type(Tv, Tg_f)
-    bc_promoted = _promote_bc(bc, Tv_out)
-    return _cubic_interp_impl(xc, y, bc_promoted, extrap, autocache, search; store = store)
+    xc = _store_grid(x, _promote_grid_float(Tg, Tv))
+    return _cubic_interp_impl(xc, y, bc, extrap, autocache, search; store = store)
 end
-
-# ── Non-Real (unit-carrying) grids: nondimensionalized solve ──
-# The Thomas machinery is unit-hostile by STORAGE, not algebra: factorization
-# overwrites h-typed arrays with L multipliers (dimensionless) and inv-diagonal
-# (1/X), and the ldiv turns the RHS buffer (Y/X) into the solution (Y/X²) in
-# place. Rather than triple-aliasing the core solver, solve on a oneunit-
-# stripped twin (division by `oneunit` is exact — bit-identical mantissas),
-# reattach units to `z`, and keep the ORIGINAL unit axis for eval/search.
-function _cubic_interp_units(x, y, bc, extrap, autocache, search, store)
-    _is_periodic_bc(bc) && throw(
-        ArgumentError(
-            "cubic PeriodicBC on a unit-carrying grid is not supported yet — " *
-                "strip units (e.g. `ustrip`) or use a Real grid"
-        )
-    )
-    ux = oneunit(eltype(x))
-    uy = _carrier_oneunit(eltype(y))
-    xs = x ./ ux
-    ys = y ./ uy
-    tw = _cubic_interp_impl(
-        xs, ys, _strip_bc_units(bc, uy, ux), NoExtrap(), autocache, search
-    )
-    z = tw.z .* (uy / (ux * ux))
-    Tgu = eltype(x)
-    # Cubic 1D ALWAYS owns its axis (copy-then-wrap) — deliberately NOT the
-    # store-aware `_policy_axis` the quadratic units path uses; do not "unify".
-    xc = _cache_axis(_convert_copy(x, Tgu), NoBC())
-    bc_u = _normalize_bc(bc, first(y))
-    # NOTE: `thomas` is the STRIPPED twin's factorization paired with a unit
-    # axis — unused by eval/integrate, but do not feed this cache back into
-    # `cubic_interp(cache, y2)`-style rebuilds with unit data.
-    cache = CubicSplineCache(xc, bc_u, tw.cache.thomas, nothing)
-    extrap_p = _resolve_extrap(extrap, xc, eltype(y))
-    return CubicInterpolant(cache, y, z, bc_u, extrap_p, search; store = store)
-end
-
-# BC payloads carry derivative units (`Y/X`, `Y/X²`, `Y/X³`) — strip to match
-# the nondimensionalized twin; structural BCs pass through.
-@inline _strip_bc_units(bc::Union{PolyFit, ZeroCurvBC, ZeroSlopeBC}, uy, ux) = bc
-@inline _strip_bc_units(bc::Deriv1, uy, ux) = Deriv1(bc.val / (uy / ux))
-@inline _strip_bc_units(bc::Deriv2, uy, ux) = Deriv2(bc.val / (uy / (ux * ux)))
-@inline _strip_bc_units(bc::Deriv3, uy, ux) = Deriv3(bc.val / (uy / (ux * ux * ux)))
-@inline _strip_bc_units(bc::BCPair, uy, ux) =
-    BCPair(_strip_bc_units(bc.left, uy, ux), _strip_bc_units(bc.right, uy, ux))
-# Catch-all: an unhandled BC type must fail HERE with an actionable message,
-# not as a MethodError deep inside the stripped solve.
-@noinline _strip_bc_units(bc::AbstractBC, uy, ux) = throw(
-    ArgumentError(
-        "BC type $(typeof(bc)) is not supported on a unit-carrying grid yet — " *
-            "strip units (e.g. `ustrip`) or use a Real grid"
-    )
-)
 
 """
     cubic_interp(cache, y; extrap=NoExtrap(), search=AutoSearch()) -> CubicInterpolant

--- a/src/cubic/cubic_interpolant.jl
+++ b/src/cubic/cubic_interpolant.jl
@@ -220,7 +220,10 @@ so the pool memory can be safely reused after this function returns.
     ) where {Tg, Tv, P <: AbstractSearchPolicy}
     Tz = _promote_eltype(_coeff_op2, eltype(cache.x), Tv)
     tmp_z = acquire!(pool, Tz, length(y))
-    _solve_system!(tmp_z, cache, y, cache.bc)
+    # Rehydrate structural placeholder payloads (the cache stores value-free
+    # zeros — no values existed at cache-build time; see `_normalize_bc(BCPair,…)`).
+    bc_solve = cache.bc isa PeriodicBC ? cache.bc : _normalize_bc(cache.bc, cache.x, y)
+    _solve_system!(tmp_z, cache, y, bc_solve)
 
     if cache.bc isa PeriodicBC
         _check_periodic_endpoints(y)
@@ -228,10 +231,9 @@ so the pool memory can be safely reused after this function returns.
         return CubicInterpolant(cache, y, tmp_z, cache.bc, WrapExtrap(), search; store = store)
     end
 
-    # cache.bc is BCPair - use it directly.
     # 3-arg form: promote FillExtrap value type to Tv (no-op for other extraps).
     extrap_p = _resolve_extrap(extrap, cache.x, Tv)
-    return CubicInterpolant(cache, y, tmp_z, cache.bc, extrap_p, search; store = store)
+    return CubicInterpolant(cache, y, tmp_z, bc_solve, extrap_p, search; store = store)
 end
 
 

--- a/src/cubic/cubic_interpolant.jl
+++ b/src/cubic/cubic_interpolant.jl
@@ -170,7 +170,7 @@ val = itp(0.5)  # returns ComplexF64
     if _is_periodic_bc(bc)
         return _build_interpolant_periodic(x, y, bc, autocache, search; store = store)
     else
-        bc_pair = _normalize_bc(bc, first(x), first(y))
+        bc_pair = _normalize_bc(bc, x, y)
         return _build_interpolant_bcpair(x, y, bc_pair, extrap, autocache, search; store = store)
     end
 end

--- a/src/cubic/cubic_interpolant.jl
+++ b/src/cubic/cubic_interpolant.jl
@@ -177,7 +177,7 @@ end
 
 # Unified entry: ONE native path for every grid eltype (Real, Dual,
 # unit-carrying). BC payloads travel verbatim — the solver's RHS rules promote
-# them in place (H9: never pre-convert into value space).
+# them in place (never pre-convert into value space).
 function cubic_interp(
         x::AbstractVector{Tg},
         y::AbstractVector{Tv};

--- a/src/cubic/cubic_interpolant.jl
+++ b/src/cubic/cubic_interpolant.jl
@@ -226,10 +226,7 @@ function _cubic_interp_units(x, y, bc, extrap, autocache, search, store)
     # NOTE: `thomas` is the STRIPPED twin's factorization paired with a unit
     # axis — unused by eval/integrate, but do not feed this cache back into
     # `cubic_interp(cache, y2)`-style rebuilds with unit data.
-    # Empty coordinate payload must match the STORED axis eltype — `_cache_axis` floats an
-    # Int-backed Unitful Range, so `Vector{Tgu}` (the original Int eltype) would not unify
-    # with the `CubicSplineCache(::AbstractVector{Tg}, …, ::Vector{Tg})` constructor.
-    cache = CubicSplineCache(xc, bc_u, tw.cache.thomas, Vector{eltype(xc)}())
+    cache = CubicSplineCache(xc, bc_u, tw.cache.thomas, nothing)
     extrap_p = _resolve_extrap(extrap, xc, eltype(y))
     return CubicInterpolant(cache, y, z, bc_u, extrap_p, search; store = store)
 end

--- a/src/cubic/cubic_interpolant.jl
+++ b/src/cubic/cubic_interpolant.jl
@@ -170,7 +170,7 @@ val = itp(0.5)  # returns ComplexF64
     if _is_periodic_bc(bc)
         return _build_interpolant_periodic(x, y, bc, autocache, search; store = store)
     else
-        bc_pair = _normalize_bc(bc, first(y))
+        bc_pair = _normalize_bc(bc, first(x), first(y))
         return _build_interpolant_bcpair(x, y, bc_pair, extrap, autocache, search; store = store)
     end
 end

--- a/src/cubic/cubic_oneshot.jl
+++ b/src/cubic/cubic_oneshot.jl
@@ -248,9 +248,6 @@ In-place cubic spline interpolation with optional automatic caching.
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg <: Number, Tv, Tq <: Number}
-    Tg <: Real || return cubic_interp(
-        x, y; bc = bc, extrap = extrap, search = search
-    )(output, x_query; deriv = deriv, hint = hint)
     # Value-matched Tg: Int/OneTo grid + Float32 data → Float32 axis, so the spline
     # cache builds (and memoises — `_CachedRange` is isbits, objectid-deterministic)
     # at the value width instead of the blind Float64.
@@ -262,7 +259,7 @@ In-place cubic spline interpolation with optional automatic caching.
         return _cubic_interp_periodic!(output, x, y, x_query, bc, autocache, deriv, searcher)
     end
 
-    bc_pair = _normalize_bc(bc, first(y))
+    bc_pair = _normalize_bc_solve(bc, x, y)
     return _cubic_interp_bcpair!(output, x, y, x_query, bc_pair, extrap, autocache, deriv, searcher)
 end
 
@@ -299,7 +296,9 @@ function cubic_interp(
         deriv::DerivOp = EvalValue(),
         search::AbstractSearchPolicy = AutoSearch()
     ) where {Tg <: Number, Tv, Tq <: Number}
-    Tr = _promote_eltype(_interp_op, eltype(cache.x), Tv, Tq)
+    Tr = _deriv_eltype(
+        _promote_eltype(_interp_op, eltype(cache.x), Tv, Tq), eltype(cache.x), deriv
+    )
     output = _alloc_query_output(Tr, x_query)
     cubic_interp!(output, cache, y, x_query; extrap = extrap, deriv = deriv, search = search)
     return output
@@ -343,10 +342,12 @@ function cubic_interp(
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg <: Number, Tv, Tq <: Number}
-    Tg <: Real || return cubic_interp(
-        x, y; bc = bc, extrap = extrap, search = search
-    )(x_query; deriv = deriv, hint = hint)
-    Tr = _promote_eltype(_interp_op, Tg, Tv, Tq)
+    # Output space is deriv-aware: value space folded by grid⁻ⁿ (`_deriv_eltype`
+    # — Real grids: identity). The reroute era hid this behind the persistent
+    # build's own allocation.
+    Tr = _deriv_eltype(
+        _promote_eltype(_interp_op, Tg, Tv, Tq), _promote_grid_float(Tg, Tv), deriv
+    )
     output = _alloc_query_output(Tr, x_query)
     cubic_interp!(output, x, y, x_query; bc, extrap, autocache, deriv, search, hint)
     return output
@@ -372,11 +373,6 @@ function cubic_interp(
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg <: Number, Tv, Tq <: Number}
-    # Unit-carrying grids route through the persistent strip→solve→reattach
-    # build — the direct pooled Thomas below runs in unit space and throws.
-    Tg <: Real || return cubic_interp(
-        x, y; bc = bc, extrap = extrap, search = search
-    )(xq; deriv = deriv, hint = hint)
     # Value-matched Tg (see the in-place form above): Ranges resolve to the value
     # width; raw Vectors pass through (identity-keyed cache — legacy width there).
     x = _resolve_axis(x, _promote_grid_float(Tg, Tv))
@@ -386,7 +382,7 @@ function cubic_interp(
         return _cubic_interp_periodic_scalar(x, y, xq, bc, autocache, deriv, searcher)
     end
 
-    bc_pair = _normalize_bc(bc, first(y))
+    bc_pair = _normalize_bc_solve(bc, x, y)
     return _cubic_interp_bcpair_scalar(x, y, xq, bc_pair, extrap, autocache, deriv, searcher)
 end
 

--- a/src/cubic/cubic_oneshot.jl
+++ b/src/cubic/cubic_oneshot.jl
@@ -259,7 +259,7 @@ In-place cubic spline interpolation with optional automatic caching.
         return _cubic_interp_periodic!(output, x, y, x_query, bc, autocache, deriv, searcher)
     end
 
-    bc_pair = _normalize_bc_solve(bc, x, y)
+    bc_pair = _normalize_bc(bc, x, y)
     return _cubic_interp_bcpair!(output, x, y, x_query, bc_pair, extrap, autocache, deriv, searcher)
 end
 
@@ -382,7 +382,7 @@ function cubic_interp(
         return _cubic_interp_periodic_scalar(x, y, xq, bc, autocache, deriv, searcher)
     end
 
-    bc_pair = _normalize_bc_solve(bc, x, y)
+    bc_pair = _normalize_bc(bc, x, y)
     return _cubic_interp_bcpair_scalar(x, y, xq, bc_pair, extrap, autocache, deriv, searcher)
 end
 

--- a/src/cubic/cubic_oneshot_series.jl
+++ b/src/cubic/cubic_oneshot_series.jl
@@ -182,11 +182,6 @@ Build cache once → anchor once → solve+eval per y-vector with z-buffer reuse
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg, Tq <: Number}
     _validate_series_lengths(s, length(x))
-    # Unit-carrying grids: the one-shot inline solve is unit-hostile by storage —
-    # route through the persistent build, which solves a nondimensionalized twin.
-    _promote_grid_float(Tg, _series_eltype(s)) <: Real || return cubic_interp(
-        x, s; bc = bc, extrap = extrap, autocache = autocache, search = search
-    )(xq; deriv = deriv, search = search, hint = hint)
     x = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
     _is_periodic_bc(bc) || _check_domain(x, xq, extrap)
     K = n_series(s)
@@ -202,7 +197,7 @@ Build cache once → anchor once → solve+eval per y-vector with z-buffer reuse
         _cubic_oneshot_series_periodic!(output, x, s, xq, bc, deriv, autocache, searcher)
         return output
     end
-    bc_pair = _normalize_bc(bc)
+    bc_pair = _normalize_bc_solve(bc, x, first(_series_vectors(s)))
     _cubic_oneshot_series_bcpair!(output, x, s, xq, bc_pair, extrap, autocache, deriv, searcher)
     return output
 end
@@ -223,10 +218,6 @@ end
     ) where {Tg, Tq <: Number}
     _validate_series_lengths(s, length(x))
     length(output) == n_series(s) || _throw_series_dim_mismatch(length(output), n_series(s))
-    # Unit grids → persistent build (nondimensionalized twin); see the scalar arm.
-    _promote_grid_float(Tg, _series_eltype(s)) <: Real || return cubic_interp(
-        x, s; bc = bc, extrap = extrap, autocache = autocache, search = search
-    )(output, xq; deriv = deriv, search = search, hint = hint)
     x = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
     _is_periodic_bc(bc) || _check_domain(x, xq, extrap)
     searcher = _resolve_search(x, xq, search, hint)
@@ -234,7 +225,7 @@ end
         _cubic_oneshot_series_periodic!(output, x, s, xq, bc, deriv, autocache, searcher)
         return output
     end
-    bc_pair = _normalize_bc(bc)
+    bc_pair = _normalize_bc_solve(bc, x, first(_series_vectors(s)))
     _cubic_oneshot_series_bcpair!(output, x, s, xq, bc_pair, extrap, autocache, deriv, searcher)
     return output
 end
@@ -257,10 +248,6 @@ end
         search::AbstractSearchPolicy = AutoSearch()
     ) where {Tg, Tq <: Number}
     _validate_series_lengths(s, length(x))
-    # Unit grids → persistent build (nondimensionalized twin); see the scalar arm.
-    _promote_grid_float(Tg, _series_eltype(s)) <: Real || return cubic_interp(
-        x, s; bc = bc, extrap = extrap, autocache = autocache, search = search
-    )(outputs, xqs; deriv = deriv, search = search)
     x = _to_float(x, _promote_grid_float(Tg, _series_eltype(s)))
     K = n_series(s)
     _validate_series_outputs(outputs, K, length(xqs))
@@ -273,7 +260,7 @@ end
         return _cubic_oneshot_series_periodic_vec!(pool, outputs, x, s, xqs, bc, deriv, autocache, search)
     end
 
-    bc_pair = _normalize_bc(bc)
+    bc_pair = _normalize_bc_solve(bc, x, first(_series_vectors(s)))
     cache = _get_cubic_cache(x, bc_pair, _effective_autocache(autocache, Tg))
 
     # Pre-compute lean op/extrap-aware anchors once (search Q times, not K×Q),

--- a/src/cubic/cubic_oneshot_series.jl
+++ b/src/cubic/cubic_oneshot_series.jl
@@ -197,7 +197,7 @@ Build cache once → anchor once → solve+eval per y-vector with z-buffer reuse
         _cubic_oneshot_series_periodic!(output, x, s, xq, bc, deriv, autocache, searcher)
         return output
     end
-    bc_pair = _normalize_bc_solve(bc, x, first(_series_vectors(s)))
+    bc_pair = _normalize_bc(bc, x, first(_series_vectors(s)))
     _cubic_oneshot_series_bcpair!(output, x, s, xq, bc_pair, extrap, autocache, deriv, searcher)
     return output
 end
@@ -225,7 +225,7 @@ end
         _cubic_oneshot_series_periodic!(output, x, s, xq, bc, deriv, autocache, searcher)
         return output
     end
-    bc_pair = _normalize_bc_solve(bc, x, first(_series_vectors(s)))
+    bc_pair = _normalize_bc(bc, x, first(_series_vectors(s)))
     _cubic_oneshot_series_bcpair!(output, x, s, xq, bc_pair, extrap, autocache, deriv, searcher)
     return output
 end
@@ -260,7 +260,7 @@ end
         return _cubic_oneshot_series_periodic_vec!(pool, outputs, x, s, xqs, bc, deriv, autocache, search)
     end
 
-    bc_pair = _normalize_bc_solve(bc, x, first(_series_vectors(s)))
+    bc_pair = _normalize_bc(bc, x, first(_series_vectors(s)))
     cache = _get_cubic_cache(x, bc_pair, _effective_autocache(autocache, Tg))
 
     # Pre-compute lean op/extrap-aware anchors once (search Q times, not K×Q),

--- a/src/cubic/cubic_series_interp.jl
+++ b/src/cubic/cubic_series_interp.jl
@@ -312,12 +312,6 @@ function cubic_interp(
     Tv_out = _value_type(Tv, Tg)
     y_mat, n_ser = _build_series_mat(s, n_pts, Tv_out)
 
-    # Non-Real (unit-carrying) grids: strip→solve→reattach twin (the batch
-    # Series solve still stores mixed unit spaces through shared buffers).
-    Tg <: Real || return _cubic_series_units(
-        x, y_mat, bc, extrap, n_ser, autocache, precompute_transpose, search
-    )
-
     # Handle periodic BC separately (only for scalar BC)
     if bc isa AbstractBC && _is_periodic_bc(bc)
         return _build_series_periodic(x, y_mat, bc, n_pts, n_ser, autocache, precompute_transpose, search)
@@ -329,16 +323,17 @@ function cubic_interp(
     z_mat = Matrix{Tz}(undef, n_pts, n_ser)
 
     if bc isa AbstractVector
-        # Per-series BC array: Tg-typed for cache matrix, Tv-typed for RHS
+        # Per-series BC array: structural (cache-key) vs payload-space (solve)
         bc_cache_array = _normalize_bc_array(bc, Tg, n_ser)
-        bc_solve_array = _normalize_bc_array(bc, Tv_out, n_ser)
+        bc_solve_array = _normalize_bc_array(bc, first(x), first(y_mat), n_ser)
         _solve_series_with_bc_array!(z_mat, y_mat, x, bc_cache_array, bc_solve_array, autocache)
         bc_representative = bc_cache_array[1]
         cache = _get_cubic_cache(x, bc_representative, _effective_autocache(autocache, eltype(x)))
     else
-        # Uniform BC: Tg-typed for cache matrix, Tv-typed for RHS
+        # Uniform BC: structural form keys the cache; the grid-aware normalize
+        # puts zero-BC payloads in their true derivative spaces (H9).
         bc_for_cache = _normalize_bc(bc)
-        bc_for_solve = _normalize_bc(bc, first(y_mat))
+        bc_for_solve = _normalize_bc(bc, first(x), first(y_mat))
         cache = _get_cubic_cache(x, bc_for_cache, _effective_autocache(autocache, eltype(x)))
         _solve_series_coefficients!(z_mat, y_mat, cache, bc_for_solve)
         bc_representative = bc_for_cache
@@ -353,65 +348,6 @@ function cubic_interp(
 
     return sitp
 end
-
-# ── Non-Real (unit-carrying) grids: nondimensionalized solve ──
-# Series strip twin: the batch solve routes every series through shared
-# buffers, so solve on a oneunit-stripped twin — division by `oneunit` is
-# exact — and reattach `z`'s order-2 units (`Y/X²`). The ORIGINAL unit axis
-# serves eval/search.
-function _cubic_series_units(
-        x, y_mat, bc, extrap, n_ser, autocache, precompute_transpose, search
-    )
-    (bc isa AbstractBC && _is_periodic_bc(bc)) && throw(
-        ArgumentError(
-            "cubic PeriodicBC on a unit-carrying grid is not supported yet — " *
-                "strip units (e.g. `ustrip`) or use a Real grid"
-        )
-    )
-    ux = oneunit(eltype(x))
-    uy = _carrier_oneunit(eltype(y_mat))
-    tw = cubic_interp(
-        x ./ ux, Series(y_mat ./ uy);
-        bc = _strip_series_bc_units(bc, uy, ux), extrap = NoExtrap(),
-        autocache = autocache, precompute_transpose = false, search = search
-    )
-    z_mat = tw.z .* (uy / (ux * ux))
-    xc = _cache_axis(_convert_copy(x, eltype(x)), NoBC())
-    bc_u = bc isa AbstractBC ? _normalize_bc(bc, first(y_mat)) :
-        _normalize_bc_array(bc, eltype(y_mat), n_ser)[1]
-    # NOTE: `thomas` is the STRIPPED twin's factorization paired with a unit axis
-    # — unused by eval, but do not feed this cache back into a unit-data rebuild.
-    cache = CubicSplineCache(xc, bc_u, tw.cache.thomas, nothing)
-    extrap_p = _promote_extrap(extrap, eltype(y_mat))
-    sitp = CubicSeriesInterpolant(cache, bc_u, y_mat, z_mat, extrap_p, search)
-
-    if precompute_transpose
-        _ensure_point_layout!(sitp)
-    end
-
-    return sitp
-end
-
-# BC payloads carry derivative units (`Y/X`, `Y/X²`, `Y/X³`) — strip to match
-# the nondimensionalized twin; structural BCs pass through. Sole remaining
-# consumer is this file's Series strip twin (deleted with it).
-@inline _strip_bc_units(bc::Union{PolyFit, ZeroCurvBC, ZeroSlopeBC}, uy, ux) = bc
-@inline _strip_bc_units(bc::Deriv1, uy, ux) = Deriv1(bc.val / (uy / ux))
-@inline _strip_bc_units(bc::Deriv2, uy, ux) = Deriv2(bc.val / (uy / (ux * ux)))
-@inline _strip_bc_units(bc::Deriv3, uy, ux) = Deriv3(bc.val / (uy / (ux * ux * ux)))
-@inline _strip_bc_units(bc::BCPair, uy, ux) =
-    BCPair(_strip_bc_units(bc.left, uy, ux), _strip_bc_units(bc.right, uy, ux))
-@noinline _strip_bc_units(bc::AbstractBC, uy, ux) = throw(
-    ArgumentError(
-        "BC type $(typeof(bc)) is not supported on a unit-carrying grid yet — " *
-            "strip units (e.g. `ustrip`) or use a Real grid"
-    )
-)
-
-# Per-series BC arrays strip element-wise; scalar BCs reuse the shared helper.
-@inline _strip_series_bc_units(bc::AbstractBC, uy, ux) = _strip_bc_units(bc, uy, ux)
-@inline _strip_series_bc_units(bc::AbstractVector, uy, ux) =
-    [_strip_bc_units(b, uy, ux) for b in bc]
 
 # Real grid promotion (Int, etc.) → convert to float and delegate
 

--- a/src/cubic/cubic_series_interp.jl
+++ b/src/cubic/cubic_series_interp.jl
@@ -392,6 +392,22 @@ function _cubic_series_units(
     return sitp
 end
 
+# BC payloads carry derivative units (`Y/X`, `Y/X²`, `Y/X³`) — strip to match
+# the nondimensionalized twin; structural BCs pass through. Sole remaining
+# consumer is this file's Series strip twin (deleted with it).
+@inline _strip_bc_units(bc::Union{PolyFit, ZeroCurvBC, ZeroSlopeBC}, uy, ux) = bc
+@inline _strip_bc_units(bc::Deriv1, uy, ux) = Deriv1(bc.val / (uy / ux))
+@inline _strip_bc_units(bc::Deriv2, uy, ux) = Deriv2(bc.val / (uy / (ux * ux)))
+@inline _strip_bc_units(bc::Deriv3, uy, ux) = Deriv3(bc.val / (uy / (ux * ux * ux)))
+@inline _strip_bc_units(bc::BCPair, uy, ux) =
+    BCPair(_strip_bc_units(bc.left, uy, ux), _strip_bc_units(bc.right, uy, ux))
+@noinline _strip_bc_units(bc::AbstractBC, uy, ux) = throw(
+    ArgumentError(
+        "BC type $(typeof(bc)) is not supported on a unit-carrying grid yet — " *
+            "strip units (e.g. `ustrip`) or use a Real grid"
+    )
+)
+
 # Per-series BC arrays strip element-wise; scalar BCs reuse the shared helper.
 @inline _strip_series_bc_units(bc::AbstractBC, uy, ux) = _strip_bc_units(bc, uy, ux)
 @inline _strip_series_bc_units(bc::AbstractVector, uy, ux) =

--- a/src/cubic/cubic_series_interp.jl
+++ b/src/cubic/cubic_series_interp.jl
@@ -331,7 +331,7 @@ function cubic_interp(
         cache = _get_cubic_cache(x, bc_representative, _effective_autocache(autocache, eltype(x)))
     else
         # Uniform BC: structural form keys the cache; the grid-aware normalize
-        # puts zero-BC payloads in their true derivative spaces (H9).
+        # puts zero-BC payloads in their true derivative spaces.
         bc_for_cache = _normalize_bc(bc)
         bc_for_solve = _normalize_bc(bc, x, y_mat)
         cache = _get_cubic_cache(x, bc_for_cache, _effective_autocache(autocache, eltype(x)))

--- a/src/cubic/cubic_series_interp.jl
+++ b/src/cubic/cubic_series_interp.jl
@@ -312,8 +312,8 @@ function cubic_interp(
     Tv_out = _value_type(Tv, Tg)
     y_mat, n_ser = _build_series_mat(s, n_pts, Tv_out)
 
-    # Non-Real (unit-carrying) grids: strip→solve→reattach, mirroring the scalar
-    # `_cubic_interp_units` (the Thomas solve is unit-hostile by STORAGE).
+    # Non-Real (unit-carrying) grids: strip→solve→reattach twin (the batch
+    # Series solve still stores mixed unit spaces through shared buffers).
     Tg <: Real || return _cubic_series_units(
         x, y_mat, bc, extrap, n_ser, autocache, precompute_transpose, search
     )
@@ -355,9 +355,8 @@ function cubic_interp(
 end
 
 # ── Non-Real (unit-carrying) grids: nondimensionalized solve ──
-# Series mirror of the scalar `_cubic_interp_units`: the Thomas machinery is
-# unit-hostile by STORAGE (factorization overwrites the h-typed diagonal with its
-# 1/X inverse), so solve on a oneunit-stripped twin — division by `oneunit` is
+# Series strip twin: the batch solve routes every series through shared
+# buffers, so solve on a oneunit-stripped twin — division by `oneunit` is
 # exact — and reattach `z`'s order-2 units (`Y/X²`). The ORIGINAL unit axis
 # serves eval/search.
 function _cubic_series_units(

--- a/src/cubic/cubic_series_interp.jl
+++ b/src/cubic/cubic_series_interp.jl
@@ -325,7 +325,7 @@ function cubic_interp(
     if bc isa AbstractVector
         # Per-series BC array: structural (cache-key) vs payload-space (solve)
         bc_cache_array = _normalize_bc_array(bc, Tg, n_ser)
-        bc_solve_array = _normalize_bc_array(bc, first(x), first(y_mat), n_ser)
+        bc_solve_array = _normalize_bc_array(bc, x, y_mat, n_ser)
         _solve_series_with_bc_array!(z_mat, y_mat, x, bc_cache_array, bc_solve_array, autocache)
         bc_representative = bc_cache_array[1]
         cache = _get_cubic_cache(x, bc_representative, _effective_autocache(autocache, eltype(x)))
@@ -333,7 +333,7 @@ function cubic_interp(
         # Uniform BC: structural form keys the cache; the grid-aware normalize
         # puts zero-BC payloads in their true derivative spaces (H9).
         bc_for_cache = _normalize_bc(bc)
-        bc_for_solve = _normalize_bc(bc, first(x), first(y_mat))
+        bc_for_solve = _normalize_bc(bc, x, y_mat)
         cache = _get_cubic_cache(x, bc_for_cache, _effective_autocache(autocache, eltype(x)))
         _solve_series_coefficients!(z_mat, y_mat, cache, bc_for_solve)
         bc_representative = bc_for_cache

--- a/src/cubic/cubic_series_interp.jl
+++ b/src/cubic/cubic_series_interp.jl
@@ -382,7 +382,7 @@ function _cubic_series_units(
         _normalize_bc_array(bc, eltype(y_mat), n_ser)[1]
     # NOTE: `thomas` is the STRIPPED twin's factorization paired with a unit axis
     # — unused by eval, but do not feed this cache back into a unit-data rebuild.
-    cache = CubicSplineCache(xc, bc_u, tw.cache.thomas, Vector{eltype(xc)}())
+    cache = CubicSplineCache(xc, bc_u, tw.cache.thomas, nothing)
     extrap_p = _promote_extrap(extrap, eltype(y_mat))
     sitp = CubicSeriesInterpolant(cache, bc_u, y_mat, z_mat, extrap_p, search)
 

--- a/src/cubic/cubic_solver.jl
+++ b/src/cubic/cubic_solver.jl
@@ -117,15 +117,6 @@ The seam-cell positivity check that previously lived here is now enforced
 by the `_ExclusivePeriodicAxis` constructor.
 """
 function _build_periodic_cache(x::AbstractVector{T}, bc::PeriodicBC) where {T}
-    # Unit-carrying grids: the S-M build still seeds dimensionless `q` into
-    # grid-space storage (native support is a follow-up) — reject with the
-    # public message contract, never a hostile-write DimensionError.
-    T <: Real || throw(
-        ArgumentError(
-            "cubic PeriodicBC on a unit-carrying grid is not supported yet — " *
-                "strip units (e.g. `ustrip`) or use a Real grid"
-        )
-    )
     cache_x = _cache_axis(_convert_copy(x, T), bc)
     n = length(cache_x) - 1   # n_cells (uniform across :inclusive / :exclusive)
 
@@ -165,12 +156,18 @@ function _build_periodic_cache(x::AbstractVector{T}, bc::PeriodicBC) where {T}
 
     thomas = thomas_factorize(dl, d_diag, du)
 
-    # Pre-compute q = A'⁻¹ · u (u = [1, 0, …, 0, 1]ᵀ).
-    q = Vector{T}(undef, n)
-    fill!(q, zero(T))
-    q[1] = one(T)
-    q[n] = one(T)
-    _ldiv_tridiagonal_nopiv!(q, q, thomas)
+    # Pre-compute q = A'⁻¹ · u (u = [1, 0, …, 0, 1]ᵀ). u is DIMENSIONLESS
+    # structure (the L-multiplier space); q lives in [1/X] (the inv_d space).
+    # Real grids collapse the two — u shares q's storage, reproducing the
+    # historic single-buffer in-place solve (`_thomas_storage` selector).
+    Tq = _promote_eltype(_inv_op, T)
+    Tu = _promote_eltype(_thomas_l_op, T, T)
+    q = Vector{Tq}(undef, n)
+    u = _thomas_storage(q, Tu)
+    fill!(u, zero(Tu))
+    u[1] = one(Tu)
+    u[n] = one(Tu)
+    _ldiv_tridiagonal_nopiv!(q, u, thomas)
 
     # Persist resolved-period bc on the cache so display / cache-pool comparison
     # / `_with_resolved_period(itp.bc, cache.bc.period)` work without a separate
@@ -378,7 +375,8 @@ Interior rows (2 .. n-1) reference only real (non-seam) cells.
 
     # Seam-touching endpoint rows go through the wrapper for cyclic indexing
     # (`y[n+1]` = y[1]) and seam-cell width (`_get_inv_h(x, n)`).
-    Tc = eltype(d)
+    # Diffs lift into VALUE space; the [Y/X] dimension enters via `inv_h`.
+    Tc = _value_space_eltype(Tg, eltype(y))
     @inbounds d[1] = 6 * _fielddiff(Tc, y[2], y[1]) * _get_inv_h(x, 1) - 6 * _fielddiff(Tc, y[1], y[n]) * _get_inv_h(x, n)
     @inbounds d[n] = 6 * _fielddiff(Tc, y[n + 1], y[n]) * _get_inv_h(x, n) - 6 * _fielddiff(Tc, y[n], y[n - 1]) * _get_inv_h(x, n - 1)
 
@@ -419,18 +417,23 @@ eval can read `z[n+1]` at the closed-cycle endpoint.
     q = cache.q
     n = length(q)   # n_cells
 
+    # y_temp is the [Y/X] RHS; the solve writes A'⁻¹d into z_workspace[1..n]
+    # ([Y/X²]) so no buffer crosses unit spaces (y_temp is consumed as the
+    # forward-sweep scratch — ldiv alias contract). Real grids: identical ops,
+    # different destination name only.
     compute_rhs_periodic!(y_temp, y, cache.x)
-    _ldiv_tridiagonal_nopiv!(y_temp, y_temp, cache.thomas)
+    _ldiv_tridiagonal_nopiv!(z_workspace, y_temp, cache.thomas)
 
     α = _get_h(cache.x, n)   # seam-cell width (last real cell or virtual seam)
 
-    vTy = α * (y_temp[1] + y_temp[n])
-    vTq = α * (q[1] + q[n])
+    vTy = α * (z_workspace[1] + z_workspace[n])   # [X]·[Y/X²] = [Y/X]
+    vTq = α * (q[1] + q[n])                        # dimensionless
 
     denom = one(Tg) + vTq
     # Defensive check: unreachable under valid inputs (denom ≥ √3 for SPD systems),
     # but guards against corrupted data (NaN/Inf from invalid grid spacing).
-    tol = sqrt(eps(Tg))
+    # denom is dimensionless — the tol must be too (unit eps would not compare).
+    tol = sqrt(eps(_dimensionless_type(Tg)))
     if !isfinite(denom) || abs(denom) < tol
         throw(
             DomainError(
@@ -441,10 +444,10 @@ eval can read `z[n+1]` at the closed-cycle endpoint.
             )
         )
     end
-    factor = vTy * inv(denom)
+    factor = vTy * inv(denom)   # [Y/X]
 
     @inbounds for i in 1:n
-        z_workspace[i] = y_temp[i] - factor * q[i]
+        z_workspace[i] = z_workspace[i] - factor * q[i]   # [Y/X²] − [Y/X]·[1/X]
     end
 
     # Mirror seam: every PeriodicBC variant (:inclusive / :exclusive / :extended)
@@ -522,7 +525,9 @@ end
         ::PeriodicBC   # API consistency with BCPair version (cache.bc is the source of truth)
     ) where {Tz, Tg, X, F}
     n = length(cache.q)   # n_cells
-    y_temp = acquire!(pool, Tz, n)
+    # RHS scratch in [Y/X] (`_coeff_op`); Real grids: Td == Tz, same acquire.
+    Td = _promote_eltype(_coeff_op, eltype(cache.x), eltype(y))
+    y_temp = acquire!(pool, Td, n)
     _solve_cubic_system_periodic!(out_z, y_temp, cache, y)
     return out_z
 end

--- a/src/cubic/cubic_solver.jl
+++ b/src/cubic/cubic_solver.jl
@@ -235,7 +235,7 @@ function _build_derivative_bc_cache(
 
     bc_pair = BCPair(left_bc, right_bc)
 
-    # Empty `q` for non-periodic (Sherman-Morrison vector unused).
+    # q = nothing: the Sherman-Morrison vector exists only for periodic caches.
     return CubicSplineCache(cache_x, bc_pair, thomas, nothing)
 end
 
@@ -252,7 +252,7 @@ end
 
 # First element - Deriv2: oneunit(Tg)·z[1] = d[1] with payload val ∈ [Y/X²] —
 # the grid-space row scale enters the RHS as `* oneunit(Tg)` ([Y/X], matching
-# the interior rows). Payloads are never pre-converted (H9): Real ×1.0 is exact.
+# the interior rows). Payloads are never pre-converted: Real ×1.0 is exact.
 @inline function _compute_rhs_first!(
         d::AbstractVector, bc::Deriv2, ::AbstractVector, ::AbstractVector{Tg}
     ) where {Tg}

--- a/src/cubic/cubic_solver.jl
+++ b/src/cubic/cubic_solver.jl
@@ -151,14 +151,14 @@ function _build_periodic_cache(x::AbstractVector{T}, bc::PeriodicBC) where {T}
         du[n - 1] = h_nm1
     end
 
-    thomas = thomas_factorize!(dl, d_diag, du)
+    thomas = thomas_factorize(dl, d_diag, du)
 
     # Pre-compute q = A'⁻¹ · u (u = [1, 0, …, 0, 1]ᵀ).
     q = Vector{T}(undef, n)
     fill!(q, zero(T))
     q[1] = one(T)
     q[n] = one(T)
-    _ldiv_tridiagonal_nopiv!(q, thomas)
+    _ldiv_tridiagonal_nopiv!(q, q, thomas)
 
     # Persist resolved-period bc on the cache so display / cache-pool comparison
     # / `_with_resolved_period(itp.bc, cache.bc.period)` work without a separate
@@ -222,12 +222,12 @@ function _build_derivative_bc_cache(
     end
 
     # ONE-PASS Thomas factorization: d_diag becomes inv_d
-    thomas = thomas_factorize!(dl, d_diag, du)
+    thomas = thomas_factorize(dl, d_diag, du)
 
     bc_pair = BCPair(left_bc, right_bc)
 
     # Empty `q` for non-periodic (Sherman-Morrison vector unused).
-    return CubicSplineCache(cache_x, bc_pair, thomas, Vector{T}())
+    return CubicSplineCache(cache_x, bc_pair, thomas, nothing)
 end
 
 # ========================================
@@ -397,7 +397,7 @@ eval can read `z[n+1]` at the closed-cycle endpoint.
     n = length(q)   # n_cells
 
     compute_rhs_periodic!(y_temp, y, cache.x)
-    _ldiv_tridiagonal_nopiv!(y_temp, cache.thomas)
+    _ldiv_tridiagonal_nopiv!(y_temp, y_temp, cache.thomas)
 
     α = _get_h(cache.x, n)   # seam-cell width (last real cell or virtual seam)
 
@@ -457,7 +457,7 @@ compatibility (callers pass `cache.bc` explicitly or a fresh BC for one-shot).
         bc_pair::BCPair{L, R}
     ) where {Tg, X, F, L <: PointBC, R <: PointBC}
     compute_rhs!(out_z, y, cache.x, bc_pair)
-    _ldiv_tridiagonal_nopiv!(out_z, cache.thomas)
+    _ldiv_tridiagonal_nopiv!(out_z, out_z, cache.thomas)
     return out_z
 end
 

--- a/src/cubic/cubic_solver.jl
+++ b/src/cubic/cubic_solver.jl
@@ -17,10 +17,13 @@
 # grid is the single source of truth for cell widths.
 
 # First row - Deriv2 (second derivative specified): z[1] = bc.val
+# Row entries live in GRID space ([X], matching the h-based interior rows), so
+# the identity row is `oneunit` (grid-space 1), never `one` (dimensionless).
+# Real grids: oneunit ≡ 1.0 — bit-identical.
 @inline function _set_first_row!(
         d_diag::AbstractVector{Tg}, du::AbstractVector{Tg}, ::Deriv2, ::AbstractVector{Tg}
     ) where {Tg}
-    d_diag[1] = one(Tg)
+    d_diag[1] = oneunit(Tg)
     du[1] = zero(Tg)
     return nothing
 end
@@ -40,7 +43,7 @@ end
         dl::AbstractVector{Tg}, d_diag::AbstractVector{Tg}, ::Deriv2, ::AbstractVector{Tg}
     ) where {Tg}
     dl[end] = zero(Tg)
-    d_diag[end] = one(Tg)
+    d_diag[end] = oneunit(Tg)
     return nothing
 end
 
@@ -57,22 +60,22 @@ end
 end
 
 # First row - Deriv3 (third derivative specified): (z[2] - z[1]) / h[1] = bc.val
-# Rearranged: -z[1] + z[2] = h[1] * val
+# Rearranged and grid-space scaled: -X·z[1] + X·z[2] = X·h[1]·val (X = oneunit)
 @inline function _set_first_row!(
         d_diag::AbstractVector{Tg}, du::AbstractVector{Tg}, ::Deriv3, ::AbstractVector{Tg}
     ) where {Tg}
-    d_diag[1] = -one(Tg)
-    du[1] = one(Tg)
+    d_diag[1] = -oneunit(Tg)
+    du[1] = oneunit(Tg)
     return nothing
 end
 
 # Last row - Deriv3 (third derivative specified): (z[n+1] - z[n]) / h[n] = bc.val
-# Rearranged: -z[n] + z[n+1] = h[n] * val
+# Rearranged and grid-space scaled: -X·z[n] + X·z[n+1] = X·h[n]·val
 @inline function _set_last_row!(
         dl::AbstractVector{Tg}, d_diag::AbstractVector{Tg}, ::Deriv3, ::AbstractVector{Tg}
     ) where {Tg}
-    dl[end] = -one(Tg)
-    d_diag[end] = one(Tg)
+    dl[end] = -oneunit(Tg)
+    d_diag[end] = oneunit(Tg)
     return nothing
 end
 
@@ -114,6 +117,15 @@ The seam-cell positivity check that previously lived here is now enforced
 by the `_ExclusivePeriodicAxis` constructor.
 """
 function _build_periodic_cache(x::AbstractVector{T}, bc::PeriodicBC) where {T}
+    # Unit-carrying grids: the S-M build still seeds dimensionless `q` into
+    # grid-space storage (native support is a follow-up) — reject with the
+    # public message contract, never a hostile-write DimensionError.
+    T <: Real || throw(
+        ArgumentError(
+            "cubic PeriodicBC on a unit-carrying grid is not supported yet — " *
+                "strip units (e.g. `ustrip`) or use a Real grid"
+        )
+    )
     cache_x = _cache_axis(_convert_copy(x, T), bc)
     n = length(cache_x) - 1   # n_cells (uniform across :inclusive / :exclusive)
 
@@ -241,27 +253,33 @@ end
 # spacing directly. PolyFit{D} BCs use `x` + `y` for endpoint derivative
 # estimation; other BC types ignore `x`.
 
-# First element - Deriv2: d[1] = bc.val (second derivative value)
+# First element - Deriv2: oneunit(Tg)·z[1] = d[1] with payload val ∈ [Y/X²] —
+# the grid-space row scale enters the RHS as `* oneunit(Tg)` ([Y/X], matching
+# the interior rows). Payloads are never pre-converted (H9): Real ×1.0 is exact.
 @inline function _compute_rhs_first!(
         d::AbstractVector, bc::Deriv2, ::AbstractVector, ::AbstractVector{Tg}
     ) where {Tg}
-    d[1] = convert(eltype(d), bc.val)
+    d[1] = bc.val * oneunit(Tg)
     return nothing
 end
 
 # First element - Deriv1: d[1] = 6[(y₂-y₁)/h₁ - S'(x₁)]
+# The diff lifts into VALUE space (`_value_space_eltype`, wrap-safe for narrow
+# eltypes); the 1/X dimension enters via `inv_h`. `bc.val` ∈ [Y/X] = RHS space,
+# so the same-space convert is legal for units.
 @inline function _compute_rhs_first!(
         d::AbstractVector, bc::Deriv1, y::AbstractVector, x::AbstractVector{Tg}
     ) where {Tg}
-    d[1] = 6 * (_fielddiff(eltype(d), y[2], y[1]) * _get_inv_h(x, 1) - convert(eltype(d), bc.val))
+    Tc = _value_space_eltype(Tg, eltype(y))
+    d[1] = 6 * (_fielddiff(Tc, y[2], y[1]) * _get_inv_h(x, 1) - convert(eltype(d), bc.val))
     return nothing
 end
 
-# Last element - Deriv2: d[end] = bc.val (second derivative value)
+# Last element - Deriv2: same grid-space scaling as the first row
 @inline function _compute_rhs_last!(
         d::AbstractVector, bc::Deriv2, ::AbstractVector, ::AbstractVector{Tg}
     ) where {Tg}
-    d[end] = convert(eltype(d), bc.val)
+    d[end] = bc.val * oneunit(Tg)
     return nothing
 end
 
@@ -270,24 +288,26 @@ end
         d::AbstractVector, bc::Deriv1, y::AbstractVector, x::AbstractVector{Tg}
     ) where {Tg}
     n = length(y) - 1
-    d[end] = 6 * (convert(eltype(d), bc.val) - _fielddiff(eltype(d), y[end], y[end - 1]) * _get_inv_h(x, n))
+    Tc = _value_space_eltype(Tg, eltype(y))
+    d[end] = 6 * (convert(eltype(d), bc.val) - _fielddiff(Tc, y[end], y[end - 1]) * _get_inv_h(x, n))
     return nothing
 end
 
-# First element - Deriv3: d[1] = h[1] * bc.val (from -z[1] + z[2] = h[1] * val)
+# First element - Deriv3: d[1] = h[1]·val·oneunit(Tg) — the grid-space row
+# scale (see `_set_first_row!` Deriv3) lands the [Y/X³] payload in [Y/X].
 @inline function _compute_rhs_first!(
         d::AbstractVector, bc::Deriv3, ::AbstractVector, x::AbstractVector{Tg}
     ) where {Tg}
-    d[1] = _get_h(x, 1) * convert(eltype(d), bc.val)
+    d[1] = _get_h(x, 1) * bc.val * oneunit(Tg)
     return nothing
 end
 
-# Last element - Deriv3: d[end] = h[n] * bc.val (from -z[n] + z[n+1] = h[n] * val)
+# Last element - Deriv3: d[end] = h[n]·val·oneunit(Tg)
 @inline function _compute_rhs_last!(
         d::AbstractVector, bc::Deriv3, ::AbstractVector, x::AbstractVector{Tg}
     ) where {Tg}
     n = length(d) - 1
-    d[end] = _get_h(x, n) * convert(eltype(d), bc.val)
+    d[end] = _get_h(x, n) * bc.val * oneunit(Tg)
     return nothing
 end
 
@@ -322,7 +342,10 @@ derivative estimation.
     ) where {Tg, L <: PointBC, R <: PointBC}
     n = length(y) - 1
     _compute_rhs_first!(d, bc_pair.left, y, x)
-    Tc = eltype(d)   # coefficient field — loop-invariant, matches compute_rhs_periodic!
+    # Diffs lift into VALUE space (loop-invariant): the coefficient dimension
+    # [Y/X] enters via `inv_h`, never by converting y into it. Real grids:
+    # value space == eltype(d) — the historic fast path, bit-identical.
+    Tc = _value_space_eltype(Tg, eltype(y))
     @inbounds for i in 2:n
         d[i] = 6 * (_fielddiff(Tc, y[i + 1], y[i]) * _get_inv_h(x, i) - _fielddiff(Tc, y[i], y[i - 1]) * _get_inv_h(x, i - 1))
     end
@@ -456,8 +479,39 @@ compatibility (callers pass `cache.bc` explicitly or a fresh BC for one-shot).
         y::AbstractVector,
         bc_pair::BCPair{L, R}
     ) where {Tg, X, F, L <: PointBC, R <: PointBC}
+    # RHS lives in [Y/X] (`_coeff_op`); the solve maps it to [Y/X²] (`out_z`).
+    Td = _promote_eltype(_coeff_op, eltype(cache.x), eltype(y))
+    return _solve_bcpair_rhs!(out_z, cache, y, bc_pair, Td)
+end
+
+# RHS space == out_z space (Real/Dual/…): the RHS shares the output buffer —
+# bit- and alloc-identical to the historic in-place solve. Storage selection by
+# dispatch (`_thomas_storage` idiom), folds at specialization time.
+@inline function _solve_bcpair_rhs!(
+        out_z::AbstractVector{Td},
+        cache::CubicSplineCache,
+        y::AbstractVector,
+        bc_pair::BCPair,
+        ::Type{Td}
+    ) where {Td}
     compute_rhs!(out_z, y, cache.x, bc_pair)
     _ldiv_tridiagonal_nopiv!(out_z, out_z, cache.thomas)
+    return out_z
+end
+
+# Distinct RHS space (unit grids): pooled [Y/X] scratch; the backward sweep
+# writes the [Y/X²] solution into `out_z` (b consumed as scratch — see
+# `_ldiv_tridiagonal_nopiv!` alias contract).
+@inline @with_pool pool function _solve_bcpair_rhs!(
+        out_z::AbstractVector,
+        cache::CubicSplineCache,
+        y::AbstractVector,
+        bc_pair::BCPair,
+        ::Type{Td}
+    ) where {Td}
+    d = acquire!(pool, Td, length(out_z))
+    compute_rhs!(d, y, cache.x, bc_pair)
+    _ldiv_tridiagonal_nopiv!(out_z, d, cache.thomas)
     return out_z
 end
 

--- a/src/cubic/cubic_types.jl
+++ b/src/cubic/cubic_types.jl
@@ -22,7 +22,8 @@ no separate `period` field.
 # Type Parameters
 - `Tg`: Grid element type (Float32, Float64, or duck e.g. `ForwardDiff.Dual`).
 - `X`: Wrapped axis type (`_CachedRange`/`_CachedVector`/`_ExclusivePeriodicAxis`).
-- `F`: Thomas factorization type (`ThomasFactorization{Tg, Vector{Tg}}`).
+- `F`: Thomas factorization type (`ThomasFactorization{Vl, Vu, Vd}` — per-field
+  storage; all three are `Vector{Tg}` for Real grids).
 - `BC`: User's boundary condition (`BCPair{L,R}`, `PeriodicBC{E,P,C}`, etc.).
   Carries the resolved period for `:exclusive` periodic so display / cache pool
   comparison works without a separate field.
@@ -46,11 +47,11 @@ no separate `period` field.
 - `bc=ZeroCurvBC()`: Zero-curvature spline with z[1] = z[n+1] = 0
 - `bc=PeriodicBC()`: Periodic spline with C2 continuity at boundaries
 """
-struct CubicSplineCache{Tg, X <: AbstractVector{Tg}, F, BC <: AbstractBC}
+struct CubicSplineCache{Tg, X <: AbstractVector{Tg}, F, BC <: AbstractBC, Q}
     x::X
     bc::BC
     thomas::F
-    q::Vector{Tg}   # Sherman-Morrison q (length n_cells for periodic; empty otherwise)
+    q::Q   # Sherman-Morrison q (periodic: Vector, length n_cells; `nothing` otherwise)
 end
 
 # AbstractExtrap types are defined in eval_ops.jl (shared across all interpolants)

--- a/src/cubic/nd/cubic_nd_adjoint.jl
+++ b/src/cubic/nd/cubic_nd_adjoint.jl
@@ -194,7 +194,7 @@ matching the forward `compute_rhs!` pattern (O(D) per axis, negligible).
             _moments_to_deriv_adjoint_1d!(z_bar, f_contrib, dy_bar_slice, x_axis)
 
             # Step b: transpose Thomas solve (A⁻ᵀ z_bar)
-            _ldiv_tridiagonal_transpose!(z_bar, cache_d.thomas)
+            _ldiv_tridiagonal_transpose!(z_bar, z_bar, cache_d.thomas)
 
             # Step c: RHS stencil adjoint (f_contrib += Rᵀ z_bar)
             _compute_rhs_adjoint!(f_contrib, z_bar, x_axis, bc_pair, pf)
@@ -333,7 +333,7 @@ barriers — no `spacings` parameter needed.
             fill!(q_t, zero(Tg))
             @inbounds q_t[1] = one(Tg)
             @inbounds q_t[n_intervals] = one(Tg)
-            _ldiv_tridiagonal_transpose!(q_t, caches[d].thomas)
+            _ldiv_tridiagonal_transpose!(q_t, q_t, caches[d].thomas)
         end
 
         for p_src in 1:bit_d

--- a/src/cubic/nd/cubic_nd_math.jl
+++ b/src/cubic/nd/cubic_nd_math.jl
@@ -387,9 +387,9 @@ This enables @simd vectorization over the contiguous dimension.
 - `thomas::ThomasFactorization{Tg}`: Thomas factorization with dl, du, inv_d
 """
 @inline function _ldiv_along_dim_vectorized!(
-        z::AbstractMatrix{Tv},
-        thomas::ThomasFactorization{Tg, V}
-    ) where {Tv, Tg, V <: AbstractVector{Tg}}
+        z::AbstractMatrix,
+        thomas::ThomasFactorization
+    )
     dl = thomas.dl
     du = thomas.du
     inv_d = thomas.inv_d

--- a/src/gridded/gridded_constant.jl
+++ b/src/gridded/gridded_constant.jl
@@ -74,11 +74,10 @@ end
     carrier = Expr(:call, :*, ones_...)
     value = :(data[$(sels...)] * $carrier)
     if !(ops <: NTuple{N, EvalValue})
-        deriv_oneunit = Expr(
-            :call, :*,
-            [:(_deriv_oneunit(oneunit(eltype(grids[$d])), ops[$d])) for d in 1:N]...
-        )
-        value = :($value * 0 * $deriv_oneunit)
+        # Canonical fold (`_nd_deriv_scale`); the sample tuple is spelled out
+        # literally — a closure/comprehension in GENERATED code is impure.
+        samples = Expr(:tuple, [:(oneunit(eltype(grids[$d]))) for d in 1:N]...)
+        value = :($value * 0 * _nd_deriv_scale($samples, ops))
     end
     body = :(out[$(js...)] = $value)
     for d in 1:N   # d = 1 built first → innermost loop (stride-1 writes)

--- a/src/hetero/hetero_adjoint.jl
+++ b/src/hetero/hetero_adjoint.jl
@@ -323,7 +323,7 @@ end
             fill!(q_t, zero(Tg))
             @inbounds q_t[1] = one(Tg)
             @inbounds q_t[n_intervals] = one(Tg)
-            _ldiv_tridiagonal_transpose!(q_t, adj.caches[d].thomas)
+            _ldiv_tridiagonal_transpose!(q_t, q_t, adj.caches[d].thomas)
         end
 
         for p_src_offset in 0:(stride_d - 1)

--- a/src/quadratic/quadratic_interpolant.jl
+++ b/src/quadratic/quadratic_interpolant.jl
@@ -130,9 +130,6 @@ end
     ) where {TX <: Number, TY}
     _check_grid_orderable(TX)
     Tg = _promote_grid_float(TX, TY)
-    # Non-Real (unit-carrying) grids: strip→solve→reattach (type-level branch folds).
-    Tg <: Real ||
-        return _quadratic_interp_units(x, y, bc, extrap, search, store)
     Tv = _value_type(TY, Tg)
     # Caching wrap (zero-copy of buffer): Range → `_CachedRange{Tg}`,
     # Vector → `_CachedVector{Tg, Tinv}` aliasing user buffer. Mirrors
@@ -154,47 +151,3 @@ end
     extrap_p = _resolve_extrap(extrap, x_eff, Tv)
     return QuadraticInterpolant(x_eff, y, a, d, extrap_p, search, bc_p; store = store)
 end
-
-# ── Non-Real (unit-carrying) grids: nondimensionalized solve ──
-# Strip→solve→reattach twin: the solver stores mixed-order coefficients through
-# shared buffers, so solve on a oneunit-stripped twin (exact division) and
-# reattach per-order units — `a` is order 2 (`Y/X²`), `d` order 1 (`Y/X`).
-# The original unit axis serves eval/search.
-function _quadratic_interp_units(x, y, bc, extrap, search, store)
-    ux = oneunit(eltype(x))
-    uy = _carrier_oneunit(eltype(y))
-    xs = x ./ ux
-    ys = y ./ uy
-    bc_s = _strip_bc_units(bc, uy, ux)
-    tw = quadratic_interp(xs, ys; bc = bc_s, extrap = NoExtrap(), search = search)
-    a = tw.a .* (uy / (ux * ux))
-    d = tw.d .* (uy / ux)
-    Tgu = eltype(x)
-    x_eff = _policy_axis(x, NoBC(), Tgu, store)
-    bc_u = _normalize_bc(bc, first(y))
-    extrap_p = _resolve_extrap(extrap, x_eff, eltype(y))
-    return QuadraticInterpolant(x_eff, y, a, d, extrap_p, search, bc_u; store = store)
-end
-
-# BC payloads carry derivative units (`Y/X`, `Y/X²`, `Y/X³`) — strip to match
-# the nondimensionalized twin; structural BCs pass through. Shared by the
-# quadratic and cubic-Series strip twins (deleted with them).
-@inline _strip_bc_units(bc::Union{PolyFit, ZeroCurvBC, ZeroSlopeBC}, uy, ux) = bc
-@inline _strip_bc_units(bc::Deriv1, uy, ux) = Deriv1(bc.val / (uy / ux))
-@inline _strip_bc_units(bc::Deriv2, uy, ux) = Deriv2(bc.val / (uy / (ux * ux)))
-@inline _strip_bc_units(bc::Deriv3, uy, ux) = Deriv3(bc.val / (uy / (ux * ux * ux)))
-@inline _strip_bc_units(bc::BCPair, uy, ux) =
-    BCPair(_strip_bc_units(bc.left, uy, ux), _strip_bc_units(bc.right, uy, ux))
-# Quadratic side-selector BCs wrap PointBC payloads — recurse into them.
-@inline _strip_bc_units(bc::Left, uy, ux) = Left(_strip_bc_units(bc.bc, uy, ux))
-@inline _strip_bc_units(bc::Right, uy, ux) = Right(_strip_bc_units(bc.bc, uy, ux))
-# MinCurvFit is a payload-free marker (like QuadraticFit/PolyFit) — strip is identity.
-@inline _strip_bc_units(bc::MinCurvFit, uy, ux) = bc
-# Catch-all: an unhandled BC type must fail HERE with an actionable message,
-# not as a MethodError deep inside the stripped solve.
-@noinline _strip_bc_units(bc::AbstractBC, uy, ux) = throw(
-    ArgumentError(
-        "BC type $(typeof(bc)) is not supported on a unit-carrying grid yet — " *
-            "strip units (e.g. `ustrip`) or use a Real grid"
-    )
-)

--- a/src/quadratic/quadratic_interpolant.jl
+++ b/src/quadratic/quadratic_interpolant.jl
@@ -156,10 +156,10 @@ end
 end
 
 # ── Non-Real (unit-carrying) grids: nondimensionalized solve ──
-# Same strategy as cubic (`_cubic_interp_units`): the solver stores mixed-order
-# coefficients through shared buffers, so solve on a oneunit-stripped twin
-# (exact division) and reattach per-order units — `a` is order 2 (`Y/X²`),
-# `d` order 1 (`Y/X`). The original unit axis serves eval/search.
+# Strip→solve→reattach twin: the solver stores mixed-order coefficients through
+# shared buffers, so solve on a oneunit-stripped twin (exact division) and
+# reattach per-order units — `a` is order 2 (`Y/X²`), `d` order 1 (`Y/X`).
+# The original unit axis serves eval/search.
 function _quadratic_interp_units(x, y, bc, extrap, search, store)
     ux = oneunit(eltype(x))
     uy = _carrier_oneunit(eltype(y))
@@ -176,8 +176,25 @@ function _quadratic_interp_units(x, y, bc, extrap, search, store)
     return QuadraticInterpolant(x_eff, y, a, d, extrap_p, search, bc_u; store = store)
 end
 
+# BC payloads carry derivative units (`Y/X`, `Y/X²`, `Y/X³`) — strip to match
+# the nondimensionalized twin; structural BCs pass through. Shared by the
+# quadratic and cubic-Series strip twins (deleted with them).
+@inline _strip_bc_units(bc::Union{PolyFit, ZeroCurvBC, ZeroSlopeBC}, uy, ux) = bc
+@inline _strip_bc_units(bc::Deriv1, uy, ux) = Deriv1(bc.val / (uy / ux))
+@inline _strip_bc_units(bc::Deriv2, uy, ux) = Deriv2(bc.val / (uy / (ux * ux)))
+@inline _strip_bc_units(bc::Deriv3, uy, ux) = Deriv3(bc.val / (uy / (ux * ux * ux)))
+@inline _strip_bc_units(bc::BCPair, uy, ux) =
+    BCPair(_strip_bc_units(bc.left, uy, ux), _strip_bc_units(bc.right, uy, ux))
 # Quadratic side-selector BCs wrap PointBC payloads — recurse into them.
 @inline _strip_bc_units(bc::Left, uy, ux) = Left(_strip_bc_units(bc.bc, uy, ux))
 @inline _strip_bc_units(bc::Right, uy, ux) = Right(_strip_bc_units(bc.bc, uy, ux))
 # MinCurvFit is a payload-free marker (like QuadraticFit/PolyFit) — strip is identity.
 @inline _strip_bc_units(bc::MinCurvFit, uy, ux) = bc
+# Catch-all: an unhandled BC type must fail HERE with an actionable message,
+# not as a MethodError deep inside the stripped solve.
+@noinline _strip_bc_units(bc::AbstractBC, uy, ux) = throw(
+    ArgumentError(
+        "BC type $(typeof(bc)) is not supported on a unit-carrying grid yet — " *
+            "strip units (e.g. `ustrip`) or use a Real grid"
+    )
+)

--- a/src/quadratic/quadratic_oneshot.jl
+++ b/src/quadratic/quadratic_oneshot.jl
@@ -178,7 +178,7 @@ vals = quadratic_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_w
     nx = length(x)
     Tcoeff = _promote_eltype(_coeff_op, eltype(x), eltype(y))
     d = acquire!(pool, Tcoeff, nx)
-    a = acquire!(pool, _promote_eltype(_deriv1_op, eltype(x), Tcoeff), nx - 1)   # order-2: [Y/X²]
+    a = acquire!(pool, _promote_eltype(_coeff_op2, eltype(x), eltype(y)), nx - 1)
     bc_promoted = _normalize_bc(bc, first(y))
     _compute_quadratic_coeffs!(d, a, x, y, bc_promoted)
 
@@ -237,7 +237,7 @@ quadratic_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear
     nx = length(x)
     Tcoeff = _promote_eltype(_coeff_op, eltype(x), eltype(y))
     d = acquire!(pool, Tcoeff, nx)
-    a = acquire!(pool, _promote_eltype(_deriv1_op, eltype(x), Tcoeff), nx - 1)   # order-2: [Y/X²]
+    a = acquire!(pool, _promote_eltype(_coeff_op2, eltype(x), eltype(y)), nx - 1)
     bc_promoted = _normalize_bc(bc, first(y))
     _compute_quadratic_coeffs!(d, a, x, y, bc_promoted)
 

--- a/src/quadratic/quadratic_oneshot.jl
+++ b/src/quadratic/quadratic_oneshot.jl
@@ -170,12 +170,6 @@ vals = quadratic_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_w
     @boundscheck length(y) == length(x) || throw(ArgumentError("x and y must have same length"))
     @boundscheck length(x) >= 2 || throw(ArgumentError("x must have at least 2 elements"))
 
-    # Unit-carrying grids route through the persistent strip→solve→reattach
-    # build — the pooled coefficient solve below runs in unit space and throws.
-    Tg <: Real || return quadratic_interp(
-        x, y; bc = bc, extrap = extrap, search = search
-    )(xq; deriv = deriv, hint = hint)
-
     # Value-matched pooled wrap: Int/OneTo grid + Float32 data → Float32 axis
     # (vector conversion lands in a pool buffer — warm one-shots stay zero-alloc).
     x = _cache_axis_pooled(pool, x, _promote_grid_float(Tg, Tv))
@@ -184,7 +178,7 @@ vals = quadratic_interp(x, y, sorted_queries; search=LinearBinarySearch(linear_w
     nx = length(x)
     Tcoeff = _promote_eltype(_coeff_op, eltype(x), eltype(y))
     d = acquire!(pool, Tcoeff, nx)
-    a = acquire!(pool, Tcoeff, nx - 1)
+    a = acquire!(pool, _promote_eltype(_deriv1_op, eltype(x), Tcoeff), nx - 1)   # order-2: [Y/X²]
     bc_promoted = _normalize_bc(bc, first(y))
     _compute_quadratic_coeffs!(d, a, x, y, bc_promoted)
 
@@ -232,9 +226,6 @@ quadratic_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear
         search::AbstractSearchPolicy = AutoSearch(),
         hint::Union{Nothing, Base.RefValue{Int}} = nothing
     ) where {Tg <: Number, Tv, Tq <: Number}
-    Tg <: Real || return quadratic_interp(
-        x, y; bc = bc, extrap = extrap, search = search
-    )(output, x_targets; deriv = deriv, hint = hint)
     @assert length(y) == length(x) "x and y must have same length"
     _check_query_output_size(output, x_targets)
     @assert length(x) >= 2 "x must have at least 2 elements"
@@ -246,7 +237,7 @@ quadratic_interp!(output, x, y, sorted_queries; search=LinearBinarySearch(linear
     nx = length(x)
     Tcoeff = _promote_eltype(_coeff_op, eltype(x), eltype(y))
     d = acquire!(pool, Tcoeff, nx)
-    a = acquire!(pool, Tcoeff, nx - 1)
+    a = acquire!(pool, _promote_eltype(_deriv1_op, eltype(x), Tcoeff), nx - 1)   # order-2: [Y/X²]
     bc_promoted = _normalize_bc(bc, first(y))
     _compute_quadratic_coeffs!(d, a, x, y, bc_promoted)
 

--- a/src/quadratic/quadratic_oneshot_series.jl
+++ b/src/quadratic/quadratic_oneshot_series.jl
@@ -45,7 +45,7 @@
     )
     output = Vector{T_out}(undef, K)
     d = acquire!(pool, Tcoeff, nx)
-    a = acquire!(pool, _promote_eltype(_deriv1_op, eltype(x), Tcoeff), nx - 1)   # order-2: [Y/X²]
+    a = acquire!(pool, _promote_eltype(_coeff_op2, Tg_actual, _series_eltype(s)), nx - 1)
     y_buf = acquire!(pool, Tv_out, nx)
     @inbounds for k in 1:K
         copyto!(y_buf, 1, vecs[k], 1, nx)
@@ -86,7 +86,7 @@ end
     Tg_actual = eltype(x)
     Tcoeff = _promote_eltype(_coeff_op, Tg_actual, _series_eltype(s))
     d = acquire!(pool, Tcoeff, nx)
-    a = acquire!(pool, _promote_eltype(_deriv1_op, eltype(x), Tcoeff), nx - 1)   # order-2: [Y/X²]
+    a = acquire!(pool, _promote_eltype(_coeff_op2, Tg_actual, _series_eltype(s)), nx - 1)
     y_buf = acquire!(pool, Tv_out, nx)
     @inbounds for k in eachindex(output)
         copyto!(y_buf, 1, vecs[k], 1, nx)
@@ -135,7 +135,7 @@ end
     _fill_series_anchors_resolved!(QuadraticInterp(), anchors, x, xqs, extrap_eff, extrap_eff isa WrapExtrap, search, nothing)
 
     d = acquire!(pool, Tcoeff, nx)
-    a = acquire!(pool, _promote_eltype(_deriv1_op, eltype(x), Tcoeff), nx - 1)   # order-2: [Y/X²]
+    a = acquire!(pool, _promote_eltype(_coeff_op2, Tg_actual, _series_eltype(s)), nx - 1)
     y_buf = acquire!(pool, Tv_out, nx)
     @inbounds for k in 1:K
         copyto!(y_buf, 1, vecs[k], 1, nx)

--- a/src/quadratic/quadratic_oneshot_series.jl
+++ b/src/quadratic/quadratic_oneshot_series.jl
@@ -24,9 +24,6 @@
     ) where {Tg, Tq <: Number}
     _validate_series_lengths(s, length(x))
     Tg_p = _promote_grid_float(Tg, _series_eltype(s))
-    Tg_p <: Real || return quadratic_interp(
-        x, s; bc = bc, extrap = extrap, search = search
-    )(xq; deriv = deriv, search = search, hint = hint)
     # Pool-backed cache: K-series loop reuses h/inv_h across all K calls.
     x = _cache_axis_pooled(pool, x, Tg_p)
     _check_domain(x, xq, extrap)
@@ -48,7 +45,7 @@
     )
     output = Vector{T_out}(undef, K)
     d = acquire!(pool, Tcoeff, nx)
-    a = acquire!(pool, Tcoeff, nx - 1)
+    a = acquire!(pool, _promote_eltype(_deriv1_op, eltype(x), Tcoeff), nx - 1)   # order-2: [Y/X²]
     y_buf = acquire!(pool, Tv_out, nx)
     @inbounds for k in 1:K
         copyto!(y_buf, 1, vecs[k], 1, nx)
@@ -75,9 +72,6 @@ end
     _validate_series_lengths(s, length(x))
     length(output) == n_series(s) || _throw_series_dim_mismatch(length(output), n_series(s))
     Tg_p = _promote_grid_float(Tg, _series_eltype(s))
-    Tg_p <: Real || return quadratic_interp(
-        x, s; bc = bc, extrap = extrap, search = search
-    )(output, xq; deriv = deriv, search = search, hint = hint)
     # Pool-backed cache: K-series loop reuses h/inv_h.
     x = _cache_axis_pooled(pool, x, Tg_p)
     _check_domain(x, xq, extrap)
@@ -92,7 +86,7 @@ end
     Tg_actual = eltype(x)
     Tcoeff = _promote_eltype(_coeff_op, Tg_actual, _series_eltype(s))
     d = acquire!(pool, Tcoeff, nx)
-    a = acquire!(pool, Tcoeff, nx - 1)
+    a = acquire!(pool, _promote_eltype(_deriv1_op, eltype(x), Tcoeff), nx - 1)   # order-2: [Y/X²]
     y_buf = acquire!(pool, Tv_out, nx)
     @inbounds for k in eachindex(output)
         copyto!(y_buf, 1, vecs[k], 1, nx)
@@ -121,9 +115,6 @@ end
     ) where {Tg, Tq <: Number}
     _validate_series_lengths(s, length(x))
     Tg_p = _promote_grid_float(Tg, _series_eltype(s))
-    Tg_p <: Real || return quadratic_interp(
-        x, s; bc = bc, extrap = extrap, search = search
-    )(outputs, xqs; deriv = deriv, search = search)
     # Pool-backed cache: K-series × Q-query loop reuses h/inv_h.
     x = _cache_axis_pooled(pool, x, Tg_p)
     K = n_series(s)
@@ -144,7 +135,7 @@ end
     _fill_series_anchors_resolved!(QuadraticInterp(), anchors, x, xqs, extrap_eff, extrap_eff isa WrapExtrap, search, nothing)
 
     d = acquire!(pool, Tcoeff, nx)
-    a = acquire!(pool, Tcoeff, nx - 1)
+    a = acquire!(pool, _promote_eltype(_deriv1_op, eltype(x), Tcoeff), nx - 1)   # order-2: [Y/X²]
     y_buf = acquire!(pool, Tv_out, nx)
     @inbounds for k in 1:K
         copyto!(y_buf, 1, vecs[k], 1, nx)

--- a/src/quadratic/quadratic_series_interp.jl
+++ b/src/quadratic/quadratic_series_interp.jl
@@ -188,28 +188,17 @@ function quadratic_interp(
     Tv_out = _value_type(Tv, Tg_new)
     y_mat, n_ser = _build_series_mat(s, n_pts, Tv_out)
 
-    if !(Tg_new <: Real)
-        ux = oneunit(Tg_new)
-        uy = _carrier_oneunit(Tv_out)
-        tw = quadratic_interp(
-            x ./ ux, Series(y_mat ./ uy);
-            bc = _strip_bc_units(bc, uy, ux), extrap = NoExtrap(), search = search
-        )
-        a_mat = tw.a .* (uy / (ux * ux))
-        d_mat = tw.d .* (uy / ux)
-        extrap_p = _promote_extrap(extrap, eltype(y_mat))
-        return QuadraticSeriesInterpolant(x, y_mat, a_mat, d_mat, extrap_p, search)
-    end
-
-    # Allocate coefficient matrices (Dual when grid is Dual)
+    # Coefficient matrices: d order-1 (`_coeff_op`), a order-2 (`_coeff_op2`).
+    # Real grids collapse both witnesses; unit grids get per-order spaces.
     Tc = _promote_eltype(_coeff_op, eltype(x), Tv_out)
-    a_mat = Matrix{Tc}(undef, n_pts, n_ser)
+    Ta = _promote_eltype(_coeff_op2, eltype(x), Tv_out)
+    a_mat = Matrix{Ta}(undef, n_pts, n_ser)
     d_mat = Matrix{Tc}(undef, n_pts, n_ser)
 
-    # Promote BC values to Tv_out for convert(Tv, bc.val) compatibility.
     # The wrapped axis `x` carries `h`/`inv_h` directly via `_get_h(x, i)`.
     bc_promoted = _normalize_bc(bc, first(y_mat))
-    _typed_zero = 0 * y_mat[1]
+    # Trailing a-row filler — an [Y/X²]-space zero via value witness.
+    _typed_zero = 0 * _coeff_op2(oneunit(eltype(x)), y_mat[1])
 
     # Compute coefficients for each series from y_mat columns
     for k in 1:n_ser

--- a/src/quadratic/quadratic_solver.jl
+++ b/src/quadratic/quadratic_solver.jl
@@ -124,7 +124,7 @@ derivatives from data. For other BC types, they are ignored.
 end
 
 # Left(Deriv2): d[1] = s[1] - (κ/2)*h[1], forward recurrence
-# κ ∈ [Y/X²] ≠ slope space — never pre-convert (H9); κ·h lands in [Y/X].
+# κ ∈ [Y/X²] ≠ slope space — never pre-convert; κ·h lands in [Y/X].
 @inline function _fill_slopes!(
         d::AbstractVector{Tc}, s::AbstractVector{Tc}, axis::AbstractVector{Tg},
         bc::Left{<:Deriv2}, ::AbstractVector{Tg}, ::AbstractVector

--- a/src/quadratic/quadratic_solver.jl
+++ b/src/quadratic/quadratic_solver.jl
@@ -41,8 +41,11 @@ Compute secant slopes: s[i] = (y[i+1] - y[i]) * inv_h[i]
 """
 @inline function _compute_quadratic_secants!(s::AbstractVector{Tc}, y::AbstractVector, axis::AbstractVector{Tg}) where {Tc, Tg}
     n = length(y) - 1
+    # Diffs lift into VALUE space (wrap-free for narrow eltypes); the [Y/X]
+    # dimension enters via `inv_h`, never by converting y into it.
+    Tvs = _value_space_eltype(Tg, eltype(y))
     @inbounds for i in 1:n
-        s[i] = _fielddiff(Tc, y[i + 1], y[i]) * _get_inv_h(axis, i)  # promote y into secant field Tc
+        s[i] = _fielddiff(Tvs, y[i + 1], y[i]) * _get_inv_h(axis, i)
     end
     return s
 end
@@ -121,12 +124,12 @@ derivatives from data. For other BC types, they are ignored.
 end
 
 # Left(Deriv2): d[1] = s[1] - (κ/2)*h[1], forward recurrence
+# κ ∈ [Y/X²] ≠ slope space — never pre-convert (H9); κ·h lands in [Y/X].
 @inline function _fill_slopes!(
         d::AbstractVector{Tc}, s::AbstractVector{Tc}, axis::AbstractVector{Tg},
         bc::Left{<:Deriv2}, ::AbstractVector{Tg}, ::AbstractVector
     ) where {Tc, Tg}
-    κ = convert(Tc, bc.bc.val)
-    d1 = s[1] - κ * (_get_h(axis, 1) / 2)  # Tv - Tv*Tg → Tv (no /(Tv,Int) needed)
+    d1 = s[1] - bc.bc.val * (_get_h(axis, 1) / 2)
     return _forward_recurrence!(d, s, d1)
 end
 
@@ -145,9 +148,8 @@ end
         d::AbstractVector{Tc}, s::AbstractVector{Tc}, axis::AbstractVector{Tg},
         bc::Right{<:Deriv2}, ::AbstractVector{Tg}, ::AbstractVector
     ) where {Tc, Tg}
-    κ = convert(Tc, bc.bc.val)
     n_intervals = length(s)
-    dn = s[end] + κ * (_get_h(axis, n_intervals) / 2)  # Tv + Tv*Tg → Tv (no /(Tv,Int) needed)
+    dn = s[end] + bc.bc.val * (_get_h(axis, n_intervals) / 2)
     return _backward_recurrence!(d, s, dn)
 end
 
@@ -203,10 +205,12 @@ O(n) time, O(1) extra space (on-the-fly β computation).
     # Σ α[i]*(s[i] - β[i])/h[i] = d[1] * Σ 1/h[i]
     # d[1] = [Σ α[i]*(s[i] - β[i])/h[i]] / [Σ 1/h[i]]
 
-    inv_h_sum = zero(Tg)
-    numerator = 0 * first(s)
+    # Accumulator spaces: inv_h_sum ∈ [1/X], numerator ∈ [Y/X²] (s·inv_h),
+    # β ∈ [Y/X] — value-witness zeros (Real: all plain 0.0, bit-identical).
+    inv_h_sum = zero(_promote_eltype(_inv_op, Tg))
+    numerator = 0 * (first(s) * _get_inv_h(axis, 1))
     β = 0 * first(s)
-    sign = one(Tg)  # α[1] = (-1)^(1+1) = +1
+    sign = one(Tg)  # dimensionless ±1 — `one`, not `oneunit`
 
     @inbounds for i in 1:n_intervals
         inv_h_i = _get_inv_h(axis, i)  # precomputed — no inv() needed
@@ -282,9 +286,10 @@ Compute quadratic coefficients: a[i] = (s[i] - d[i]) * inv_h[i]
 - `Tv`: Value type (unconstrained)
 - `Tg`: Grid type
 """
-@inline function _compute_quadratic_coefficients!(a::AbstractVector{Tc}, d::AbstractVector{Tc}, s::AbstractVector{Tc}, axis::AbstractVector{Tg}) where {Tc, Tg}
+# `a` lives one `inv_h` power above `d`/`s` — no shared-eltype pin.
+@inline function _compute_quadratic_coefficients!(a::AbstractVector, d::AbstractVector{Tc}, s::AbstractVector{Tc}, axis::AbstractVector{Tg}) where {Tc, Tg}
     @inbounds for i in eachindex(a)
-        a[i] = (s[i] - d[i]) * _get_inv_h(axis, i)  # (Tv - Tv) * Tg → Tv
+        a[i] = (s[i] - d[i]) * _get_inv_h(axis, i)  # [Y/X] * [1/X] → [Y/X²]
     end
     return a
 end
@@ -364,10 +369,12 @@ function _compute_quadratic_coeffs(
     ) where {Tg}
     nx = length(x)
 
-    # Allocate arrays — widened type when grid is duck-typed (e.g. Dual)
+    # d is order-1 ([Y/X], `_coeff_op`); a is order-2 ([Y/X²], `_coeff_op2`).
+    # Real grids collapse both to one float — the historic single witness.
     Tcoeff = _promote_eltype(_coeff_op, Tg, eltype(y))
+    Ta = _promote_eltype(_coeff_op2, Tg, eltype(y))
     d = Vector{Tcoeff}(undef, nx)
-    a = Vector{Tcoeff}(undef, nx - 1)
+    a = Vector{Ta}(undef, nx - 1)
 
     # Fill using in-place version
     _compute_quadratic_coeffs!(d, a, x, y, bc)

--- a/src/vector_calculus.jl
+++ b/src/vector_calculus.jl
@@ -123,8 +123,9 @@ end
                 :(_eval_at_cell(itp, cell, $ops))
             end for i in 1:N
     ]
-    # Gradient component i is ∂f/∂xᵢ — scale the value-space zero by `inv(gridᵢ unit)`
-    # so a unit-grid FillExtrap OOB returns `value/gridᵢ` (identity on Real grids).
+    # Gradient component i is ∂f/∂xᵢ — the FILL value carries the zero (a NaN
+    # fill poisons OOB derivatives, matching the 1D/ND eval rule; interior data
+    # never leaks into OOB), scaled by `inv(gridᵢ unit)` into `value/gridᵢ`.
     zero_tuple = [:(0 * zref * _deriv_oneunit(oneunit(eltype(itp.grids[$i])), DerivOp(1))) for i in 1:N]
 
     return quote
@@ -133,7 +134,7 @@ end
         hints = _ensure_hint_nd(hint, Val($N))
         mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
-            zref = _sample_data(itp)
+            zref = _first_fill_value(itp.extraps)
             return tuple($(zero_tuple...))
         end
         cell = _locate_cell(itp, query_r, policies, hints, mono)
@@ -221,7 +222,7 @@ end
         hints = _ensure_hint_nd(hint, Val($N))
         mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
-            zref = _sample_data(itp)
+            zref = _first_fill_value(itp.extraps)
             @inbounds for i in 1:$N
                 G[i] = 0 * zref * _deriv_oneunit(oneunit(eltype(itp.grids[i])), DerivOp(1))
             end
@@ -321,9 +322,8 @@ end
         hints = _ensure_hint_nd(hint, Val($N))
         mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
-            zref = _sample_data(itp)
-            fill_val = _first_fill_value(itp.extraps)
-            return (fill_val, tuple($(zero_tuple...)))
+            zref = _first_fill_value(itp.extraps)
+            return (zref, tuple($(zero_tuple...)))
         end
         cell = _locate_cell(itp, query_r, policies, hints, mono)
         val = $value_call
@@ -430,13 +430,13 @@ end
         )
     end
 
-    # OOB (FillExtrap) zeros per element: `zero(zref)` (sign-free, NaN-free —
-    # matches the old `fill!(zero(Tq))` on concrete eltypes) scaled into each
+    # OOB (FillExtrap) zeros per element: the FILL value carries the zero (a
+    # NaN fill poisons OOB derivatives — 1D/ND eval rule), scaled into each
     # entry's own `[value]/[gridᵢ·gridⱼ]` space. Also serves abstract-eltype
     # stores, where `zero(eltype(H))` has no method.
     oob_stmts = [
         :(
-                H[$i, $j] = zero(zref) *
+                H[$i, $j] = 0 * zref *
                 _deriv_oneunit(oneunit(eltype(itp.grids[$i])), DerivOp(1)) *
                 _deriv_oneunit(oneunit(eltype(itp.grids[$j])), DerivOp(1))
             )
@@ -455,7 +455,7 @@ end
         hints = _ensure_hint_nd(hint, Val($N))
         mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
-            zref = _sample_data(itp)
+            zref = _first_fill_value(itp.extraps)
             $(oob_stmts...)
             return H
         end
@@ -556,7 +556,7 @@ end
     # no method for abstract-eltype stores (`Matrix{Any}`), which are accepted.
     oob_stmts = [
         :(
-                H[$i, $j] = zero(zref) *
+                H[$i, $j] = 0 * zref *
                 _deriv_oneunit(oneunit(eltype(itp.grids[$i])), DerivOp(1)) *
                 _deriv_oneunit(oneunit(eltype(itp.grids[$j])), DerivOp(1))
             )
@@ -574,7 +574,7 @@ end
         hints = _ensure_hint_nd(hint, Val($N))
         mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
-            zref = _sample_data(itp)
+            zref = _first_fill_value(itp.extraps)
             $(oob_stmts...)
             return H
         end
@@ -666,7 +666,7 @@ end
         hints = _ensure_hint_nd(hint, Val($N))
         mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
-            return 0 * _sample_data(itp) * _deriv_oneunit(oneunit(eltype(itp.grids[1])), DerivOp(2))
+            return 0 * _first_fill_value(itp.extraps) * _deriv_oneunit(oneunit(eltype(itp.grids[1])), DerivOp(2))
         end
         cell = _locate_cell(itp, query_r, policies, hints, mono)
         return +($(deriv_calls...))

--- a/src/vector_calculus.jl
+++ b/src/vector_calculus.jl
@@ -38,7 +38,7 @@
 # ∂²f/∂xᵢ∂xⱼ eltype: the `_deriv1_op` witness folded once per axis (never `h^-2`,
 # which is type-unstable for units). `i == j` is the same expression twice.
 @inline _deriv2_pair_eltype(::Type{Tv}, ::Type{Gi}, ::Type{Gj}) where {Tv, Gi, Gj} =
-    _promote_eltype(_deriv1_op, _promote_eltype(_deriv1_op, Tv, eltype(Gi)), eltype(Gj))
+    _promote_eltype(_deriv1_op, eltype(Gj), _promote_eltype(_deriv1_op, eltype(Gi), Tv))
 
 # Unrolled at compile time: `@generated` keeps the N² / N type folds out of the
 # runtime frame entirely (a `map`/`ntuple` over types can leave Type objects on
@@ -57,7 +57,7 @@ end
 
 @generated function _nd_gradient_eltype(::Type{Tv}, grids::Tuple{Vararg{Any, N}}) where {Tv, N}
     G = grids.parameters
-    terms = [:(_promote_eltype(_deriv1_op, Tv, eltype($(G[i])))) for i in 1:N]
+    terms = [:(_promote_eltype(_deriv1_op, eltype($(G[i])), Tv)) for i in 1:N]
     return :(promote_type($(terms...)))
 end
 

--- a/src/vector_calculus.jl
+++ b/src/vector_calculus.jl
@@ -142,7 +142,7 @@ end
     ]
     # Gradient component i is ∂f/∂xᵢ — scale the value-space zero by `inv(gridᵢ unit)`
     # so a unit-grid FillExtrap OOB returns `value/gridᵢ` (identity on Real grids).
-    zero_tuple = [:(0 * zref * inv(oneunit(eltype(itp.grids[$i])))) for i in 1:N]
+    zero_tuple = [:(0 * zref * _deriv_oneunit(oneunit(eltype(itp.grids[$i])), DerivOp(1))) for i in 1:N]
 
     return quote
         query_r = map(_resolve_grididx, query, itp.grids)
@@ -240,7 +240,7 @@ end
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
             zref = _sample_data(itp)
             @inbounds for i in 1:$N
-                G[i] = 0 * zref * inv(oneunit(eltype(itp.grids[i])))
+                G[i] = 0 * zref * _deriv_oneunit(oneunit(eltype(itp.grids[i])), DerivOp(1))
             end
             return G
         end
@@ -330,7 +330,7 @@ end
     ]
     # Gradient component i is ∂f/∂xᵢ — scale the value-space zero by `inv(gridᵢ unit)`
     # so a unit-grid FillExtrap OOB returns `value/gridᵢ` (identity on Real grids).
-    zero_tuple = [:(0 * zref * inv(oneunit(eltype(itp.grids[$i])))) for i in 1:N]
+    zero_tuple = [:(0 * zref * _deriv_oneunit(oneunit(eltype(itp.grids[$i])), DerivOp(1))) for i in 1:N]
 
     return quote
         query_r = map(_resolve_grididx, query, itp.grids)
@@ -656,7 +656,7 @@ end
         hints = _ensure_hint_nd(hint, Val($N))
         mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
-            return 0 * _sample_data(itp) * inv(oneunit(eltype(itp.grids[1])))^2
+            return 0 * _sample_data(itp) * _deriv_oneunit(oneunit(eltype(itp.grids[1])), DerivOp(2))
         end
         cell = _locate_cell(itp, query_r, policies, hints, mono)
         return +($(deriv_calls...))

--- a/src/vector_calculus.jl
+++ b/src/vector_calculus.jl
@@ -16,7 +16,7 @@
 # This file is included last in the module to ensure all interpolant types are defined.
 
 # ========================================
-# Shared-element-type guards (mixed-unit grids)
+# Shared-element-type guards (uniform-eltype outputs)
 # ========================================
 # `gradient` returns a Tuple, so its per-axis components may carry different
 # units (`K/s`, `K/m`) — nothing has to agree. `hessian` (a Matrix), `laplacian`
@@ -61,33 +61,37 @@ end
     return :(promote_type($(terms...)))
 end
 
-@noinline function _throw_mixed_unit_nd(what::String, alternative::String, T)
+# Guard for uniform-eltype outputs: the per-axis components must share ONE
+# concrete element type. Pure type algebra (isconcretetype ∘ promote) — mixed
+# units are just the typical trigger, not a Unitful special case.
+@noinline function _throw_nd_component_eltype(what::String, alternative::String, T)
     throw(
         ArgumentError(
-            "$what on a mixed-unit ND grid is not supported: the per-axis components " *
-                "carry different units, so they have no shared element type " *
-                "(they promote to the abstract `$T`). $alternative"
+            "$what on this ND grid is not supported: the per-axis components " *
+                "have no shared concrete element type — they promote to the " *
+                "abstract `$T` (typical for mixed-unit axes). $alternative"
         )
     )
 end
 
-@inline function _check_nd_hessian_units(::Type{Tv}, grids::Tuple) where {Tv}
+@inline function _check_nd_hessian_eltype(::Type{Tv}, grids::Tuple) where {Tv}
     T = _nd_hessian_eltype(Tv, grids)
-    isconcretetype(T) || _throw_mixed_unit_nd(
+    isconcretetype(T) || _throw_nd_component_eltype(
         "hessian",
         "Query the components you need individually, e.g. " *
-            "`itp(query...; deriv = DerivOp(2, 0))`, or strip units (`ustrip`).",
+            "`itp(query...; deriv = DerivOp(2, 0))`.",
         T,
     )
     return nothing
 end
 
-@inline function _check_nd_laplacian_units(::Type{Tv}, grids::Tuple) where {Tv}
+@inline function _check_nd_laplacian_eltype(::Type{Tv}, grids::Tuple) where {Tv}
     T = _nd_laplacian_eltype(Tv, grids)
-    isconcretetype(T) || _throw_mixed_unit_nd(
+    isconcretetype(T) || _throw_nd_component_eltype(
         "laplacian",
-        "Its terms `∂²f/∂xᵢ²` would have to be added across axes. Query them " *
-            "individually, e.g. `itp(query...; deriv = DerivOp(2, 0))`, or strip units (`ustrip`).",
+        "Its terms `∂²f/∂xᵢ²` would have to be ADDED across axes, which is " *
+            "dimensionally undefined here. Query them individually, e.g. " *
+            "`itp(query...; deriv = DerivOp(2, 0))`.",
         T,
     )
     return nothing
@@ -97,25 +101,23 @@ end
 # caller's store holds all of them — accept it even when `T` itself is abstract.
 # A concrete `T` (Real, same-unit) short-circuits before the subtype test, so a
 # `Float32` store still takes `Float64` components exactly as it always did.
-@inline function _check_nd_gradient_store_units(::Type{Tv}, grids::Tuple, ::Type{TS}) where {Tv, TS}
+@inline function _check_nd_gradient_store_eltype(::Type{Tv}, grids::Tuple, ::Type{TS}) where {Tv, TS}
     T = _nd_gradient_eltype(Tv, grids)
-    (isconcretetype(T) || T <: TS) || _throw_mixed_unit_nd(
+    (isconcretetype(T) || T <: TS) || _throw_nd_component_eltype(
         "gradient!",
-        "Use the allocating `gradient`, which returns a Tuple and so keeps each " *
-            "component's own units, pass a store that can hold them (e.g. " *
-            "`Vector{Any}`), or strip units (`ustrip`).",
+        "Use the allocating `gradient` (a Tuple — each component keeps its own " *
+            "type) or pass a store that can hold them (e.g. `Vector{Any}`).",
         T,
     )
     return nothing
 end
 
-@inline function _check_nd_hessian_store_units(::Type{Tv}, grids::Tuple, ::Type{TS}) where {Tv, TS}
+@inline function _check_nd_hessian_store_eltype(::Type{Tv}, grids::Tuple, ::Type{TS}) where {Tv, TS}
     T = _nd_hessian_eltype(Tv, grids)
-    (isconcretetype(T) || T <: TS) || _throw_mixed_unit_nd(
+    (isconcretetype(T) || T <: TS) || _throw_nd_component_eltype(
         "hessian!",
-        "Query the components you need individually, e.g. " *
-            "`itp(query...; deriv = DerivOp(2, 0))`, pass a store that can hold them " *
-            "(e.g. `Matrix{Any}`), or strip units (`ustrip`).",
+        "Query the components individually via `deriv = DerivOp(2, 0)` or pass " *
+            "a store that can hold them (e.g. `Matrix{Any}`).",
         T,
     )
     return nothing
@@ -280,7 +282,7 @@ See also: [`gradient`](@ref), [`value_gradient`](@ref), [`hessian!`](@ref)
         query::Tuple{Vararg{Number, N}};
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
-    _check_nd_gradient_store_units(Tv, itp.grids, eltype(G))
+    _check_nd_gradient_store_eltype(Tv, itp.grids, eltype(G))
     return _gradient_generic!(G, itp, query, hint)
 end
 
@@ -500,7 +502,7 @@ See also: [`gradient`](@ref), [`hessian!`](@ref), [`laplacian`](@ref)
         query::Tuple{Vararg{Number, N}};
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
-    _check_nd_hessian_units(Tv, itp.grids)
+    _check_nd_hessian_eltype(Tv, itp.grids)
     return _hessian_generic(itp, query, hint)
 end
 
@@ -604,7 +606,7 @@ See also: [`hessian`](@ref), [`gradient!`](@ref)
         query::Tuple{Vararg{Number, N}};
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
-    _check_nd_hessian_store_units(Tv, itp.grids, eltype(H))
+    _check_nd_hessian_store_eltype(Tv, itp.grids, eltype(H))
     return _hessian_generic!(H, itp, query, hint)
 end
 
@@ -696,7 +698,7 @@ See also: [`gradient`](@ref), [`hessian`](@ref)
         query::Tuple{Vararg{Number, N}};
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
-    _check_nd_laplacian_units(Tv, itp.grids)
+    _check_nd_laplacian_eltype(Tv, itp.grids)
     return _laplacian_generic(itp, query, hint)
 end
 

--- a/src/vector_calculus.jl
+++ b/src/vector_calculus.jl
@@ -18,22 +18,14 @@
 # ========================================
 # Shared-element-type guards (uniform-eltype outputs)
 # ========================================
-# `gradient` returns a Tuple, so its per-axis components may carry different
-# units (`K/s`, `K/m`) — nothing has to agree. `hessian` (a Matrix), `laplacian`
-# (a sum) and `gradient!` (the caller's Vector) each need ONE element type for
-# every component. On a mixed-unit grid the components differ per axis, so the
-# promotion lands on an abstract `Quantity` — which has no `zero`/`oneunit`, so
-# `det`, `zeros` and `similar` fail downstream even if we handed it back.
-#
-# The in-place forms are the exception: whether ONE type exists is a property of
-# the caller's BUFFER, not of the grid. A `Vector{Any}` (or an abstract-`Quantity`
-# store) holds `K/s` beside `K/m` fine and the generic kernels already fill it —
-# so they check `T <: eltype(store)` too and only refuse a buffer that genuinely
-# cannot hold the components.
-#
-# The decision is purely type-level (grid eltypes × value eltype × store eltype),
-# so the check constant-folds away on Real and same-unit grids. Without it the
-# user meets a raw `DimensionError` from inside the kernel.
+# Every component of `gradient` (Tuple) and `hessian` (Matrix with the
+# components' promoted eltype — abstract for mixed-unit axes, each entry still
+# concretely typed) exists, so both return values. Only two cases guard:
+# `laplacian` must ADD `∂²f/∂xᵢ²` across axes — dimensionally undefined when
+# the axes' units differ — and the in-place forms refuse a store whose eltype
+# genuinely cannot hold the components (`T <: eltype(store)`; `Vector{Any}` or
+# an abstract-`Quantity` store is accepted). The decision is purely type-level,
+# so the checks constant-fold away on Real and same-unit grids.
 
 # ∂²f/∂xᵢ∂xⱼ eltype: the `_deriv1_op` witness folded once per axis (never `h^-2`,
 # which is type-unstable for units). `i == j` is the same expression twice.
@@ -72,17 +64,6 @@ end
                 "abstract `$T` (typical for mixed-unit axes). $alternative"
         )
     )
-end
-
-@inline function _check_nd_hessian_eltype(::Type{Tv}, grids::Tuple) where {Tv}
-    T = _nd_hessian_eltype(Tv, grids)
-    isconcretetype(T) || _throw_nd_component_eltype(
-        "hessian",
-        "Query the components you need individually, e.g. " *
-            "`itp(query...; deriv = DerivOp(2, 0))`.",
-        T,
-    )
-    return nothing
 end
 
 @inline function _check_nd_laplacian_eltype(::Type{Tv}, grids::Tuple) where {Tv}
@@ -449,21 +430,33 @@ end
         )
     end
 
+    # OOB (FillExtrap) zeros per element: `zero(zref)` (sign-free, NaN-free —
+    # matches the old `fill!(zero(Tq))` on concrete eltypes) scaled into each
+    # entry's own `[value]/[gridᵢ·gridⱼ]` space. Also serves abstract-eltype
+    # stores, where `zero(eltype(H))` has no method.
+    oob_stmts = [
+        :(
+                H[$i, $j] = zero(zref) *
+                _deriv_oneunit(oneunit(eltype(itp.grids[$i])), DerivOp(1)) *
+                _deriv_oneunit(oneunit(eltype(itp.grids[$j])), DerivOp(1))
+            )
+            for i in 1:N for j in 1:N
+    ]
+
     return quote
         query_r = map(_resolve_grididx, query, itp.grids)
-        # Hessian entries are 2nd derivatives (value/grid²) — fold the `_deriv1_op` witness
-        # twice via `_deriv_eltype`, the same type-level machinery the one-shot deriv paths
-        # use. Pure `Base.promote_op`, so it needs neither `oneunit(Tv)` (value duck types
-        # like colorants define `Real*T` but not `one`) nor `oneunit(Tg)`, stays concrete,
-        # and is type-stable for units (one `inv(h)` per order, never `h^-2`). The old
-        # `promote_type(coord, grid, value)` went abstract on unit grids, so `zero(Tq)` threw.
-        Tq = _deriv_eltype($Tv, $Tg, DerivOp{2}())
+        # Container eltype = the promotion of every component (`_nd_hessian_eltype`,
+        # the same witness the store guard consults): concrete for Real/same-unit
+        # grids, the tightest abstract `Quantity` supertype for mixed-unit axes —
+        # each entry still carries its own concrete units.
+        Tq = _nd_hessian_eltype($Tv, itp.grids)
         H = Matrix{Tq}(undef, $N, $N)
         policies = _resolve_search_nd(itp.searches, Val($N))
         hints = _ensure_hint_nd(hint, Val($N))
         mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
-            fill!(H, zero(Tq))
+            zref = _sample_data(itp)
+            $(oob_stmts...)
             return H
         end
         cell = _locate_cell(itp, query_r, policies, hints, mono)
@@ -479,7 +472,11 @@ end
 
 Compute the Hessian matrix (matrix of second partial derivatives) at `query`.
 
-Returns an `N×N` matrix where `H[i,j] = ∂²f/∂xᵢ∂xⱼ`.
+Returns an `N×N` matrix where `H[i,j] = ∂²f/∂xᵢ∂xⱼ`. On mixed-unit grids the
+entries carry per-element units (`value/gridᵢ·gridⱼ`), so the matrix eltype is
+their tightest common supertype (an abstract `Quantity`) — element access is
+unit-correct, while whole-matrix linear algebra (`det`, `eigen`, `\\`) does not
+apply to a dimensionally heterogeneous matrix.
 
 # Performance
 ~9x faster than `ForwardDiff.hessian` by using analytical derivatives.
@@ -502,7 +499,6 @@ See also: [`gradient`](@ref), [`hessian!`](@ref), [`laplacian`](@ref)
         query::Tuple{Vararg{Number, N}};
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tg, Tv, N}
-    _check_nd_hessian_eltype(Tv, itp.grids)
     return _hessian_generic(itp, query, hint)
 end
 
@@ -556,6 +552,17 @@ end
         )
     end
 
+    # Same per-element OOB zeros as the allocating form — `zero(eltype(H))` has
+    # no method for abstract-eltype stores (`Matrix{Any}`), which are accepted.
+    oob_stmts = [
+        :(
+                H[$i, $j] = zero(zref) *
+                _deriv_oneunit(oneunit(eltype(itp.grids[$i])), DerivOp(1)) *
+                _deriv_oneunit(oneunit(eltype(itp.grids[$j])), DerivOp(1))
+            )
+            for i in 1:N for j in 1:N
+    ]
+
     return quote
         query_r = map(_resolve_grididx, query, itp.grids)
         @boundscheck size(H) == ($N, $N) || throw(
@@ -567,7 +574,8 @@ end
         hints = _ensure_hint_nd(hint, Val($N))
         mono = _scalar_mono(hint, Val($N))
         if _is_fill_oob(query_r, itp.grids, itp.extraps)
-            fill!(H, zero(eltype(H)))
+            zref = _sample_data(itp)
+            $(oob_stmts...)
             return H
         end
         cell = _locate_cell(itp, query_r, policies, hints, mono)

--- a/test/ext/test_autodiff_ForwardDiff.jl
+++ b/test/ext/test_autodiff_ForwardDiff.jl
@@ -1373,24 +1373,29 @@ const FI = FastInterpolations
     end
 
     # =========================================================================
-    # Duck-typed grid cache fallback (Dual grid → 2-arg _get_cubic_cache)
+    # Duck-typed grid cache banking (Dual grid → 2-arg _get_cubic_cache)
     # =========================================================================
-    @testset "Dual grid 2-arg cache API (duck-type fallback)" begin
+    @testset "Dual grid 2-arg cache API (banks by full isequal)" begin
         using FastInterpolations: _get_cubic_cache, clear_cubic_cache!
         clear_cubic_cache!()
 
         x_dual = ForwardDiff.Dual.(Float64[0, 1, 2, 3, 4], 1.0)
 
-        # Derivative BC — duck-type fallback builds fresh (no caching).
-        # Cache stores Dual grid as-is (partials needed for AD correctness).
+        # Dual grids bank under their exact eltype; the pool's `isequal` scan
+        # compares primal AND partials, so same-seed rebuilds hit and a
+        # different seed misses (AD correctness preserved).
         DualT = eltype(x_dual)
         cache_d = _get_cubic_cache(x_dual, ZeroCurvBC())
         @test cache_d isa CubicSplineCache{DualT}
 
         cache_d2 = _get_cubic_cache(x_dual, ZeroCurvBC())
-        @test cache_d2 !== cache_d  # fresh build each time, not cached
+        @test cache_d2 === cache_d  # bank hit: same primal + partials
 
-        # Periodic BC — duck-type periodic fallback
+        x_dual_s2 = ForwardDiff.Dual.(Float64[0, 1, 2, 3, 4], 2.0)
+        cache_s2 = _get_cubic_cache(x_dual_s2, ZeroCurvBC())
+        @test cache_s2 !== cache_d  # same primal, different partials → miss
+
+        # Periodic BC — banks through the periodic pool the same way
         x_dual_p = ForwardDiff.Dual.(Float64[0, 1, 2, 3, 4, 5, 6], 1.0)
         cache_p = _get_cubic_cache(x_dual_p, PeriodicBC())
         @test cache_p isa CubicSplineCache{DualT}

--- a/test/test_cache_bank_duck.jl
+++ b/test/test_cache_bank_duck.jl
@@ -1,0 +1,82 @@
+# ========================================
+# Cache bank duck widening — refac/duck-thomas Phase 2b contracts
+# ========================================
+# The autocache pool banks any `<:Number` grid eltype whose `isequal` is
+# grid-faithful (`_grid_bankable`, default true) — unit grids and Duals
+# included. Banks are segregated by ENTRY TYPE (exact grid eltype), so
+# cross-unit `isequal(1.0m, 100.0cm) == true` can never produce a cross-typed
+# hit, and the pool's linear isequal scan never touches `hash` (Unitful and
+# ForwardDiff both bend the isequal/hash contract, in opposite directions).
+
+@testitem "cache bank: unit grids bank and hit (Vector + Range)" begin
+    using Unitful
+    const FI = FastInterpolations
+
+    yw = [1.0, 2.0, 0.5, 3.0, 2.5] .* u"W"
+
+    @testset "Vector grid" begin
+        FI.clear_cubic_cache!()
+        xu = [0.0, 1.0, 2.5, 3.0, 4.5] .* u"s"
+        i1 = cubic_interp(xu, yw)
+        i2 = cubic_interp(xu, yw)
+        @test i2.cache === i1.cache            # pass-1: objectid hint
+        xu_fresh = [0.0, 1.0, 2.5, 3.0, 4.5] .* u"s"
+        i3 = cubic_interp(xu_fresh, yw)
+        @test i3.cache === i1.cache            # pass-2: isequal (fresh array)
+        i4 = cubic_interp(xu, yw; autocache = false)
+        @test i4.cache !== i1.cache            # explicit opt-out stays fresh
+        @test i4(2.2u"s") === i1(2.2u"s")      # values agree either way
+    end
+
+    @testset "Range grid (_CachedRange bank)" begin
+        FI.clear_cubic_cache!()
+        yr = [1.0, 2.0, 0.5, 3.0, 2.5, 1.0, 4.0, 2.0, 3.5, 0.5] .* u"W"
+        r1 = cubic_interp(1.0u"s":1.0u"s":10.0u"s", yr)
+        r2 = cubic_interp(1.0u"s":1.0u"s":10.0u"s", yr)
+        @test r2.cache === r1.cache            # isbits range: deterministic key
+    end
+end
+
+@testitem "cache bank: cross-unit isolation (m vs cm, type-stable returns)" begin
+    using Unitful
+    const FI = FastInterpolations
+
+    # `isequal([1.0m], [100.0cm])` is TRUE in Unitful — the pool must never
+    # compare them: different eltypes land in different (type-keyed) banks.
+    # (Passes pre-widening too — this is the regression guard for the widened
+    # pool, pinning that a build's return type depends only on its inputs.)
+    FI.clear_cubic_cache!()
+    y = [1.0, 2.0, 0.5, 3.0] .* u"W"
+    xm = [0.0, 1.0, 2.0, 3.0] .* u"m"
+    xcm = [0.0, 100.0, 200.0, 300.0] .* u"cm"   # same physical values
+    @test isequal(xm, xcm)                       # the trap is real…
+    im_ = cubic_interp(xm, y)
+    icm = cubic_interp(xcm, y)
+    @test im_.cache !== icm.cache                # …and never taken
+    @test eltype(im_.cache.x) === typeof(1.0u"m")
+    @test eltype(icm.cache.x) === typeof(1.0u"cm")
+end
+
+@testitem "cache bank: Dual grids bank by full isequal (primal + partials)" begin
+    using ForwardDiff
+    using ForwardDiff: Dual
+    const FI = FastInterpolations
+
+    # ForwardDiff's array `isequal` distinguishes partials (probe-verified), so
+    # banking Duals is CORRECT: same-seed rebuilds hit, different seeds miss.
+    # This pin watches that upstream semantic — if ForwardDiff ever made
+    # `isequal` primal-only, the miss case would silently become a wrong-hit.
+    FI.clear_cubic_cache!()
+    mk(p) = [Dual(0.0, p), Dual(1.0, 0.0), Dual(2.5, 0.0), Dual(3.0, 0.0)]
+    y = [1.0, 2.0, 0.5, 3.0]
+
+    x1 = mk(1.0)
+    d1 = cubic_interp(x1, y)
+    d2 = cubic_interp(x1, y)
+    @test d2.cache === d1.cache                # pass-1: same array
+    d3 = cubic_interp(mk(1.0), y)
+    @test d3.cache === d1.cache                # pass-2: same primal AND partials
+    d4 = cubic_interp(mk(2.0), y)
+    @test d4.cache !== d1.cache                # same primal, different seed → miss
+    @test d4.z != d1.z                         # …and the partials really differ
+end

--- a/test/test_cache_bank_duck.jl
+++ b/test/test_cache_bank_duck.jl
@@ -57,6 +57,60 @@ end
     @test eltype(icm.cache.x) === typeof(1.0u"cm")
 end
 
+@testitem "cache bank: periodic pool mirrors the derivative pins (Range + cross-unit)" begin
+    using Unitful
+    const FI = FastInterpolations
+
+    # The periodic pool is a separate bank family (own key path, own entry
+    # type carrying the S-M `q` slot) — mirror the derivative-bank pins so a
+    # widening regression can't hide there.
+
+    @testset "Range grid (_CachedRange periodic bank)" begin
+        FI.clear_cubic_cache!()
+        yr = [1.0, 2.0, 0.5, 3.0, 2.5, 1.0, 4.0, 2.0, 3.5, 0.5] .* u"W"
+        bc = PeriodicBC(endpoint = :exclusive)   # period inferred from the range
+        p1 = cubic_interp(1.0u"s":1.0u"s":10.0u"s", yr; bc = bc)
+        p2 = cubic_interp(1.0u"s":1.0u"s":10.0u"s", yr; bc = bc)
+        # :exclusive extension is step-preserving, so the banked axis is the
+        # wrapped range — this pins the _CachedRange periodic duck arm.
+        @test p1.cache.x isa FI._CachedRange
+        @test p2.cache === p1.cache
+    end
+
+    @testset "cross-unit isolation (m vs cm)" begin
+        FI.clear_cubic_cache!()
+        y = [1.0, 2.0, 0.5, 1.0] .* u"W"            # closed cycle (inclusive)
+        xm = [0.0, 1.0, 2.0, 3.0] .* u"m"
+        xcm = [0.0, 100.0, 200.0, 300.0] .* u"cm"   # same physical values
+        @test isequal(xm, xcm)                       # the trap is real…
+        pm = cubic_interp(xm, y; bc = PeriodicBC())
+        pcm = cubic_interp(xcm, y; bc = PeriodicBC())
+        @test pm.cache !== pcm.cache                 # …and never taken
+        @test eltype(pm.cache.x) === typeof(1.0u"m")
+        @test eltype(pcm.cache.x) === typeof(1.0u"cm")
+    end
+end
+
+@testitem "cache bank: _grid_bankable open default + opt-out demotion wiring" begin
+    const FI = FastInterpolations
+
+    # Open trait: an unknown grid eltype banks unless it opts out. This pin
+    # fails if the pool ever reverts to a whitelist (`_PromotableValue`-era).
+    struct _SomeDuckGrid end
+    @test FI._grid_bankable(_SomeDuckGrid)
+    @test FI._effective_autocache(true, _SomeDuckGrid)
+
+    # Escape-hatch wiring: a false trait demotes `autocache` at the surface.
+    # Composed with the existing `autocache=false` fresh-build coverage this
+    # is the whole opt-out contract — no opt-outs ship, so a test-local type
+    # pins the wiring without ever building a cache.
+    struct _UnbankableGrid end
+    FI._grid_bankable(::Type{_UnbankableGrid}) = false
+    @test !FI._effective_autocache(true, _UnbankableGrid)
+    @test !FI._effective_autocache(false, _UnbankableGrid)
+    @test FI._effective_autocache(true, Float64)     # Real default untouched
+end
+
 @testitem "cache bank: Dual grids bank by full isequal (primal + partials)" begin
     using ForwardDiff
     using ForwardDiff: Dual

--- a/test/test_constant_nd_adjoint_periodic.jl
+++ b/test/test_constant_nd_adjoint_periodic.jl
@@ -1,9 +1,10 @@
 @testitem "ConstantAdjointND PeriodicBC dot-product identity" begin
-    using LinearAlgebra: dot
+    using LinearAlgebra: dot, norm
 
-    # Constant interp is single-point (no blending), so the dot-product
-    # identity ⟨W·f, ȳ⟩ == ⟨f, Wᵀ·ȳ⟩ is not just within rtol but exact —
-    # both sides are sums over a 1-1 mapping query → grid index.
+    # Constant interp is single-point (no blending): both sides sum the SAME
+    # products f[cell(q)]·ȳ[q], but Wᵀ groups them per cell first — that
+    # regrouping shifts ULPs, and a randn dot can land near 0 where rtol
+    # alone fails. Scale the tolerance by the operands, not the result.
     function dot_id_test(grids, xqs, f, y_bar; bc, side = NearestSide(), extrap = NoExtrap())
         itp = constant_interp(grids, f; bc = bc, side = side, extrap = extrap)
         adj = constant_adjoint(grids, xqs; bc = bc, side = side, extrap = extrap)
@@ -15,7 +16,10 @@
         WTy = adj(y_bar)
         @test size(WTy) == size(f)
 
-        return isapprox(dot(Wf, y_bar), dot(vec(f), vec(WTy)); rtol = 1.0e-12)
+        return isapprox(
+            dot(Wf, y_bar), dot(vec(f), vec(WTy));
+            rtol = 1.0e-12, atol = 1.0e-12 * norm(Wf) * norm(y_bar)
+        )
     end
 
     n_query = 40

--- a/test/test_constextrap_fill.jl
+++ b/test/test_constextrap_fill.jl
@@ -458,10 +458,11 @@
     end
 
     # ────────────────────────────────────────────
-    # P1: Vector-calculus OOB guard for FillExtrap
+    # P1: Vector-calculus OOB with FillExtrap — fill value is the OOB authority
     # ────────────────────────────────────────────
-    @testset "Vector-calculus OOB guard with FillExtrap" begin
-        # 2D cubic interpolant with NaN fill
+    @testset "Vector-calculus OOB with FillExtrap(NaN)" begin
+        # The fill value IS the OOB region's data (test_oob_zero_carrier_contract):
+        # a NaN fill poisons OOB derivatives, matching the 1D and ND eval paths.
         xg = range(0.0, 1.0, length = 6)
         yg = range(0.0, 1.0, length = 6)
         data = [sin(x + y) for x in xg, y in yg]
@@ -473,36 +474,42 @@
         @test all(isfinite, g_in)
         @test !all(iszero, g_in)
 
-        # OOB query: all derivatives should be zero
+        # OOB query: the NaN fill flows into every derivative
         q_oob = (-0.2, 0.5)
         g_oob = gradient(itp, q_oob)
-        @test all(iszero, g_oob)
+        @test all(isnan, g_oob)
 
         # gradient! OOB
         G = zeros(2)
         gradient!(G, itp, q_oob)
-        @test all(iszero, G)
+        @test all(isnan, G)
 
         # hessian OOB
         H = hessian(itp, q_oob)
-        @test all(iszero, H)
+        @test all(isnan, H)
 
         # hessian! OOB
         H2 = ones(2, 2)
         hessian!(H2, itp, q_oob)
-        @test all(iszero, H2)
+        @test all(isnan, H2)
 
         # laplacian OOB
-        @test laplacian(itp, q_oob) == 0.0
+        @test isnan(laplacian(itp, q_oob))
 
         # Both axes OOB
         q_oob2 = (-0.1, 1.5)
-        @test all(iszero, gradient(itp, q_oob2))
-        @test laplacian(itp, q_oob2) == 0.0
+        @test all(isnan, gradient(itp, q_oob2))
+        @test isnan(laplacian(itp, q_oob2))
 
         # Vector API passes through correctly
         g_vec = gradient(itp, [-0.2, 0.5])
-        @test all(iszero, g_vec)
+        @test all(isnan, g_vec)
+
+        # A FINITE fill keeps clean derivative zeros OOB
+        itp0 = cubic_interp((xg, yg), data; extrap = FillExtrap(0.0))
+        @test all(iszero, gradient(itp0, q_oob))
+        @test all(iszero, hessian(itp0, q_oob))
+        @test iszero(laplacian(itp0, q_oob))
     end
 
     # ────────────────────────────────────────────
@@ -592,15 +599,15 @@
         @test g_oob_x[1] ≈ 0.0 atol = 0.05  # ∂f/∂x at x=0 boundary
         @test isfinite(g_oob_x[2])  # in-domain axis
 
-        # OOB on axis 2 (Fill) → NaN value, all derivatives zero
+        # OOB on axis 2 (Fill) → NaN value; the NaN fill poisons the derivatives
         val_oob_y = itp((0.5, 1.5))
         @test isnan(val_oob_y)  # FillExtrap → NaN
         g_oob_y = gradient(itp, (0.5, 1.5))
-        @test all(iszero, g_oob_y)  # FillExtrap total short-circuit
+        @test all(isnan, g_oob_y)  # fill value carries the OOB zeros
 
-        # Hessian: OOB on Fill axis → all zero
+        # Hessian: OOB on Fill axis → NaN fill flows through
         H = hessian(itp, (0.5, 1.5))
-        @test all(iszero, H)
+        @test all(isnan, H)
 
         # Hessian: OOB on Clamp axis only → real derivatives at boundary
         H2 = hessian(itp, (-0.2, 0.5))

--- a/test/test_cubic_adjoint.jl
+++ b/test/test_cubic_adjoint.jl
@@ -197,8 +197,8 @@
         b1 = randn(n_grid)
         b2 = copy(b1)
 
-        FastInterpolations._ldiv_tridiagonal_nopiv!(b1, thomas)
-        FastInterpolations._ldiv_tridiagonal_transpose!(b2, thomas)
+        FastInterpolations._ldiv_tridiagonal_nopiv!(b1, b1, thomas)
+        FastInterpolations._ldiv_tridiagonal_transpose!(b2, b2, thomas)
 
         @test b1 ≈ b2
     end

--- a/test/test_cubic_unit_native.jl
+++ b/test/test_cubic_unit_native.jl
@@ -94,10 +94,13 @@ end
     end
 end
 
-@testitem "cubic Real release-parity pins (per BC, bit-exact)" begin
+@testitem "cubic Real release-parity pins (per BC)" begin
     # Literals generated from the pre-Phase-2 branch (Real path proven
-    # bit-identical to the v0.4.17 release by the Phase 1 A/B) — Phase 2+ edits
-    # to rows/RHS/normalize must not move a single bit on Real grids.
+    # bit-identical to the v0.4.17 release by the Phase 1 A/B). The z pins stay
+    # `===`: the solve is plain arithmetic, bit-stable across Julia versions and
+    # platforms. The EVAL kernels are muladd chains whose fma/SIMD lowering
+    # shifts a few tens of ULPs per Julia/LLVM version and ISA, so the eval
+    # pins assert rtol (the bit-level eval A/B lives on the minting machine).
     xf = [0.0, 1.0, 2.5, 3.0, 4.5]
     yf = [1.0, 2.0, 0.5, 3.0, 2.5]
 
@@ -143,8 +146,8 @@ end
         @testset "$(typeof(bc))" begin
             itp = cubic_interp(xf, yf; bc = bc, autocache = false)
             @test all(i -> itp.z[i] === z_pin[i], eachindex(z_pin))
-            @test itp(2.2) === v22
-            @test itp(0.35) === v035
+            @test itp(2.2) ≈ v22 rtol = 1.0e-13
+            @test itp(0.35) ≈ v035 rtol = 1.0e-13
         end
     end
 end

--- a/test/test_cubic_unit_native.jl
+++ b/test/test_cubic_unit_native.jl
@@ -175,11 +175,15 @@ end
         @test eltype(sitp.cache.thomas.inv_d) === typeof(inv(1.0u"s"))
     end
 
-    @testset "ZeroCurvBC: payload zero lives in [Y/X²]" begin
+    @testset "ZeroCurvBC: solve uses payload-space zeros" begin
+        # The stored `bc_for_solve` is the structural (cache-key) form by
+        # design; the payload-space contract itself is pinned on the scalar
+        # path — here the bit-equivalence proves the Series solve consumed
+        # correctly-spaced zeros.
         sitp = cubic_interp(xu, Series(yw, y2); bc = ZeroCurvBC())
         ref = cubic_interp(xf, Series(yf, y2f); bc = ZeroCurvBC())
         @test sitp(0.35u"s")[1] === ref(0.35)[1] * u"W"
-        @test sitp.bc.left.val === 0.0u"W/s^2"
+        @test sitp(2.2u"s")[2] === ref(2.2)[2] * u"W"
     end
 
     @testset "per-series BC array (unit payloads)" begin

--- a/test/test_cubic_unit_native.jl
+++ b/test/test_cubic_unit_native.jl
@@ -178,8 +178,8 @@ end
     @testset "exclusive: explicit unit period" begin
         xe = [0.0, 1.0, 2.5, 3.0] .* u"s"
         ye = [1.0, 2.0, 0.5, 3.0] .* u"W"
-        itp_u = cubic_interp(xe, ye; bc = PeriodicBC(period = 4.5u"s"), autocache = false)
-        ref = cubic_interp([0.0, 1.0, 2.5, 3.0], [1.0, 2.0, 0.5, 3.0]; bc = PeriodicBC(period = 4.5), autocache = false)
+        itp_u = cubic_interp(xe, ye; bc = PeriodicBC(endpoint = :exclusive, period = 4.5u"s"), autocache = false)
+        ref = cubic_interp([0.0, 1.0, 2.5, 3.0], [1.0, 2.0, 0.5, 3.0]; bc = PeriodicBC(endpoint = :exclusive, period = 4.5), autocache = false)
         @test itp_u(2.2u"s") === ref(2.2) * u"W"
         @test itp_u(4.0u"s") === ref(4.0) * u"W"   # seam cell
     end

--- a/test/test_cubic_unit_native.jl
+++ b/test/test_cubic_unit_native.jl
@@ -149,6 +149,50 @@ end
     end
 end
 
+@testitem "cubic unit one-shot ≡ persistent (fork-free contract)" begin
+    using Unitful
+    const FI = FastInterpolations
+
+    # One-shot entry points must produce BIT-identical results to the
+    # persistent build on unit grids — first via the reroute (pre-P6), then
+    # natively through the pooled pipeline (post-P6). The pins survive the swap.
+    xu = [0.0, 1.0, 2.5, 3.0, 4.5] .* u"s"
+    yw = [1.0, 2.0, 0.5, 3.0, 2.5] .* u"W"
+    y2 = [0.5, 1.5, 2.0, 0.0, 1.0] .* u"W"
+    q = 2.2u"s"
+    qv = [0.35, 2.2, 4.1] .* u"s"
+
+    for (nm, bc) in (
+            ("CubicFit", CubicFit()),
+            ("Deriv2", Deriv2(-0.3u"W/s^2")),
+            ("ZeroCurvBC", ZeroCurvBC()),
+        )
+        @testset "$nm" begin
+            itp = cubic_interp(xu, yw; bc = bc)
+            @test cubic_interp(xu, yw, q; bc = bc) === itp(q)
+            vv = cubic_interp(xu, yw, qv; bc = bc)
+            pv = itp(qv)
+            @test all(i -> vv[i] === pv[i], eachindex(pv))
+            out = similar(pv)
+            cubic_interp!(out, xu, yw, qv; bc = bc)
+            @test all(i -> out[i] === pv[i], eachindex(pv))
+        end
+    end
+
+    @testset "PeriodicBC one-shot" begin
+        ywp = [1.0, 2.0, 0.5, 3.0, 1.0] .* u"W"
+        itp = cubic_interp(xu, ywp; bc = PeriodicBC())
+        @test cubic_interp(xu, ywp, q; bc = PeriodicBC()) === itp(q)
+    end
+
+    @testset "Series one-shot" begin
+        sitp = cubic_interp(xu, Series(yw, y2))
+        sv = cubic_interp(xu, Series(yw, y2), q)
+        sp = sitp(q)
+        @test all(i -> sv[i] === sp[i], eachindex(sp))
+    end
+end
+
 @testitem "cubic Series unit native: self-consistent cache + payload spaces + periodic" begin
     using Unitful
     const FI = FastInterpolations

--- a/test/test_cubic_unit_native.jl
+++ b/test/test_cubic_unit_native.jl
@@ -1,0 +1,172 @@
+# ========================================
+# Cubic 1D native duck (unit) build — refac/duck-thomas Phase 2 contracts
+# ========================================
+# The public unit API routes through the strip-twin today, so these tests pin
+# the NATIVE build/solve seam directly (internal-path RED strategy). After the
+# twin is deleted, `cubic_interp` itself lands on these paths.
+#
+# Unit conventions: SI-coherent u"s"/u"W" so stripped-vs-native mantissas are
+# bit-identical (conversion factor exactly 1.0) — pins use `===` on ustrip.
+
+@testitem "cubic unit native: derivative-BC builder + solve (internal seam)" begin
+    using Unitful
+    const FI = FastInterpolations
+
+    xu = [0.0, 1.0, 2.5, 3.0, 4.5] .* u"s"
+    yw = [1.0, 2.0, 0.5, 3.0, 2.5] .* u"W"
+    xf = [0.0, 1.0, 2.5, 3.0, 4.5]
+    yf = [1.0, 2.0, 0.5, 3.0, 2.5]
+
+    # (name, unit-payload BC pair, stripped-payload BC pair)
+    cases = [
+        ("Deriv1", (FI.Deriv1(0.7u"W/s"), FI.Deriv1(0.7u"W/s")), (FI.Deriv1(0.7), FI.Deriv1(0.7))),
+        ("Deriv2", (FI.Deriv2(-0.3u"W/s^2"), FI.Deriv2(-0.3u"W/s^2")), (FI.Deriv2(-0.3), FI.Deriv2(-0.3))),
+        ("Deriv3", (FI.Deriv3(0.2u"W/s^3"), FI.Deriv3(0.2u"W/s^3")), (FI.Deriv3(0.2), FI.Deriv3(0.2))),
+        ("mixed D1/D2", (FI.Deriv1(0.7u"W/s"), FI.Deriv2(-0.3u"W/s^2")), (FI.Deriv1(0.7), FI.Deriv2(-0.3))),
+    ]
+
+    for (name, (lu, ru), (lf, rf)) in cases
+        @testset "$name" begin
+            cache_u = FI._build_derivative_bc_cache(xu, lu, ru)
+
+            # Witness-typed factorization spaces (Phase 1 contract through the builder):
+            # l dimensionless, du grid-space, inv_d reciprocal-grid-space.
+            @test eltype(cache_u.x) === typeof(1.0u"s")
+            @test eltype(cache_u.thomas.dl) === Float64
+            @test eltype(cache_u.thomas.du) === typeof(1.0u"s")
+            @test eltype(cache_u.thomas.inv_d) === typeof(inv(1.0u"s"))
+
+            Tz = FI._promote_eltype(FI._coeff_op2, eltype(cache_u.x), eltype(yw))
+            zu = Vector{Tz}(undef, length(yw))
+            FI._solve_system!(zu, cache_u, yw, FI.BCPair(lu, ru))
+
+            # Reference: stripped Real system (identical mantissas, SI-coherent).
+            cache_f = FI._build_derivative_bc_cache(xf, lf, rf)
+            zf = Vector{Float64}(undef, length(yf))
+            FI._solve_system!(zf, cache_f, yf, FI.BCPair(lf, rf))
+
+            @test all(i -> ustrip(u"W/s^2", zu[i]) === zf[i], eachindex(zf))
+        end
+    end
+end
+
+@testitem "cubic unit native: impl seam end-to-end (normalized + payload BCs)" begin
+    using Unitful
+    const FI = FastInterpolations
+
+    xu = [0.0, 1.0, 2.5, 3.0, 4.5] .* u"s"
+    yw = [1.0, 2.0, 0.5, 3.0, 2.5] .* u"W"
+    xf = [0.0, 1.0, 2.5, 3.0, 4.5]
+    yf = [1.0, 2.0, 0.5, 3.0, 2.5]
+
+    cases = [
+        ("CubicFit", CubicFit(), CubicFit()),
+        ("ZeroCurvBC", ZeroCurvBC(), ZeroCurvBC()),
+        ("ZeroSlopeBC", ZeroSlopeBC(), ZeroSlopeBC()),
+        ("Deriv1", Deriv1(0.7u"W/s"), Deriv1(0.7)),
+        ("Deriv2", Deriv2(-0.3u"W/s^2"), Deriv2(-0.3)),
+        ("BCPair mixed", BCPair(Deriv1(0.7u"W/s"), Deriv2(-0.3u"W/s^2")), BCPair(Deriv1(0.7), Deriv2(-0.3))),
+    ]
+
+    for (name, bcu, bcf) in cases
+        @testset "$name" begin
+            itp_u = FI._cubic_interp_impl(xu, yw, bcu, NoExtrap(), false, AutoSearch())
+            ref = cubic_interp(xf, yf; bc = bcf, autocache = false)
+
+            @test eltype(itp_u.cache.x) === typeof(1.0u"s")
+            @test all(i -> ustrip(u"W/s^2", itp_u.z[i]) === ref.z[i], eachindex(ref.z))
+            @test itp_u(2.2u"s") === ref(2.2) * u"W"
+            @test itp_u(0.35u"s") === ref(0.35) * u"W"
+        end
+    end
+
+    @testset "H9: normalized zero-BC payloads live in payload space" begin
+        # ZeroCurvBC → Deriv2 payload is [Y/X²]; ZeroSlopeBC → Deriv1 payload is
+        # [Y/X]. A value-space (`0 * first(y)`) zero would make the RHS rule
+        # `bc.val * oneunit(Tg)` dimensionally wrong — pin the stored payloads.
+        itp_c = FI._cubic_interp_impl(xu, yw, ZeroCurvBC(), NoExtrap(), false, AutoSearch())
+        @test itp_c.bc.left.val === 0.0u"W/s^2"
+        @test itp_c.bc.right.val === 0.0u"W/s^2"
+
+        itp_s = FI._cubic_interp_impl(xu, yw, ZeroSlopeBC(), NoExtrap(), false, AutoSearch())
+        @test itp_s.bc.left.val === 0.0u"W/s"
+        @test itp_s.bc.right.val === 0.0u"W/s"
+    end
+end
+
+@testitem "cubic Real release-parity pins (per BC, bit-exact)" begin
+    # Literals generated from the pre-Phase-2 branch (Real path proven
+    # bit-identical to the v0.4.17 release by the Phase 1 A/B) — Phase 2+ edits
+    # to rows/RHS/normalize must not move a single bit on Real grids.
+    xf = [0.0, 1.0, 2.5, 3.0, 4.5]
+    yf = [1.0, 2.0, 0.5, 3.0, 2.5]
+
+    pins = [
+        (
+            CubicFit(),
+            [-10.093793472445158, -3.612413055109683, 10.770572498662384, -3.327340823970036, -16.0506153023007],
+            -0.10312808988764004, 2.166403347378277,
+        ),
+        (
+            ZeroCurvBC(),
+            [0.0, -6.150537634408604, 12.501792114695343, -9.562724014336917, 0.0],
+            -0.10735483870967825, 1.6648306451612904,
+        ),
+        (
+            ZeroSlopeBC(),
+            [6.910112359550562, -7.820224719101122, 13.46067415730337, -12.224719101123595, 6.779026217228464],
+            -0.09069662921348325, 1.317983848314607,
+        ),
+        (
+            Deriv1(0.7),
+            [4.558426966292134, -7.3168539325842685, 13.350561797752809, -12.853932584269666, 8.493632958801498],
+            -0.11504719101123588, 1.4393448735955057,
+        ),
+        (
+            Deriv2(-0.3),
+            [-0.3, -6.077956989247312, 12.459856630824373, -9.444982078853046, -0.3],
+            -0.10805161290322544, 1.6798841733870968,
+        ),
+        (
+            Deriv3(0.2),
+            [-5.093015873015873, -4.893015873015873, 11.705396825396825, -6.964126984126984, -6.664126984126984],
+            -0.1118857142857143, 1.9190930555555554,
+        ),
+        (
+            BCPair(Deriv1(0.7), Deriv2(-0.3)),
+            [4.4784848484848485, -7.156969696969696, 12.87090909090909, -9.496363636363638, -0.3],
+            -0.07475636363636377, 1.436162178030303,
+        ),
+    ]
+
+    for (bc, z_pin, v22, v035) in pins
+        @testset "$(typeof(bc))" begin
+            itp = cubic_interp(xf, yf; bc = bc, autocache = false)
+            @test all(i -> itp.z[i] === z_pin[i], eachindex(z_pin))
+            @test itp(2.2) === v22
+            @test itp(0.35) === v035
+        end
+    end
+end
+
+@testitem "cubic unit native: periodic guard lives in the builder" begin
+    using Unitful
+    const FI = FastInterpolations
+
+    # Phase 2 relocates the friendly PeriodicBC-on-units rejection from the
+    # twin into `_build_periodic_cache` (Phase 3 replaces it with native
+    # support). Message contract matches the public F7 pin: name the feature
+    # and the workaround — never a raw DimensionError from a hostile write.
+    xu = [0.0, 1.0, 2.5, 4.0] .* u"s"
+    err = try
+        FI._build_periodic_cache(xu, FI.PeriodicBC())
+        nothing
+    catch e
+        e
+    end
+    @test err isa ArgumentError
+    msg = sprint(showerror, err)
+    @test occursin("PeriodicBC", msg)
+    @test occursin("unit-carrying", msg)
+    @test occursin("ustrip", msg)
+end

--- a/test/test_cubic_unit_native.jl
+++ b/test/test_cubic_unit_native.jl
@@ -254,8 +254,12 @@ end
         ref = cubic_interp(xf, Series([1.0, 2.0, 0.5, 3.0, 1.0], [0.5, 1.5, 2.0, 0.0, 0.5]); bc = PeriodicBC())
         v = sitp(2.2u"s")
         vr = ref(2.2)
-        @test v[1] === vr[1] * u"W"
-        @test v[2] === vr[2] * u"W"
+        # `===` is flag-fragile here: the z solve is bit-identical to the Real
+        # twin, but under default flags (`check-bounds=auto`, unlike Pkg.test's
+        # `=yes`) the @inbounds Series eval kernel vectorizes differently for
+        # unit vs Real carriers — a few-ULP, data-dependent jitter.
+        @test v[1] ≈ vr[1] * u"W" rtol = 1.0e-14
+        @test v[2] ≈ vr[2] * u"W" rtol = 1.0e-14
     end
 end
 
@@ -299,5 +303,45 @@ end
         i1 = cubic_interp(xu, yw; bc = PeriodicBC())
         i2 = cubic_interp(xu, yw; bc = PeriodicBC())
         @test i2.cache === i1.cache
+    end
+end
+
+@testitem "cubic unit native: structural Real-zero BC payloads rehydrate (cache + BCPair)" begin
+    using Unitful
+
+    xu = [0.0, 1.0, 2.5, 3.0, 4.5] .* u"s"
+    yw = [1.0, 2.0, 0.5, 3.0, 2.5] .* u"W"
+    q = 2.2u"s"
+
+    @testset "cache-then-values: marker BCs (placeholder zeros)" begin
+        # CubicSplineCache stores structural Deriv2(0.0)/Deriv1(0.0) — no values
+        # exist at cache-build time. The solve must rehydrate the zero into its
+        # payload space; pin bit-parity against the one-step build.
+        for (bc, ref) in (
+                (ZeroCurvBC(), cubic_interp(xu, yw; bc = ZeroCurvBC())),
+                (ZeroSlopeBC(), cubic_interp(xu, yw; bc = ZeroSlopeBC())),
+            )
+            cache = CubicSplineCache(xu; bc = bc)
+            itp = cubic_interp(cache, yw)
+            @test itp(q) === ref(q)
+        end
+    end
+
+    @testset "main path: BCPair with structural Real zeros" begin
+        ref = cubic_interp(xu, yw; bc = ZeroCurvBC())
+        itp = cubic_interp(xu, yw; bc = BCPair(Deriv2(0.0), Deriv2(0.0)))
+        @test itp(q) === ref(q)
+    end
+
+    @testset "nonzero unitless payload stays rejected (actionable error)" begin
+        # 0 is the only unit-unambiguous Real payload; 0.3 has no inferable unit.
+        @test_throws ArgumentError cubic_interp(xu, yw; bc = BCPair(Deriv2(0.3), Deriv2(0.3)))
+    end
+
+    @testset "embeddable carriers unaffected (Real payload + Complex values)" begin
+        yc = complex.([1.0, 2.0, 0.5, 3.0, 2.5], [0.5, -1.0, 0.0, 1.0, -0.5])
+        xf = [0.0, 1.0, 2.5, 3.0, 4.5]
+        itp = cubic_interp(xf, yc; bc = BCPair(Deriv2(0.3), Deriv2(-0.1)))
+        @test itp(2.2) isa ComplexF64
     end
 end

--- a/test/test_cubic_unit_native.jl
+++ b/test/test_cubic_unit_native.jl
@@ -149,24 +149,45 @@ end
     end
 end
 
-@testitem "cubic unit native: periodic guard lives in the builder" begin
+@testitem "cubic unit native: periodic S-M build + solve" begin
     using Unitful
     const FI = FastInterpolations
 
-    # Phase 2 relocates the friendly PeriodicBC-on-units rejection from the
-    # twin into `_build_periodic_cache` (Phase 3 replaces it with native
-    # support). Message contract matches the public F7 pin: name the feature
-    # and the workaround — never a raw DimensionError from a hostile write.
-    xu = [0.0, 1.0, 2.5, 4.0] .* u"s"
-    err = try
-        FI._build_periodic_cache(xu, FI.PeriodicBC())
-        nothing
-    catch e
-        e
+    # Sherman-Morrison is dimensionally clean end-to-end: u is the
+    # DIMENSIONLESS structural vector [1,0,…,1], q = A'⁻¹u lives in [1/X]
+    # (the inv_d space), vᵀq is dimensionless, and the correction
+    # z − (vᵀy/(1+vᵀq))·q stays in [Y/X²]. Real grids collapse u and q to one
+    # eltype — the historic single-buffer in-place build.
+    xf = [0.0, 1.0, 2.5, 3.0, 4.5]
+    yf = [1.0, 2.0, 0.5, 3.0, 1.0]          # closed cycle
+    xu = xf .* u"s"
+    yw = yf .* u"W"
+
+    @testset "inclusive: bit parity + witness spaces" begin
+        itp_u = cubic_interp(xu, yw; bc = PeriodicBC(), autocache = false)
+        ref = cubic_interp(xf, yf; bc = PeriodicBC(), autocache = false)
+
+        @test eltype(itp_u.cache.q) === typeof(inv(1.0u"s"))
+        @test eltype(itp_u.cache.thomas.dl) === Float64
+        @test eltype(itp_u.cache.thomas.inv_d) === typeof(inv(1.0u"s"))
+        @test all(i -> ustrip(u"W/s^2", itp_u.z[i]) === ref.z[i], eachindex(ref.z))
+        @test itp_u(2.2u"s") === ref(2.2) * u"W"
+        @test itp_u(6.0u"s") === ref(6.0) * u"W"   # wrap extrapolation
     end
-    @test err isa ArgumentError
-    msg = sprint(showerror, err)
-    @test occursin("PeriodicBC", msg)
-    @test occursin("unit-carrying", msg)
-    @test occursin("ustrip", msg)
+
+    @testset "exclusive: explicit unit period" begin
+        xe = [0.0, 1.0, 2.5, 3.0] .* u"s"
+        ye = [1.0, 2.0, 0.5, 3.0] .* u"W"
+        itp_u = cubic_interp(xe, ye; bc = PeriodicBC(period = 4.5u"s"), autocache = false)
+        ref = cubic_interp([0.0, 1.0, 2.5, 3.0], [1.0, 2.0, 0.5, 3.0]; bc = PeriodicBC(period = 4.5), autocache = false)
+        @test itp_u(2.2u"s") === ref(2.2) * u"W"
+        @test itp_u(4.0u"s") === ref(4.0) * u"W"   # seam cell
+    end
+
+    @testset "periodic bank: unit grids hit" begin
+        FI.clear_cubic_cache!()
+        i1 = cubic_interp(xu, yw; bc = PeriodicBC())
+        i2 = cubic_interp(xu, yw; bc = PeriodicBC())
+        @test i2.cache === i1.cache
+    end
 end

--- a/test/test_cubic_unit_native.jl
+++ b/test/test_cubic_unit_native.jl
@@ -149,6 +149,68 @@ end
     end
 end
 
+@testitem "cubic Series unit native: self-consistent cache + payload spaces + periodic" begin
+    using Unitful
+    const FI = FastInterpolations
+
+    xf = [0.0, 1.0, 2.5, 3.0, 4.5]
+    yf = [1.0, 2.0, 0.5, 3.0, 2.5]
+    y2f = [0.5, 1.5, 2.0, 0.0, 1.0]
+    xu = xf .* u"s"
+    yw = yf .* u"W"
+    y2 = y2f .* u"W"
+
+    @testset "default BC: equivalence + native factorization on the cache" begin
+        sitp = cubic_interp(xu, Series(yw, y2))
+        ref = cubic_interp(xf, Series(yf, y2f))
+        v = sitp(2.2u"s")
+        vr = ref(2.2)
+        @test v[1] === vr[1] * u"W"
+        @test v[2] === vr[2] * u"W"
+        @test eltype(sitp.z) === typeof(1.0u"W/s^2")
+        # The cache must be self-consistent: a unit axis carries a unit-typed
+        # factorization (the twin paired a Float64 thomas with a unit axis and
+        # forbade reuse — that lie ends here).
+        @test eltype(sitp.cache.thomas.du) === typeof(1.0u"s")
+        @test eltype(sitp.cache.thomas.inv_d) === typeof(inv(1.0u"s"))
+    end
+
+    @testset "ZeroCurvBC: payload zero lives in [Y/X²]" begin
+        sitp = cubic_interp(xu, Series(yw, y2); bc = ZeroCurvBC())
+        ref = cubic_interp(xf, Series(yf, y2f); bc = ZeroCurvBC())
+        @test sitp(0.35u"s")[1] === ref(0.35)[1] * u"W"
+        @test sitp.bc.left.val === 0.0u"W/s^2"
+    end
+
+    @testset "per-series BC array (unit payloads)" begin
+        bcs = [
+            BCPair(Deriv1(0.7u"W/s"), Deriv1(0.7u"W/s")),
+            BCPair(Deriv2(-0.3u"W/s^2"), Deriv2(-0.3u"W/s^2")),
+        ]
+        bcs_f = [
+            BCPair(Deriv1(0.7), Deriv1(0.7)),
+            BCPair(Deriv2(-0.3), Deriv2(-0.3)),
+        ]
+        sitp = cubic_interp(xu, Series(yw, y2); bc = bcs)
+        ref = cubic_interp(xf, Series(yf, y2f); bc = bcs_f)
+        v = sitp(2.2u"s")
+        vr = ref(2.2)
+        @test v[1] === vr[1] * u"W"
+        @test v[2] === vr[2] * u"W"
+    end
+
+    @testset "PeriodicBC Series (new capability — twin rejected this)" begin
+        ywp = [1.0, 2.0, 0.5, 3.0, 1.0] .* u"W"
+        y2p = [0.5, 1.5, 2.0, 0.0, 0.5] .* u"W"
+        sitp = cubic_interp(xu, Series(ywp, y2p); bc = PeriodicBC())
+        ref = cubic_interp(xf, Series([1.0, 2.0, 0.5, 3.0, 1.0], [0.5, 1.5, 2.0, 0.0, 0.5]); bc = PeriodicBC())
+        v = sitp(2.2u"s")
+        vr = ref(2.2)
+        @test v[1] === vr[1] * u"W"
+        @test v[2] === vr[2] * u"W"
+    end
+end
+
 @testitem "cubic unit native: periodic S-M build + solve" begin
     using Unitful
     const FI = FastInterpolations

--- a/test/test_duck_grid_lint.jl
+++ b/test/test_duck_grid_lint.jl
@@ -170,11 +170,11 @@ end
     src_dir = dirname(pathof(FastInterpolations))
 
     expected_tokens = Dict(
-        "_cubic_interp_units" => 5,
+        "_cubic_interp_units" => 0,   # P2: cubic scalar twin deleted
         "_cubic_series_units" => 2,
         "_quadratic_interp_units" => 2,
         "_strip_series_bc_units" => 3,
-        "_strip_bc_units" => 15,
+        "_strip_bc_units" => 14,      # P2: cubic call gone; defs moved beside the quadratic twin
     )
     # `Tg <: Real || return …` / `if !(Tg <: Real)` REROUTE forks, counted only
     # inside the solver family trees (cubic/, quadratic/) — `utils.jl`'s
@@ -183,7 +183,7 @@ end
     # actionable error for a not-yet-native combo is the endorsed idiom, not a
     # parallel solve path (e.g. the periodic-units guard until Phase 3).
     fork_res = (r"<: Real \|\|", r"if !\([A-Za-z_][A-Za-z0-9_]* <: Real\)")
-    expected_forks = 15
+    expected_forks = 14   # P2: cubic scalar surface fork deleted
 
     counts, forks = let counts = Dict(k => 0 for k in keys(expected_tokens)), forks = 0
         for (root, _, files) in walkdir(src_dir), f in files

--- a/test/test_duck_grid_lint.jl
+++ b/test/test_duck_grid_lint.jl
@@ -155,8 +155,8 @@ end
 # `_strip_*_units` helpers, `<: Real` reroute forks in the solver families) is
 # banned; the counts below ratchet DOWN to zero as the duck-thomas phases
 # delete each site, and any INCREASE is a regression. Exact-name matching only:
-# `_check_nd_hessian_units`, `_strip_periodic_bc`, `_strip_wrap_extrap` are
-# legitimate names a broad pattern would false-positive on.
+# `_strip_periodic_bc`, `_strip_wrap_extrap` are legitimate names a broad
+# pattern would false-positive on.
 #
 # Phase schedule (update counts consciously at each phase commit):
 #   P2 cubic scalar twin → P3 periodic → P4 quadratic scalar+Series twins

--- a/test/test_duck_grid_lint.jl
+++ b/test/test_duck_grid_lint.jl
@@ -151,3 +151,58 @@
     end
     @test allowed_hits == expected_hits
 end
+
+# ========================================
+# Strip-twin ratchet (refac/duck-thomas)
+# ========================================
+# The strip→solve→reattach twin style (`_*_units` sibling builders,
+# `_strip_*_units` helpers, `<: Real` reroute forks in the solver families) is
+# banned; the counts below ratchet DOWN to zero as the duck-thomas phases
+# delete each site, and any INCREASE is a regression. Exact-name matching only:
+# `_check_nd_hessian_units`, `_strip_periodic_bc`, `_strip_wrap_extrap` are
+# legitimate names a broad pattern would false-positive on.
+#
+# Phase schedule (update counts consciously at each phase commit):
+#   P2 cubic scalar twin → P3 periodic → P4 quadratic scalar+Series twins
+#   → P5 cubic Series twin → P6 one-shot reroute forks → all zeros.
+
+@testitem "Duck grid: strip-twin ratchet — mention counts must only decrease" begin
+    src_dir = dirname(pathof(FastInterpolations))
+
+    expected_tokens = Dict(
+        "_cubic_interp_units" => 5,
+        "_cubic_series_units" => 2,
+        "_quadratic_interp_units" => 2,
+        "_strip_series_bc_units" => 3,
+        "_strip_bc_units" => 15,
+    )
+    # `Tg <: Real || return …` / `if !(Tg <: Real)` reroute forks, counted only
+    # inside the solver family trees (cubic/, quadratic/) — `utils.jl`'s
+    # promotion arm and adjoint gating live elsewhere and are legitimate.
+    fork_res = (r"<: Real \|\|", r"if !\([A-Za-z_][A-Za-z0-9_]* <: Real\)")
+    expected_forks = 15
+
+    counts, forks = let counts = Dict(k => 0 for k in keys(expected_tokens)), forks = 0
+        for (root, _, files) in walkdir(src_dir), f in files
+            endswith(f, ".jl") || continue
+            path = joinpath(root, f)
+            rel = relpath(path, src_dir)
+            in_family = startswith(rel, "cubic") || startswith(rel, "quadratic")
+            for line in eachline(path)
+                for k in keys(expected_tokens)
+                    occursin(k, line) && (counts[k] += 1)
+                end
+                if in_family && (occursin(fork_res[1], line) || occursin(fork_res[2], line))
+                    forks += 1
+                end
+            end
+        end
+        counts, forks
+    end
+
+    if counts != expected_tokens || forks != expected_forks
+        @info "strip-twin ratchet drift (decreases: update table at the phase commit; increases: regression)" counts expected_tokens forks expected_forks
+    end
+    @test counts == expected_tokens
+    @test forks == expected_forks
+end

--- a/test/test_duck_grid_lint.jl
+++ b/test/test_duck_grid_lint.jl
@@ -176,9 +176,12 @@ end
         "_strip_series_bc_units" => 3,
         "_strip_bc_units" => 15,
     )
-    # `Tg <: Real || return …` / `if !(Tg <: Real)` reroute forks, counted only
+    # `Tg <: Real || return …` / `if !(Tg <: Real)` REROUTE forks, counted only
     # inside the solver family trees (cubic/, quadratic/) — `utils.jl`'s
     # promotion arm and adjoint gating live elsewhere and are legitimate.
+    # Reject-guards (`<: Real || throw(...)`) are exempt: throwing an
+    # actionable error for a not-yet-native combo is the endorsed idiom, not a
+    # parallel solve path (e.g. the periodic-units guard until Phase 3).
     fork_res = (r"<: Real \|\|", r"if !\([A-Za-z_][A-Za-z0-9_]* <: Real\)")
     expected_forks = 15
 
@@ -193,7 +196,7 @@ end
                     occursin(k, line) && (counts[k] += 1)
                 end
                 if in_family && (occursin(fork_res[1], line) || occursin(fork_res[2], line))
-                    forks += 1
+                    occursin("throw", line) || (forks += 1)   # reject-guard exemption
                 end
             end
         end

--- a/test/test_duck_grid_lint.jl
+++ b/test/test_duck_grid_lint.jl
@@ -123,7 +123,6 @@
         # Series (build nondimensionalizes like the scalar path) — one-shot was 5,
         # now 0 → key dropped; interp was 4, now 1 = the `Tg <: Real ||` units-branch
         # idiom itself (allowlist class 3b).
-        "cubic/cubic_series_interp.jl" => 1,
         "cubic/nd/cubic_nd_adjoint.jl" => 1,
         # derivative_view.jl: in-place view query bounds relaxed to Number (Codex
         # #4) — was 2, now 0 → key dropped.
@@ -168,12 +167,13 @@ end
 @testitem "Duck grid: strip-twin ratchet — mention counts must only decrease" begin
     src_dir = dirname(pathof(FastInterpolations))
 
+    # P2/P4/P5: every strip-twin family is gone — these ratchet at ZERO forever.
     expected_tokens = Dict(
-        "_cubic_interp_units" => 0,      # P2: cubic scalar twin deleted
-        "_cubic_series_units" => 2,
-        "_quadratic_interp_units" => 0,  # P4: quadratic scalar twin deleted
-        "_strip_series_bc_units" => 3,
-        "_strip_bc_units" => 9,          # P4: defs beside their last consumer (cubic Series twin)
+        "_cubic_interp_units" => 0,
+        "_cubic_series_units" => 0,
+        "_quadratic_interp_units" => 0,
+        "_strip_series_bc_units" => 0,
+        "_strip_bc_units" => 0,
     )
     # `Tg <: Real || return …` / `if !(Tg <: Real)` REROUTE forks, counted only
     # inside the solver family trees (cubic/, quadratic/) — `utils.jl`'s
@@ -182,7 +182,7 @@ end
     # actionable error for a not-yet-native combo is the endorsed idiom, not a
     # parallel solve path (e.g. the periodic-units guard until Phase 3).
     fork_res = (r"<: Real \|\|", r"if !\([A-Za-z_][A-Za-z0-9_]* <: Real\)")
-    expected_forks = 12   # P2: cubic surface fork gone; P4: quadratic surface + Series forks gone
+    expected_forks = 11   # persistent-path forks all gone (P2/P4/P5); 11 = one-shot reroutes (P6)
 
     counts, forks = let counts = Dict(k => 0 for k in keys(expected_tokens)), forks = 0
         for (root, _, files) in walkdir(src_dir), f in files

--- a/test/test_duck_grid_lint.jl
+++ b/test/test_duck_grid_lint.jl
@@ -118,7 +118,6 @@
         "core/utils.jl" => 6,
         "cubic/cubic_adjoint.jl" => 1,
         "cubic/cubic_anchor.jl" => 4,
-        "cubic/cubic_oneshot.jl" => 3,
         # cubic series + one-shot: eval sigs relaxed to Number for unit-grid cubic
         # Series (build nondimensionalizes like the scalar path) — one-shot was 5,
         # now 0 → key dropped; interp was 4, now 1 = the `Tg <: Real ||` units-branch
@@ -134,7 +133,6 @@
         "linear/nd/linear_nd_adjoint.jl" => 1,
         "quadratic/nd/quadratic_nd_adjoint.jl" => 1,
         "quadratic/quadratic_anchor.jl" => 8,
-        "quadratic/quadratic_oneshot.jl" => 2,
         # quadratic series + one-shot: eval sigs relaxed to Number (Codex parity;
         # eval reaches a documented solver-storage limit, but the SIG isn't the
         # blocker) — were 4 + 4, now 0 → keys dropped.
@@ -181,8 +179,10 @@ end
     # Reject-guards (`<: Real || throw(...)`) are exempt: throwing an
     # actionable error for a not-yet-native combo is the endorsed idiom, not a
     # parallel solve path (e.g. the periodic-units guard until Phase 3).
+    # P2–P6: every reroute fork is gone — the solver families are fork-free
+    # forever (reject-guards with `throw` remain exempt).
     fork_res = (r"<: Real \|\|", r"if !\([A-Za-z_][A-Za-z0-9_]* <: Real\)")
-    expected_forks = 11   # persistent-path forks all gone (P2/P4/P5); 11 = one-shot reroutes (P6)
+    expected_forks = 0
 
     counts, forks = let counts = Dict(k => 0 for k in keys(expected_tokens)), forks = 0
         for (root, _, files) in walkdir(src_dir), f in files

--- a/test/test_duck_grid_lint.jl
+++ b/test/test_duck_grid_lint.jl
@@ -135,7 +135,6 @@
         "linear/nd/linear_nd_adjoint.jl" => 1,
         "quadratic/nd/quadratic_nd_adjoint.jl" => 1,
         "quadratic/quadratic_anchor.jl" => 8,
-        "quadratic/quadratic_interpolant.jl" => 1,
         "quadratic/quadratic_oneshot.jl" => 2,
         # quadratic series + one-shot: eval sigs relaxed to Number (Codex parity;
         # eval reaches a documented solver-storage limit, but the SIG isn't the
@@ -170,11 +169,11 @@ end
     src_dir = dirname(pathof(FastInterpolations))
 
     expected_tokens = Dict(
-        "_cubic_interp_units" => 0,   # P2: cubic scalar twin deleted
+        "_cubic_interp_units" => 0,      # P2: cubic scalar twin deleted
         "_cubic_series_units" => 2,
-        "_quadratic_interp_units" => 2,
+        "_quadratic_interp_units" => 0,  # P4: quadratic scalar twin deleted
         "_strip_series_bc_units" => 3,
-        "_strip_bc_units" => 14,      # P2: cubic call gone; defs moved beside the quadratic twin
+        "_strip_bc_units" => 9,          # P4: defs beside their last consumer (cubic Series twin)
     )
     # `Tg <: Real || return …` / `if !(Tg <: Real)` REROUTE forks, counted only
     # inside the solver family trees (cubic/, quadratic/) — `utils.jl`'s
@@ -183,7 +182,7 @@ end
     # actionable error for a not-yet-native combo is the endorsed idiom, not a
     # parallel solve path (e.g. the periodic-units guard until Phase 3).
     fork_res = (r"<: Real \|\|", r"if !\([A-Za-z_][A-Za-z0-9_]* <: Real\)")
-    expected_forks = 14   # P2: cubic scalar surface fork deleted
+    expected_forks = 12   # P2: cubic surface fork gone; P4: quadratic surface + Series forks gone
 
     counts, forks = let counts = Dict(k => 0 for k in keys(expected_tokens)), forks = 0
         for (root, _, files) in walkdir(src_dir), f in files

--- a/test/test_duck_typing_comprehensive.jl
+++ b/test/test_duck_typing_comprehensive.jl
@@ -1943,3 +1943,20 @@ end
         end
     end
 end
+
+@testitem "Duck Typing: Real-zero BC payloads rehydrate duck-safely (BCPair + cache)" setup = [DuckTypeSetup] begin
+    # Structural Real zeros (user BCPair, cache markers) must mint the duck-space
+    # zero via `0 * value-witness` — `one`/`oneunit(Tv)` are not duck-contract ops.
+    ref = cubic_interp(x_vec, y_generic; bc = ZeroCurvBC())
+
+    @testset "user BCPair with Real zeros beside duck data" begin
+        itp = cubic_interp(x_vec, y_generic; bc = BCPair(Deriv2(0.0), Deriv2(0.0)))
+        @test _val(itp(xq)) === _val(ref(xq))
+    end
+
+    @testset "cache markers (Deriv{Float64} zeros) rehydrate against duck values" begin
+        cache = CubicSplineCache(x_vec; bc = ZeroCurvBC())
+        itp_c = cubic_interp(cache, y_generic)
+        @test _val(itp_c(xq)) === _val(ref(xq))
+    end
+end

--- a/test/test_gradient_hessian.jl
+++ b/test/test_gradient_hessian.jl
@@ -476,7 +476,7 @@ end
 
         val, grad = value_gradient(itp, (2.0, 0.5))
         @test isnan(val)
-        @test all(g -> g == 0.0, grad)
+        @test all(isnan, grad)   # fill-value rule: a NaN fill poisons OOB derivs too
 
         # Also test with finite non-zero fill value
         itp2 = cubic_interp((x, y), data; extrap = FillExtrap(-999.0))
@@ -822,5 +822,42 @@ end
         check_splat_equiv(itp, (GridIdx(3), GridIdx(5)))  # both GridIdx
         check_splat_equiv(itp, (GridIdx(3), 0.9))          # GridIdx + Float64
         @test isequal(gradient(itp, GridIdx(3), 0.9), gradient(itp, (GridIdx(3), 0.9)))
+    end
+end
+
+@testitem "FillExtrap OOB derivatives derive from the FILL value (NaN rule)" begin
+    # Package rule (1D + ND eval agree): the OOB region belongs to the fill
+    # value — FillExtrap(NaN) poisons OOB derivatives; interior data NaN does
+    # NOT leak into OOB. The vector-calculus OOB zeros used a DATA sample,
+    # which was backwards on both counts.
+    x = [0.0, 1.0, 2.0]
+    y = [0.0, 0.5, 1.0]
+    data = [1.0 2.0 3.0; 2.0 3.0 4.0; 3.0 4.0 5.0]
+    q_oob = (9.0, 0.5)
+
+    @testset "fill = NaN poisons OOB derivs (matches eval/1D)" begin
+        itp = interp((x, y), data; method = LinearInterp(), extrap = FillExtrap(NaN))
+        @test isnan(itp(q_oob; deriv = (DerivOp(1), DerivOp(0))))   # eval rule anchor
+        @test all(isnan, gradient(itp, q_oob))
+        vg = value_gradient(itp, q_oob)
+        @test isnan(vg[1]) && all(isnan, vg[2])
+        @test all(isnan, hessian(itp, q_oob))
+        @test isnan(laplacian(itp, q_oob))
+        G = zeros(2)
+        gradient!(G, itp, q_oob)
+        @test all(isnan, G)
+        H = zeros(2, 2)
+        hessian!(H, itp, q_oob)
+        @test all(isnan, H)
+    end
+
+    @testset "interior data NaN does NOT leak into OOB" begin
+        dn = copy(data)
+        dn[1, 1] = NaN
+        itp = interp((x, y), dn; method = LinearInterp(), extrap = FillExtrap(0.0))
+        @test itp(q_oob) === 0.0
+        @test all(iszero, gradient(itp, q_oob))
+        @test all(iszero, hessian(itp, q_oob))
+        @test iszero(laplacian(itp, q_oob))
     end
 end

--- a/test/test_nd_mixed_unit_guards.jl
+++ b/test/test_nd_mixed_unit_guards.jl
@@ -1,17 +1,13 @@
 # ========================================
-# ND vector calculus on mixed-unit grids: explicit guards
+# ND vector calculus on mixed-unit grids: values where they exist, guards where not
 # ========================================
-# `gradient` returns a Tuple, so per-axis components may carry different units
-# (`K/s`, `K/m`) and it works. The three APIs that need ONE shared element type
-# cannot: `hessian` (Matrix), `laplacian` (a sum), `gradient!` (a user Vector).
-# Their component units differ per axis, so the promotion collapses to an
-# abstract `Quantity` with no `zero`/`oneunit`.
-#
-# Without a guard the user meets a raw `DimensionError` from deep inside the
-# kernel. These pin an `ArgumentError` naming the API and the workaround, in the
-# same style as the hetero-ND unit guard.
+# `gradient` (Tuple) and `hessian` (Matrix with the components' promoted —
+# possibly abstract — eltype) return VALUES: every component exists, only a
+# shared concrete type may not. `laplacian` stays guarded (its terms must be
+# ADDED across axes — dimensionally undefined for mixed units), and the
+# in-place forms refuse only a store that genuinely cannot hold the components.
 
-@testitem "ND mixed-unit: hessian/laplacian/gradient! refuse with an explanation" begin
+@testitem "ND mixed-unit: hessian returns the abstract-eltype matrix; laplacian/gradient! guard" begin
     using Unitful
 
     xs = (0.0:1.0:4.0)u"s"
@@ -19,18 +15,31 @@
     V = [Float64(i + j) for i in 1:5, j in 1:4]u"K"
     itp = linear_interp((xs, ym), V)
 
-    @testset "hessian" begin
-        e = try
-            hessian(itp, 1.5u"s", 1.5u"m")
-            nothing
-        catch err
-            err
-        end
-        @test e isa ArgumentError
-        msg = sprint(showerror, e)
-        @test occursin("hessian", msg)
-        @test occursin("not supported", msg)
-        @test occursin("deriv", msg)            # names the per-component workaround
+    @testset "hessian: per-element units, values ≡ component deriv queries" begin
+        H = hessian(itp, 1.5u"s", 1.5u"m")
+        @test !isconcretetype(eltype(H))
+        @test eltype(H) <: Quantity{Float64}
+        @test unit(H[1, 1]) === u"K" / u"s"^2
+        @test unit(H[2, 2]) === u"K" / u"m"^2
+        @test H[1, 2] === itp((1.5u"s", 1.5u"m"); deriv = (DerivOp(1), DerivOp(1)))
+        @test H[2, 1] === H[1, 2]
+        # Vector-query form agrees.
+        Hv = hessian(itp, [1.5u"s", 1.5u"m"])
+        @test all(i -> Hv[i] === H[i], eachindex(H))
+    end
+
+    @testset "hessian: FillExtrap OOB zeros carry per-element units" begin
+        itp_f = linear_interp((xs, ym), V; extrap = FillExtrap(0.0u"K"))
+        Ho = hessian(itp_f, 9.0u"s", 1.5u"m")
+        @test unit(Ho[1, 1]) === u"K" / u"s"^2
+        @test unit(Ho[1, 2]) === u"K" / (u"s" * u"m")
+        @test all(iszero, Ho)
+        # In-place with an Any store takes the same per-element OOB path
+        # (was: fill!(H, zero(Any)) → MethodError).
+        Ha = Matrix{Any}(undef, 2, 2)
+        hessian!(Ha, itp_f, 9.0u"s", 1.5u"m")
+        @test unit(Ha[2, 2]) === u"K" / u"m"^2
+        @test all(iszero, Ha)
     end
 
     @testset "laplacian" begin
@@ -61,8 +70,7 @@
         @test occursin("gradient", msg)         # points at the Tuple-returning form
     end
 
-    # Vector-query and splatted entries route through the same guard.
-    @test_throws ArgumentError hessian(itp, [1.5u"s", 1.5u"m"])
+    # Vector-query and splatted entries route through the same guards.
     @test_throws ArgumentError laplacian(itp, (1.5u"s", 1.5u"m"))
     @test_throws ArgumentError gradient!(Vector{typeof(1.0u"K/s")}(undef, 2), itp, [1.5u"s", 1.5u"m"])
 end

--- a/test/test_quadratic_unit_native.jl
+++ b/test/test_quadratic_unit_native.jl
@@ -38,6 +38,37 @@
     end
 end
 
+@testitem "quadratic unit one-shot ≡ persistent (fork-free contract)" begin
+    using Unitful
+
+    xu = [0.0, 1.0, 2.5, 3.0, 4.5] .* u"s"
+    yw = [1.0, 2.0, 0.5, 3.0, 2.5] .* u"W"
+    y2 = [0.5, 1.5, 2.0, 0.0, 1.0] .* u"W"
+    q = 2.2u"s"
+    qv = [0.35, 2.2, 4.1] .* u"s"
+
+    for (nm, bc) in (
+            ("default", Left(QuadraticFit())),
+            ("Right(Deriv2)", Right(Deriv2(-0.3u"W/s^2"))),
+            ("MinCurvFit", MinCurvFit()),
+        )
+        @testset "$nm" begin
+            itp = quadratic_interp(xu, yw; bc = bc)
+            @test quadratic_interp(xu, yw, q; bc = bc) === itp(q)
+            vv = quadratic_interp(xu, yw, qv; bc = bc)
+            pv = itp(qv)
+            @test all(i -> vv[i] === pv[i], eachindex(pv))
+        end
+    end
+
+    @testset "Series one-shot" begin
+        sitp = quadratic_interp(xu, Series(yw, y2))
+        sv = quadratic_interp(xu, Series(yw, y2), q)
+        sp = sitp(q)
+        @test all(i -> sv[i] === sp[i], eachindex(sp))
+    end
+end
+
 @testitem "quadratic unit: surface + Series equivalence (pre/post twin deletion)" begin
     using Unitful
     const FI = FastInterpolations

--- a/test/test_quadratic_unit_native.jl
+++ b/test/test_quadratic_unit_native.jl
@@ -1,0 +1,70 @@
+# ========================================
+# Quadratic 1D native duck (unit) build — refac/duck-thomas Phase 4 contracts
+# ========================================
+# Internal-seam RED (the public unit API routes through the strip-twin today):
+# `_compute_quadratic_coeffs` must produce d in [Y/X] and a in [Y/X²] natively.
+# Surface/Series testitems are EQUIVALENCE pins — green via the twin now, and
+# they must stay green unchanged when the twin is deleted.
+
+@testitem "quadratic unit native: coeff kernels (internal seam)" begin
+    using Unitful
+    const FI = FastInterpolations
+
+    xu = [0.0, 1.0, 2.5, 3.0, 4.5] .* u"s"
+    yw = [1.0, 2.0, 0.5, 3.0, 2.5] .* u"W"
+    xf = [0.0, 1.0, 2.5, 3.0, 4.5]
+    yf = [1.0, 2.0, 0.5, 3.0, 2.5]
+
+    cases = [
+        ("Left(QuadraticFit)", Left(QuadraticFit()), Left(QuadraticFit())),
+        ("Right(QuadraticFit)", Right(QuadraticFit()), Right(QuadraticFit())),
+        ("MinCurvFit", MinCurvFit(), MinCurvFit()),
+        ("Left(Deriv1)", Left(Deriv1(0.7u"W/s")), Left(Deriv1(0.7))),
+        ("Right(Deriv2)", Right(Deriv2(-0.3u"W/s^2")), Right(Deriv2(-0.3))),
+    ]
+
+    for (name, bcu, bcf) in cases
+        @testset "$name" begin
+            xw = FI._policy_axis(xu, FI.NoBC(), eltype(xu), FI.StorePolicy())
+            du, au = FI._compute_quadratic_coeffs(xw, yw, bcu)
+            @test eltype(du) === typeof(1.0u"W/s")
+            @test eltype(au) === typeof(1.0u"W/s^2")
+
+            xwf = FI._policy_axis(xf, FI.NoBC(), Float64, FI.StorePolicy())
+            df, af = FI._compute_quadratic_coeffs(xwf, yf, bcf)
+            @test all(i -> ustrip(u"W/s", du[i]) === df[i], eachindex(df))
+            @test all(i -> ustrip(u"W/s^2", au[i]) === af[i], eachindex(af))
+        end
+    end
+end
+
+@testitem "quadratic unit: surface + Series equivalence (pre/post twin deletion)" begin
+    using Unitful
+    const FI = FastInterpolations
+
+    xu = [0.0, 1.0, 2.5, 3.0, 4.5] .* u"s"
+    yw = [1.0, 2.0, 0.5, 3.0, 2.5] .* u"W"
+    y2 = [0.5, 1.5, 2.0, 0.0, 1.0] .* u"W"
+    xf = [0.0, 1.0, 2.5, 3.0, 4.5]
+    yf = [1.0, 2.0, 0.5, 3.0, 2.5]
+
+    @testset "scalar surface" begin
+        itp = quadratic_interp(xu, yw)
+        ref = quadratic_interp(xf, yf)
+        @test itp(2.2u"s") === ref(2.2) * u"W"
+        @test eltype(itp.d) === typeof(1.0u"W/s")
+        @test eltype(itp.a) === typeof(1.0u"W/s^2")
+        itp_d2 = quadratic_interp(xu, yw; bc = Right(Deriv2(-0.3u"W/s^2")))
+        ref_d2 = quadratic_interp(xf, yf; bc = Right(Deriv2(-0.3)))
+        @test itp_d2(0.35u"s") === ref_d2(0.35) * u"W"
+    end
+
+    @testset "Series" begin
+        sitp = quadratic_interp(xu, Series(yw, y2))
+        v = sitp(2.2u"s")
+        ref = quadratic_interp(xf, yf)
+        @test v[1] === ref(2.2) * u"W"
+        @test eltype(sitp.a) === typeof(1.0u"W/s^2")
+        @test eltype(sitp.d) === typeof(1.0u"W/s")
+    end
+end

--- a/test/test_quadratic_unit_native.jl
+++ b/test/test_quadratic_unit_native.jl
@@ -49,6 +49,7 @@ end
 
     for (nm, bc) in (
             ("default", Left(QuadraticFit())),
+            ("Left(Deriv1)", Left(Deriv1(0.4u"W/s"))),
             ("Right(Deriv2)", Right(Deriv2(-0.3u"W/s^2"))),
             ("MinCurvFit", MinCurvFit()),
         )

--- a/test/test_rcu.jl
+++ b/test/test_rcu.jl
@@ -13,7 +13,7 @@ Tests for the thread-safe autocache implementation:
 @testitem "RCU Bank" begin
     # Common type aliases for tests
     FI = FastInterpolations
-    EntryType = FI.CacheEntry{Float64, FI.Deriv2{Float64}, FI.Deriv2{Float64}, Vector{Float64}, FI.CubicSplineCache{Float64, FI._CachedVector{Float64, Float64}, FI.ThomasFactorization{Float64, Vector{Float64}}, FI.BCPair{FI.Deriv2{Float64}, FI.Deriv2{Float64}}}}
+    EntryType = FI.CacheEntry{Float64, FI.Deriv2{Float64}, FI.Deriv2{Float64}, Vector{Float64}, FI.CubicSplineCache{Float64, FI._CachedVector{Float64, Float64}, FI.ThomasFactorization{Vector{Float64}, Vector{Float64}, Vector{Float64}}, FI.BCPair{FI.Deriv2{Float64}, FI.Deriv2{Float64}}, Nothing}}
     BankType = FI.CacheBank{EntryType}
 
 
@@ -287,7 +287,7 @@ end  # RCU Bank
 @testitem "RCU Registry" begin
     # Common type aliases for tests
     FI = FastInterpolations
-    EntryType = FI.CacheEntry{Float64, FI.Deriv2{Float64}, FI.Deriv2{Float64}, Vector{Float64}, FI.CubicSplineCache{Float64, FI._CachedVector{Float64, Float64}, FI.ThomasFactorization{Float64, Vector{Float64}}, FI.BCPair{FI.Deriv2{Float64}, FI.Deriv2{Float64}}}}
+    EntryType = FI.CacheEntry{Float64, FI.Deriv2{Float64}, FI.Deriv2{Float64}, Vector{Float64}, FI.CubicSplineCache{Float64, FI._CachedVector{Float64, Float64}, FI.ThomasFactorization{Vector{Float64}, Vector{Float64}, Vector{Float64}}, FI.BCPair{FI.Deriv2{Float64}, FI.Deriv2{Float64}}, Nothing}}
     BankType = FI.CacheBank{EntryType}
 
 

--- a/test/test_thomas_lu_solver.jl
+++ b/test/test_thomas_lu_solver.jl
@@ -299,3 +299,165 @@
         end
     end
 end
+
+# ========================================
+# Witness-typed Thomas core (duck grids)
+# ========================================
+# The factorization mixes three unit spaces — l (dimensionless), du (X),
+# inv_d (1/X) — so the storage is per-field typed and the solve writes its
+# result (B/X space) into a caller-provided output instead of overwriting the
+# RHS. Real grids must stay bit-identical: the reference implementations below
+# are the pre-refactor in-place loops, op-for-op (muladd order preserved), used
+# as an executable spec.
+
+@testitem "Thomas duck core: Real bit-identity vs reference algorithm" begin
+    const FI = FastInterpolations
+
+    # ── pre-refactor loops (executable spec; do not "simplify") ──
+    function ref_factorize!(dl, d, du)
+        n = length(d)
+        @inbounds begin
+            inv_d_val = inv(d[1])
+            d[1] = inv_d_val
+            for i in 1:(n - 1)
+                l_val = dl[i] * inv_d_val
+                dl[i] = l_val
+                d_next = d[i + 1] - l_val * du[i]
+                inv_d_val = inv(d_next)
+                d[i + 1] = inv_d_val
+            end
+        end
+        return dl, du, d   # (l, du, inv_d)
+    end
+    function ref_nopiv!(b, l, du, inv_d)
+        n = length(inv_d)
+        @inbounds for i in 1:(n - 1)
+            b[i + 1] = muladd(-l[i], b[i], b[i + 1])
+        end
+        @inbounds b[n] *= inv_d[n]
+        @inbounds for i in (n - 1):-1:1
+            b[i] = muladd(-du[i], b[i + 1], b[i]) * inv_d[i]
+        end
+        return b
+    end
+    function ref_transpose!(b, l, du, inv_d)
+        n = length(inv_d)
+        @inbounds b[1] *= inv_d[1]
+        @inbounds for i in 2:n
+            b[i] = muladd(-du[i - 1], b[i - 1], b[i]) * inv_d[i]
+        end
+        @inbounds for i in (n - 1):-1:1
+            b[i] = muladd(-l[i], b[i + 1], b[i])
+        end
+        return b
+    end
+
+    mk(n) = (
+        d = [4.0 + sin(i) for i in 1:n],
+        dl = [1.0 + 0.1 * cos(i) for i in 1:(n - 1)],
+        du = [1.0 + 0.1 * sin(2i) for i in 1:(n - 1)],
+        b = [sin(3i) for i in 1:n],
+    )
+    bitsame(a, b) = length(a) == length(b) && all(a[i] === b[i] for i in eachindex(a))
+
+    for n in (5, 64)
+        t = mk(n)
+        l_r, du_r, inv_r = ref_factorize!(copy(t.dl), copy(t.d), copy(t.du))
+
+        F = FI.thomas_factorize(t.dl, t.d, t.du)
+        @test typeof(F.dl) === Vector{Float64}
+        @test typeof(F.inv_d) === Vector{Float64}
+        @test F.du === t.du                    # stored by reference, unchanged
+        @test bitsame(F.dl, l_r)
+        @test bitsame(F.inv_d, inv_r)
+        # inputs are read-only now
+        fresh = mk(n)
+        @test bitsame(t.dl, fresh.dl) && bitsame(t.d, fresh.d)
+
+        # nopiv: alias form ≡ old in-place, bit-for-bit
+        b_ref = ref_nopiv!(copy(t.b), l_r, du_r, inv_r)
+        b_alias = copy(t.b)
+        @test FI._ldiv_tridiagonal_nopiv!(b_alias, b_alias, F) === b_alias
+        @test bitsame(b_alias, b_ref)
+        # nopiv: separate-output form (b is forward-sweep scratch)
+        x = similar(t.b)
+        FI._ldiv_tridiagonal_nopiv!(x, copy(t.b), F)
+        @test bitsame(x, b_ref)
+
+        # transpose: alias + separate-output, bit-for-bit
+        bt_ref = ref_transpose!(copy(t.b), l_r, du_r, inv_r)
+        bt_alias = copy(t.b)
+        @test FI._ldiv_tridiagonal_transpose!(bt_alias, bt_alias, F) === bt_alias
+        @test bitsame(bt_alias, bt_ref)
+        xt = similar(t.b)
+        FI._ldiv_tridiagonal_transpose!(xt, copy(t.b), F)
+        @test bitsame(xt, bt_ref)
+
+        # batch Val{2} consumes the new struct; rows ≡ per-row nopiv
+        z = [sin(i + j) for i in 1:3, j in 1:n]
+        z_ref = copy(z)
+        for i in 1:3
+            row = z_ref[i, :]
+            FI._ldiv_tridiagonal_nopiv!(row, row, F)
+            z_ref[i, :] = row
+        end
+        FI._ldiv_along_dim!(z, F, Val(2))
+        @test z ≈ z_ref rtol = 1.0e-12
+        @test_throws ArgumentError FI._ldiv_along_dim!(z, F, Val(1))
+    end
+end
+
+@testitem "Thomas duck core: unit-carrying axis solves in witness spaces" begin
+    using Unitful
+    const FI = FastInterpolations
+
+    n = 6
+    d = [(4.0 + sin(i)) * u"s" for i in 1:n]
+    dl = [(1.0 + 0.1 * cos(i)) * u"s" for i in 1:(n - 1)]
+    du = [(1.0 + 0.1 * sin(2i)) * u"s" for i in 1:(n - 1)]
+
+    F = FI.thomas_factorize(dl, d, du)
+    @test eltype(F.dl) === Float64                    # L multipliers: dimensionless
+    @test eltype(F.inv_d) === typeof(inv(1.0u"s"))    # 1/X
+    @test F.du === du                                 # X, by reference
+
+    # value-preservation: identical mantissas to the ustrip'd Real solve
+    Fr = FI.thomas_factorize(ustrip.(u"s", dl), ustrip.(u"s", d), ustrip.(u"s", du))
+    @test all(F.dl[i] === Fr.dl[i] for i in eachindex(Fr.dl))
+    @test all(ustrip(u"s^-1", F.inv_d[i]) === Fr.inv_d[i] for i in eachindex(Fr.inv_d))
+
+    # cubic-shaped RHS: Y/X in, Y/X² out
+    b = [sin(3i) * u"W/s" for i in 1:n]
+    x = Vector{typeof(1.0u"W/s^2")}(undef, n)
+    FI._ldiv_tridiagonal_nopiv!(x, copy(b), F)
+    xr = Vector{Float64}(undef, n)
+    FI._ldiv_tridiagonal_nopiv!(xr, ustrip.(u"W/s", b), Fr)
+    @test all(ustrip(u"W/s^2", x[i]) === xr[i] for i in 1:n)
+
+    # transpose (adjoint path): same spaces
+    xt = Vector{typeof(1.0u"W/s^2")}(undef, n)
+    FI._ldiv_tridiagonal_transpose!(xt, copy(b), F)
+    xtr = Vector{Float64}(undef, n)
+    FI._ldiv_tridiagonal_transpose!(xtr, ustrip.(u"W/s", b), Fr)
+    @test all(ustrip(u"W/s^2", xt[i]) === xtr[i] for i in 1:n)
+end
+
+@testitem "Thomas duck core: Dual grid keeps flowing (Dual <: Real)" begin
+    using ForwardDiff: Dual, value
+    const FI = FastInterpolations
+
+    n = 5
+    d = Dual.([4.0 + sin(i) for i in 1:n], 1.0)
+    dl = Dual.([1.0 + 0.1 * cos(i) for i in 1:(n - 1)], 0.0)
+    du = Dual.([1.0 + 0.1 * sin(2i) for i in 1:(n - 1)], 0.0)
+
+    F = FI.thomas_factorize(dl, d, du)
+    @test eltype(F.dl) <: Dual
+    @test eltype(F.inv_d) <: Dual
+
+    b = Dual.([sin(3i) for i in 1:n], 1.0)
+    x = similar(b)
+    FI._ldiv_tridiagonal_nopiv!(x, copy(b), F)
+    @test eltype(x) <: Dual
+    @test all(isfinite, value.(x))
+end

--- a/test/test_thomas_lu_solver.jl
+++ b/test/test_thomas_lu_solver.jl
@@ -312,7 +312,7 @@ end
 # are the pre-refactor in-place loops, op-for-op (muladd order preserved), used
 # as an executable spec.
 
-@testitem "Thomas duck core: Real bit-identity vs reference algorithm" begin
+@testitem "Thomas duck core: Real bit-identity vs reference algorithm" setup = [AllocConstants] begin
     const FI = FastInterpolations
 
     # ── pre-refactor loops (executable spec; do not "simplify") ──
@@ -377,7 +377,7 @@ end
         @test F.dl === t.dl
         @test F.inv_d === t.d
         t3 = mk(n)
-        @test (@allocated FI.thomas_factorize(t3.dl, t3.d, t3.du)) == 0
+        @test (@allocated FI.thomas_factorize(t3.dl, t3.d, t3.du)) <= ALLOC_THRESHOLD
 
         # nopiv: alias form ≡ old in-place, bit-for-bit
         b_ref = ref_nopiv!(copy(t.b), l_r, du_r, inv_r)

--- a/test/test_thomas_lu_solver.jl
+++ b/test/test_thomas_lu_solver.jl
@@ -372,9 +372,12 @@ end
         @test F.du === t.du                    # stored by reference, unchanged
         @test bitsame(F.dl, l_r)
         @test bitsame(F.inv_d, inv_r)
-        # inputs are read-only now
-        fresh = mk(n)
-        @test bitsame(t.dl, fresh.dl) && bitsame(t.d, fresh.d)
+        # Real path: witness spaces equal the input eltypes → the donated inputs
+        # ARE the storage (old in-place layout — zero extra allocation, ns-parity).
+        @test F.dl === t.dl
+        @test F.inv_d === t.d
+        t3 = mk(n)
+        @test (@allocated FI.thomas_factorize(t3.dl, t3.d, t3.du)) == 0
 
         # nopiv: alias form ≡ old in-place, bit-for-bit
         b_ref = ref_nopiv!(copy(t.b), l_r, du_r, inv_r)
@@ -418,10 +421,13 @@ end
     dl = [(1.0 + 0.1 * cos(i)) * u"s" for i in 1:(n - 1)]
     du = [(1.0 + 0.1 * sin(2i)) * u"s" for i in 1:(n - 1)]
 
+    dl0, d0 = copy(dl), copy(d)
     F = FI.thomas_factorize(dl, d, du)
     @test eltype(F.dl) === Float64                    # L multipliers: dimensionless
     @test eltype(F.inv_d) === typeof(inv(1.0u"s"))    # 1/X
     @test F.du === du                                 # X, by reference
+    # unit path: witness spaces differ → fresh outputs, donated inputs untouched
+    @test dl == dl0 && d == d0
 
     # value-preservation: identical mantissas to the ustrip'd Real solve
     Fr = FI.thomas_factorize(ustrip.(u"s", dl), ustrip.(u"s", d), ustrip.(u"s", du))
@@ -456,6 +462,10 @@ end
     F = FI.thomas_factorize(dl, d, du)
     @test eltype(F.dl) <: Dual
     @test eltype(F.inv_d) <: Dual
+    # Dual is autocache-OFF (ephemeral grids) → factorize runs on EVERY build;
+    # the reuse-storage arm must cover it too (inv(Dual) is the same Dual type).
+    @test F.dl === dl
+    @test F.inv_d === d
 
     b = Dual.([sin(3i) for i in 1:n], 1.0)
     x = similar(b)

--- a/test/test_thomas_lu_solver.jl
+++ b/test/test_thomas_lu_solver.jl
@@ -146,9 +146,9 @@
                     dl = copy(A.dl)
                     d_diag = copy(A.d)
                     du = copy(A.du)
-                    thomas = FI.thomas_factorize!(dl, d_diag, du)
+                    thomas = FI.thomas_factorize(dl, d_diag, du)
                     x_custom = copy(rhs)
-                    FI._ldiv_tridiagonal_nopiv!(x_custom, thomas)
+                    FI._ldiv_tridiagonal_nopiv!(x_custom, x_custom, thomas)
 
                     # Residuals should be comparable
                     resid_base = maximum(abs.(A * x_base .- rhs))
@@ -189,9 +189,9 @@
                 dl = copy(Aprime.dl)
                 d_diag = copy(Aprime.d)
                 du = copy(Aprime.du)
-                thomas = FI.thomas_factorize!(dl, d_diag, du)
+                thomas = FI.thomas_factorize(dl, d_diag, du)
                 x_custom = copy(rhs)
-                FI._ldiv_tridiagonal_nopiv!(x_custom, thomas)
+                FI._ldiv_tridiagonal_nopiv!(x_custom, x_custom, thomas)
 
                 resid_base = maximum(abs.(Aprime * x_base .- rhs))
                 resid_custom = maximum(abs.(Aprime * x_custom .- rhs))
@@ -227,11 +227,11 @@
                 dl = copy(Aprime.dl)
                 d_diag = copy(Aprime.d)
                 du = copy(Aprime.du)
-                thomas = FI.thomas_factorize!(dl, d_diag, du)
+                thomas = FI.thomas_factorize(dl, d_diag, du)
                 q_custom = zeros(T, n_sys)
                 q_custom[1] = one(T)
                 q_custom[end] = one(T)
-                FI._ldiv_tridiagonal_nopiv!(q_custom, thomas)
+                FI._ldiv_tridiagonal_nopiv!(q_custom, q_custom, thomas)
 
                 # Residual check: A' * q ≈ u
                 u_ref = zeros(T, n_sys)
@@ -272,7 +272,8 @@
 
                     # Sequential reference: solve each RHS row independently
                     @inbounds for i in 1:n_batch
-                        FI._ldiv_tridiagonal_nopiv!(view(z_seq, i, :), cache.thomas)
+                        v = view(z_seq, i, :)
+                        FI._ldiv_tridiagonal_nopiv!(v, v, cache.thomas)
                     end
 
                     FI._ldiv_along_dim!(z_batch, cache.thomas, Val(2))
@@ -291,7 +292,8 @@
             z_ref = copy(z)
 
             @inbounds for i in 1:size(z, 1)
-                FI._ldiv_tridiagonal_nopiv!(view(z_ref, i, :), cache.thomas)
+                v = view(z_ref, i, :)
+                FI._ldiv_tridiagonal_nopiv!(v, v, cache.thomas)
             end
 
             FI._ldiv_along_dim!(z, cache.thomas, Val(2))

--- a/test/test_unitful_api_smoke.jl
+++ b/test/test_unitful_api_smoke.jl
@@ -9,8 +9,9 @@
 #   B  1D DerivativeView eval     — deriv1/2/3(itp)(q::Quantity)
 #   E  ND GriddedQuery eval       — _anchor_loc coord promotion
 #   G  Series eval                — query bound widened to Number
-# Adjoints / mixed-unit hessian / solver-family series build are design-excluded
-# (kept <:Real) — their friendly-error contract is pinned separately.
+# Adjoints / mixed-unit hessian remain design-excluded (kept <:Real) — their
+# friendly-error contract is pinned separately. Solver-family Series builds
+# are unit-native since the duck Thomas core (see test_cubic_unit_native.jl).
 
 @testitem "Unitful A: show(text/plain) renders for every built family" begin
     using Unitful

--- a/test/test_unitful_grid_1d.jl
+++ b/test/test_unitful_grid_1d.jl
@@ -1006,3 +1006,35 @@ end
         @test iu(1.5u"s") ≈ ir(1.5) * u"W"
     end
 end
+
+@testitem "PolyFit{D>=4} endpoint fits survive unit grids (twin-era regression)" begin
+    using Unitful
+
+    # The twin era stripped units before the generic barycentric kernels, so
+    # PolyFit{4}+ worked; the native-unit route hit grid-typed intermediate
+    # buffers (β lives in X^(1-N)) and a same-type-only uniform kernel.
+    xu = [0.0, 1.0, 2.5, 3.0, 4.5] .* u"s"
+    xru = range(0.0u"s", 4.5u"s", length = 5)
+    xf = [0.0, 1.0, 2.5, 3.0, 4.5]
+    yu = [1.0, 2.0, 0.5, 3.0, 2.5] .* u"W"
+    yf = [1.0, 2.0, 0.5, 3.0, 2.5]
+
+    @testset "cubic PolyFit{4}: vector + range grids" begin
+        @test cubic_interp(xu, yu; bc = PolyFit{4}())(2.2u"s") ≈
+            cubic_interp(xf, yf; bc = PolyFit{4}())(2.2) * u"W" rtol = 1.0e-12
+        @test cubic_interp(xru, yu; bc = PolyFit{4}())(2.2u"s") ≈
+            cubic_interp(range(0.0, 4.5, length = 5), yf; bc = PolyFit{4}())(2.2) * u"W" rtol = 1.0e-12
+    end
+    @testset "quadratic Left(PolyFit{4})" begin
+        @test quadratic_interp(xu, yu; bc = Left(PolyFit{4}()))(2.2u"s") ≈
+            quadratic_interp(xf, yf; bc = Left(PolyFit{4}()))(2.2) * u"W" rtol = 1.0e-12
+    end
+    @testset "cubic PolyFit{5} (6 points)" begin
+        x6u = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0] .* u"s"
+        x6f = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+        y6u = [1.0, 2.0, 0.5, 3.0, 2.5, 1.0] .* u"W"
+        y6f = [1.0, 2.0, 0.5, 3.0, 2.5, 1.0]
+        @test cubic_interp(x6u, y6u; bc = PolyFit{5}())(2.2u"s") ≈
+            cubic_interp(x6f, y6f; bc = PolyFit{5}())(2.2) * u"W" rtol = 1.0e-12
+    end
+end

--- a/test/test_unitful_grid_1d.jl
+++ b/test/test_unitful_grid_1d.jl
@@ -398,11 +398,13 @@ end
 @testitem "Unitful 1D: cubic PeriodicBC rejection is friendly (review pin F7)" begin
     using Unitful
 
-    # `_cubic_interp_units` deliberately rejects PeriodicBC (strip→solve→reattach
-    # has no periodic factorization path yet) — pin the ERROR QUALITY, not just
-    # that it throws: message must name the feature and the workaround.
+    # Native unit builds reject PeriodicBC inside `_build_periodic_cache` (the
+    # S-M q-seed write is the remaining hostile site) — pin the ERROR QUALITY,
+    # not just that it throws: message must name the feature and the workaround.
+    # Closed cycle (y[1] == y[end]) so the endpoint check upstream passes and
+    # the pin exercises the builder guard itself.
     xs = [0.0, 1.0, 2.5, 3.0] .* u"s"
-    yw = [1.0, 2.0, 4.0, 8.0] .* u"W"
+    yw = [1.0, 2.0, 4.0, 1.0] .* u"W"
     err = try
         cubic_interp(xs, yw; bc = PeriodicBC())
         nothing
@@ -414,18 +416,6 @@ end
     @test occursin("PeriodicBC", msg)
     @test occursin("unit-carrying", msg)
     @test occursin("ustrip", msg)   # actionable workaround named
-
-    @testset "unhandled BC type: catch-all is actionable, not a solve MethodError" begin
-        struct _F7UnknownBC <: FastInterpolations.AbstractBC end
-        err2 = try
-            FastInterpolations._strip_bc_units(_F7UnknownBC(), 1.0u"W", 1.0u"s")
-            nothing
-        catch e
-            e
-        end
-        @test err2 isa ArgumentError
-        @test occursin("ustrip", sprint(showerror, err2))
-    end
 end
 
 @testitem "Unitful 1D: batch eval across families (review pin F8)" begin

--- a/test/test_unitful_grid_1d.jl
+++ b/test/test_unitful_grid_1d.jl
@@ -1038,3 +1038,36 @@ end
             cubic_interp(x6f, y6f; bc = PolyFit{5}())(2.2) * u"W" rtol = 1.0e-12
     end
 end
+
+@testitem "Unitful 1D: constant deriv zeros scale from the GRID unit (in-domain ≡ OOB)" begin
+    using Unitful
+
+    # hr grid + s queries: the in-domain kernel scaled its zero from the query
+    # offset (→ W/s) while OOB used the grid axis (→ W/hr) — the return type
+    # flipped across the domain boundary. The grid axis is canonical (matches
+    # linear/cubic deriv spaces and the ND grid⁻ᴺ pins).
+    xh = [0.0, 1.0, 2.0, 3.0] .* u"hr"
+    yW = [1.0, 2.0, 3.0, 4.0] .* u"W"
+    itp = constant_interp(xh, yW; extrap = ClampExtrap())
+    q_in = 3600.0u"s"      # = 1 hr, in-domain
+    q_oob = -3600.0u"s"
+
+    for (nm, op, U) in (
+            ("deriv1", DerivOp(1), u"W/hr"),
+            ("deriv2", DerivOp(2), u"W/hr^2"),
+            ("deriv4", DerivOp(4), u"W/hr^4"),
+        )
+        @testset "$nm" begin
+            din = itp(q_in; deriv = op)
+            doob = itp(q_oob; deriv = op)
+            @test unit(din) === Unitful.unit(1.0 * U)
+            @test typeof(din) === typeof(doob)   # no boundary type flip
+            @test iszero(din)
+        end
+    end
+
+    @testset "one-shot mirrors the persistent kernel" begin
+        v = constant_interp(xh, yW, q_in; deriv = DerivOp(1), extrap = ClampExtrap())
+        @test unit(v) === Unitful.unit(1.0u"W/hr")
+    end
+end

--- a/test/test_unitful_grid_1d.jl
+++ b/test/test_unitful_grid_1d.jl
@@ -395,27 +395,19 @@ end
     end
 end
 
-@testitem "Unitful 1D: cubic PeriodicBC rejection is friendly (review pin F7)" begin
+@testitem "Unitful 1D: cubic PeriodicBC native S-M (was rejection pin F7)" begin
     using Unitful
 
-    # Native unit builds reject PeriodicBC inside `_build_periodic_cache` (the
-    # S-M q-seed write is the remaining hostile site) — pin the ERROR QUALITY,
-    # not just that it throws: message must name the feature and the workaround.
-    # Closed cycle (y[1] == y[end]) so the endpoint check upstream passes and
-    # the pin exercises the builder guard itself.
+    # The strip-twin era rejected PeriodicBC on unit grids; the native build
+    # supports it (u dimensionless, q in [1/X]). Public-API sanity here — the
+    # internal bit pins live in test_cubic_unit_native.jl.
     xs = [0.0, 1.0, 2.5, 3.0] .* u"s"
     yw = [1.0, 2.0, 4.0, 1.0] .* u"W"
-    err = try
-        cubic_interp(xs, yw; bc = PeriodicBC())
-        nothing
-    catch e
-        e
-    end
-    @test err isa ArgumentError
-    msg = sprint(showerror, err)
-    @test occursin("PeriodicBC", msg)
-    @test occursin("unit-carrying", msg)
-    @test occursin("ustrip", msg)   # actionable workaround named
+    itp = cubic_interp(xs, yw; bc = PeriodicBC())
+    ref = cubic_interp([0.0, 1.0, 2.5, 3.0], [1.0, 2.0, 4.0, 1.0]; bc = PeriodicBC())
+    @test itp(1.0u"s") === 2.0u"W"                    # node hit
+    @test ustrip(u"W", itp(1.7u"s")) === ref(1.7)     # stripped bit parity
+    @test itp(4.2u"s") ≈ itp(1.2u"s")                 # wrap (period 3s)
 end
 
 @testitem "Unitful 1D: batch eval across families (review pin F8)" begin


### PR DESCRIPTION
## Summary

Deletes the strip→solve→reattach twin machinery that #199 introduced as a stopgap for the solver families, and makes the Thomas LU solver and the cubic/quadratic coefficient kernels natively unit-capable. The solve math was always dimensionally clean — only the *storage* crossed unit spaces — so each buffer now lives in its witness space and one code path serves Real, Unitful, and Dual grids. All 11 one-shot `<: Real` reroute forks are gone, and the cubic cache pool banks duck grid eltypes under exact-eltype keys. The Real path is bit-identical and zero-cost by measurement, and both are pinned by tests.

## Mechanism

- **Witness-space storage.** Factorization fields: `l` dimensionless, `du` grid-space `[X]`, `inv_d` `[1/X]`; RHS `[Y/X]`; `z` `[Y/X²]`; Sherman–Morrison `q ∈ [1/X]` with dimensionless `u`. Types come from op-witnesses (`_coeff_op`/`_coeff_op2`/`_inv_op`/`_thomas_l_op`), never ad-hoc conversion.
- **Two-arm storage selectors.** `_thomas_storage`-style dispatch on witness ≡ eltype: Real reuses the historic single buffer in-place (bit-identical), duck grids get fresh witness-typed storage from the pool.
- **BC payload rules.** Matrix rows scale in grid space (`oneunit(Tg)`); payloads travel verbatim and promote in the RHS. Structural Real-zero payloads (cache markers, `BCPair(Deriv2(0.0), …)`) rehydrate into their derivative space `[Y/Xⁿ]` — zero is the one Real with no unit ambiguity; a nonzero unitless payload beside unit data raises an actionable error.
- **Duck cache banking.** Banks are keyed by the exact grid eltype, so a cross-unit `isequal` hit (`isequal([1.0m], [100.0cm])` is true!) is structurally unreachable; the pool scans by `isequal` and never hashes (Unitful and ForwardDiff bend the `isequal`/`hash` contract in opposite directions). `_grid_bankable` is an open trait — Dual grids bank by full `isequal` (primal *and* partials), so same-seed rebuilds hit.

## Rides along (found while closing the seams)

- **PolyFit{D>3} on unit grids** — a twin-era capability this branch had regressed. The generic barycentric kernels now run on an exact dimensionless reparameterization behind type-folded branches; Real values pinned bit-equal to master.
- **Mixed-unit `hessian` returns** a `Matrix` with the components' promoted (abstract `Quantity`) eltype — every entry exists and is concretely unit-typed; `laplacian` stays guarded (its cross-axis sum is dimensionally undefined). The `*_units` guard helpers are renamed `*_eltype` (the check is type algebra, not Unitful).
- **OOB derivative zeros derive from the FILL value** (the 1D/ND-eval rule): `FillExtrap(NaN)` now poisons gradient/hessian/laplacian OOB results too, and interior data NaN no longer leaks out-of-bounds.
- **Constant in-domain derivative zeros** scale from the grid unit, so a query in different (compatible) units can no longer flip the return type at the domain boundary.

## New capabilities (fell out of the native core)

Unit-grid periodic splines (scalar + Series, inclusive/exclusive, bit-parity with Real), unit cubic/quadratic Series builds, `cubic_interp(cache, y)` with marker BCs on unit data, unit one-shots bit-identical to persistent builds, and self-consistent unit caches (a unit axis carries a unit-typed factorization, so repeat builds bank-hit like Real).

## Real path is unchanged

Every branch is type-folded (`T === typeof(one(x))`-class conditions), so Real executes the pre-existing code verbatim: release-parity `===` pins per BC (z vectors and eval values), PolyFit{4} bit-equal to master on vector/range/quadratic paths, cold build 19,008 B (−32 B vs master), bank-hit 6,336 B, one-shots 0 B, and ns within noise. A source lint ratchets the strip-twin token count and reroute-fork count at zero permanently.

## Unit-side wins

Repeat unit builds cost 295,104 B — the same as a Real bank hit (the twin era paid 983,680 B and forbade cache reuse); unit eval and one-shot scalar paths are 0 B.

## Testing

`test_cubic_unit_native.jl` / `test_quadratic_unit_native.jl` (witness-space pins, release-parity literals, one-shot ≡ persistent), `test_cache_bank_duck.jl` (bank hits, cross-unit isolation, Dual isequal semantics, periodic mirrors, trait wiring), `test_duck_grid_lint.jl` (zero-ratchet), plus new pins for PolyFit{D>3}, payload rehydration, the fill-value NaN rule, and mixed-unit hessian/guard contracts.

## Deferred

Adjoint operators on unit grids (friendly error naming the `ustrip` workaround), ND solver/hetero-family coefficient builds on unit grids (friendly errors; the heterogeneous-storage campaign — Hermite ND PreCompute first — is the tracked next step), and the quadratic mirror of Real-zero payload rehydration.
