### PR TITLE
feat(nd): unit axes for the ND solver families via dimensionless twins

### DIFF
--- a/src/constant/constant_interpolant.jl
+++ b/src/constant/constant_interpolant.jl
@@ -133,9 +133,9 @@ end
     # OneShot path continues to use the lazy wrapper (constant_oneshot.jl).
     x_ext, y_ext, bc_eff, extrap_eff = _periodic_extend_1d(x, y, bc, extrap)
     x_eff = _policy_axis(x_ext, bc_eff, Tg, store)
-    # Storage stays raw, but the kernel's `* one(dL)` returns the float value
-    # space — the fill must be promoted there (linear's spelling), else an Int
-    # `y` rejects a float fill at construction.
-    extrap_p = _promote_extrap(extrap_eff, _value_type(Tv, _promote_grid_float(Tg, Tv)))
+    # Constant returns data values verbatim, so the fill lives in `Tv`: it is
+    # promoted there at construction, and one that `Tv` cannot represent (a NaN
+    # beside Int data) is rejected up front rather than at eval.
+    extrap_p = _promote_extrap(extrap_eff, Tv)
     return ConstantInterpolant(x_eff, y_ext, extrap_p, side, search; bc = bc_eff, store = store)
 end

--- a/src/constant/constant_interpolant.jl
+++ b/src/constant/constant_interpolant.jl
@@ -133,6 +133,9 @@ end
     # OneShot path continues to use the lazy wrapper (constant_oneshot.jl).
     x_ext, y_ext, bc_eff, extrap_eff = _periodic_extend_1d(x, y, bc, extrap)
     x_eff = _policy_axis(x_ext, bc_eff, Tg, store)
-    extrap_p = _promote_extrap(extrap_eff, Tv)
+    # Storage stays raw, but the kernel's `* one(dL)` returns the float value
+    # space — the fill must be promoted there (linear's spelling), else an Int
+    # `y` rejects a float fill at construction.
+    extrap_p = _promote_extrap(extrap_eff, _value_type(Tv, _promote_grid_float(Tg, Tv)))
     return ConstantInterpolant(x_eff, y_ext, extrap_p, side, search; bc = bc_eff, store = store)
 end

--- a/src/constant/nd/constant_nd_eval.jl
+++ b/src/constant/nd/constant_nd_eval.jl
@@ -149,10 +149,11 @@ paths share this signature.
         push!(exprs, :($h_sym = @inbounds hs[$d]))
     end
 
-    # dL_d = q_eval[d] - Ls[d]
+    # dL_d = q_eval[d] - Ls[d]  (`_coord_value` unwraps a resolved GridIdx —
+    # identity otherwise; the search already consumed its index)
     for d in 1:N
         dL_sym = Symbol("dL_", d)
-        push!(exprs, :($dL_sym = @inbounds q_eval[$d] - Ls[$d]))
+        push!(exprs, :($dL_sym = @inbounds _coord_value(q_eval[$d]) - Ls[$d]))
     end
 
     # offset_d = _compute_single_offset(sides[d], h_d, dL_d)

--- a/src/constant/nd/constant_nd_interpolant.jl
+++ b/src/constant/nd/constant_nd_interpolant.jl
@@ -61,7 +61,7 @@ function constant_interp(
     # Raw storage (no Float widening): `Tg = promote_type(eltype.(grids)...)`,
     # `Tv = eltype(data)`. Kernel handles return-type widening via per-axis
     # `* one(dL_d)`.
-    grids_typed, Tg, Tv = _nd_promote_grids_raw(grids, data)
+    grids_typed, _, Tv = _nd_promote_grids_raw(grids, data)
     data_typed = data
 
     # Resolve per-axis configuration
@@ -76,8 +76,8 @@ function constant_interp(
     grids_typed = _policy_axes(grids_typed, bcs_post, store)
 
     # Per-axis extrap: validate + auto-promote `WrapExtrap` on periodic axes.
-    # The fill lives in the kernel's float value space, not in raw `Tv` (1D mirror).
-    extrap_vals = _resolve_extrap(extrap, bcs, Val(N), _value_type(Tv, _promote_grid_float(Tg, Tv)))
+    # The fill lives in `Tv` — Constant returns data verbatim (1D mirror).
+    extrap_vals = _resolve_extrap(extrap, bcs, Val(N), Tv)
     extrap_vals = map(_resolve_extrap, extrap_vals, grids_typed)
     return ConstantInterpolantND(grids_typed, data_typed, extrap_vals, sides, searches; bcs = bcs_post, store = store)
 end

--- a/src/constant/nd/constant_nd_interpolant.jl
+++ b/src/constant/nd/constant_nd_interpolant.jl
@@ -61,7 +61,7 @@ function constant_interp(
     # Raw storage (no Float widening): `Tg = promote_type(eltype.(grids)...)`,
     # `Tv = eltype(data)`. Kernel handles return-type widening via per-axis
     # `* one(dL_d)`.
-    grids_typed, _, Tv = _nd_promote_grids_raw(grids, data)
+    grids_typed, Tg, Tv = _nd_promote_grids_raw(grids, data)
     data_typed = data
 
     # Resolve per-axis configuration
@@ -76,7 +76,8 @@ function constant_interp(
     grids_typed = _policy_axes(grids_typed, bcs_post, store)
 
     # Per-axis extrap: validate + auto-promote `WrapExtrap` on periodic axes.
-    extrap_vals = _resolve_extrap(extrap, bcs, Val(N), Tv)
+    # The fill lives in the kernel's float value space, not in raw `Tv` (1D mirror).
+    extrap_vals = _resolve_extrap(extrap, bcs, Val(N), _value_type(Tv, _promote_grid_float(Tg, Tv)))
     extrap_vals = map(_resolve_extrap, extrap_vals, grids_typed)
     return ConstantInterpolantND(grids_typed, data_typed, extrap_vals, sides, searches; bcs = bcs_post, store = store)
 end

--- a/src/constant/nd/constant_nd_oneshot.jl
+++ b/src/constant/nd/constant_nd_oneshot.jl
@@ -77,7 +77,7 @@ function _constant_interp_nd_oneshot_batch!(
     extraps_eff = _resolve_extrap(extraps_val, bcs, grids_eff, data, Val(N))
     extraps_eff = _validate_nd_domain(grids_eff, queries, extraps_eff)
     @inbounds for k in 1:nq
-        query_k = _extract_query_point(queries, k, Val(N))
+        query_k = _extract_query_point(queries, k, Val(N), grids_eff)
         oob_val = _try_fill_oob(query_k, grids_eff, extraps_eff, ops, first(data))
         if oob_val !== nothing
             output[k] = oob_val

--- a/src/core/axis_types.jl
+++ b/src/core/axis_types.jl
@@ -136,6 +136,35 @@ struct _ExclusivePeriodicAxis{Tg, X <: AbstractVector{Tg}, Tp} <: AbstractVector
     end
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# _ReparamAxis — lazy dimensionless twin of a non-Real axis
+# ─────────────────────────────────────────────────────────────────────────────
+"""
+    _ReparamAxis{T, X<:AbstractVector, W, U} <: AbstractVector{T}
+
+Lazy `_reparam_op` view of a unit-carrying axis: element `i` is
+`inner[i] * scale` with `scale = inv(oneunit(eltype(inner)))`.
+
+The solver-family scaled store keeps `[Y]`-homogeneous partials, which pair
+with DIMENSIONLESS cell widths — and both consumers (the fiber solve and the
+separable integrate engine) only ever ask an axis for `getindex` and
+`_get_h`/`_get_inv_h`. So the twin needs no array of its own: it is a view,
+and its widths come from the parent's cache times a scalar.
+
+Methods + the outer ctor live in `nd_utils.jl` beside `_reparam_grids`, the
+only producer.
+
+# Fields
+- `inner::X` — the physical axis (possibly itself wrapped).
+- `scale::W` — the canonical `_deriv_oneunit(…, DerivOp(1))` witness.
+- `unit::U` — `oneunit(eltype(inner))`; restores `inv_h` without a division.
+"""
+struct _ReparamAxis{T, X <: AbstractVector, W, U} <: AbstractVector{T}
+    inner::X
+    scale::W
+    unit::U
+end
+
 # Convenience outer ctor — type params inferred from inputs. The element type
 # must hold the virtual seam point `inner[1] + period`, so widen a narrow grid
 # eltype against the period type before wrapping (an Int grid with a float period

--- a/src/core/bc_types.jl
+++ b/src/core/bc_types.jl
@@ -570,6 +570,10 @@ Note: PeriodicBC is handled separately via `_is_periodic_bc()` check before
 # are not duck-Tv contract ops, so they must never run on duck data.
 @inline _normalize_bc(bc::BCPair, x::AbstractArray, y::AbstractArray) =
     BCPair(_rehydrate_pointbc(bc.left, x, y), _rehydrate_pointbc(bc.right, x, y))
+# Bare PointBC (grid-aware): same rehydration through the pair arm — the
+# shape-only fallback below must not swallow payload-carrying BCs.
+@inline _normalize_bc(bc::PointBC, x::AbstractArray, y::AbstractArray) =
+    _normalize_bc(BCPair(bc, bc), x, y)
 @inline _rehydrate_pointbc(bc::Deriv1, x, y) = Deriv1(_rehydrate_payload(bc.val, x, y, DerivOp(1)))
 @inline _rehydrate_pointbc(bc::Deriv2, x, y) = Deriv2(_rehydrate_payload(bc.val, x, y, DerivOp(2)))
 @inline _rehydrate_pointbc(bc::Deriv3, x, y) = Deriv3(_rehydrate_payload(bc.val, x, y, DerivOp(3)))
@@ -720,8 +724,9 @@ function _normalize_bc_array(
     end
     return [_normalize_bc(bc, x, y) for bc in bcs]
 end
-@inline _normalize_bc_array(bcs::AbstractVector{<:BCPair}, ::AbstractArray, y::AbstractArray, n_series::Int) =
-    _normalize_bc_array(bcs, eltype(y), n_series)
+# NOTE: no `Vector{<:BCPair}` fast path here — unlike the type-only 3-arg form,
+# the solve side must rehydrate each pair's structural Real payloads, so
+# `Vector{<:BCPair}` deliberately takes the general per-element arm above.
 
 
 # ========================================

--- a/src/core/core.jl
+++ b/src/core/core.jl
@@ -7,7 +7,7 @@ include("bc_types.jl")         # 3. Boundary condition types
 include("interp_method_types.jl") # 3b. Per-axis method specification (CubicMethod, etc.)
 include("coeff_types.jl")         # 3c. AbstractCoeffStrategy, PreCompute, OnTheFly, AutoCoeffs
 include("polyfit_kernels.jl")       # 4. Boundary condition computation kernels (Lagrange, etc.)
-include("axis_types.jl")       # 4b. Axis struct definitions (_CachedRange / _CachedVector / _ExclusivePeriodicAxis) — central types-first
+include("axis_types.jl")       # 4b. Axis struct definitions (_CachedRange / _CachedVector / _ExclusivePeriodicAxis / _ReparamAxis) — central types-first
 include("cached_range.jl")     # 5. _CachedRange methods (_to_float, _get_h, _resolve_axis, _cache_axis*)
 include("cached_vector.jl")    # 5c. _CachedVector methods (build ctor, _get_h, _resolve_axis, _cache_axis*)
 include("search.jl")           # 6. Search policy + interval search

--- a/src/core/eval_ops.jl
+++ b/src/core/eval_ops.jl
@@ -127,10 +127,12 @@ Base.promote_rule(::Type{GridIdx{T}}, ::Type{S}) where {T, S <: Real} = promote_
 Base.convert(::Type{T}, g::GridIdx) where {T <: Number} = convert(T, g.val)
 Base.float(g::GridIdx) = float(g.val)
 (::Type{T})(g::GridIdx) where {T <: AbstractFloat} = T(g.val)
-# The one value-consuming seam: every kernel reads a resolved coordinate as
-# `q - L` (dL / α). A direct method keeps Number payloads (unit axes) out of
-# the promotion machinery entirely; identical folds for Real payloads.
-Base.:-(g::GridIdx, x::Number) = g.val - x
+# Coordinate accessor for the one value-consuming seam (`q - L` → dL / α).
+# Real axes let the wrapper ride its own `Real`-ness through promotion; a unit
+# axis cannot (see the promote_rule note), so the seam reads the payload
+# directly. Identity for every non-GridIdx query — no Real-path cost.
+@inline _coord_value(q) = q
+@inline _coord_value(g::GridIdx) = g.val
 
 """
     _resolve_grididx(q, grid) -> resolved coordinate

--- a/src/core/eval_ops.jl
+++ b/src/core/eval_ops.jl
@@ -86,7 +86,8 @@ Search functions short-circuit when they see a `GridIdx` — zero search cost.
 `GridIdx <: Real`: it flows through `Tuple{Vararg{Number, N}}` dispatch transparently.
 Before resolution, `val = NaN` — a poison sentinel that propagates visibly if
 `_resolve_grididx` is ever skipped. After resolution, `val` holds the grid coordinate
-and arithmetic auto-promotes via `promote_rule` (stripping the `GridIdx` wrapper).
+(payload `T <: Number` — unit axes resolve to their Quantity coordinate) and
+arithmetic auto-promotes via `promote_rule` (stripping the `GridIdx` wrapper).
 
 # Examples
 ```julia
@@ -102,27 +103,34 @@ itp_hetero = interp((x, y), data; method=(CubicInterp(), LinearInterp()))
 itp_hetero((0.5, GridIdx(10)))   # search short-circuited on axis 2
 ```
 """
-struct GridIdx{T <: Real} <: Real
+struct GridIdx{T <: Number} <: Real
     idx::Int
     val::T
     function GridIdx(i::Integer)
         i >= 1 || throw(ArgumentError("GridIdx index must be ≥ 1, got $i"))
         return new{Float64}(Int(i), NaN64)
     end
-    function GridIdx{T}(i::Int, v::T) where {T <: Real}
+    function GridIdx{T}(i::Int, v::T) where {T <: Number}
         return new{T}(i, v)
     end
 end
 
 Base.show(io::IO, g::GridIdx) = print(io, "GridIdx(", g.idx, ")")
 
-# GridIdx <: Real: arithmetic works transparently via promotion.
+# GridIdx <: Real: Real arithmetic works transparently via promotion.
 # promote(GridIdx{T}, S) → promote_type(T, S), stripping the GridIdx wrapper.
 # Zero overhead — LLVM compiles to identical code as manual g.val extraction.
+# The rule stays S <: Real ON PURPOSE: Unitful's generic Quantity-vs-Real rules
+# see the wrapper (a Real) and nest (`Quantity{Quantity{…}}`) if we promote
+# against Quantity — unit coordinates instead flow through the direct `-` below.
 Base.promote_rule(::Type{GridIdx{T}}, ::Type{S}) where {T, S <: Real} = promote_type(T, S)
 Base.convert(::Type{T}, g::GridIdx) where {T <: Number} = convert(T, g.val)
 Base.float(g::GridIdx) = float(g.val)
 (::Type{T})(g::GridIdx) where {T <: AbstractFloat} = T(g.val)
+# The one value-consuming seam: every kernel reads a resolved coordinate as
+# `q - L` (dL / α). A direct method keeps Number payloads (unit axes) out of
+# the promotion machinery entirely; identical folds for Real payloads.
+Base.:-(g::GridIdx, x::Number) = g.val - x
 
 """
     _resolve_grididx(q, grid) -> resolved coordinate

--- a/src/core/interpolant_protocol.jl
+++ b/src/core/interpolant_protocol.jl
@@ -305,7 +305,7 @@ end
     ) where {Tg, Tv, N}
     zref = _sample_data(itp)
     @inbounds for k in 1:_query_length(queries)
-        query_k = _extract_query_point(queries, k, Val(N))
+        query_k = _extract_query_point(queries, k, Val(N), itp.grids)
         # `extraps_eff` carries per-axis `InBounds()` from `_validate_nd_domain`
         # when all batch queries on that axis are in-bounds (1D `_check_domain`
         # union-split per axis via the heterogeneous `map`). `_try_fill_oob` and

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1166,7 +1166,7 @@ end
         indices::NTuple{N, Int},
         Ls::Tuple{Vararg{Number, N}},
         ::Type{Tg},
-    ) where {N, Tg}
+    ) where {N, Tg <: Real}
     hs = ntuple(Val(N)) do d
         @inbounds convert(Tg, _get_h(grids[d], indices[d]))
     end
@@ -1178,6 +1178,16 @@ end
     end
     return hs, inv_hs, dLs
 end
+
+# Non-Real width tag (unit type or abstract promotion tag) → the dimensionless
+# collapse: the axes carry the witnesses, the tag itself is never instantiated.
+@inline _compute_all_local_params(
+    q_evals::Tuple{Vararg{Number, N}},
+    grids::Tuple{Vararg{AbstractVector, N}},
+    indices::NTuple{N, Int},
+    Ls::Tuple{Vararg{Number, N}},
+    ::Type,
+) where {N} = _compute_all_local_params_reparam(q_evals, grids, indices, Ls)
 
 # Dimensionless axis twins for the solver-family ND builds — the
 # `_float_grids_peraxis` peel idiom (build paths ban closure-maps over axis
@@ -1212,6 +1222,26 @@ end
 @inline _scale_bc_reparam(bc::AbstractBC, _x, _data) = bc
 @inline _scale_payload_reparam(v::Real, _u, data) = _payload_val(v, @inbounds first(data))
 @inline _scale_payload_reparam(v, u, _data) = v * u
+
+# Solve-frame selection for the scaled-store families (persistent build + one-shot
+# pool): Real axes solve natively; non-Real axes solve on their dimensionless
+# twins with [Y]-rescaled BC payloads. Dispatch on the promotion tag, not a
+# boolean test (gate style) — the Real arm folds to a passthrough.
+@inline _reparam_solve_frame(grids, bcs, data) =
+    _reparam_solve_frame(_promote_grid_eltype(grids), grids, bcs, data)
+@inline _reparam_solve_frame(::Type{<:Real}, grids, bcs, _data) = (grids, bcs)
+@inline _reparam_solve_frame(::Type, grids, bcs, data) =
+    (_reparam_grids(grids), _scale_bcs_reparam(bcs, grids, data))
+
+# Cell-seam restoration for the scaled-store families: the kernel runs
+# dimensionless over the [Y]-homogeneous partials, so a non-Real grid multiplies
+# the result back into value/coordᴺ space (canonical `_nd_fill_deriv_scale`
+# fold). The Real arm is an identity ARM, not ×1.0 — branch preservation is
+# load-bearing (LLVM folds only ×true).
+@inline _restore_nd_deriv_scale(r, grids, ops) =
+    _restore_nd_deriv_scale(_promote_grid_eltype(grids), r, grids, ops)
+@inline _restore_nd_deriv_scale(::Type{<:Real}, r, _grids, _ops) = r
+@inline _restore_nd_deriv_scale(::Type, r, grids, ops) = r * _nd_fill_deriv_scale(grids, ops)
 
 # Reparameterized (dimensionless) local params for non-Real axes: each axis's
 # h/inv_h/dL collapses to Real via the canonical `_deriv_oneunit` witness — the

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1197,10 +1197,15 @@ end
     ::Type,
 ) where {N} = _compute_all_local_params_reparam(q_evals, grids, indices, Ls)
 
+# Canonical per-element reparam transform (axis element → dimensionless twin).
+# The solver gate (`_check_nd_reparam_eltype`) probes exactly this op, so the
+# gate's promise (`oneunit`, `inv`, `*`) is what it actually checks.
+@inline _reparam_op(x) = x * _deriv_oneunit(x, DerivOp(1))
+
 # Dimensionless axis twins for the solver-family ND builds — the
 # `_float_grids_peraxis` peel idiom (build paths ban closure-maps over axis
-# wraps); scaling spelled with the canonical `_deriv_oneunit` witness
-# (= inv(oneunit(axis))). Ranges stay ranges.
+# wraps); `_reparam_op` spelled `.*` with a hoisted witness so Ranges stay
+# ranges.
 @inline _reparam_grids(::Tuple{}) = ()
 @inline _reparam_grids(grids::Tuple) = (
     first(grids) .* _deriv_oneunit(first(first(grids)), DerivOp(1)),

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -259,6 +259,14 @@ end
     return :(($(exprs...),))
 end
 
+# One-shot fill/extrap payload space (scalar entries don't eagerly convert data):
+# Real axes widen by the family coeff witness (`_coeff_op2` cubic, `_coeff_op`
+# quadratic); a non-Real tag cannot run the witness — the value space serves
+# (the persistent entry's convention).
+@inline _oneshot_fill_eltype(op::F, ::Type{Tg}, ::Type{Tv}) where {F, Tg <: Real, Tv} =
+    _promote_eltype(op, Tg, Tv)
+@inline _oneshot_fill_eltype(::F, ::Type{Tg}, ::Type{Tv}) where {F, Tg, Tv} = _value_type(Tv, Tg)
+
 # ── Periodic BC compatibility checks for Mode types ──────────────────
 
 @inline function _check_mode_periodic_compat(extrap::AbstractExtrap, bcs::Tuple{Vararg{AbstractBC, N}}, ::Val{N}) where {N}

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1293,7 +1293,7 @@ Base.IndexStyle(::Type{<:_ReparamAxis}) = IndexLinear()
         @inbounds _get_inv_h(grids[d], indices[d]) * oneunit(first(grids[d]))
     end
     dLs = ntuple(Val(N)) do d
-        @inbounds (q_evals[d] - Ls[d]) * _deriv_oneunit(first(grids[d]), DerivOp(1))
+        @inbounds (_coord_value(q_evals[d]) - Ls[d]) * _deriv_oneunit(first(grids[d]), DerivOp(1))
     end
     return hs, inv_hs, dLs
 end

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1201,8 +1201,10 @@ end
 
 # Typed PointBC payloads live in [Y/Xᵏ] → scale by oneunit(axis)ᵏ onto the
 # dimensionless axis ([Y]). Structural Real payloads rehydrate via the canonical
-# `_payload_val` against a data sample — the ND fiber solve (`_deriv_1d!`) has
-# no normalize of its own. Left/Right are quadratic's side wrappers.
+# `_payload_val` in that TRUE space (witness `first(data)·u⁻¹` — matches the 1D
+# rejection of dimensionally incomplete nonzero Reals) before scaling into [Y];
+# the ND fiber solve (`_deriv_1d!`) has no normalize of its own. Left/Right are
+# quadratic's side wrappers.
 @inline _scale_bcs_reparam(::Tuple{}, ::Tuple{}, _data) = ()
 @inline _scale_bcs_reparam(bcs::Tuple, grids::Tuple, data) = (
     _scale_bc_reparam(first(bcs), first(grids), data),
@@ -1219,7 +1221,8 @@ end
 @inline _scale_bc_reparam(bc::Deriv3, x, data) =
     Deriv3(_scale_payload_reparam(bc.val, oneunit(eltype(x))^3, data))
 @inline _scale_bc_reparam(bc::AbstractBC, _x, _data) = bc
-@inline _scale_payload_reparam(v::Real, _u, data) = _payload_val(v, @inbounds first(data))
+@inline _scale_payload_reparam(v::Real, u, data) =
+    _payload_val(v, (@inbounds first(data)) * inv(u)) * u
 @inline _scale_payload_reparam(v, u, _data) = v * u
 
 # Solve-frame selection for the scaled-store families (persistent build + one-shot

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1208,10 +1208,10 @@ end
 # access. The eltype comes from the same op that the gate probes and the view
 # applies — one witness, three uses.
 @inline function _ReparamAxis(inner::AbstractVector)
-    scale = _deriv_oneunit(first(inner), DerivOp(1))
-    return _ReparamAxis{_promote_eltype(_reparam_op, eltype(inner)), typeof(inner), typeof(scale), typeof(oneunit(eltype(inner)))}(
-        inner, scale, oneunit(eltype(inner))
-    )
+    u = oneunit(eltype(inner))                       # type-derived: never touches the data
+    scale = _deriv_oneunit(u, DerivOp(1))
+    T = _promote_eltype(_reparam_op, eltype(inner))
+    return _ReparamAxis{T, typeof(inner), typeof(scale), typeof(u)}(inner, scale, u)
 end
 
 @inline Base.size(a::_ReparamAxis) = size(a.inner)

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -143,8 +143,10 @@ end
 @inline _nd_deriv_scale(samples::Tuple, ops::Tuple) =
     _deriv_oneunit(first(samples), first(ops)) * _nd_deriv_scale(Base.tail(samples), Base.tail(ops))
 
-# FillExtrap OOB form: axis samples from the grid eltypes; a scalar op
-# broadcasts to every axis.
+# Grid-sample adapter for the fold above (axis samples from the grid eltypes; a
+# scalar op broadcasts to every axis). Despite the historical "fill" name it
+# serves BOTH the FillExtrap OOB zeros and the scaled-store in-domain restore
+# seam (`_restore_nd_deriv_scale`) — eval correctness rides on it.
 @inline _nd_fill_deriv_scale(grids::Tuple, op::AbstractEvalOp) = _nd_fill_deriv_scale(grids, map(_ -> op, grids))
 @inline _nd_fill_deriv_scale(grids::Tuple, ops::Tuple) =
     _nd_deriv_scale(map(g -> oneunit(eltype(g)), grids), ops)

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1279,7 +1279,17 @@ end
 # Owned cached wrap (PreCompute/adjoint inner ctors): cache + `_convert_copy`
 # per axis. Closure-map forms of this are banned — see the store-policy lint.
 @generated function _convert_cache_axes(grids::NTuple{N, AbstractVector}, bcs, ::Type{Tg}) where {N, Tg}
-    exprs = [:(_convert_copy(_cache_axis(grids[$i], bcs[$i], Tg), Tg)) for i in 1:N]
+    if isconcretetype(Tg)
+        exprs = [:(_convert_copy(_cache_axis(grids[$i], bcs[$i], Tg), Tg)) for i in 1:N]
+    else
+        # Mixed-unit axes: the promoted `Tg` is an abstract promotion tag —
+        # wrap + own each axis at its OWN eltype (mirrors `_store_axes`;
+        # `oneunit(abstract)` is undefined).
+        exprs = [
+            :(_convert_copy(_cache_axis(grids[$i], bcs[$i], eltype(grids[$i])), eltype(grids[$i])))
+                for i in 1:N
+        ]
+    end
     return :(($(exprs...),))
 end
 

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1204,15 +1204,33 @@ end
 # gate's promise (`oneunit`, `inv`, `*`) is what it actually checks.
 @inline _reparam_op(x) = x * _deriv_oneunit(x, DerivOp(1))
 
+# Lazy twin (see `_ReparamAxis` in axis_types.jl): `_reparam_op` applied per
+# access. The eltype comes from the same op that the gate probes and the view
+# applies — one witness, three uses.
+@inline function _ReparamAxis(inner::AbstractVector)
+    scale = _deriv_oneunit(first(inner), DerivOp(1))
+    return _ReparamAxis{_promote_eltype(_reparam_op, eltype(inner)), typeof(inner), typeof(scale), typeof(oneunit(eltype(inner)))}(
+        inner, scale, oneunit(eltype(inner))
+    )
+end
+
+@inline Base.size(a::_ReparamAxis) = size(a.inner)
+Base.IndexStyle(::Type{<:_ReparamAxis}) = IndexLinear()
+@inline Base.@propagate_inbounds Base.getindex(a::_ReparamAxis, i::Int) = a.inner[i] * a.scale
+# Widths pass through the parent's cache — a scalar multiply, no re-subtraction.
+@inline Base.@propagate_inbounds _get_h(a::_ReparamAxis, i::Int) = _get_h(a.inner, i) * a.scale
+@inline Base.@propagate_inbounds _get_inv_h(a::_ReparamAxis, i::Int) = _get_inv_h(a.inner, i) * a.unit
+
 # Dimensionless axis twins for the solver-family ND builds — the
 # `_float_grids_peraxis` peel idiom (build paths ban closure-maps over axis
-# wraps); `_reparam_op` spelled `.*` with a hoisted witness so Ranges stay
-# ranges.
+# wraps). Ranges keep the arithmetic form: Base's range broadcast already
+# yields an isbits range (no array) and preserves the `_CachedRange` objectid
+# fast path in the solve cache banks. Everything else takes the lazy view.
+@inline _reparam_axis(x::AbstractRange) = x .* _deriv_oneunit(first(x), DerivOp(1))
+@inline _reparam_axis(x::AbstractVector) = _ReparamAxis(x)
 @inline _reparam_grids(::Tuple{}) = ()
-@inline _reparam_grids(grids::Tuple) = (
-    first(grids) .* _deriv_oneunit(first(first(grids)), DerivOp(1)),
-    _reparam_grids(Base.tail(grids))...,
-)
+@inline _reparam_grids(grids::Tuple) =
+    (_reparam_axis(first(grids)), _reparam_grids(Base.tail(grids))...)
 
 # Typed PointBC payloads live in [Y/Xᵏ] → scale by oneunit(axis)ᵏ onto the
 # dimensionless axis ([Y]). Structural Real payloads rehydrate via the canonical

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1324,7 +1324,13 @@ end
 
 # Pooled value-matched wrap (cubic/quadratic PreCompute scalar backends).
 @generated function _cache_axes_pooled(pool, grids::NTuple{N, AbstractVector}, ::Type{Tg}) where {N, Tg}
-    exprs = [:(_cache_axis_pooled(pool, grids[$i], Tg)) for i in 1:N]
+    if isconcretetype(Tg)
+        exprs = [:(_cache_axis_pooled(pool, grids[$i], Tg)) for i in 1:N]
+    else
+        # Mixed-unit axes: the promoted `Tg` is an abstract promotion tag —
+        # wrap each axis at its OWN eltype (mirrors `_convert_cache_axes`).
+        exprs = [:(_cache_axis_pooled(pool, grids[$i], eltype(grids[$i]))) for i in 1:N]
+    end
     return :(($(exprs...),))
 end
 

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1179,6 +1179,31 @@ end
     return hs, inv_hs, dLs
 end
 
+# Dimensionless axis twins for the solver-family ND builds — the
+# `_float_grids_peraxis` peel idiom (build paths ban closure-maps over axis
+# wraps); scaling spelled with the canonical `_deriv_oneunit` witness
+# (= inv(oneunit(axis))). Ranges stay ranges.
+@inline _reparam_grids(::Tuple{}) = ()
+@inline _reparam_grids(grids::Tuple) = (
+    first(grids) .* _deriv_oneunit(first(first(grids)), DerivOp(1)),
+    _reparam_grids(Base.tail(grids))...,
+)
+
+# Typed PointBC payloads live in [Y/Xᵏ] → on the dimensionless axis they must be
+# [Y]: scale by oneunit(axis)ᵏ. Structural Real payloads pass through — the 1D
+# solve's normalize (zero-mint / embeddable / reject) owns their semantics.
+# Left/Right are quadratic's side wrappers around the same PointBC payloads.
+@inline _scale_bc_reparam(bc::BCPair, x) =
+    BCPair(_scale_bc_reparam(bc.left, x), _scale_bc_reparam(bc.right, x))
+@inline _scale_bc_reparam(bc::Left, x) = Left(_scale_bc_reparam(bc.bc, x))
+@inline _scale_bc_reparam(bc::Right, x) = Right(_scale_bc_reparam(bc.bc, x))
+@inline _scale_bc_reparam(bc::Deriv1, x) = Deriv1(_scale_payload_reparam(bc.val, oneunit(eltype(x))))
+@inline _scale_bc_reparam(bc::Deriv2, x) = Deriv2(_scale_payload_reparam(bc.val, oneunit(eltype(x))^2))
+@inline _scale_bc_reparam(bc::Deriv3, x) = Deriv3(_scale_payload_reparam(bc.val, oneunit(eltype(x))^3))
+@inline _scale_bc_reparam(bc::AbstractBC, _x) = bc
+@inline _scale_payload_reparam(v::Real, _u) = v
+@inline _scale_payload_reparam(v, u) = v * u
+
 # Reparameterized (dimensionless) local params for non-Real axes: each axis's
 # h/inv_h/dL collapses to Real via the canonical `_deriv_oneunit` witness — the
 # scaled-store kernels ([Y]-homogeneous partials) then run entirely in the value

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1179,6 +1179,30 @@ end
     return hs, inv_hs, dLs
 end
 
+# Reparameterized (dimensionless) local params for non-Real axes: each axis's
+# h/inv_h/dL collapses to Real via the canonical `_deriv_oneunit` witness — the
+# scaled-store kernels ([Y]-homogeneous partials) then run entirely in the value
+# space, and mixed-unit axes converge to homogeneous Real tuples. Real callers
+# never come here (type-folded branch at the call sites). Multiplication (not
+# conversion) preserves Dual-query partials in `dLs`.
+@inline function _compute_all_local_params_reparam(
+        q_evals::Tuple{Vararg{Number, N}},
+        grids::Tuple{Vararg{AbstractVector, N}},
+        indices::NTuple{N, Int},
+        Ls::Tuple{Vararg{Number, N}},
+    ) where {N}
+    hs = ntuple(Val(N)) do d
+        @inbounds _get_h(grids[d], indices[d]) * _deriv_oneunit(first(grids[d]), DerivOp(1))
+    end
+    inv_hs = ntuple(Val(N)) do d
+        @inbounds _get_inv_h(grids[d], indices[d]) * oneunit(first(grids[d]))
+    end
+    dLs = ntuple(Val(N)) do d
+        @inbounds (q_evals[d] - Ls[d]) * _deriv_oneunit(first(grids[d]), DerivOp(1))
+    end
+    return hs, inv_hs, dLs
+end
+
 
 # ========================================
 # @generated Tensor-Product Code Generation Helpers

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1199,11 +1199,10 @@ end
     _reparam_grids(Base.tail(grids))...,
 )
 
-# Typed PointBC payloads live in [Y/Xᵏ] → on the dimensionless axis they must be
-# [Y]: scale by oneunit(axis)ᵏ. Structural Real payloads take the canonical
-# `_payload_val` rehydration against a data sample — on the t-axis the payload
-# space IS [Y], and the ND fiber solve (`_deriv_1d!`) has no normalize of its
-# own. Left/Right are quadratic's side wrappers around the same PointBC payloads.
+# Typed PointBC payloads live in [Y/Xᵏ] → scale by oneunit(axis)ᵏ onto the
+# dimensionless axis ([Y]). Structural Real payloads rehydrate via the canonical
+# `_payload_val` against a data sample — the ND fiber solve (`_deriv_1d!`) has
+# no normalize of its own. Left/Right are quadratic's side wrappers.
 @inline _scale_bcs_reparam(::Tuple{}, ::Tuple{}, _data) = ()
 @inline _scale_bcs_reparam(bcs::Tuple, grids::Tuple, data) = (
     _scale_bc_reparam(first(bcs), first(grids), data),
@@ -1233,22 +1232,18 @@ end
 @inline _reparam_solve_frame(::Type, grids, bcs, data) =
     (_reparam_grids(grids), _scale_bcs_reparam(bcs, grids, data))
 
-# Cell-seam restoration for the scaled-store families: the kernel runs
-# dimensionless over the [Y]-homogeneous partials, so a non-Real grid multiplies
-# the result back into value/coordᴺ space (canonical `_nd_fill_deriv_scale`
-# fold). The Real arm is an identity ARM, not ×1.0 — branch preservation is
-# load-bearing (LLVM folds only ×true).
+# Cell-seam restoration: scaled-store kernels run dimensionless over the
+# [Y]-homogeneous partials, so a non-Real grid multiplies the result back into
+# value/coordᴺ space. The Real arm is an identity ARM, not ×1.0 — LLVM folds only ×true.
 @inline _restore_nd_deriv_scale(r, grids, ops) =
     _restore_nd_deriv_scale(_promote_grid_eltype(grids), r, grids, ops)
 @inline _restore_nd_deriv_scale(::Type{<:Real}, r, _grids, _ops) = r
 @inline _restore_nd_deriv_scale(::Type, r, grids, ops) = r * _nd_fill_deriv_scale(grids, ops)
 
 # Reparameterized (dimensionless) local params for non-Real axes: each axis's
-# h/inv_h/dL collapses to Real via the canonical `_deriv_oneunit` witness — the
-# scaled-store kernels ([Y]-homogeneous partials) then run entirely in the value
-# space, and mixed-unit axes converge to homogeneous Real tuples. Real callers
-# never come here (type-folded branch at the call sites). Multiplication (not
-# conversion) preserves Dual-query partials in `dLs`.
+# h/inv_h/dL collapses to Real via the canonical `_deriv_oneunit` witness, so the
+# [Y]-homogeneous kernels run in value space even on mixed-unit axes.
+# Multiplication (not conversion) preserves Dual-query partials in `dLs`.
 @inline function _compute_all_local_params_reparam(
         q_evals::Tuple{Vararg{Number, N}},
         grids::Tuple{Vararg{AbstractVector, N}},

--- a/src/core/nd_utils.jl
+++ b/src/core/nd_utils.jl
@@ -1190,19 +1190,28 @@ end
 )
 
 # Typed PointBC payloads live in [Y/Xᵏ] → on the dimensionless axis they must be
-# [Y]: scale by oneunit(axis)ᵏ. Structural Real payloads pass through — the 1D
-# solve's normalize (zero-mint / embeddable / reject) owns their semantics.
-# Left/Right are quadratic's side wrappers around the same PointBC payloads.
-@inline _scale_bc_reparam(bc::BCPair, x) =
-    BCPair(_scale_bc_reparam(bc.left, x), _scale_bc_reparam(bc.right, x))
-@inline _scale_bc_reparam(bc::Left, x) = Left(_scale_bc_reparam(bc.bc, x))
-@inline _scale_bc_reparam(bc::Right, x) = Right(_scale_bc_reparam(bc.bc, x))
-@inline _scale_bc_reparam(bc::Deriv1, x) = Deriv1(_scale_payload_reparam(bc.val, oneunit(eltype(x))))
-@inline _scale_bc_reparam(bc::Deriv2, x) = Deriv2(_scale_payload_reparam(bc.val, oneunit(eltype(x))^2))
-@inline _scale_bc_reparam(bc::Deriv3, x) = Deriv3(_scale_payload_reparam(bc.val, oneunit(eltype(x))^3))
-@inline _scale_bc_reparam(bc::AbstractBC, _x) = bc
-@inline _scale_payload_reparam(v::Real, _u) = v
-@inline _scale_payload_reparam(v, u) = v * u
+# [Y]: scale by oneunit(axis)ᵏ. Structural Real payloads take the canonical
+# `_payload_val` rehydration against a data sample — on the t-axis the payload
+# space IS [Y], and the ND fiber solve (`_deriv_1d!`) has no normalize of its
+# own. Left/Right are quadratic's side wrappers around the same PointBC payloads.
+@inline _scale_bcs_reparam(::Tuple{}, ::Tuple{}, _data) = ()
+@inline _scale_bcs_reparam(bcs::Tuple, grids::Tuple, data) = (
+    _scale_bc_reparam(first(bcs), first(grids), data),
+    _scale_bcs_reparam(Base.tail(bcs), Base.tail(grids), data)...,
+)
+@inline _scale_bc_reparam(bc::BCPair, x, data) =
+    BCPair(_scale_bc_reparam(bc.left, x, data), _scale_bc_reparam(bc.right, x, data))
+@inline _scale_bc_reparam(bc::Left, x, data) = Left(_scale_bc_reparam(bc.bc, x, data))
+@inline _scale_bc_reparam(bc::Right, x, data) = Right(_scale_bc_reparam(bc.bc, x, data))
+@inline _scale_bc_reparam(bc::Deriv1, x, data) =
+    Deriv1(_scale_payload_reparam(bc.val, oneunit(eltype(x)), data))
+@inline _scale_bc_reparam(bc::Deriv2, x, data) =
+    Deriv2(_scale_payload_reparam(bc.val, oneunit(eltype(x))^2, data))
+@inline _scale_bc_reparam(bc::Deriv3, x, data) =
+    Deriv3(_scale_payload_reparam(bc.val, oneunit(eltype(x))^3, data))
+@inline _scale_bc_reparam(bc::AbstractBC, _x, _data) = bc
+@inline _scale_payload_reparam(v::Real, _u, data) = _payload_val(v, @inbounds first(data))
+@inline _scale_payload_reparam(v, u, _data) = v * u
 
 # Reparameterized (dimensionless) local params for non-Real axes: each axis's
 # h/inv_h/dL collapses to Real via the canonical `_deriv_oneunit` witness — the

--- a/src/core/periodic_axis.jl
+++ b/src/core/periodic_axis.jl
@@ -302,7 +302,7 @@ end
 # interior cells. At the seam, the wrapper's `search_interval` returns
 # `xR = g._x_max` by direct field read — bit-equal to the comparand here.
 @inline _alpha_of(q, L, R, g::_ExclusivePeriodicAxis) =
-    R == g._x_max ? (q - L) / float(R - L) : _alpha_of(q, L, R, g.inner)
+    R == g._x_max ? (_coord_value(q) - L) / float(R - L) : _alpha_of(q, L, R, g.inner)
 
 # ========================================
 # View specialization: preserve wrapper for full-virtual range

--- a/src/core/query_protocol.jl
+++ b/src/core/query_protocol.jl
@@ -70,6 +70,14 @@ end
 @inline _extract_query_point(q, k, ::Val{N}) where {N} =
     _as_ntuple(_query_extract(q, k), Val(N))
 
+# Grid-aware form for the batch loops: a bare `GridIdx(k)` carries no coordinate
+# (`val = NaN` poison) until it meets its axis, and the scalar entries resolve at
+# the door. Batch points must resolve too — an unresolved index on an
+# INTERPOLATING axis silently evaluates the kernel at NaN. Identity for every
+# non-GridIdx element, so Real batches keep their codegen.
+@inline _extract_query_point(q, k, ::Val{N}, grids::Tuple{Vararg{AbstractVector, N}}) where {N} =
+    map(_resolve_grididx, _extract_query_point(q, k, Val(N)), grids)
+
 @inline _as_ntuple(x::NTuple{N, <:Real}, ::Val{N}) where {N} = x
 @inline _as_ntuple(x, ::Val{N}) where {N} = ntuple(d -> @inbounds(x[d]), Val(N))
 

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -122,13 +122,10 @@ end
     return nothing
 end
 
-# Cubic ND admits non-Real axes via the exact dimensionless reparameterization
-# t = x·_deriv_oneunit(x, DerivOp(1)) (= x·inv(oneunit(x))): the 2^N store then
-# holds ∂ᵏf·Πoneunit(axis)ᵏ — every slot in the value space [Y], so the single
-# homogeneous partials array survives unit grids. Capability is probed PER AXIS
-# (a mixed-unit promoted Tg is an abstract tag — witnesses must come from
-# per-axis eltypes) with the canonical `_coeff_op` witness: missing `oneunit`/
-# `inv` arithmetic infers `Union{}`/non-Real → friendly refusal. `Real` folds away.
+# Solver-family axes must be Real or dimensionless-reparameterizable (unit-carrying).
+# Probed PER AXIS with the canonical `_coeff_op` witness — a mixed-unit promoted Tg
+# is an abstract tag no witness may run on. Missing `oneunit`/`inv` arithmetic
+# infers `Union{}`/non-Real → friendly refusal; `Real` folds away.
 @inline _check_nd_reparam_grid(::Tuple{}) = nothing
 @inline function _check_nd_reparam_grid(grids::Tuple)
     _check_nd_reparam_eltype(eltype(first(grids)))

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -122,18 +122,16 @@ end
     return nothing
 end
 
-# Solver-family ND builds store mixed derivative-mask orders in ONE homogeneous
-# array — unit-heterogeneous by construction (f vs ∂²f differ even on same-unit
-# axes). The gate is `<: Real` (Dual passes; units are the canonical rejected
-# case, but any non-Real Number is refused); `Real` folds away.
+# One-shot solver-family ND entries: the pooled pipeline (axis wrap, partials
+# buffer, local params) has no reparameterized arm yet — refuse non-Real axes
+# with a pointer at the persistent builders, which DO support them via the
+# scaled store. The gate is `<: Real` (Dual passes); `Real` folds away.
 @inline _check_nd_solver_grid(::Type{<:Real}) = nothing
 @noinline _check_nd_solver_grid(::Type{Tg}) where {Tg} = throw(
     ArgumentError(
-        "PreCompute ND coefficient builds (Cubic/Quadratic/Hermite axes) do not " *
-            "support non-Real grid eltypes yet (grid eltype $(Tg)) — the nodal-" *
-            "derivative store is one homogeneous array, which unit-carrying grids " *
-            "break (derivative orders of different dimensions). Use LinearInterp/" *
-            "ConstantInterp ND, integrate per-fiber 1-D, or use a Real grid (units: `ustrip`)."
+        "one-shot solver-family ND entries (Cubic/Quadratic) do not support " *
+            "non-Real grid eltypes yet (grid eltype $(Tg)). The persistent " *
+            "builders DO — build once and evaluate: `cubic_interp(grids, data)(q)`."
     )
 )
 

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -146,14 +146,15 @@ end
 )
 
 # Same contract for the per-axis (hetero) ND engine — which also backs
-# PCHIP/Akima/Cardinal ND. Neither builder path (OnTheFly eval kernels nor the
-# PreCompute partials store) handles non-Real grids yet; without this gate
-# the failure is a deep MethodError (or a "successful" build whose eval throws).
+# PCHIP/Akima/Cardinal ND — and for Hermite ND (user partials per-axis in
+# [Y/Xᵈ], no scaled store). Neither builder path handles non-Real grids yet;
+# without this gate the failure is a deep MethodError (or a "successful"
+# build whose eval throws).
 @inline _check_nd_hetero_grid(::Type{<:Real}) = nothing
 @noinline _check_nd_hetero_grid(::Type{Tg}) where {Tg} = throw(
     ArgumentError(
         "Per-axis (hetero) ND interpolants — including PCHIP/Akima/Cardinal ND — " *
-            "do not support non-Real grid eltypes yet (grid eltype $(Tg)). " *
+            "and Hermite ND do not support non-Real grid eltypes yet (grid eltype $(Tg)). " *
             "Use LinearInterp/ConstantInterp ND, work per-fiber 1-D, or use a Real grid (units: `ustrip`)."
     )
 )

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -156,10 +156,10 @@ end
 end
 @noinline _throw_nd_reparam_grid(::Type{Tg}) where {Tg} = throw(
     ArgumentError(
-        "PreCompute cubic ND builds accept Real or unit-carrying grid axes; the " *
-            "non-Real grid eltype $(Tg) supports no dimensionless reparameterization " *
-            "(needs `oneunit`, `inv`, `*`). Use LinearInterp/ConstantInterp ND, " *
-            "work per-fiber 1-D, or use a Real grid."
+        "Solver-family PreCompute ND builds (Cubic/Quadratic axes) accept Real or " *
+            "unit-carrying grid axes; the non-Real grid eltype $(Tg) supports no " *
+            "dimensionless reparameterization (needs `oneunit`, `inv`, `*`). Use " *
+            "LinearInterp/ConstantInterp ND, work per-fiber 1-D, or use a Real grid."
     )
 )
 

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -123,9 +123,10 @@ end
 end
 
 # Solver-family axes must be Real or dimensionless-reparameterizable (unit-carrying).
-# Probed PER AXIS with the canonical `_coeff_op` witness — a mixed-unit promoted Tg
-# is an abstract tag no witness may run on. Missing `oneunit`/`inv` arithmetic
-# infers `Union{}`/non-Real → friendly refusal; `Real` folds away.
+# Probed PER AXIS with the canonical `_reparam_op` witness — the exact transform the
+# twin build applies (a mixed-unit promoted Tg is an abstract tag no witness may run
+# on). Missing `oneunit`/`inv`/`*` infers `Union{}`/non-Real → friendly refusal;
+# `Real` folds away.
 @inline _check_nd_reparam_grid(::Tuple{}) = nothing
 @inline function _check_nd_reparam_grid(grids::Tuple)
     _check_nd_reparam_eltype(eltype(first(grids)))
@@ -133,7 +134,7 @@ end
 end
 @inline _check_nd_reparam_eltype(::Type{<:Real}) = nothing
 @inline function _check_nd_reparam_eltype(::Type{Tg}) where {Tg}
-    Tt = Base.promote_op(_coeff_op, Tg, Tg)
+    Tt = Base.promote_op(_reparam_op, Tg)
     return (Tt !== Union{} && Tt <: Real) ? nothing : _throw_nd_reparam_grid(Tg)
 end
 @noinline _throw_nd_reparam_grid(::Type{Tg}) where {Tg} = throw(

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -122,19 +122,6 @@ end
     return nothing
 end
 
-# One-shot solver-family ND entries: the pooled pipeline (axis wrap, partials
-# buffer, local params) has no reparameterized arm yet — refuse non-Real axes
-# with a pointer at the persistent builders, which DO support them via the
-# scaled store. The gate is `<: Real` (Dual passes); `Real` folds away.
-@inline _check_nd_solver_grid(::Type{<:Real}) = nothing
-@noinline _check_nd_solver_grid(::Type{Tg}) where {Tg} = throw(
-    ArgumentError(
-        "one-shot solver-family ND entries (Cubic/Quadratic) do not support " *
-            "non-Real grid eltypes yet (grid eltype $(Tg)). The persistent " *
-            "builders DO — build once and evaluate: `cubic_interp(grids, data)(q)`."
-    )
-)
-
 # Cubic ND admits non-Real axes via the exact dimensionless reparameterization
 # t = x·_deriv_oneunit(x, DerivOp(1)) (= x·inv(oneunit(x))): the 2^N store then
 # holds ∂ᵏf·Πoneunit(axis)ᵏ — every slot in the value space [Y], so the single
@@ -595,7 +582,7 @@ end
 end
 
 # Dispatch, not a boolean test, so the accepted case is a signature (matching the
-# `_check_nd_solver_grid` style above) and the check folds to nothing on `Real`.
+# `_check_nd_hetero_grid` style above) and the check folds to nothing on `Real`.
 @inline _check_adjoint_grid_real(::Type{<:Real}, ::Type{<:Real}) = nothing
 @noinline _check_adjoint_grid_real(::Type{Tg}, ::Type{Tq}) where {Tg, Tq} =
     _throw_adjoint_grid_not_real(Tg, Tq)

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -124,27 +124,29 @@ end
 
 # Solver-family ND builds store mixed derivative-mask orders in ONE homogeneous
 # array — unit-heterogeneous by construction (f vs ∂²f differ even on same-unit
-# axes). Reject unit-carrying grids with an actionable error; `Real` folds away.
+# axes). The gate is `<: Real` (Dual passes; units are the canonical rejected
+# case, but any non-Real Number is refused); `Real` folds away.
 @inline _check_nd_solver_grid(::Type{<:Real}) = nothing
 @noinline _check_nd_solver_grid(::Type{Tg}) where {Tg} = throw(
     ArgumentError(
         "PreCompute ND coefficient builds (Cubic/Quadratic/Hermite axes) do not " *
-            "support unit-carrying grids yet (grid eltype $(Tg)) — the nodal-" *
-            "derivative store mixes derivative orders of different dimensions. " *
-            "Use LinearInterp/ConstantInterp ND, integrate per-fiber 1-D, or strip units."
+            "support non-Real grid eltypes yet (grid eltype $(Tg)) — the nodal-" *
+            "derivative store is one homogeneous array, which unit-carrying grids " *
+            "break (derivative orders of different dimensions). Use LinearInterp/" *
+            "ConstantInterp ND, integrate per-fiber 1-D, or use a Real grid (units: `ustrip`)."
     )
 )
 
 # Same contract for the per-axis (hetero) ND engine — which also backs
 # PCHIP/Akima/Cardinal ND. Neither builder path (OnTheFly eval kernels nor the
-# PreCompute partials store) handles unit-carrying grids yet; without this gate
+# PreCompute partials store) handles non-Real grids yet; without this gate
 # the failure is a deep MethodError (or a "successful" build whose eval throws).
 @inline _check_nd_hetero_grid(::Type{<:Real}) = nothing
 @noinline _check_nd_hetero_grid(::Type{Tg}) where {Tg} = throw(
     ArgumentError(
         "Per-axis (hetero) ND interpolants — including PCHIP/Akima/Cardinal ND — " *
-            "do not support unit-carrying grids yet (grid eltype $(Tg)). " *
-            "Use LinearInterp/ConstantInterp ND, work per-fiber 1-D, or strip units."
+            "do not support non-Real grid eltypes yet (grid eltype $(Tg)). " *
+            "Use LinearInterp/ConstantInterp ND, work per-fiber 1-D, or use a Real grid (units: `ustrip`)."
     )
 )
 
@@ -559,10 +561,11 @@ end
 @noinline function _throw_adjoint_grid_not_real(::Type{Tg}, ::Type{Tq}) where {Tg, Tq}
     throw(
         ArgumentError(
-            "adjoint operators on a unit-carrying grid are not supported (grid eltype " *
-                "`$Tg`, query eltype `$Tq`): the anchor weights are built homogeneously " *
-                "in the grid type. Strip units first (`ustrip`) and reattach them to the " *
-                "result, or differentiate the forward evaluation, which does preserve units."
+            "adjoint operators on non-Real grid or query eltypes are not supported " *
+                "(grid eltype `$Tg`, query eltype `$Tq`): the anchor weights are built " *
+                "homogeneously in the grid type. Use a Real grid — for units, strip them " *
+                "(`ustrip`) and reattach to the result, or differentiate the forward " *
+                "evaluation, which does preserve units."
         )
     )
 end

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -169,6 +169,13 @@ Determine the output value type from y element type and grid type.
 @inline _value_type(::Type{Complex{T}}, ::Type{Tg}) where {T <: Real, Tg <: AbstractFloat} = Complex{Tg}
 # Duck-typing fallback for Tv: custom value types preserved as-is
 @inline _value_type(::Type{T}, ::Type{Tg}) where {T, Tg <: AbstractFloat} = T
+# Non-AbstractFloat grid tags, promotable values: duck REAL grids (Dual) keep the
+# value raw (no grid-parameter partials in y), but non-Real (unit) tags float it —
+# eval/solve run in the float value space there, so fills must too (Real-axis parity).
+@inline _value_type(::Type{T}, ::Type{Tg}) where {T <: _PromotableValue, Tg} =
+    _value_type_nonfloat_grid(T, Tg)
+@inline _value_type_nonfloat_grid(::Type{T}, ::Type{<:Real}) where {T} = T
+@inline _value_type_nonfloat_grid(::Type{T}, ::Type) where {T} = float(T)
 # Duck-typing fallback for Tg: when grid is duck-typed (Dual, Measurement, etc.),
 # values are not promoted to grid type (no grid-parameter partials in y).
 @inline _value_type(::Type{T}, ::Type{Tg}) where {T, Tg} = T

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -137,6 +137,32 @@ end
     )
 )
 
+# Cubic ND admits non-Real axes via the exact dimensionless reparameterization
+# t = x·_deriv_oneunit(x, DerivOp(1)) (= x·inv(oneunit(x))): the 2^N store then
+# holds ∂ᵏf·Πoneunit(axis)ᵏ — every slot in the value space [Y], so the single
+# homogeneous partials array survives unit grids. Capability is probed PER AXIS
+# (a mixed-unit promoted Tg is an abstract tag — witnesses must come from
+# per-axis eltypes) with the canonical `_coeff_op` witness: missing `oneunit`/
+# `inv` arithmetic infers `Union{}`/non-Real → friendly refusal. `Real` folds away.
+@inline _check_nd_reparam_grid(::Tuple{}) = nothing
+@inline function _check_nd_reparam_grid(grids::Tuple)
+    _check_nd_reparam_eltype(eltype(first(grids)))
+    return _check_nd_reparam_grid(Base.tail(grids))
+end
+@inline _check_nd_reparam_eltype(::Type{<:Real}) = nothing
+@inline function _check_nd_reparam_eltype(::Type{Tg}) where {Tg}
+    Tt = Base.promote_op(_coeff_op, Tg, Tg)
+    return (Tt !== Union{} && Tt <: Real) ? nothing : _throw_nd_reparam_grid(Tg)
+end
+@noinline _throw_nd_reparam_grid(::Type{Tg}) where {Tg} = throw(
+    ArgumentError(
+        "PreCompute cubic ND builds accept Real or unit-carrying grid axes; the " *
+            "non-Real grid eltype $(Tg) supports no dimensionless reparameterization " *
+            "(needs `oneunit`, `inv`, `*`). Use LinearInterp/ConstantInterp ND, " *
+            "work per-fiber 1-D, or use a Real grid."
+    )
+)
+
 # Same contract for the per-axis (hetero) ND engine — which also backs
 # PCHIP/Akima/Cardinal ND. Neither builder path (OnTheFly eval kernels nor the
 # PreCompute partials store) handles non-Real grids yet; without this gate

--- a/src/cubic/cubic_interpolant.jl
+++ b/src/cubic/cubic_interpolant.jl
@@ -61,8 +61,9 @@ so the pool memory can be safely reused after this function returns.
     tmp_z = acquire!(pool, Tz, length(y))
     # Solve uses original BC for proper RHS materialization
     _solve_system!(tmp_z, cache, y, bc_pair)
-    # 3-arg form: promote FillExtrap value type to Tv (no-op for other extraps).
-    extrap_p = _resolve_extrap(extrap, cache.x, Tv)
+    # 3-arg form: promote the FillExtrap value into the solved value space
+    # (`cache.x` is the float axis) — no-op for other extraps.
+    extrap_p = _resolve_extrap(extrap, cache.x, _value_type(Tv, eltype(cache.x)))
     return CubicInterpolant(cache, y, tmp_z, bc_pair, extrap_p, search; store = store)
 end
 
@@ -230,8 +231,9 @@ so the pool memory can be safely reused after this function returns.
         return CubicInterpolant(cache, y, tmp_z, cache.bc, WrapExtrap(), search; store = store)
     end
 
-    # 3-arg form: promote FillExtrap value type to Tv (no-op for other extraps).
-    extrap_p = _resolve_extrap(extrap, cache.x, Tv)
+    # 3-arg form: promote the FillExtrap value into the solved value space
+    # (`cache.x` is the float axis) — no-op for other extraps.
+    extrap_p = _resolve_extrap(extrap, cache.x, _value_type(Tv, eltype(cache.x)))
     return CubicInterpolant(cache, y, tmp_z, bc_solve, extrap_p, search; store = store)
 end
 

--- a/src/cubic/nd/cubic_nd_build.jl
+++ b/src/cubic/nd/cubic_nd_build.jl
@@ -580,23 +580,56 @@ Compute all partial derivatives for N-dimensional Hermite interpolation.
 - `_NodalDerivativesND{Tv, N, N+1}` containing the partials array
 """
 function _build_nd_coeffs(
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::Tuple{Vararg{AbstractVector, N}},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
-    ) where {Tg, Tv, N}
+    ) where {Tv, N}
     # Validate periodic BCs and PolyFit requirements (runs once at construction time)
     _validate_nd_bcs!(grids, bcs, data, Val(N))
 
+    # Non-Real axes solve on their exact dimensionless twins t = x·inv(oneunit(x)):
+    # every stored slot then lands in the value space [Y] (= ∂ᵏf·Πoneunit(axis)ᵏ),
+    # keeping the single homogeneous partials array. Real axes fold to passthrough
+    # (original arrays, zero copies). Typed BC payloads [Y/Xᵏ] scale into [Y];
+    # structural Real payloads stay for the 1D normalize/rehydrate to own.
+    _check_nd_reparam_grid(grids)
+    grids_solve, bcs_solve = if _promote_grid_eltype(grids) <: Real
+        grids, bcs
+    else
+        _reparam_grids(grids), map(_scale_bc_reparam, bcs, grids)
+    end
+
     # Allocate partials array: (2^N, n₁, n₂, ..., nₙ)
-    # Tz widens Tv with Tg: when grid is Dual, derivatives = data × inv_h → Dual-typed.
-    _check_nd_solver_grid(Tg)
-    Tz = _promote_eltype(_coeff_op2, Tg, Tv)
+    # Tz widens Tv with the solve-grid eltype: Dual grids → Dual-typed derivatives;
+    # unit grids solve dimensionless → Tz stays in the value space.
+    Tz = _promote_eltype(_coeff_op2, _promote_grid_eltype(grids_solve), Tv)
     n_partials = 1 << N
     partials_shape = (n_partials, size(data)...)
     partials = Array{Tz, N + 1}(undef, partials_shape)
 
     # Compute all partial derivatives
-    _compute_nd_partials!(partials, grids, data, bcs)
+    _compute_nd_partials!(partials, grids_solve, data, bcs_solve)
 
     return _NodalDerivativesND{Tz, N, N + 1}(partials)
 end
+
+# Dimensionless axis twins — `_float_grids_peraxis` peel idiom (build paths ban
+# closure-maps over axis wraps); scaling spelled with the canonical
+# `_deriv_oneunit` witness (= inv(oneunit(axis))). Ranges stay ranges.
+@inline _reparam_grids(::Tuple{}) = ()
+@inline _reparam_grids(grids::Tuple) = (
+    first(grids) .* _deriv_oneunit(first(first(grids)), DerivOp(1)),
+    _reparam_grids(Base.tail(grids))...,
+)
+
+# Typed PointBC payloads live in [Y/Xᵏ] → on the dimensionless axis they must be
+# [Y]: scale by oneunit(axis)ᵏ. Structural Real payloads pass through — the 1D
+# solve's normalize (zero-mint / embeddable / reject) owns their semantics.
+@inline _scale_bc_reparam(bc::BCPair, x) =
+    BCPair(_scale_bc_reparam(bc.left, x), _scale_bc_reparam(bc.right, x))
+@inline _scale_bc_reparam(bc::Deriv1, x) = Deriv1(_scale_payload_reparam(bc.val, oneunit(eltype(x))))
+@inline _scale_bc_reparam(bc::Deriv2, x) = Deriv2(_scale_payload_reparam(bc.val, oneunit(eltype(x))^2))
+@inline _scale_bc_reparam(bc::Deriv3, x) = Deriv3(_scale_payload_reparam(bc.val, oneunit(eltype(x))^3))
+@inline _scale_bc_reparam(bc::AbstractBC, _x) = bc
+@inline _scale_payload_reparam(v::Real, _u) = v
+@inline _scale_payload_reparam(v, u) = v * u

--- a/src/cubic/nd/cubic_nd_build.jl
+++ b/src/cubic/nd/cubic_nd_build.jl
@@ -593,11 +593,7 @@ function _build_nd_coeffs(
     # (original arrays, zero copies). Typed BC payloads [Y/Xᵏ] scale into [Y];
     # structural Real payloads stay for the 1D normalize/rehydrate to own.
     _check_nd_reparam_grid(grids)
-    grids_solve, bcs_solve = if _promote_grid_eltype(grids) <: Real
-        grids, bcs
-    else
-        _reparam_grids(grids), _scale_bcs_reparam(bcs, grids, data)
-    end
+    grids_solve, bcs_solve = _reparam_solve_frame(grids, bcs, data)
 
     # Allocate partials array: (2^N, n₁, n₂, ..., nₙ)
     # Tz widens Tv with the solve-grid eltype: Dual grids → Dual-typed derivatives;

--- a/src/cubic/nd/cubic_nd_build.jl
+++ b/src/cubic/nd/cubic_nd_build.jl
@@ -587,11 +587,9 @@ function _build_nd_coeffs(
     # Validate periodic BCs and PolyFit requirements (runs once at construction time)
     _validate_nd_bcs!(grids, bcs, data, Val(N))
 
-    # Non-Real axes solve on their exact dimensionless twins t = x·inv(oneunit(x)):
-    # every stored slot then lands in the value space [Y] (= ∂ᵏf·Πoneunit(axis)ᵏ),
-    # keeping the single homogeneous partials array. Real axes fold to passthrough
-    # (original arrays, zero copies). Typed BC payloads [Y/Xᵏ] scale into [Y];
-    # structural Real payloads stay for the 1D normalize/rehydrate to own.
+    # Non-Real axes solve on their dimensionless twins t = x·inv(oneunit(x)), so the
+    # single 2^N store stays [Y]-homogeneous (= ∂ᵏf·Πoneunit(axis)ᵏ); Real axes pass
+    # through untouched. BC payloads scale [Y/Xᵏ]→[Y] inside the frame helper.
     _check_nd_reparam_grid(grids)
     grids_solve, bcs_solve = _reparam_solve_frame(grids, bcs, data)
 

--- a/src/cubic/nd/cubic_nd_build.jl
+++ b/src/cubic/nd/cubic_nd_build.jl
@@ -596,7 +596,7 @@ function _build_nd_coeffs(
     grids_solve, bcs_solve = if _promote_grid_eltype(grids) <: Real
         grids, bcs
     else
-        _reparam_grids(grids), map(_scale_bc_reparam, bcs, grids)
+        _reparam_grids(grids), _scale_bcs_reparam(bcs, grids, data)
     end
 
     # Allocate partials array: (2^N, n₁, n₂, ..., nₙ)

--- a/src/cubic/nd/cubic_nd_build.jl
+++ b/src/cubic/nd/cubic_nd_build.jl
@@ -613,23 +613,5 @@ function _build_nd_coeffs(
     return _NodalDerivativesND{Tz, N, N + 1}(partials)
 end
 
-# Dimensionless axis twins — `_float_grids_peraxis` peel idiom (build paths ban
-# closure-maps over axis wraps); scaling spelled with the canonical
-# `_deriv_oneunit` witness (= inv(oneunit(axis))). Ranges stay ranges.
-@inline _reparam_grids(::Tuple{}) = ()
-@inline _reparam_grids(grids::Tuple) = (
-    first(grids) .* _deriv_oneunit(first(first(grids)), DerivOp(1)),
-    _reparam_grids(Base.tail(grids))...,
-)
-
-# Typed PointBC payloads live in [Y/Xᵏ] → on the dimensionless axis they must be
-# [Y]: scale by oneunit(axis)ᵏ. Structural Real payloads pass through — the 1D
-# solve's normalize (zero-mint / embeddable / reject) owns their semantics.
-@inline _scale_bc_reparam(bc::BCPair, x) =
-    BCPair(_scale_bc_reparam(bc.left, x), _scale_bc_reparam(bc.right, x))
-@inline _scale_bc_reparam(bc::Deriv1, x) = Deriv1(_scale_payload_reparam(bc.val, oneunit(eltype(x))))
-@inline _scale_bc_reparam(bc::Deriv2, x) = Deriv2(_scale_payload_reparam(bc.val, oneunit(eltype(x))^2))
-@inline _scale_bc_reparam(bc::Deriv3, x) = Deriv3(_scale_payload_reparam(bc.val, oneunit(eltype(x))^3))
-@inline _scale_bc_reparam(bc::AbstractBC, _x) = bc
-@inline _scale_payload_reparam(v::Real, _u) = v
-@inline _scale_payload_reparam(v, u) = v * u
+# `_reparam_grids` / `_scale_bc_reparam` (shared with quadratic ND) live in
+# core/nd_utils.jl next to the reparam local-params.

--- a/src/cubic/nd/cubic_nd_eval.jl
+++ b/src/cubic/nd/cubic_nd_eval.jl
@@ -77,7 +77,11 @@ end
     # 6-arg search: per-axis `extraps` let InBounds range axes take the lean direct
     # search (one-sided clamp; hint still written back) — bit-identical, per-axis, all N.
     indices, Ls, _ = _search_all_intervals(q_evals, itp.grids, policies, hints, mono, extraps)
-    hs, inv_hs, dLs = _compute_all_local_params(q_evals, itp.grids, indices, Ls)
+    # Non-Real axes: the scaled store is [Y]-homogeneous, so the kernel consumes
+    # dimensionless local params (type-folded — Real is the exact old call).
+    hs, inv_hs, dLs = Tg <: Real ?
+        _compute_all_local_params(q_evals, itp.grids, indices, Ls) :
+        _compute_all_local_params_reparam(q_evals, itp.grids, indices, Ls)
 
     return (itp.nodal_derivs.partials, indices, hs, inv_hs, dLs)
 end
@@ -86,14 +90,18 @@ end
 # N=2, so a hand-destructured 2D variant is equal-or-slower (verified via
 # same-process method-swap A/B).
 
-# Evaluate kernel at a pre-located cell with given derivative ops
+# Evaluate kernel at a pre-located cell with given derivative ops.
+# Non-Real axes: the kernel runs dimensionless over the [Y]-scaled store, so
+# derivative results restore their per-axis grid⁻ᵏ units at this single seam
+# (canonical `_nd_deriv_scale` fold; `true` on value ops and Real grids — folds).
 @inline function _eval_at_cell(
-        ::CubicInterpolantND,
+        itp::CubicInterpolantND{Tg},
         cell::Tuple,
         ops::NTuple{N, AbstractEvalOp}
-    ) where {N}
+    ) where {Tg, N}
     partials, indices, hs, inv_hs, dLs = cell
-    return _eval_nd_cell(partials, indices, hs, inv_hs, dLs, ops)
+    r = _eval_nd_cell(partials, indices, hs, inv_hs, dLs, ops)
+    return Tg <: Real ? r : r * _nd_fill_deriv_scale(itp.grids, ops)
 end
 
 # Per-method sample of `Tv` for fill-value paths (e.g. `_try_fill_oob`).

--- a/src/cubic/nd/cubic_nd_eval.jl
+++ b/src/cubic/nd/cubic_nd_eval.jl
@@ -88,10 +88,9 @@ end
 # N=2, so a hand-destructured 2D variant is equal-or-slower (verified via
 # same-process method-swap A/B).
 
-# Evaluate kernel at a pre-located cell with given derivative ops.
-# Non-Real axes: the kernel runs dimensionless over the [Y]-scaled store, so
-# derivative results restore their per-axis grid⁻ᵏ units at this single seam
-# (canonical `_nd_deriv_scale` fold; `true` on value ops and Real grids — folds).
+# Evaluate kernel at a pre-located cell with given derivative ops. Non-Real axes
+# run dimensionless over the [Y]-scaled store — `_restore_nd_deriv_scale`
+# re-attaches the per-axis grid⁻ᵏ units at this single seam.
 @inline function _eval_at_cell(
         itp::CubicInterpolantND{Tg},
         cell::Tuple,

--- a/src/cubic/nd/cubic_nd_eval.jl
+++ b/src/cubic/nd/cubic_nd_eval.jl
@@ -78,10 +78,8 @@ end
     # search (one-sided clamp; hint still written back) — bit-identical, per-axis, all N.
     indices, Ls, _ = _search_all_intervals(q_evals, itp.grids, policies, hints, mono, extraps)
     # Non-Real axes: the scaled store is [Y]-homogeneous, so the kernel consumes
-    # dimensionless local params (type-folded — Real is the exact old call).
-    hs, inv_hs, dLs = Tg <: Real ?
-        _compute_all_local_params(q_evals, itp.grids, indices, Ls) :
-        _compute_all_local_params_reparam(q_evals, itp.grids, indices, Ls)
+    # dimensionless local params (the width-tag dispatch routes; Real = exact old width).
+    hs, inv_hs, dLs = _compute_all_local_params(q_evals, itp.grids, indices, Ls, Tg)
 
     return (itp.nodal_derivs.partials, indices, hs, inv_hs, dLs)
 end
@@ -101,7 +99,7 @@ end
     ) where {Tg, N}
     partials, indices, hs, inv_hs, dLs = cell
     r = _eval_nd_cell(partials, indices, hs, inv_hs, dLs, ops)
-    return Tg <: Real ? r : r * _nd_fill_deriv_scale(itp.grids, ops)
+    return _restore_nd_deriv_scale(r, itp.grids, ops)
 end
 
 # Per-method sample of `Tv` for fill-value paths (e.g. `_try_fill_oob`).

--- a/src/cubic/nd/cubic_nd_interpolant.jl
+++ b/src/cubic/nd/cubic_nd_interpolant.jl
@@ -71,9 +71,11 @@ function _cubic_interp_nd(
         coeffs::AbstractCoeffStrategy = PreCompute(),
         store::StorePolicy = StorePolicy()
     ) where {N, Tv_raw}
+    # Gate on the RAW eltype BEFORE float promotion — a non-Real duck Number
+    # dies inside `_nd_promote_grids` (`AbstractFloat(x)` MethodError) otherwise.
+    _check_nd_solver_grid(_promote_grid_eltype(grids))
     # Zero-allocation type promotion + grid conversion
-    grids_typed, Tg_p, Tv, _ = _nd_promote_grids(grids, data)
-    _check_nd_solver_grid(Tg_p)
+    grids_typed, _, Tv, _ = _nd_promote_grids(grids, data)
 
     # Promote data type (Int→Float64, Complex{T}→Complex{Tg}, custom types preserved)
     data_typed = Tv === Tv_raw ? data : Tv.(data)

--- a/src/cubic/nd/cubic_nd_interpolant.jl
+++ b/src/cubic/nd/cubic_nd_interpolant.jl
@@ -71,9 +71,11 @@ function _cubic_interp_nd(
         coeffs::AbstractCoeffStrategy = PreCompute(),
         store::StorePolicy = StorePolicy()
     ) where {N, Tv_raw}
-    # Gate on the RAW eltype BEFORE float promotion — a non-Real duck Number
-    # dies inside `_nd_promote_grids` (`AbstractFloat(x)` MethodError) otherwise.
-    _check_nd_solver_grid(_promote_grid_eltype(grids))
+    # Gate on the RAW per-axis eltypes BEFORE float promotion — a non-Real duck
+    # Number dies inside `_nd_promote_grids` (`AbstractFloat(x)` MethodError)
+    # otherwise. Cubic admits reparameterizable axes (units); per-axis probe —
+    # the mixed-unit promoted Tg is an abstract tag no witness can run on.
+    _check_nd_reparam_grid(grids)
     # Zero-allocation type promotion + grid conversion
     grids_typed, _, Tv, _ = _nd_promote_grids(grids, data)
 
@@ -111,13 +113,13 @@ end
 Build CubicInterpolantND with precomputed coefficients.
 """
 function _build_nd_interpolant(
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::Tuple{Vararg{AbstractVector, N}},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC},
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
         searches::NTuple{N, AbstractSearchPolicy},
         ::PreCompute
-    ) where {Tg, Tv, N}
+    ) where {Tv, N}
     # Extend grids/data for exclusive periodic axes; periodic bcs are
     # promoted to `:extended` per axis (via `_bc_after_extend` inside the
     # helper) so downstream dispatch reflects the closed-cycle layout.

--- a/src/cubic/nd/cubic_nd_interpolant.jl
+++ b/src/cubic/nd/cubic_nd_interpolant.jl
@@ -71,10 +71,8 @@ function _cubic_interp_nd(
         coeffs::AbstractCoeffStrategy = PreCompute(),
         store::StorePolicy = StorePolicy()
     ) where {N, Tv_raw}
-    # Gate on the RAW per-axis eltypes BEFORE float promotion — a non-Real duck
-    # Number dies inside `_nd_promote_grids` (`AbstractFloat(x)` MethodError)
-    # otherwise. Cubic admits reparameterizable axes (units); per-axis probe —
-    # the mixed-unit promoted Tg is an abstract tag no witness can run on.
+    # Gate on the RAW per-axis eltypes BEFORE float promotion — a non-reparameterizable
+    # duck Number would die deep inside `_nd_promote_grids` otherwise.
     _check_nd_reparam_grid(grids)
     # Zero-allocation type promotion + grid conversion
     grids_typed, _, Tv, _ = _nd_promote_grids(grids, data)

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -9,6 +9,13 @@
 # ONE-SHOT PUBLIC API
 # ========================================
 
+# One-shot fill/extrap payload space: data is not eagerly converted here, so Real
+# axes widen by the coeff witness; a non-Real tag cannot run the witness — the
+# value space itself serves (the persistent entry's convention).
+@inline _oneshot_fill_eltype(::Type{Tg}, ::Type{Tv}) where {Tg <: Real, Tv} =
+    _promote_eltype(_coeff_op2, Tg, Tv)
+@inline _oneshot_fill_eltype(::Type{Tg}, ::Type{Tv}) where {Tg, Tv} = _value_type(Tv, Tg)
+
 """
     cubic_interp(grids, data, query; deriv=EvalValue(), kwargs...)
 
@@ -45,10 +52,7 @@ function cubic_interp(
     # Float32 data → Float32), so the OnTheFly eval + witness `Tr` agree. Batch keeps eager-convert.
     Tg_raw = _promote_grid_eltype(grids)
     Tg = _promote_grid_float(Tg_raw, Tv)
-    # Non-Real axes: `Tg` is a unit type (abstract tag on mixed axes) no witness may
-    # run on — the fill/extrap space is the value space, mirroring the persistent
-    # entry (`_resolve_extrap(…, Tv)` after `_nd_promote_grids`).
-    Tv_p = Tg_raw <: Real ? _promote_eltype(_coeff_op2, Tg, Tv) : _value_type(Tv, Tg_raw)
+    Tv_p = _oneshot_fill_eltype(Tg, Tv)
     _validate_nd_grids(grids, data)
     # Reparameterizable axes only (Real or unit-carrying) — the persistent builder's gate.
     _check_nd_reparam_grid(grids)
@@ -151,8 +155,7 @@ Zero-allocation after warmup (pool reuse).
     # value-deterministic objectid); a mismatched Vector converts into a POOL buffer
     # (warm one-shots stay zero-alloc), so the whole solve pipeline runs at `Tg`.
     # Non-Real axes wrap at their OWN eltype (abstract-tag arm of the @generated map).
-    Tg_raw = _promote_grid_eltype(grids)
-    Tg = _promote_grid_float(Tg_raw, Tv)
+    Tg = _promote_grid_float(_promote_grid_eltype(grids), Tv)
     grids = _cache_axes_pooled(pool, grids, Tg)  # @generated static-Tg unroll (no Type-captured closure)
     # Bare GridIdx(k).val is NaN → resolve to the grid coordinate for the value kernel (search still uses .idx).
     query = map(_resolve_grididx, query, grids)
@@ -173,19 +176,12 @@ Zero-allocation after warmup (pool reuse).
     extraps_eff = map(_resolve_extrap, extraps_val, grids_p)
 
     # 2. Pool-allocate partials array (THE KEY: pool instead of heap)
-    # Tz widens Tv with Tg: when grid is Dual, derivatives = data × inv_h → Dual-typed.
-    # Non-Real axes solve on the dimensionless twins — the pooled partials stay
-    # [Y]-homogeneous exactly as in the persistent scaled-store build (search and
-    # local params below keep reading the unit axes `grids_p`).
-    if Tg_raw <: Real
-        grids_solve = grids_p
-        bcs_solve = bcs_p
-        Tz = _promote_eltype(_coeff_op2, Tg, Tv)
-    else
-        grids_solve = _reparam_grids(grids_p)
-        bcs_solve = _scale_bcs_reparam(bcs_p, grids_p, data_p)
-        Tz = _promote_eltype(_coeff_op2, _promote_grid_eltype(grids_solve), Tv)
-    end
+    # Tz widens Tv with the solve-grid eltype: Dual grids → Dual-typed derivatives.
+    # Non-Real axes solve on the dimensionless twins (`_reparam_solve_frame`) — the
+    # pooled partials stay [Y]-homogeneous exactly as in the persistent scaled-store
+    # build (search and local params below keep reading the unit axes `grids_p`).
+    grids_solve, bcs_solve = _reparam_solve_frame(grids_p, bcs_p, data_p)
+    Tz = _promote_eltype(_coeff_op2, _promote_grid_eltype(grids_solve), Tv)
     n_partials = 1 << N
     partials = acquire!(pool, Tz, (n_partials, size(data_p)...))
 
@@ -196,16 +192,15 @@ Zero-allocation after warmup (pool reuse).
     # 4. Eval pipeline (all standalone functions, no Interpolant needed).
     # Axis-only forms — `grids_p` axes carry `h`/`inv_h` directly via `_get_h`/
     # `_get_inv_h` (cached lookup for wrapped axes, on-the-fly diff for raw Vector);
-    # the data-aware form width-types hs/inv_hs at `Tg` (raw Int-Vector axes included).
+    # the data-aware form width-types hs/inv_hs at `Tg` (raw Int-Vector axes included;
+    # a non-Real tag routes to the dimensionless collapse by dispatch).
     q_evals = _handle_all_extraps(query, grids_p, extraps_eff)
     indices, Ls, _ = _search_all_intervals(q_evals, grids_p, searches, hints, extraps_eff)
-    hs, inv_hs, dLs = Tg_raw <: Real ?
-        _compute_all_local_params(q_evals, grids_p, indices, Ls, Tg) :
-        _compute_all_local_params_reparam(q_evals, grids_p, indices, Ls)
+    hs, inv_hs, dLs = _compute_all_local_params(q_evals, grids_p, indices, Ls, Tg)
 
     # 6. Tensor-product kernel evaluation ([Y]-scaled partials → grid⁻ᵏ restore at the seam)
     r = _eval_nd_cell(partials, indices, hs, inv_hs, dLs, ops)
-    return Tg_raw <: Real ? r : r * _nd_fill_deriv_scale(grids_p, ops)
+    return _restore_nd_deriv_scale(r, grids_p, ops)
 end
 
 """
@@ -249,15 +244,8 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
     extraps_eff = _validate_nd_domain(grids_p, queries, extraps_eff)
     # Non-Real axes solve on the dimensionless twins (persistent scaled-store mirror);
     # search + local params below keep reading the unit axes `grids_p`.
-    if Tg_raw <: Real
-        grids_solve = grids_p
-        bcs_solve = bcs_p
-        Tz = _promote_eltype(_coeff_op2, Tg_raw, Tv)
-    else
-        grids_solve = _reparam_grids(grids_p)
-        bcs_solve = _scale_bcs_reparam(bcs_p, grids_p, data_p)
-        Tz = _promote_eltype(_coeff_op2, _promote_grid_eltype(grids_solve), Tv)
-    end
+    grids_solve, bcs_solve = _reparam_solve_frame(grids_p, bcs_p, data_p)
+    Tz = _promote_eltype(_coeff_op2, _promote_grid_eltype(grids_solve), Tv)
     n_partials = 1 << N
     partials = acquire!(pool, Tz, (n_partials, size(data_p)...))
     _compute_nd_partials!(partials, grids_solve, data_p, bcs_solve)
@@ -272,11 +260,9 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
         end
         q_evals = _handle_all_extraps(query_k, grids_p, extraps_eff)
         indices, Ls, _ = _search_all_intervals(q_evals, grids_p, policies, hints, extraps_eff)
-        hs, inv_hs, dLs = Tg_raw <: Real ?
-            _compute_all_local_params(q_evals, grids_p, indices, Ls) :
-            _compute_all_local_params_reparam(q_evals, grids_p, indices, Ls)
+        hs, inv_hs, dLs = _compute_all_local_params(q_evals, grids_p, indices, Ls, Tg_raw)
         r = _eval_nd_cell(partials, indices, hs, inv_hs, dLs, ops)
-        output[k] = Tg_raw <: Real ? r : r * _nd_fill_deriv_scale(grids_p, ops)
+        output[k] = _restore_nd_deriv_scale(r, grids_p, ops)
     end
     return output
 end

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -16,8 +16,8 @@ One-shot ND cubic interpolation at a single point.
 Zero-allocation after warmup: uses pool-based partials instead of constructing an Interpolant.
 
 Non-Real (unit-carrying) axes mirror the persistent scaled-store build: the solve runs
-on dimensionless axis twins and the result is restored to grid⁻ᵏ units. The zero-alloc
-contract is the Real-axis path's; the unit arm allocates its per-call twins.
+on dimensionless axis twins (lazy `_ReparamAxis` views — no per-call array) and the
+result is restored to grid⁻ᵏ units, so the zero-alloc contract holds there too.
 
 # Keywords
 - `deriv`: `DerivOp` or `NTuple{N,DerivOp}` for mixed partials

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -71,10 +71,9 @@ function cubic_interp(
 
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv_p)
 
-    # OnTheFly: skip full partials build — use sequential 1D collapse (2^N× less work).
-    # A non-Real query never resolves here under AutoCoeffs (the Real-tuple arm skips
-    # it → PreCompute pool); an EXPLICIT OnTheFly rides the hetero collapse engine,
-    # whose non-Real gate keeps the refusal actionable.
+    # OnTheFly: skip full partials build — sequential 1D collapse (2^N× less work).
+    # Non-Real queries resolve PreCompute by dispatch (Real-tuple arm); an explicit
+    # OnTheFly rides the hetero collapse, whose gate keeps the refusal friendly.
     coeffs_resolved = _resolve_coeffs_nd_oneshot(coeffs, query, ntuple(_ -> CubicInterp(), Val(N)))
     if coeffs_resolved isa OnTheFly
         _check_nd_hetero_grid(Tg_raw)
@@ -175,11 +174,9 @@ Zero-allocation after warmup (pool reuse).
     # 2-arg primitive is identity for tag-struct extraps (Wrap, Clamp, ...).
     extraps_eff = map(_resolve_extrap, extraps_val, grids_p)
 
-    # 2. Pool-allocate partials array (THE KEY: pool instead of heap)
-    # Tz widens Tv with the solve-grid eltype: Dual grids → Dual-typed derivatives.
-    # Non-Real axes solve on the dimensionless twins (`_reparam_solve_frame`) — the
-    # pooled partials stay [Y]-homogeneous exactly as in the persistent scaled-store
-    # build (search and local params below keep reading the unit axes `grids_p`).
+    # 2. Pool-allocate partials array (THE KEY: pool instead of heap). Tz widens Tv
+    # with the solve-grid eltype (Dual grids → Dual derivs). Non-Real axes solve on
+    # the dimensionless twins; search/local params below keep reading `grids_p`.
     grids_solve, bcs_solve = _reparam_solve_frame(grids_p, bcs_p, data_p)
     Tz = _promote_eltype(_coeff_op2, _promote_grid_eltype(grids_solve), Tv)
     n_partials = 1 << N
@@ -192,8 +189,7 @@ Zero-allocation after warmup (pool reuse).
     # 4. Eval pipeline (all standalone functions, no Interpolant needed).
     # Axis-only forms — `grids_p` axes carry `h`/`inv_h` directly via `_get_h`/
     # `_get_inv_h` (cached lookup for wrapped axes, on-the-fly diff for raw Vector);
-    # the data-aware form width-types hs/inv_hs at `Tg` (raw Int-Vector axes included;
-    # a non-Real tag routes to the dimensionless collapse by dispatch).
+    # the data-aware form width-types hs/inv_hs at `Tg` (raw Int-Vector axes included).
     q_evals = _handle_all_extraps(query, grids_p, extraps_eff)
     indices, Ls, _ = _search_all_intervals(q_evals, grids_p, searches, hints, extraps_eff)
     hs, inv_hs, dLs = _compute_all_local_params(q_evals, grids_p, indices, Ls, Tg)

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -242,7 +242,7 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
     # Eval loop: search + kernel per query point. Axis-only helpers read
     # `h`/`inv_h` directly from `grids_p` (no transient pool spacings).
     @inbounds for k in 1:nq
-        query_k = _extract_query_point(queries, k, Val(N))
+        query_k = _extract_query_point(queries, k, Val(N), grids_p)
         oob_val = _try_fill_oob(query_k, grids_p, extraps_eff, ops, first(data_p))
         if oob_val !== nothing
             output[k] = oob_val; continue

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -15,6 +15,10 @@
 One-shot ND cubic interpolation at a single point.
 Zero-allocation after warmup: uses pool-based partials instead of constructing an Interpolant.
 
+Non-Real (unit-carrying) axes mirror the persistent scaled-store build: the solve runs
+on dimensionless axis twins and the result is restored to grid⁻ᵏ units. The zero-alloc
+contract is the Real-axis path's; the unit arm allocates its per-call twins.
+
 # Keywords
 - `deriv`: `DerivOp` or `NTuple{N,DerivOp}` for mixed partials
 - `bc`, `extrap`, `search`, `coeffs`: Same as the Interpolant constructor form
@@ -39,14 +43,21 @@ function cubic_interp(
     # Scalar one-shot: raw grids — a stable grid id lets `_get_cubic_cache` memoise
     # (a per-call copy would miss every time + alloc). `Tg` is value-matched (Int/OneTo grid +
     # Float32 data → Float32), so the OnTheFly eval + witness `Tr` agree. Batch keeps eager-convert.
-    Tg = _promote_grid_float(_promote_grid_eltype(grids), Tv)
-    Tv_p = _promote_eltype(_coeff_op2, Tg, Tv)
+    Tg_raw = _promote_grid_eltype(grids)
+    Tg = _promote_grid_float(Tg_raw, Tv)
+    # Non-Real axes: `Tg` is a unit type (abstract tag on mixed axes) no witness may
+    # run on — the fill/extrap space is the value space, mirroring the persistent
+    # entry (`_resolve_extrap(…, Tv)` after `_nd_promote_grids`).
+    Tv_p = Tg_raw <: Real ? _promote_eltype(_coeff_op2, Tg, Tv) : _value_type(Tv, Tg_raw)
     _validate_nd_grids(grids, data)
-    # PreCompute/OnTheFly ND cubic solve does not support unit-carrying grids —
-    # match the persistent builder's actionable error instead of a deep MethodError.
-    _check_nd_solver_grid(_promote_grid_eltype(grids))
-    Tq = promote_type(typeof.(query)...)
-    Tr = _promote_eltype(_interp_op, Tg, Tv, Tq)
+    # Reparameterizable axes only (Real or unit-carrying) — the persistent builder's gate.
+    _check_nd_reparam_grid(grids)
+    ops = _resolve_deriv_nd(deriv, Val(N))
+    # `ops` folds into the witness BEFORE the assertion (linear canonical): a derivative
+    # query lands in value/coordᴺ — identity on Real grids and on `DerivOp{0}`.
+    Tr = _deriv_eltype_nd(
+        _nd_value_eltype(_interp_op, Tv, grids, promote_type(typeof.(query)...)), grids, ops
+    )
 
     bcs = _resolve_bcs_nd(bc, Val(N))
     searches = _resolve_search_nd(search, Val(N), query)  # NTuple{N,Real} <: Tuple → BinarySearch/axis
@@ -55,11 +66,14 @@ function cubic_interp(
     _validate_nd_bcs!(grids, bcs, data, Val(N))
 
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv_p)
-    ops = _resolve_deriv_nd(deriv, Val(N))
 
-    # OnTheFly: skip full partials build — use sequential 1D collapse (2^N× less work)
+    # OnTheFly: skip full partials build — use sequential 1D collapse (2^N× less work).
+    # A non-Real query never resolves here under AutoCoeffs (the Real-tuple arm skips
+    # it → PreCompute pool); an EXPLICIT OnTheFly rides the hetero collapse engine,
+    # whose non-Real gate keeps the refusal actionable.
     coeffs_resolved = _resolve_coeffs_nd_oneshot(coeffs, query, ntuple(_ -> CubicInterp(), Val(N)))
     if coeffs_resolved isa OnTheFly
+        _check_nd_hetero_grid(Tg_raw)
         methods = map(CubicInterp, bcs)
         return _interp_nd_oneshot_onthefly(grids, data, query, methods, extraps_val, searches, ops, hint)::Tr
     end
@@ -90,10 +104,12 @@ function _cubic_interp_nd_oneshot_alloc(
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
-    _check_nd_solver_grid(_promote_grid_eltype(grids))
-    _, Tg, _, _ = _nd_promote_grids(grids, data)
+    _check_nd_reparam_grid(grids)
     Tq = _query_eltype(queries)
-    Tr = _promote_eltype(_interp_op, Tg, Tv, Tq)
+    # Same fold as the scalar entry (linear canonical): the buffer must be sized in
+    # ∂-units, else a unit-grid derivative batch throws on the first store.
+    ops = _resolve_deriv_nd(deriv, Val(N))
+    Tr = _deriv_eltype_nd(_nd_value_eltype(_interp_op, Tv, grids, Tq), grids, ops)
     output = _alloc_query_output(Tr, queries)
     _cubic_interp_nd_oneshot_batch!(output, grids, data, queries; deriv, bc, extrap, search, coeffs, hint)
     return output
@@ -134,7 +150,9 @@ Zero-allocation after warmup (pool reuse).
     # → isbits `_CachedRange{Tg}` (the per-axis spline caches still memoise via
     # value-deterministic objectid); a mismatched Vector converts into a POOL buffer
     # (warm one-shots stay zero-alloc), so the whole solve pipeline runs at `Tg`.
-    Tg = _promote_grid_float(_promote_grid_eltype(grids), Tv)
+    # Non-Real axes wrap at their OWN eltype (abstract-tag arm of the @generated map).
+    Tg_raw = _promote_grid_eltype(grids)
+    Tg = _promote_grid_float(Tg_raw, Tv)
     grids = _cache_axes_pooled(pool, grids, Tg)  # @generated static-Tg unroll (no Type-captured closure)
     # Bare GridIdx(k).val is NaN → resolve to the grid coordinate for the value kernel (search still uses .idx).
     query = map(_resolve_grididx, query, grids)
@@ -156,13 +174,24 @@ Zero-allocation after warmup (pool reuse).
 
     # 2. Pool-allocate partials array (THE KEY: pool instead of heap)
     # Tz widens Tv with Tg: when grid is Dual, derivatives = data × inv_h → Dual-typed.
-    Tz = _promote_eltype(_coeff_op2, Tg, Tv)
+    # Non-Real axes solve on the dimensionless twins — the pooled partials stay
+    # [Y]-homogeneous exactly as in the persistent scaled-store build (search and
+    # local params below keep reading the unit axes `grids_p`).
+    if Tg_raw <: Real
+        grids_solve = grids_p
+        bcs_solve = bcs_p
+        Tz = _promote_eltype(_coeff_op2, Tg, Tv)
+    else
+        grids_solve = _reparam_grids(grids_p)
+        bcs_solve = _scale_bcs_reparam(bcs_p, grids_p, data_p)
+        Tz = _promote_eltype(_coeff_op2, _promote_grid_eltype(grids_solve), Tv)
+    end
     n_partials = 1 << N
     partials = acquire!(pool, Tz, (n_partials, size(data_p)...))
 
     # 3. Compute all partial derivatives in-place
     #    (internally uses autocached 1D caches + nested @with_pool for temp buffers)
-    _compute_nd_partials!(partials, grids_p, data_p, bcs_p)
+    _compute_nd_partials!(partials, grids_solve, data_p, bcs_solve)
 
     # 4. Eval pipeline (all standalone functions, no Interpolant needed).
     # Axis-only forms — `grids_p` axes carry `h`/`inv_h` directly via `_get_h`/
@@ -170,10 +199,13 @@ Zero-allocation after warmup (pool reuse).
     # the data-aware form width-types hs/inv_hs at `Tg` (raw Int-Vector axes included).
     q_evals = _handle_all_extraps(query, grids_p, extraps_eff)
     indices, Ls, _ = _search_all_intervals(q_evals, grids_p, searches, hints, extraps_eff)
-    hs, inv_hs, dLs = _compute_all_local_params(q_evals, grids_p, indices, Ls, Tg)
+    hs, inv_hs, dLs = Tg_raw <: Real ?
+        _compute_all_local_params(q_evals, grids_p, indices, Ls, Tg) :
+        _compute_all_local_params_reparam(q_evals, grids_p, indices, Ls)
 
-    # 6. Tensor-product kernel evaluation
-    return _eval_nd_cell(partials, indices, hs, inv_hs, dLs, ops)
+    # 6. Tensor-product kernel evaluation ([Y]-scaled partials → grid⁻ᵏ restore at the seam)
+    r = _eval_nd_cell(partials, indices, hs, inv_hs, dLs, ops)
+    return Tg_raw <: Real ? r : r * _nd_fill_deriv_scale(grids_p, ops)
 end
 
 """
@@ -185,9 +217,12 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
 
 `extraps_val` must be a pre-resolved tuple of concrete `AbstractExtrap` instances.
 """
+# `grids` is NOT pinned to one shared axis eltype: mixed-unit grids (`s` × `m`)
+# reach this backend as a heterogeneous per-axis-float tuple — requiring a common
+# `Tg` excluded them from the batch path entirely (the linear sibling relaxed first).
 @with_pool pool function _cubic_interp_nd_oneshot_batch!(
         output::AbstractArray,
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         queries,
         bcs::NTuple{N, AbstractBC},
@@ -195,12 +230,13 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
         ops::NTuple{N, AbstractEvalOp},
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}},
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}},
-    ) where {Tg, Tv, N}
+    ) where {Tv, N}
     # Resolve here so the fresh Ref tuple stays local to this frame (stack-elidable).
     policies, hints = _resolve_oneshot_search_nd(search, queries, hint, Val(N))
     nq = _query_length(queries)
     _check_query_output_size(output, queries)
     _query_validate(queries)
+    Tg_raw = _promote_grid_eltype(grids)
 
     # Build phase (same as scalar, done once)
     grids_p, data_p, bcs_p = _prepare_periodic_nd_pooled(pool, grids, data, bcs)
@@ -211,10 +247,20 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
     # per axis when all its queries are in-bounds, so the per-query `_try_fill_oob` /
     # `_handle_all_extraps` branches compile away.
     extraps_eff = _validate_nd_domain(grids_p, queries, extraps_eff)
-    Tz = _promote_eltype(_coeff_op2, Tg, Tv)
+    # Non-Real axes solve on the dimensionless twins (persistent scaled-store mirror);
+    # search + local params below keep reading the unit axes `grids_p`.
+    if Tg_raw <: Real
+        grids_solve = grids_p
+        bcs_solve = bcs_p
+        Tz = _promote_eltype(_coeff_op2, Tg_raw, Tv)
+    else
+        grids_solve = _reparam_grids(grids_p)
+        bcs_solve = _scale_bcs_reparam(bcs_p, grids_p, data_p)
+        Tz = _promote_eltype(_coeff_op2, _promote_grid_eltype(grids_solve), Tv)
+    end
     n_partials = 1 << N
     partials = acquire!(pool, Tz, (n_partials, size(data_p)...))
-    _compute_nd_partials!(partials, grids_p, data_p, bcs_p)
+    _compute_nd_partials!(partials, grids_solve, data_p, bcs_solve)
 
     # Eval loop: search + kernel per query point. Axis-only helpers read
     # `h`/`inv_h` directly from `grids_p` (no transient pool spacings).
@@ -226,8 +272,11 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
         end
         q_evals = _handle_all_extraps(query_k, grids_p, extraps_eff)
         indices, Ls, _ = _search_all_intervals(q_evals, grids_p, policies, hints, extraps_eff)
-        hs, inv_hs, dLs = _compute_all_local_params(q_evals, grids_p, indices, Ls)
-        output[k] = _eval_nd_cell(partials, indices, hs, inv_hs, dLs, ops)
+        hs, inv_hs, dLs = Tg_raw <: Real ?
+            _compute_all_local_params(q_evals, grids_p, indices, Ls) :
+            _compute_all_local_params_reparam(q_evals, grids_p, indices, Ls)
+        r = _eval_nd_cell(partials, indices, hs, inv_hs, dLs, ops)
+        output[k] = Tg_raw <: Real ? r : r * _nd_fill_deriv_scale(grids_p, ops)
     end
     return output
 end
@@ -251,7 +300,7 @@ Writes results into pre-allocated `output` vector.
 # Public ND in-place batch one-shot (N≥2; N=1 is intercepted by the collapse method
 # below and only reaches here via the OnTheFly branch, which has no 1D equivalent).
 @inline function cubic_interp!(output::AbstractArray, grids::NTuple{N, AbstractVector}, data::AbstractArray{<:Any, N}, queries; kwargs...) where {N}
-    _check_nd_solver_grid(_promote_grid_eltype(grids))
+    _check_nd_reparam_grid(grids)
     return _cubic_interp_nd_oneshot_batch!(output, grids, data, queries; kwargs...)
 end
 

--- a/src/cubic/nd/cubic_nd_oneshot.jl
+++ b/src/cubic/nd/cubic_nd_oneshot.jl
@@ -9,13 +9,6 @@
 # ONE-SHOT PUBLIC API
 # ========================================
 
-# One-shot fill/extrap payload space: data is not eagerly converted here, so Real
-# axes widen by the coeff witness; a non-Real tag cannot run the witness — the
-# value space itself serves (the persistent entry's convention).
-@inline _oneshot_fill_eltype(::Type{Tg}, ::Type{Tv}) where {Tg <: Real, Tv} =
-    _promote_eltype(_coeff_op2, Tg, Tv)
-@inline _oneshot_fill_eltype(::Type{Tg}, ::Type{Tv}) where {Tg, Tv} = _value_type(Tv, Tg)
-
 """
     cubic_interp(grids, data, query; deriv=EvalValue(), kwargs...)
 
@@ -52,7 +45,7 @@ function cubic_interp(
     # Float32 data → Float32), so the OnTheFly eval + witness `Tr` agree. Batch keeps eager-convert.
     Tg_raw = _promote_grid_eltype(grids)
     Tg = _promote_grid_float(Tg_raw, Tv)
-    Tv_p = _oneshot_fill_eltype(Tg, Tv)
+    Tv_p = _oneshot_fill_eltype(_coeff_op2, Tg, Tv)
     _validate_nd_grids(grids, data)
     # Reparameterizable axes only (Real or unit-carrying) — the persistent builder's gate.
     _check_nd_reparam_grid(grids)

--- a/src/cubic/nd/cubic_nd_types.jl
+++ b/src/cubic/nd/cubic_nd_types.jl
@@ -82,7 +82,7 @@ struct CubicInterpolantND{
         Tv,
         N,
         NP1,
-        G <: NTuple{N, AbstractVector{Tg}},
+        G <: Tuple{Vararg{AbstractVector, N}},
         B <: NTuple{N, AbstractBC},
         E <: Tuple{Vararg{AbstractExtrap, N}},
         P <: NTuple{N, AbstractSearchPolicy},
@@ -94,13 +94,16 @@ struct CubicInterpolantND{
     searches::P
 
     function CubicInterpolantND(
-            grids::Tuple{Vararg{AbstractVector{Tg}, N}},
+            grids::Tuple{Vararg{AbstractVector, N}},
             nodal_derivs::_NodalDerivativesND{Tv, N, NP1},
             bcs::NTuple{N, AbstractBC},
             extraps::Tuple{Vararg{AbstractExtrap, N}},
             searches::NTuple{N, AbstractSearchPolicy}
-        ) where {Tg, Tv, N, NP1}
+        ) where {Tv, N, NP1}
         NP1 == N + 1 || throw(ArgumentError("NP1 must equal N+1"))
+        # Promotion-tag Tg (mixed-unit axes → abstract tag, mirrors LinearInterpolantND);
+        # Real axes keep the concrete common eltype — same params as before.
+        Tg = _promote_grid_eltype(grids)
         # Wrapper-aware ownership copy + idempotent cache_axis insurance.
         # When the outer API has already wrapped + extended the grids, this
         # is just a per-axis `copy` of the wrapper (no buffer duplication

--- a/src/gridded/gridded_constant.jl
+++ b/src/gridded/gridded_constant.jl
@@ -224,11 +224,10 @@ end
         extrap,
         deriv
     ) where {Tv, N}
-    grids_typed, Tg, _ = _nd_promote_grids_raw(grids, data)
+    grids_typed, _, _ = _nd_promote_grids_raw(grids, data)
     _validate_nd_grids(grids_typed, data)
     bcs = map(m -> m.bc, methods)
     ops = _resolve_deriv_nd(deriv, Val(N))
-    # Fill lives in the kernel's float value space (persistent ctor mirror).
-    extraps = _resolve_extrap(extrap, bcs, Val(N), _value_type(Tv, _promote_grid_float(Tg, Tv)))
+    extraps = _resolve_extrap(extrap, bcs, Val(N), Tv)
     return _gridded_eval_methods!(out_nd, grids_typed, data, targets, methods, ops, extraps)
 end

--- a/src/gridded/gridded_constant.jl
+++ b/src/gridded/gridded_constant.jl
@@ -224,10 +224,11 @@ end
         extrap,
         deriv
     ) where {Tv, N}
-    grids_typed, _, _ = _nd_promote_grids_raw(grids, data)
+    grids_typed, Tg, _ = _nd_promote_grids_raw(grids, data)
     _validate_nd_grids(grids_typed, data)
     bcs = map(m -> m.bc, methods)
     ops = _resolve_deriv_nd(deriv, Val(N))
-    extraps = _resolve_extrap(extrap, bcs, Val(N), Tv)
+    # Fill lives in the kernel's float value space (persistent ctor mirror).
+    extraps = _resolve_extrap(extrap, bcs, Val(N), _value_type(Tv, _promote_grid_float(Tg, Tv)))
     return _gridded_eval_methods!(out_nd, grids_typed, data, targets, methods, ops, extraps)
 end

--- a/src/gridded/gridded_partials.jl
+++ b/src/gridded/gridded_partials.jl
@@ -184,6 +184,26 @@ end
 @inline _gridded_methods(itp::QuadraticInterpolantND{Tg, Tv, N}) where {Tg, Tv, N} =
     map(QuadraticInterp, itp.bcs)
 
+# Non-Real axes decline the fused fast path: its anchors store PHYSICAL
+# h/inv_h/dL against the [Y]-scaled store — the restore-aware pointwise core
+# serves instead (dispatch: the `Tg <: Real` arms below win for Real).
+@inline _gridded_eval_itp_methods!(
+    ::AbstractArray{<:Any, N},
+    ::CubicInterpolantND,
+    ::GriddedQuery,
+    _ops,
+    _extraps,
+    ::Tuple{Vararg{CubicInterp, N}}
+) where {N} = false
+@inline _gridded_eval_itp_methods!(
+    ::AbstractArray{<:Any, N},
+    ::QuadraticInterpolantND,
+    ::GriddedQuery,
+    _ops,
+    _extraps,
+    ::Tuple{Vararg{QuadraticInterp, N}}
+) where {N} = false
+
 @inline function _gridded_eval_itp_methods!(
         out::AbstractArray{<:Any, N},
         itp::CubicInterpolantND{Tg, Tv, N},
@@ -191,7 +211,7 @@ end
         ops,
         extraps,
         methods::Tuple{Vararg{CubicInterp, N}}
-    ) where {Tg, Tv, N}
+    ) where {Tg <: Real, Tv, N}
     _gridded_eval_cubic_partials!(
         out, itp.grids, itp.nodal_derivs.partials, gq.axes, methods, ops, extraps, _sample_data(itp)
     )
@@ -205,7 +225,7 @@ end
         ops,
         extraps,
         methods::Tuple{Vararg{QuadraticInterp, N}}
-    ) where {Tg, Tv, N}
+    ) where {Tg <: Real, Tv, N}
     _gridded_eval_quadratic_partials!(
         out, itp.grids, itp.nodal_derivs.partials, gq.axes, methods, ops, extraps, _sample_data(itp)
     )
@@ -225,6 +245,17 @@ end
         coeffs
     ) where {Tv, N}
     coeffs isa OnTheFly && return false
+    # Non-Real axes decline (tag dispatch): the fused build runs the physical-unit
+    # pipeline — the pointwise batch core serves those instead.
+    return _cubic_gridded_oneshot_try!(
+        _promote_grid_eltype(grids), out_nd, grids, data, gq, methods, extrap, deriv
+    )
+end
+@inline _cubic_gridded_oneshot_try!(::Type, _out, _grids, _data, _gq, _methods, _extrap, _deriv) =
+    false
+@inline function _cubic_gridded_oneshot_try!(
+        ::Type{<:Real}, out_nd, grids, data, gq, methods, extrap, deriv
+    )
     _cubic_gridded_oneshot_fused!(out_nd, grids, data, gq.axes, methods, extrap, deriv)
     return true
 end
@@ -266,6 +297,15 @@ end
         coeffs
     ) where {Tv, N}
     coeffs isa OnTheFly && return false
+    return _quadratic_gridded_oneshot_try!(
+        _promote_grid_eltype(grids), out_nd, grids, data, gq, methods, extrap, deriv
+    )
+end
+@inline _quadratic_gridded_oneshot_try!(::Type, _out, _grids, _data, _gq, _methods, _extrap, _deriv) =
+    false
+@inline function _quadratic_gridded_oneshot_try!(
+        ::Type{<:Real}, out_nd, grids, data, gq, methods, extrap, deriv
+    )
     _quadratic_gridded_oneshot_fused!(out_nd, grids, data, gq.axes, methods, extrap, deriv)
     return true
 end

--- a/src/hermite/nd/hermite_nd_interpolant.jl
+++ b/src/hermite/nd/hermite_nd_interpolant.jl
@@ -36,6 +36,9 @@ function CubicHermiteInterpolantND(
     # Only the full mixed set (K = 2^N - 1) is accepted. `HermitePartials`
     # already enforces this, so this guards direct struct construction.
     K == (1 << N) - 1 || _throw_partials_not_full_mixed(N, K)
+    # No scaled-store/reparam seam here (user partials live per-axis in [Y/Xᵈ]) —
+    # non-Real axes get the friendly refusal instead of deep coerce MethodErrors.
+    _check_nd_hetero_grid(_promote_grid_eltype(grids))
 
     # Promote across (grid, data, partials) to a single Tv — the grid value-match must
     # see the partials' width too (value space = data ∪ partials, matching one-shot).

--- a/src/hermite/nd/hermite_nd_oneshot.jl
+++ b/src/hermite/nd/hermite_nd_oneshot.jl
@@ -111,6 +111,8 @@ end
         bc, extrap, search, deriv,
     ) where {N, Tv_part, K}
     K == (1 << N) - 1 || _throw_partials_not_full_mixed(N, K)
+    # Non-Real axes: same friendly refusal as the persistent ctor.
+    _check_nd_hetero_grid(_promote_grid_eltype(grids))
 
     # Raw grids: the pack + cell-eval float the cell width, so no eager `Tg.(x)` copy.
     # `Tg` value-matched to data∪partials (Int grid + Float32 → Float32) keeps `Tv` narrow,

--- a/src/hermite/nd/hermite_nd_oneshot.jl
+++ b/src/hermite/nd/hermite_nd_oneshot.jl
@@ -209,7 +209,7 @@ end
     extraps_eff = _validate_nd_domain(grids_p, queries, extraps_eff)
 
     @inbounds for k in 1:nq
-        query_k = _extract_query_point(queries, k, Val(N))
+        query_k = _extract_query_point(queries, k, Val(N), grids_p)
         oob_val = _try_fill_oob(query_k, grids_p, extraps_eff, ops, first(data))
         if oob_val !== nothing
             output[k] = oob_val

--- a/src/hetero/hetero_oneshot.jl
+++ b/src/hetero/hetero_oneshot.jl
@@ -100,7 +100,7 @@ end
 
     # Eval loop (per query) — axis-only helpers read `h`/`inv_h` from `grids_p`
     @inbounds for k in 1:nq
-        query_k = _extract_query_point(queries, k, Val(N))
+        query_k = _extract_query_point(queries, k, Val(N), grids_p)
         oob_val = _try_fill_oob(query_k, grids_p, extraps_eff, ops, first(data_p))
         if oob_val !== nothing
             output[k] = oob_val
@@ -373,7 +373,7 @@ end
         # (follow-up).
         searches = _resolve_search_nd(search, Val(N))
         @inbounds for k in 1:nq
-            query_k = _extract_query_point(queries, k, Val(N))
+            query_k = _extract_query_point(queries, k, Val(N), grids)
             output[k] = _interp_nd_oneshot_onthefly(grids, data, query_k, methods, extraps_val, searches, ops, hints)
         end
         return output

--- a/src/integral/integrate_common_nd.jl
+++ b/src/integral/integrate_common_nd.jl
@@ -1,8 +1,7 @@
 @inline function _normalize_bounds_nd(lo::Tuple{Vararg{Number, N}}, hi::Tuple{Vararg{Number, N}}) where {N}
-    nflips = 0
-    @inbounds for d in 1:N
-        nflips += (lo[d] > hi[d])
-    end
+    # Static unroll like the `ntuple`s below: a runtime-`d` index into a
+    # heterogeneous (mixed-unit) bounds tuple leaks the element Union → boxing.
+    nflips = sum(ntuple(d -> @inbounds(lo[d] > hi[d]), Val(N)))
     sign = iseven(nflips) ? 1 : -1
     lo2 = ntuple(d -> @inbounds(min(lo[d], hi[d])), Val(N))
     hi2 = ntuple(d -> @inbounds(max(lo[d], hi[d])), Val(N))

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -589,13 +589,15 @@ end
 # Scaled-store families (cubic/quadratic ND) integrate on their exact
 # dimensionless axis twins — the [Y]-scaled partials pair with dimensionless
 # weights, and the volume element Π oneunit(axis) restores ∫…dx from ∫…dt.
-# Native-unit engines return `nothing` (fold), as does the Real path of the
-# scaled families (type-folded on the promotion tag).
+# Native-unit engines return `nothing` (fold), as does the Real arm of the
+# scaled families (dispatch on the promotion tag).
 @inline _integrate_reparam(::AbstractInterpolantND) = nothing
 @inline _integrate_reparam(
     itp::Union{CubicInterpolantND{Tg}, QuadraticInterpolantND{Tg}}
-) where {Tg} =
-    Tg <: Real ? nothing : (_reparam_grids(itp.grids), _nd_volume_scale(itp.grids))
+) where {Tg} = _integrate_reparam(Tg, itp)
+@inline _integrate_reparam(::Type{<:Real}, _itp) = nothing
+@inline _integrate_reparam(::Type, itp) =
+    (_reparam_grids(itp.grids), _nd_volume_scale(itp.grids))
 @inline _nd_volume_scale(::Tuple{}) = true
 @inline _nd_volume_scale(grids::Tuple) =
     oneunit(eltype(first(grids))) * _nd_volume_scale(Base.tail(grids))

--- a/src/integral/integrate_fulldomain.jl
+++ b/src/integral/integrate_fulldomain.jl
@@ -586,12 +586,40 @@ end
 @inline _nd_int_zero(::Type{Tout}, payload) where {Tout <: Number} = zero(Tout)
 @inline _nd_int_zero(::Type{Tout}, payload) where {Tout} = 0 * @inbounds(payload[begin])
 
+# Scaled-store families (cubic/quadratic ND) integrate on their exact
+# dimensionless axis twins — the [Y]-scaled partials pair with dimensionless
+# weights, and the volume element Π oneunit(axis) restores ∫…dx from ∫…dt.
+# Native-unit engines return `nothing` (fold), as does the Real path of the
+# scaled families (type-folded on the promotion tag).
+@inline _integrate_reparam(::AbstractInterpolantND) = nothing
+@inline _integrate_reparam(
+    itp::Union{CubicInterpolantND{Tg}, QuadraticInterpolantND{Tg}}
+) where {Tg} =
+    Tg <: Real ? nothing : (_reparam_grids(itp.grids), _nd_volume_scale(itp.grids))
+@inline _nd_volume_scale(::Tuple{}) = true
+@inline _nd_volume_scale(grids::Tuple) =
+    oneunit(eltype(first(grids))) * _nd_volume_scale(Base.tail(grids))
+# Dimensionless coordinate tuples (bounds) — per-axis `_deriv_oneunit` scaling.
+@inline _reparam_coords(::Tuple{}, ::Tuple{}) = ()
+@inline _reparam_coords(qs::Tuple, grids::Tuple) = (
+    first(qs) * _deriv_oneunit(first(first(grids)), DerivOp(1)),
+    _reparam_coords(Base.tail(qs), Base.tail(grids))...,
+)
+
 @inline function integrate(itp::AbstractInterpolantND{Tg, Tv, N}) where {Tg, Tv, N}
     tags, payload = _separable_spec(itp)
-    # Per-axis span-product fold (∫∫ f dx dy :: Tv·X₁·X₂) — see _integrate_nd_out_grids.
-    Tout = _integrate_nd_out_grids(Tv, itp.grids)
-    z = _nd_int_zero(Tout, payload)
-    return _integrate_separable_nd_fulldomain(tags, itp.grids, payload, Tout, z)
+    reparam = _integrate_reparam(itp)
+    if reparam === nothing
+        # Per-axis span-product fold (∫∫ f dx dy :: Tv·X₁·X₂) — see _integrate_nd_out_grids.
+        Tout = _integrate_nd_out_grids(Tv, itp.grids)
+        z = _nd_int_zero(Tout, payload)
+        return _integrate_separable_nd_fulldomain(tags, itp.grids, payload, Tout, z)
+    else
+        axes_t, vol = reparam
+        Tout_t = _integrate_nd_out_grids(Tv, axes_t)
+        z_t = _nd_int_zero(Tout_t, payload)
+        return _integrate_separable_nd_fulldomain(tags, axes_t, payload, Tout_t, z_t) * vol
+    end
 end
 
 @inline function integrate(
@@ -605,12 +633,25 @@ end
     sign, lo2, hi2, idx_lo, idx_hi = _integrate_nd_preamble(
         itp.grids, itp.extraps, lo, hi, search, hint
     )
-    Tout = _integrate_nd_output_type(Tv, Tg, lo2, hi2)
-    z = _nd_int_zero(Tout, payload)
-    sign == 0 && return z
-    specs = _nd_bounded_axis_specs(itp.grids, lo2, hi2, idx_lo, idx_hi)
-    total = _integrate_separable_nd_bounded(tags, specs, itp.grids, payload, Tout, z)
-    return sign * total
+    reparam = _integrate_reparam(itp)
+    if reparam === nothing
+        Tout = _integrate_nd_output_type(Tv, Tg, lo2, hi2)
+        z = _nd_int_zero(Tout, payload)
+        sign == 0 && return z
+        specs = _nd_bounded_axis_specs(itp.grids, lo2, hi2, idx_lo, idx_hi)
+        total = _integrate_separable_nd_bounded(tags, specs, itp.grids, payload, Tout, z)
+        return sign * total
+    else
+        axes_t, vol = reparam
+        lo_t = _reparam_coords(lo2, itp.grids)
+        hi_t = _reparam_coords(hi2, itp.grids)
+        Tout_t = _integrate_nd_output_type(Tv, Tg, lo_t, hi_t)
+        z_t = _nd_int_zero(Tout_t, payload)
+        sign == 0 && return z_t * vol
+        specs = _nd_bounded_axis_specs(axes_t, lo_t, hi_t, idx_lo, idx_hi)
+        total = _integrate_separable_nd_bounded(tags, specs, axes_t, payload, Tout_t, z_t)
+        return sign * (total * vol)
+    end
 end
 
 # Scalar bounds on an ND interpolant → point at the tuple form (otherwise the 1D

--- a/src/linear/linear_kernels.jl
+++ b/src/linear/linear_kernels.jl
@@ -147,6 +147,8 @@ end
 #     `one`, so LLVM folds the `×inv_h` away (α = q - L). No `_UnitStep` method needed.
 #   - plain `AbstractVector`: divide by the on-the-fly `R - L` (EvalValue can then DCE
 #     the separately-extracted `inv_h`, which only EvalDeriv1 kernels use).
-@inline _alpha_of(q, L, inv_h) = (q - L) * inv_h
-@inline _alpha_of(q, L, R, x::_CachedRange) = (q - L) * _get_inv_h(x)
-@inline _alpha_of(q, L, R, ::AbstractVector) = (q - L) / float(R - L)
+# `_coord_value` unwraps a resolved `GridIdx` (identity otherwise): the search
+# is already done, and on a unit axis the wrapper cannot ride promotion.
+@inline _alpha_of(q, L, inv_h) = (_coord_value(q) - L) * inv_h
+@inline _alpha_of(q, L, R, x::_CachedRange) = (_coord_value(q) - L) * _get_inv_h(x)
+@inline _alpha_of(q, L, R, ::AbstractVector) = (_coord_value(q) - L) / float(R - L)

--- a/src/linear/nd/linear_nd_oneshot.jl
+++ b/src/linear/nd/linear_nd_oneshot.jl
@@ -101,7 +101,7 @@ function _linear_interp_nd_oneshot_batch!(
     # wrap/clamp/fill via `_handle_axis_extrap(::InBounds)`.
     extraps_eff = _validate_nd_domain(grids_eff, queries, extraps_eff)
     @inbounds for k in 1:nq
-        query_k = _extract_query_point(queries, k, Val(N))
+        query_k = _extract_query_point(queries, k, Val(N), grids_eff)
         oob_val = _try_fill_oob(query_k, grids_eff, extraps_eff, ops, first(data))
         if oob_val !== nothing
             output[k] = oob_val; continue

--- a/src/quadratic/nd/quadratic_nd_build.jl
+++ b/src/quadratic/nd/quadratic_nd_build.jl
@@ -339,11 +339,7 @@ function _build_nd_coeffs_quadratic(
     # scaled-store build): every stored slot lands in the value space [Y] and the
     # single homogeneous partials array survives unit grids. Real folds through.
     _check_nd_reparam_grid(grids)
-    grids_solve, bcs_solve = if _promote_grid_eltype(grids) <: Real
-        grids, bcs
-    else
-        _reparam_grids(grids), _scale_bcs_reparam(bcs, grids, data)
-    end
+    grids_solve, bcs_solve = _reparam_solve_frame(grids, bcs, data)
 
     # Allocate partials array: (2^N, n₁, n₂, ..., nₙ)
     # Tz widens Tv with the solve-grid eltype: Dual grids → Dual-typed derivatives;

--- a/src/quadratic/nd/quadratic_nd_build.jl
+++ b/src/quadratic/nd/quadratic_nd_build.jl
@@ -342,7 +342,7 @@ function _build_nd_coeffs_quadratic(
     grids_solve, bcs_solve = if _promote_grid_eltype(grids) <: Real
         grids, bcs
     else
-        _reparam_grids(grids), map(_scale_bc_reparam, bcs, grids)
+        _reparam_grids(grids), _scale_bcs_reparam(bcs, grids, data)
     end
 
     # Allocate partials array: (2^N, n₁, n₂, ..., nₙ)

--- a/src/quadratic/nd/quadratic_nd_build.jl
+++ b/src/quadratic/nd/quadratic_nd_build.jl
@@ -331,20 +331,30 @@ Compute all partial derivatives for N-dimensional quadratic interpolation.
 - `_NodalDerivativesND{Tv, N, N+1}` containing the partials array
 """
 function _build_nd_coeffs_quadratic(
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::Tuple{Vararg{AbstractVector, N}},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
-    ) where {Tg, Tv, N}
+    ) where {Tv, N}
+    # Non-Real axes solve on their exact dimensionless twins (mirrors the cubic
+    # scaled-store build): every stored slot lands in the value space [Y] and the
+    # single homogeneous partials array survives unit grids. Real folds through.
+    _check_nd_reparam_grid(grids)
+    grids_solve, bcs_solve = if _promote_grid_eltype(grids) <: Real
+        grids, bcs
+    else
+        _reparam_grids(grids), map(_scale_bc_reparam, bcs, grids)
+    end
+
     # Allocate partials array: (2^N, n₁, n₂, ..., nₙ)
-    # Tz widens Tv with Tg: when grid is Dual, derivatives = data × inv_h → Dual-typed.
-    _check_nd_solver_grid(Tg)
-    Tz = _promote_eltype(_coeff_op, Tg, Tv)
+    # Tz widens Tv with the solve-grid eltype: Dual grids → Dual-typed derivatives;
+    # unit grids solve dimensionless → Tz stays in the value space.
+    Tz = _promote_eltype(_coeff_op, _promote_grid_eltype(grids_solve), Tv)
     n_partials = 1 << N
     partials_shape = (n_partials, size(data)...)
     partials = Array{Tz, N + 1}(undef, partials_shape)
 
     # Compute all partial derivatives
-    _compute_nd_partials_quadratic!(partials, grids, data, bcs)
+    _compute_nd_partials_quadratic!(partials, grids_solve, data, bcs_solve)
 
     return _NodalDerivativesND{Tz, N, N + 1}(partials)
 end

--- a/src/quadratic/nd/quadratic_nd_build.jl
+++ b/src/quadratic/nd/quadratic_nd_build.jl
@@ -335,9 +335,8 @@ function _build_nd_coeffs_quadratic(
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC}
     ) where {Tv, N}
-    # Non-Real axes solve on their exact dimensionless twins (mirrors the cubic
-    # scaled-store build): every stored slot lands in the value space [Y] and the
-    # single homogeneous partials array survives unit grids. Real folds through.
+    # Non-Real axes solve on their dimensionless twins (mirrors the cubic
+    # scaled-store build); Real axes pass through untouched.
     _check_nd_reparam_grid(grids)
     grids_solve, bcs_solve = _reparam_solve_frame(grids, bcs, data)
 

--- a/src/quadratic/nd/quadratic_nd_eval.jl
+++ b/src/quadratic/nd/quadratic_nd_eval.jl
@@ -97,10 +97,8 @@ end
     # `_compute_all_local_params` uses the spacings-free overload (cached h/inv_h).
     indices, Ls, _ = _search_all_intervals(q_evals, itp.grids, policies, hints, mono, extraps)
     # Non-Real axes: the scaled store is [Y]-homogeneous, so the kernel consumes
-    # dimensionless local params (type-folded — Real is the exact old call).
-    hs, inv_hs, dLs = Tg <: Real ?
-        _compute_all_local_params(q_evals, itp.grids, indices, Ls) :
-        _compute_all_local_params_reparam(q_evals, itp.grids, indices, Ls)
+    # dimensionless local params (the width-tag dispatch routes; Real = exact old width).
+    hs, inv_hs, dLs = _compute_all_local_params(q_evals, itp.grids, indices, Ls, Tg)
 
     return (itp.nodal_derivs.partials, indices, hs, inv_hs, dLs)
 end
@@ -120,7 +118,7 @@ end
     ) where {Tg, N}
     partials, indices, _, inv_hs, dLs = cell   # `hs` in the cell tuple is unused by quadratic
     r = _eval_nd_quad_cell(partials, indices, inv_hs, dLs, ops)
-    return Tg <: Real ? r : r * _nd_fill_deriv_scale(itp.grids, ops)
+    return _restore_nd_deriv_scale(r, itp.grids, ops)
 end
 
 # Per-method sample of `Tv` for fill-value paths (e.g. `_try_fill_oob`).

--- a/src/quadratic/nd/quadratic_nd_eval.jl
+++ b/src/quadratic/nd/quadratic_nd_eval.jl
@@ -96,7 +96,11 @@ end
     # search (one-sided clamp; hint still written back) — bit-identical, per-axis, all N.
     # `_compute_all_local_params` uses the spacings-free overload (cached h/inv_h).
     indices, Ls, _ = _search_all_intervals(q_evals, itp.grids, policies, hints, mono, extraps)
-    hs, inv_hs, dLs = _compute_all_local_params(q_evals, itp.grids, indices, Ls)
+    # Non-Real axes: the scaled store is [Y]-homogeneous, so the kernel consumes
+    # dimensionless local params (type-folded — Real is the exact old call).
+    hs, inv_hs, dLs = Tg <: Real ?
+        _compute_all_local_params(q_evals, itp.grids, indices, Ls) :
+        _compute_all_local_params_reparam(q_evals, itp.grids, indices, Ls)
 
     return (itp.nodal_derivs.partials, indices, hs, inv_hs, dLs)
 end
@@ -105,14 +109,18 @@ end
 # N=2, so a hand-destructured 2D variant is equal-or-slower (verified via
 # same-process method-swap A/B).
 
-# Evaluate kernel at a pre-located cell with given derivative ops
+# Evaluate kernel at a pre-located cell with given derivative ops.
+# Non-Real axes: the kernel runs dimensionless over the [Y]-scaled store, so
+# derivative results restore their per-axis grid⁻ᵏ units at this single seam
+# (canonical `_nd_deriv_scale` fold; `true` on value ops and Real grids — folds).
 @inline function _eval_at_cell(
-        ::QuadraticInterpolantND,
+        itp::QuadraticInterpolantND{Tg},
         cell::Tuple,
         ops::NTuple{N, AbstractEvalOp}
-    ) where {N}
+    ) where {Tg, N}
     partials, indices, _, inv_hs, dLs = cell   # `hs` in the cell tuple is unused by quadratic
-    return _eval_nd_quad_cell(partials, indices, inv_hs, dLs, ops)
+    r = _eval_nd_quad_cell(partials, indices, inv_hs, dLs, ops)
+    return Tg <: Real ? r : r * _nd_fill_deriv_scale(itp.grids, ops)
 end
 
 # Per-method sample of `Tv` for fill-value paths (e.g. `_try_fill_oob`).

--- a/src/quadratic/nd/quadratic_nd_eval.jl
+++ b/src/quadratic/nd/quadratic_nd_eval.jl
@@ -107,10 +107,9 @@ end
 # N=2, so a hand-destructured 2D variant is equal-or-slower (verified via
 # same-process method-swap A/B).
 
-# Evaluate kernel at a pre-located cell with given derivative ops.
-# Non-Real axes: the kernel runs dimensionless over the [Y]-scaled store, so
-# derivative results restore their per-axis grid⁻ᵏ units at this single seam
-# (canonical `_nd_deriv_scale` fold; `true` on value ops and Real grids — folds).
+# Evaluate kernel at a pre-located cell with given derivative ops. Non-Real axes
+# run dimensionless over the [Y]-scaled store — `_restore_nd_deriv_scale`
+# re-attaches the per-axis grid⁻ᵏ units at this single seam.
 @inline function _eval_at_cell(
         itp::QuadraticInterpolantND{Tg},
         cell::Tuple,

--- a/src/quadratic/nd/quadratic_nd_interpolant.jl
+++ b/src/quadratic/nd/quadratic_nd_interpolant.jl
@@ -57,9 +57,10 @@ function quadratic_interp(
         return _build_hetero_nd(grids, data, methods, extrap, search)
     end
 
-    # Gate on the RAW eltype BEFORE float promotion — a non-Real duck Number
-    # dies inside `_nd_promote_grids` (`AbstractFloat(x)` MethodError) otherwise.
-    _check_nd_solver_grid(_promote_grid_eltype(grids))
+    # Gate on the RAW per-axis eltypes BEFORE float promotion — a non-Real duck
+    # Number dies inside `_nd_promote_grids` (`AbstractFloat(x)` MethodError)
+    # otherwise. Quadratic admits reparameterizable axes (units) like cubic.
+    _check_nd_reparam_grid(grids)
     # Zero-allocation type promotion and grid conversion
     grids_typed, _, Tv, _ = _nd_promote_grids(grids, data)
     data_typed = Tv === Tv_raw ? data : Tv.(data)
@@ -110,16 +111,18 @@ end
 # ========================================
 
 function _build_nd_quadratic_interpolant(
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::Tuple{Vararg{AbstractVector, N}},
         data::AbstractArray{Tv, N},
         bcs::NTuple{N, AbstractBC},
         extraps_val::Tuple{Vararg{AbstractExtrap, N}},
         searches::NTuple{N, AbstractSearchPolicy}
-    ) where {Tg, Tv, N}
+    ) where {Tv, N}
     # Cache axes for the build phase — inner ctor of `QuadraticInterpolantND`
     # handles the owned `_convert_copy` separately, so we only wrap (no copy)
-    # here. Already-cached axes pass through idempotently in the ctor.
-    grids_cached = map(_cache_axis, grids, bcs, ntuple(_ -> Tg, Val(N)))
+    # here. Already-cached axes pass through idempotently in the ctor. Grids
+    # arrive value-promoted, so the Tg-less 2-arg wrap is the right form
+    # (mixed-unit axes have no common Tg; mirrors the cubic assembly).
+    grids_cached = map(_cache_axis, grids, bcs)
     nodal_derivs = _build_nd_coeffs_quadratic(grids_cached, data, bcs)
 
     return QuadraticInterpolantND(grids_cached, nodal_derivs, bcs, extraps_val, searches)

--- a/src/quadratic/nd/quadratic_nd_interpolant.jl
+++ b/src/quadratic/nd/quadratic_nd_interpolant.jl
@@ -57,9 +57,11 @@ function quadratic_interp(
         return _build_hetero_nd(grids, data, methods, extrap, search)
     end
 
+    # Gate on the RAW eltype BEFORE float promotion — a non-Real duck Number
+    # dies inside `_nd_promote_grids` (`AbstractFloat(x)` MethodError) otherwise.
+    _check_nd_solver_grid(_promote_grid_eltype(grids))
     # Zero-allocation type promotion and grid conversion
-    grids_typed, Tg_p, Tv, _ = _nd_promote_grids(grids, data)
-    _check_nd_solver_grid(Tg_p)
+    grids_typed, _, Tv, _ = _nd_promote_grids(grids, data)
     data_typed = Tv === Tv_raw ? data : Tv.(data)
 
     # Validate dimensions

--- a/src/quadratic/nd/quadratic_nd_interpolant.jl
+++ b/src/quadratic/nd/quadratic_nd_interpolant.jl
@@ -57,9 +57,8 @@ function quadratic_interp(
         return _build_hetero_nd(grids, data, methods, extrap, search)
     end
 
-    # Gate on the RAW per-axis eltypes BEFORE float promotion — a non-Real duck
-    # Number dies inside `_nd_promote_grids` (`AbstractFloat(x)` MethodError)
-    # otherwise. Quadratic admits reparameterizable axes (units) like cubic.
+    # Gate on the RAW per-axis eltypes BEFORE float promotion — a non-reparameterizable
+    # duck Number would die deep inside `_nd_promote_grids` otherwise.
     _check_nd_reparam_grid(grids)
     # Zero-allocation type promotion and grid conversion
     grids_typed, _, Tv, _ = _nd_promote_grids(grids, data)

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -170,6 +170,9 @@ function quadratic_interp(
     # Scalar one-shot: raw grids — both PreCompute and OnTheFly accept them
     # (`_compute_all_local_params` floats the cell width). Batch keeps eager-convert.
     Tg_raw = _promote_grid_eltype(grids)
+    # Fill payload space mirrors the cubic scalar entry (raw Int data must not
+    # pin the fill: `FillExtrap(0.5)` + Int data threw at the eager resolve).
+    Tv_p = _oneshot_fill_eltype(_coeff_op, _promote_grid_float(Tg_raw, Tv), Tv)
     _validate_nd_grids(grids, data)
     # Reparameterizable axes only (Real or unit-carrying) — the persistent builder's gate.
     _check_nd_reparam_grid(grids)
@@ -183,7 +186,7 @@ function quadratic_interp(
     bcs = _resolve_bcs_nd(bc, Val(N))
     searches = _resolve_search_nd(search, Val(N), query)  # NTuple{N,Real} <: Tuple → BinarySearch/axis
 
-    extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)
+    extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv_p)
 
     # Central policy (same as cubic): scalar AutoCoeffs → OnTheFly. Bit-exact parity
     # with the persistent interpolant stays available via explicit coeffs=PreCompute().
@@ -254,11 +257,12 @@ function quadratic_interp!(
     ) where {Tv, N}
     _query_check_ndims(queries, Val(N))
     _check_nd_reparam_grid(grids)
-    grids_typed, _, _, _ = _nd_promote_grids(grids, data)
+    # `Tv_p` (3rd return) is the promoted fill space — the cubic in-place mirror.
+    grids_typed, _, Tv_p, _ = _nd_promote_grids(grids, data)
     _validate_nd_grids(grids_typed, data)
 
     bcs = _resolve_bcs_nd(bc, Val(N))
-    extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)
+    extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv_p)
     ops = _resolve_deriv_nd(deriv, Val(N))
     return _quadratic_nd_batch_dispatch!(output, grids_typed, data, queries, bcs, extraps_val, ops, search, hint)
 end

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -47,9 +47,7 @@ Zero-allocation after warmup (pool reuse).
 
     # 2. Pool-allocate partials array (THE KEY: pool instead of heap). Tz widens Tv
     # with the solve-grid eltype (Dual grid → Dual derivs); `_coeff_op` floats Int.
-    # Non-Real axes solve on the dimensionless twins (`_reparam_solve_frame`) — the
-    # pooled partials stay [Y]-homogeneous exactly as in the persistent scaled-store
-    # build (search/local params keep reading `grids_c`).
+    # Non-Real axes solve on the dimensionless twins; search/params keep reading `grids_c`.
     grids_solve, bcs_solve = _reparam_solve_frame(grids_c, bcs, data)
     Tz = _promote_eltype(_coeff_op, _promote_grid_eltype(grids_solve), Tv)
     n_partials = 1 << N
@@ -61,8 +59,7 @@ Zero-allocation after warmup (pool reuse).
     # 4. Per-axis extrap passthrough against the (possibly extended) grid.
     extraps_eff = map(_resolve_extrap, extraps_val, grids_c)
 
-    # 5. Eval pipeline (axis-only — grids carry `h`/`inv_h` directly; a non-Real
-    # width tag routes to the dimensionless collapse by dispatch)
+    # 5. Eval pipeline (axis-only — grids carry `h`/`inv_h` directly)
     q_eval = _handle_all_extraps(query, grids_c, extraps_eff)
     indices, Ls, _ = _search_all_intervals(q_eval, grids_c, searches, hints, extraps_eff)
     _, inv_hs, dLs = _compute_all_local_params(q_eval, grids_c, indices, Ls, Tg)
@@ -190,9 +187,8 @@ function quadratic_interp(
 
     # Central policy (same as cubic): scalar AutoCoeffs → OnTheFly. Bit-exact parity
     # with the persistent interpolant stays available via explicit coeffs=PreCompute().
-    # A non-Real query never resolves OnTheFly under AutoCoeffs (Real-tuple arm →
-    # PreCompute pool); an EXPLICIT OnTheFly rides the hetero collapse engine,
-    # whose non-Real gate keeps the refusal actionable.
+    # Non-Real queries resolve PreCompute by dispatch (Real-tuple arm); an explicit
+    # OnTheFly rides the hetero collapse, whose gate keeps the refusal friendly.
     coeffs_resolved = _resolve_coeffs_nd_oneshot(coeffs, query, ntuple(_ -> QuadraticInterp(), Val(N)))
     if coeffs_resolved isa OnTheFly
         _check_nd_hetero_grid(Tg_raw)

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -115,7 +115,7 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
     extraps_eff = _validate_nd_domain(grids_c, queries, extraps_eff)
 
     @inbounds for k in 1:nq
-        query_k = _extract_query_point(queries, k, Val(N))
+        query_k = _extract_query_point(queries, k, Val(N), grids_c)
         oob_val = _try_fill_oob(query_k, grids_c, extraps_eff, ops, first(data))
         if oob_val !== nothing
             output[k] = oob_val; continue

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -42,23 +42,16 @@ Zero-allocation after warmup (pool reuse).
     # 1. Value-matched grid float (Int/OneTo grid + Float32 data → Float32) shared by the pooled
     # per-axis cache and the partials type, so the pool buffer + output follow natural promote_type.
     # Non-Real axes wrap at their OWN eltype (abstract-tag arm of the @generated map).
-    Tg_raw = _promote_grid_eltype(grids)
-    Tg = _promote_grid_float(Tg_raw, Tv)
+    Tg = _promote_grid_float(_promote_grid_eltype(grids), Tv)
     grids_c = _cache_axes_pooled(pool, grids, Tg)  # @generated static-Tg unroll (no Type-captured closure)
 
-    # 2. Pool-allocate partials array (THE KEY: pool instead of heap). Tz widens Tv with Tg
-    # (Dual grid → Dual derivs); `_coeff_op` floats Int. Non-Real axes solve on the
-    # dimensionless twins — the pooled partials stay [Y]-homogeneous exactly as in
-    # the persistent scaled-store build (search/local params keep reading `grids_c`).
-    if Tg_raw <: Real
-        grids_solve = grids_c
-        bcs_solve = bcs
-        Tz = _promote_eltype(_coeff_op, Tg, Tv)
-    else
-        grids_solve = _reparam_grids(grids_c)
-        bcs_solve = _scale_bcs_reparam(bcs, grids_c, data)
-        Tz = _promote_eltype(_coeff_op, _promote_grid_eltype(grids_solve), Tv)
-    end
+    # 2. Pool-allocate partials array (THE KEY: pool instead of heap). Tz widens Tv
+    # with the solve-grid eltype (Dual grid → Dual derivs); `_coeff_op` floats Int.
+    # Non-Real axes solve on the dimensionless twins (`_reparam_solve_frame`) — the
+    # pooled partials stay [Y]-homogeneous exactly as in the persistent scaled-store
+    # build (search/local params keep reading `grids_c`).
+    grids_solve, bcs_solve = _reparam_solve_frame(grids_c, bcs, data)
+    Tz = _promote_eltype(_coeff_op, _promote_grid_eltype(grids_solve), Tv)
     n_partials = 1 << N
     partials = acquire!(pool, Tz, (n_partials, size(data)...))
 
@@ -68,16 +61,15 @@ Zero-allocation after warmup (pool reuse).
     # 4. Per-axis extrap passthrough against the (possibly extended) grid.
     extraps_eff = map(_resolve_extrap, extraps_val, grids_c)
 
-    # 5. Eval pipeline (axis-only — grids carry `h`/`inv_h` directly)
+    # 5. Eval pipeline (axis-only — grids carry `h`/`inv_h` directly; a non-Real
+    # width tag routes to the dimensionless collapse by dispatch)
     q_eval = _handle_all_extraps(query, grids_c, extraps_eff)
     indices, Ls, _ = _search_all_intervals(q_eval, grids_c, searches, hints, extraps_eff)
-    _, inv_hs, dLs = Tg_raw <: Real ?
-        _compute_all_local_params(q_eval, grids_c, indices, Ls) :
-        _compute_all_local_params_reparam(q_eval, grids_c, indices, Ls)
+    _, inv_hs, dLs = _compute_all_local_params(q_eval, grids_c, indices, Ls, Tg)
 
     # 6. Tensor-product kernel evaluation ([Y]-scaled partials → grid⁻ᵏ restore at the seam)
     r = _eval_nd_quad_cell(partials, indices, inv_hs, dLs, ops)
-    return Tg_raw <: Real ? r : r * _nd_fill_deriv_scale(grids_c, ops)
+    return _restore_nd_deriv_scale(r, grids_c, ops)
 end
 
 """
@@ -115,15 +107,8 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
 
     # Build phase (done once). Non-Real axes solve on the dimensionless twins
     # (persistent scaled-store mirror); the eval loop keeps reading `grids_c`.
-    if Tg_raw <: Real
-        grids_solve = grids_c
-        bcs_solve = bcs
-        Tz = _promote_eltype(_coeff_op, Tg_raw, Tv)
-    else
-        grids_solve = _reparam_grids(grids_c)
-        bcs_solve = _scale_bcs_reparam(bcs, grids_c, data)
-        Tz = _promote_eltype(_coeff_op, _promote_grid_eltype(grids_solve), Tv)
-    end
+    grids_solve, bcs_solve = _reparam_solve_frame(grids_c, bcs, data)
+    Tz = _promote_eltype(_coeff_op, _promote_grid_eltype(grids_solve), Tv)
     n_partials = 1 << N
     partials = acquire!(pool, Tz, (n_partials, size(data)...))
     _compute_nd_partials_quadratic!(partials, grids_solve, data, bcs_solve)
@@ -140,11 +125,9 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
         end
         q_eval = _handle_all_extraps(query_k, grids_c, extraps_eff)
         indices, Ls, _ = _search_all_intervals(q_eval, grids_c, policies, hints, extraps_eff)
-        _, inv_hs, dLs = Tg_raw <: Real ?
-            _compute_all_local_params(q_eval, grids_c, indices, Ls) :
-            _compute_all_local_params_reparam(q_eval, grids_c, indices, Ls)
+        _, inv_hs, dLs = _compute_all_local_params(q_eval, grids_c, indices, Ls, Tg_raw)
         r = _eval_nd_quad_cell(partials, indices, inv_hs, dLs, ops)
-        output[k] = Tg_raw <: Real ? r : r * _nd_fill_deriv_scale(grids_c, ops)
+        output[k] = _restore_nd_deriv_scale(r, grids_c, ops)
     end
     return output
 end

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -41,18 +41,29 @@ Zero-allocation after warmup (pool reuse).
 
     # 1. Value-matched grid float (Int/OneTo grid + Float32 data → Float32) shared by the pooled
     # per-axis cache and the partials type, so the pool buffer + output follow natural promote_type.
-    # `map` dispatches per-element on the concrete axis type (Range vs Vector).
-    Tg = _promote_grid_float(_promote_grid_eltype(grids), Tv)
+    # Non-Real axes wrap at their OWN eltype (abstract-tag arm of the @generated map).
+    Tg_raw = _promote_grid_eltype(grids)
+    Tg = _promote_grid_float(Tg_raw, Tv)
     grids_c = _cache_axes_pooled(pool, grids, Tg)  # @generated static-Tg unroll (no Type-captured closure)
 
     # 2. Pool-allocate partials array (THE KEY: pool instead of heap). Tz widens Tv with Tg
-    # (Dual grid → Dual derivs); `_coeff_op` floats Int.
-    Tz = _promote_eltype(_coeff_op, Tg, Tv)
+    # (Dual grid → Dual derivs); `_coeff_op` floats Int. Non-Real axes solve on the
+    # dimensionless twins — the pooled partials stay [Y]-homogeneous exactly as in
+    # the persistent scaled-store build (search/local params keep reading `grids_c`).
+    if Tg_raw <: Real
+        grids_solve = grids_c
+        bcs_solve = bcs
+        Tz = _promote_eltype(_coeff_op, Tg, Tv)
+    else
+        grids_solve = _reparam_grids(grids_c)
+        bcs_solve = _scale_bcs_reparam(bcs, grids_c, data)
+        Tz = _promote_eltype(_coeff_op, _promote_grid_eltype(grids_solve), Tv)
+    end
     n_partials = 1 << N
     partials = acquire!(pool, Tz, (n_partials, size(data)...))
 
     # 3. Compute all partial derivatives in-place
-    _compute_nd_partials_quadratic!(partials, grids_c, data, bcs)
+    _compute_nd_partials_quadratic!(partials, grids_solve, data, bcs_solve)
 
     # 4. Per-axis extrap passthrough against the (possibly extended) grid.
     extraps_eff = map(_resolve_extrap, extraps_val, grids_c)
@@ -60,10 +71,13 @@ Zero-allocation after warmup (pool reuse).
     # 5. Eval pipeline (axis-only — grids carry `h`/`inv_h` directly)
     q_eval = _handle_all_extraps(query, grids_c, extraps_eff)
     indices, Ls, _ = _search_all_intervals(q_eval, grids_c, searches, hints, extraps_eff)
-    _, inv_hs, dLs = _compute_all_local_params(q_eval, grids_c, indices, Ls)
+    _, inv_hs, dLs = Tg_raw <: Real ?
+        _compute_all_local_params(q_eval, grids_c, indices, Ls) :
+        _compute_all_local_params_reparam(q_eval, grids_c, indices, Ls)
 
-    # 6. Tensor-product kernel evaluation (quadratic uses only inv_h/dL)
-    return _eval_nd_quad_cell(partials, indices, inv_hs, dLs, ops)
+    # 6. Tensor-product kernel evaluation ([Y]-scaled partials → grid⁻ᵏ restore at the seam)
+    r = _eval_nd_quad_cell(partials, indices, inv_hs, dLs, ops)
+    return Tg_raw <: Real ? r : r * _nd_fill_deriv_scale(grids_c, ops)
 end
 
 """
@@ -73,9 +87,12 @@ Pool-based in-place batch one-shot ND quadratic evaluation.
 Computes partials ONCE, then evaluates at all query points into `output`.
 Uses query protocol (`_query_length`, `_query_extract`) — works with any query format.
 """
+# `grids` is NOT pinned to one shared axis eltype: mixed-unit grids (`s` × `m`)
+# reach this backend as a heterogeneous per-axis-float tuple — requiring a common
+# `Tg` excluded them from the batch path entirely (the linear sibling relaxed first).
 @with_pool pool function _quadratic_interp_nd_oneshot_batch!(
         output::AbstractArray,
-        grids::NTuple{N, AbstractVector{Tg}},
+        grids::NTuple{N, AbstractVector},
         data::AbstractArray{Tv, N},
         queries,
         bcs::NTuple{N, AbstractBC},
@@ -83,23 +100,33 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
         ops::NTuple{N, AbstractEvalOp},
         search::Union{AbstractSearchPolicy, Tuple{Vararg{AbstractSearchPolicy, N}}},
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}},
-    ) where {Tg, Tv, N}
+    ) where {Tv, N}
     # Resolve here so the fresh Ref tuple stays local to this frame (stack-elidable).
     policies, hints = _resolve_oneshot_search_nd(search, queries, hint, Val(N))
     nq = _query_length(queries)
     _check_query_output_size(output, queries)
     _query_validate(queries)
+    Tg_raw = _promote_grid_eltype(grids)
 
     # Pool-backed per-axis cache — build phase + eval loop reuse h/inv_h.
     # `map` over the tuple dispatches per-element on concrete axis type;
     # `ntuple(d -> grids[d], ...)` would Union-box heterogeneous tuples.
     grids_c = map(g -> _cache_axis_pooled(pool, g), grids)
 
-    # Build phase (done once)
-    Tz = _promote_eltype(_coeff_op, Tg, Tv)
+    # Build phase (done once). Non-Real axes solve on the dimensionless twins
+    # (persistent scaled-store mirror); the eval loop keeps reading `grids_c`.
+    if Tg_raw <: Real
+        grids_solve = grids_c
+        bcs_solve = bcs
+        Tz = _promote_eltype(_coeff_op, Tg_raw, Tv)
+    else
+        grids_solve = _reparam_grids(grids_c)
+        bcs_solve = _scale_bcs_reparam(bcs, grids_c, data)
+        Tz = _promote_eltype(_coeff_op, _promote_grid_eltype(grids_solve), Tv)
+    end
     n_partials = 1 << N
     partials = acquire!(pool, Tz, (n_partials, size(data)...))
-    _compute_nd_partials_quadratic!(partials, grids_c, data, bcs)
+    _compute_nd_partials_quadratic!(partials, grids_solve, data, bcs_solve)
     extraps_eff = map(_resolve_extrap, extraps_val, grids_c)
     # Validate + batch-level InBounds promotion (see cubic_nd_oneshot.jl): all-in-bounds axes get
     # `InBounds()`, eliding per-query wrap/clamp/fill branches.
@@ -113,8 +140,11 @@ Uses query protocol (`_query_length`, `_query_extract`) — works with any query
         end
         q_eval = _handle_all_extraps(query_k, grids_c, extraps_eff)
         indices, Ls, _ = _search_all_intervals(q_eval, grids_c, policies, hints, extraps_eff)
-        _, inv_hs, dLs = _compute_all_local_params(q_eval, grids_c, indices, Ls)
-        output[k] = _eval_nd_quad_cell(partials, indices, inv_hs, dLs, ops)
+        _, inv_hs, dLs = Tg_raw <: Real ?
+            _compute_all_local_params(q_eval, grids_c, indices, Ls) :
+            _compute_all_local_params_reparam(q_eval, grids_c, indices, Ls)
+        r = _eval_nd_quad_cell(partials, indices, inv_hs, dLs, ops)
+        output[k] = Tg_raw <: Real ? r : r * _nd_fill_deriv_scale(grids_c, ops)
     end
     return output
 end
@@ -133,6 +163,9 @@ end
 
 One-shot ND quadratic interpolation at a single point.
 Zero-allocation after warmup.
+
+Non-Real (unit-carrying) axes mirror the persistent scaled-store build (dimensionless
+twin solve + grid⁻ᵏ restore); the zero-alloc contract is the Real-axis path's.
 
 # Strategy selection (`coeffs`)
 - `AutoCoeffs()` (default): shared `_resolve_coeffs_nd_oneshot` policy, same as cubic —
@@ -155,25 +188,31 @@ function quadratic_interp(
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
     # Scalar one-shot: raw grids — both PreCompute and OnTheFly accept them
-    # (`_compute_all_local_params` floats the cell width). `Tg` value-matched (Int/OneTo grid +
-    # Float32 data → Float32) so eval + witness `Tr` agree. Batch keeps eager-convert.
-    Tg = _promote_grid_float(_promote_grid_eltype(grids), Tv)
+    # (`_compute_all_local_params` floats the cell width). Batch keeps eager-convert.
+    Tg_raw = _promote_grid_eltype(grids)
     _validate_nd_grids(grids, data)
-    # PreCompute/OnTheFly ND quadratic solve does not support unit-carrying grids —
-    # match the persistent builder's actionable error instead of a deep MethodError.
-    _check_nd_solver_grid(_promote_grid_eltype(grids))
-    Tr = _promote_eltype(_interp_op, Tg, Tv, promote_type(typeof.(query)...))
+    # Reparameterizable axes only (Real or unit-carrying) — the persistent builder's gate.
+    _check_nd_reparam_grid(grids)
+    ops = _resolve_deriv_nd(deriv, Val(N))
+    # `ops` folds into the witness BEFORE the assertion (linear canonical): a derivative
+    # query lands in value/coordᴺ — identity on Real grids and on `DerivOp{0}`.
+    Tr = _deriv_eltype_nd(
+        _nd_value_eltype(_interp_op, Tv, grids, promote_type(typeof.(query)...)), grids, ops
+    )
 
     bcs = _resolve_bcs_nd(bc, Val(N))
     searches = _resolve_search_nd(search, Val(N), query)  # NTuple{N,Real} <: Tuple → BinarySearch/axis
 
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)
-    ops = _resolve_deriv_nd(deriv, Val(N))
 
     # Central policy (same as cubic): scalar AutoCoeffs → OnTheFly. Bit-exact parity
     # with the persistent interpolant stays available via explicit coeffs=PreCompute().
+    # A non-Real query never resolves OnTheFly under AutoCoeffs (Real-tuple arm →
+    # PreCompute pool); an EXPLICIT OnTheFly rides the hetero collapse engine,
+    # whose non-Real gate keeps the refusal actionable.
     coeffs_resolved = _resolve_coeffs_nd_oneshot(coeffs, query, ntuple(_ -> QuadraticInterp(), Val(N)))
     if coeffs_resolved isa OnTheFly
+        _check_nd_hetero_grid(Tg_raw)
         sample = @inbounds first(data)
         methods = map(bc_i -> QuadraticInterp(_to_quadratic_bc(bc_i, sample)), bcs)
         return _interp_nd_oneshot_onthefly(grids, data, query, methods, extraps_val, searches, ops, hint)::Tr
@@ -201,9 +240,11 @@ function quadratic_interp(
         coeffs::AbstractCoeffStrategy = AutoCoeffs(),
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
-    _, Tg, _, _ = _nd_promote_grids(grids, data)
     Tq = _query_eltype(queries)
-    Tr = _promote_eltype(_interp_op, Tg, Tv, Tq)
+    # Same fold as the scalar entry (linear canonical): the buffer must be sized in
+    # ∂-units, else a unit-grid derivative batch throws on the first store.
+    ops = _resolve_deriv_nd(deriv, Val(N))
+    Tr = _deriv_eltype_nd(_nd_value_eltype(_interp_op, Tv, grids, Tq), grids, ops)
     output = _alloc_query_output(Tr, queries)
     quadratic_interp!(output, grids, data, queries; deriv, bc, extrap, search, coeffs, hint)
     return output
@@ -233,9 +274,9 @@ function quadratic_interp!(
         hint::Union{Nothing, NTuple{N, Base.RefValue{Int}}} = nothing
     ) where {Tv, N}
     _query_check_ndims(queries, Val(N))
+    _check_nd_reparam_grid(grids)
     grids_typed, _, _, _ = _nd_promote_grids(grids, data)
     _validate_nd_grids(grids_typed, data)
-    _check_nd_solver_grid(_promote_grid_eltype(grids))
 
     bcs = _resolve_bcs_nd(bc, Val(N))
     extraps_val = _resolve_extrap(extrap, bcs, Val(N), Tv)

--- a/src/quadratic/nd/quadratic_nd_oneshot.jl
+++ b/src/quadratic/nd/quadratic_nd_oneshot.jl
@@ -145,7 +145,7 @@ One-shot ND quadratic interpolation at a single point.
 Zero-allocation after warmup.
 
 Non-Real (unit-carrying) axes mirror the persistent scaled-store build (dimensionless
-twin solve + grid⁻ᵏ restore); the zero-alloc contract is the Real-axis path's.
+twin solve + grid⁻ᵏ restore); the twins are lazy views, so zero-alloc holds there too.
 
 # Strategy selection (`coeffs`)
 - `AutoCoeffs()` (default): shared `_resolve_coeffs_nd_oneshot` policy, same as cubic —

--- a/src/quadratic/nd/quadratic_nd_types.jl
+++ b/src/quadratic/nd/quadratic_nd_types.jl
@@ -83,13 +83,16 @@ struct QuadraticInterpolantND{
     # BC tuple (Quadratic accepts Left/Right/MinCurvFit as well as ZeroCurvBC,
     # PolyFit{D}, etc — all `<: AbstractBC`).
     function QuadraticInterpolantND(
-            grids::Tuple{Vararg{AbstractVector{Tg}, N}},
+            grids::Tuple{Vararg{AbstractVector, N}},
             nodal_derivs::_NodalDerivativesND{Tv, N, NP1},
             bcs::Tuple{Vararg{AbstractBC, N}},
             extraps::Tuple{Vararg{AbstractExtrap, N}},
             searches::Tuple{Vararg{AbstractSearchPolicy, N}}
-        ) where {Tg, Tv, N, NP1}
+        ) where {Tv, N, NP1}
         NP1 == N + 1 || throw(ArgumentError("NP1 must equal N+1"))
+        # Promotion-tag Tg (mixed-unit axes → abstract tag, mirrors the cubic/
+        # linear ctors); Real axes keep the concrete common eltype.
+        Tg = _promote_grid_eltype(grids)
         grids_c = _convert_cache_axes(grids, bcs, Tg)
         return new{Tg, Tv, N, NP1, typeof(grids_c), typeof(bcs), typeof(extraps), typeof(searches)}(
             grids_c, nodal_derivs, bcs, extraps, searches

--- a/test/test_adjoint_unit_guard.jl
+++ b/test/test_adjoint_unit_guard.jl
@@ -40,6 +40,7 @@
         msg = sprint(showerror, e)
         @test occursin("adjoint", msg)
         @test occursin("not supported", msg)
+        @test occursin("non-Real", msg)        # names the condition (`<: Real` gate)
         @test occursin("ustrip", msg)          # names the workaround
     end
 

--- a/test/test_constant_eltype.jl
+++ b/test/test_constant_eltype.jl
@@ -467,6 +467,8 @@ end
     end
 
     @testset "1D persistent: Int data + Float fill → InexactError on construction" begin
+        # Constant returns data values verbatim, so the fill lives in `Tv`: a
+        # float fill on Int data is rejected at construction (Int has no NaN).
         x = Float64.(0:4)
         y = [10, 20, 30, 40, 50]
         @test_throws InexactError constant_interp(x, y; extrap = FillExtrap(NaN))

--- a/test/test_constextrap_fill.jl
+++ b/test/test_constextrap_fill.jl
@@ -729,3 +729,38 @@
         end
     end
 end
+
+@testitem "FillExtrap: a float fill on integer data lives in the output space" begin
+    # The kernels already float Int data against a float grid (`itp(2.2)::Float64`),
+    # but several persistent entries promoted the fill against the RAW data eltype
+    # → `convert(Int, 0.5)` InexactError at construction. Real axes, plain Int data.
+    x = [0.0, 1.0, 2.5, 3.0, 4.5]
+    y = [0.0, 1.0, 2.0, 3.5]
+    yint = [1, 2, 3, 4, 5]
+    Zint = [i + j for i in 1:5, j in 1:4]
+    q_oob, q_in = 9.9, 2.2
+
+    @testset "1D persistent: every family accepts it" begin
+        for mk in (linear_interp, constant_interp, cubic_interp, quadratic_interp, pchip_interp)
+            itp = mk(x, yint; extrap = FillExtrap(0.5))
+            @test itp(q_oob) === 0.5
+            @test itp(q_in) isa Float64
+        end
+    end
+
+    @testset "1D one-shot mirrors" begin
+        @test cubic_interp(x, yint, q_oob; extrap = FillExtrap(0.5)) === 0.5
+        @test linear_interp(x, yint, q_oob; extrap = FillExtrap(0.5)) === 0.5
+        @test constant_interp(x, yint, q_oob; extrap = FillExtrap(0.5)) === 0.5
+    end
+
+    @testset "ND persistent + gridded" begin
+        for m in (LinearInterp(), ConstantInterp())
+            itp = interp((x, y), Zint; method = m, extrap = FillExtrap(0.5))
+            @test itp((q_oob, 1.0)) === 0.5
+            # Gridded (axis-target) path shares the fill promotion.
+            @test itp(([q_oob], [1.0]))[1] === 0.5
+        end
+        @test cubic_interp((x, y), Zint; extrap = FillExtrap(0.5))((q_oob, 1.0)) === 0.5
+    end
+end

--- a/test/test_constextrap_fill.jl
+++ b/test/test_constextrap_fill.jl
@@ -740,8 +740,11 @@ end
     Zint = [i + j for i in 1:5, j in 1:4]
     q_oob, q_in = 9.9, 2.2
 
-    @testset "1D persistent: every family accepts it" begin
-        for mk in (linear_interp, constant_interp, cubic_interp, quadratic_interp, pchip_interp)
+    # `ConstantInterp` is excluded on purpose: it returns data values verbatim,
+    # so its fill lives in `Tv` and a float fill on Int data is rejected at
+    # construction (Int has no NaN) — pinned in test_constant_eltype.jl.
+    @testset "1D persistent: every interpolating family accepts it" begin
+        for mk in (linear_interp, cubic_interp, quadratic_interp, pchip_interp)
             itp = mk(x, yint; extrap = FillExtrap(0.5))
             @test itp(q_oob) === 0.5
             @test itp(q_in) isa Float64
@@ -751,16 +754,21 @@ end
     @testset "1D one-shot mirrors" begin
         @test cubic_interp(x, yint, q_oob; extrap = FillExtrap(0.5)) === 0.5
         @test linear_interp(x, yint, q_oob; extrap = FillExtrap(0.5)) === 0.5
-        @test constant_interp(x, yint, q_oob; extrap = FillExtrap(0.5)) === 0.5
     end
 
     @testset "ND persistent + gridded" begin
-        for m in (LinearInterp(), ConstantInterp())
-            itp = interp((x, y), Zint; method = m, extrap = FillExtrap(0.5))
-            @test itp((q_oob, 1.0)) === 0.5
-            # Gridded (axis-target) path shares the fill promotion.
-            @test itp(([q_oob], [1.0]))[1] === 0.5
-        end
+        itp = interp((x, y), Zint; method = LinearInterp(), extrap = FillExtrap(0.5))
+        @test itp((q_oob, 1.0)) === 0.5
+        # Gridded (axis-target) path shares the fill promotion.
+        @test itp(([q_oob], [1.0]))[1] === 0.5
         @test cubic_interp((x, y), Zint; extrap = FillExtrap(0.5))((q_oob, 1.0)) === 0.5
+    end
+
+    @testset "NaN fill propagates wherever the value space holds NaN" begin
+        for mk in (linear_interp, cubic_interp, quadratic_interp)
+            @test isnan(mk(x, yint; extrap = FillExtrap(NaN))(q_oob))
+            @test isnan(mk(Float32.(x), Float32.(yint); extrap = FillExtrap(NaN))(Float32(q_oob)))
+        end
+        @test isnan(constant_interp(x, Float64.(yint); extrap = FillExtrap(NaN))(q_oob))
     end
 end

--- a/test/test_cubic_unit_native.jl
+++ b/test/test_cubic_unit_native.jl
@@ -348,3 +348,43 @@ end
         @test itp(2.2) isa ComplexF64
     end
 end
+
+@testitem "cubic unit native: bare-PointBC + Series-array Real-zero payloads rehydrate" begin
+    using Unitful
+
+    # The scalar `BCPair` 3-arg normalize rehydrates structural Real zeros, but two
+    # sibling arms skipped it: (A) the solve-side `_normalize_bc_array` overload for
+    # `Vector{<:BCPair}` delegated to the type-only path; (B) the 3-arg catch-all
+    # dropped (x, y) for bare `PointBC`s. Pin all shapes to the ZeroCurvBC mint.
+    xf = [0.0, 1.0, 2.5, 3.0, 4.5]
+    xu = xf .* u"m"
+    yw = [sin(xi) for xi in xf] .* u"K"
+    q = 2.2u"m"
+    ref = cubic_interp(xu, yw; bc = ZeroCurvBC())
+    S = Series(reshape(yw, :, 1))
+
+    @testset "plain 1D: scalar bare Deriv2(0.0) ≡ ZeroCurvBC" begin
+        itp = cubic_interp(xu, yw; bc = Deriv2(0.0))
+        @test itp(q) === ref(q)
+    end
+
+    @testset "Series: scalar bare Deriv2(0.0)" begin
+        sitp = cubic_interp(xu, S; bc = Deriv2(0.0))
+        @test sitp(q)[1] === ref(q)
+    end
+
+    @testset "Series: [Deriv2(0.0)] vector (general grid-aware arm)" begin
+        sitp = cubic_interp(xu, S; bc = [Deriv2(0.0)])
+        @test sitp(q)[1] === ref(q)
+    end
+
+    @testset "Series: [BCPair(Deriv2(0.0), Deriv2(0.0))] (Vector{BCPair} solve arm)" begin
+        sitp = cubic_interp(xu, S; bc = [BCPair(Deriv2(0.0), Deriv2(0.0))])
+        @test sitp(q)[1] === ref(q)
+    end
+
+    @testset "nonzero unitless payloads keep the actionable rejection on the new arms" begin
+        @test_throws ArgumentError cubic_interp(xu, yw; bc = Deriv2(0.3))
+        @test_throws ArgumentError cubic_interp(xu, S; bc = [BCPair(Deriv2(0.3), Deriv2(0.3))])
+    end
+end

--- a/test/test_cubic_unit_native.jl
+++ b/test/test_cubic_unit_native.jl
@@ -388,3 +388,25 @@ end
         @test_throws ArgumentError cubic_interp(xu, S; bc = [BCPair(Deriv2(0.3), Deriv2(0.3))])
     end
 end
+
+@testitem "cubic unit native: inference pins — rehydrated builds + FillExtrap" begin
+    using Unitful
+    using Test: @inferred
+
+    # The rehydration arms and unit FillExtrap must keep eval concretely inferred
+    # (fill values normalize into the value space at build, so OOB == in-domain type).
+    xf = [0.0, 1.0, 2.5, 3.0, 4.5]
+    xu = xf .* u"m"
+    yw = [sin(v) for v in xf] .* u"K"
+    TK = typeof(1.0u"K")
+
+    itp = cubic_interp(xu, yw; bc = Deriv2(0.0))
+    @test (@inferred itp(2.2u"m")) isa TK
+
+    sitp = cubic_interp(xu, Series(reshape(yw, :, 1)); bc = [BCPair(Deriv2(0.0), Deriv2(0.0))])
+    @test (@inferred sitp(2.2u"m")) isa Vector{TK}
+
+    itpf = cubic_interp(xu, yw; extrap = FillExtrap(NaN * u"K"))
+    @test (@inferred itpf(2.2u"m")) isa TK
+    @test (@inferred itpf(9.9u"m")) isa TK
+end

--- a/test/test_duck_grid_lint.jl
+++ b/test/test_duck_grid_lint.jl
@@ -44,6 +44,13 @@
             (rel == "core/utils.jl" && occursin("_promote_extrap", line)) ||
             # 3. `_inv_const` Real arm — dispatch pair with the dimensionless arm.
             occursin("_inv_const", line) ||
+            # 3a. Scaled-store policy seams: each is a dispatch PAIR whose
+            #     unconstrained sibling serves duck/unit grids (fill eltype,
+            #     local params → reparam collapse, gridded fused → pointwise).
+            #     The Real arm exists to keep that path byte-identical.
+            occursin("_oneshot_fill_eltype", line) ||
+            (rel == "core/nd_utils.jl" && occursin("Tg <: Real}", line)) ||
+            (rel == "gridded/gridded_partials.jl" && occursin("Tg <: Real,", line)) ||
             # 3b. Type-level units-branch idiom (`Tg <: Real || return _*_units(...)`).
             occursin("<: Real ||", line) ||
             # 4. DEFERRED: Series EVAL + anchored-query paths (integrate-side series
@@ -105,8 +112,14 @@
         # anchor_common.jl (`_anchor_loc` ×2 + `_AnchorLoc` struct): relaxed to
         # Number for the deferred anchored-query paths (ND GriddedQuery on unit
         # grids) — was 3, now 0 → key dropped.
-        "core/nd_utils.jl" => 2,
+        # core/nd_utils.jl: 2 `q::Real` axis-search arms + 2 scaled-store policy
+        # seams (`_oneshot_fill_eltype`, `_compute_all_local_params`), each a
+        # dispatch pair whose unconstrained sibling serves duck/unit grids.
+        "core/nd_utils.jl" => 4,
         "core/search.jl" => 4,
+        # gridded/gridded_partials.jl: the 2 persistent fused arms; their
+        # unconstrained siblings decline non-Real axes to the pointwise core.
+        "gridded/gridded_partials.jl" => 2,
         # series_lean_anchors.jl (`_build_series_anchor`): relaxed to Number for
         # unit-grid Series eval — was 1, now 0 → key dropped.
         # series_utils.jl (the 6 `_constant_extrap_boundary_value` /

--- a/test/test_duck_typing_comprehensive.jl
+++ b/test/test_duck_typing_comprehensive.jl
@@ -1551,9 +1551,13 @@ end
     # standard numeric promotion is unaffected by duck-typing paths.
     # ================================================================
     @testset "33. Contract boundaries" begin
-        # DuckFloat5 has no convert(DuckFloat5, Float64) → cross-type Deriv must fail
-        @testset "cubic Deriv1(0.0) fails without convert" begin
-            @test_throws MethodError cubic_interp(x_vec, y_generic; bc = Deriv1(0.0))
+        # MyDuck has no convert from Float64 → a cross-type Deriv payload must
+        # fail. Exception (the #201 rule, extended to the bare-PointBC arm):
+        # a STRUCTURAL Real zero is dimensionally unambiguous and mints into the
+        # payload space, so `Deriv1(0.0)` builds; a nonzero one still fails.
+        @testset "cubic Deriv1: structural zero mints, nonzero fails" begin
+            @test cubic_interp(x_vec, y_generic; bc = Deriv1(0.0)) isa CubicInterpolant
+            @test_throws MethodError cubic_interp(x_vec, y_generic; bc = Deriv1(0.25))
         end
         @testset "quadratic Left(Deriv1(0.0)) fails without convert" begin
             @test_throws MethodError quadratic_interp(

--- a/test/test_nd_oneshot_deriv_units.jl
+++ b/test/test_nd_oneshot_deriv_units.jl
@@ -10,9 +10,10 @@
 # an abstract `Quantity{Float64}`, the assertion becomes vacuous and the bug
 # hides — the "less broken" case is the one that reports it.
 #
-# Linear is the only family this reaches: cubic/quadratic/hetero ND one-shots
-# refuse unit grids up front (`_check_nd_solver_grid` / `_check_nd_hetero_grid`)
-# and Constant already folds through `_interp_nd_output_eltype`.
+# Linear/Constant are the value-native families this pins: Constant folds through
+# `_interp_nd_output_eltype`, cubic/quadratic one-shots reparameterize (pinned in
+# test_unitful_grid_nd.jl), and hetero ND one-shots refuse unit grids up front
+# (`_check_nd_hetero_grid`).
 
 @testitem "ND one-shot: derivative queries keep the grid's derivative units" begin
     using Unitful

--- a/test/test_nointerp.jl
+++ b/test/test_nointerp.jl
@@ -1748,3 +1748,19 @@ end
         end
     end
 end
+
+@testitem "NoInterp + GridIdx: KNOWN BROKEN — 1-D batch queries" begin
+    # `GridIdx` resolves at the scalar door and (since the ND batch fix) per
+    # point in the N-D batch loops. The 1-D vector loops have neither: the
+    # domain check sees the unresolved `val = NaN` and throws. Loud, never
+    # silent. Present in v0.4.17 and earlier — recorded, not fixed: resolution
+    # would have to reach each family's 1-D loop, and rebuilding the query
+    # array at the entry would break the batch zero-alloc contract.
+    x = [0.0, 1.0, 2.5, 3.0, 4.5]
+    y = [0.0, 1.0, 2.0, 3.0, 4.0]
+    itp = linear_interp(x, y)
+
+    @test itp(GridIdx(2)) === y[2]                      # scalar path works
+    @test_broken itp([GridIdx(2), GridIdx(4)]) == [y[2], y[4]]
+    @test_broken cubic_interp(x, y)([GridIdx(2)])[1] === cubic_interp(x, y)(GridIdx(2))
+end

--- a/test/test_nointerp.jl
+++ b/test/test_nointerp.jl
@@ -414,6 +414,42 @@ end
         @test L ≈ ref_d2 rtol = 1.0e-10
     end
 
+    @testset "Batch: GridIdx on an INTERPOLATING axis matches the scalar query" begin
+        # Existing batch coverage puts GridIdx on a NoInterp axis, whose kernel
+        # never reads the coordinate — so the unresolved `val = NaN` sentinel
+        # stayed invisible. On an interpolating axis the batch loops must resolve
+        # per point, exactly as the scalar entries do.
+        for (nm, itp) in (
+                ("linear", interp((x, y), data_2d; method = LinearInterp())),
+                ("constant", interp((x, y), data_2d; method = ConstantInterp())),
+                ("cubic", cubic_interp((x, y), data_2d)),
+                ("quadratic", quadratic_interp((x, y), data_2d)),
+            )
+            @testset "$nm" begin
+                # AoS (`Vector{<:Tuple}`): every point carries its own GridIdx.
+                # (SoA with a scalar axis is a separate, pre-sliced entry — see
+                # the `interp!` NoInterp testsets below.)
+                @test itp([(GridIdx(2), GridIdx(3))])[1] === itp((GridIdx(2), GridIdx(3)))
+                @test itp([(qx, GridIdx(3)), (GridIdx(2), qy)]) ==
+                    [itp((qx, GridIdx(3))), itp((GridIdx(2), qy))]
+            end
+        end
+
+        @testset "one-shot batch" begin
+            @test cubic_interp((x, y), data_2d, [(GridIdx(2), GridIdx(3))])[1] ≈
+                cubic_interp((x, y), data_2d)((GridIdx(2), GridIdx(3))) rtol = 1.0e-14
+            @test interp((x, y), data_2d, [(GridIdx(2), GridIdx(3))]; method = LinearInterp())[1] ===
+                interp((x, y), data_2d; method = LinearInterp())((GridIdx(2), GridIdx(3)))
+        end
+
+        @testset "3D + derivative" begin
+            itp3 = interp((x, y, z), data_3d; method = LinearInterp())
+            @test itp3([(qx, GridIdx(3), qz)])[1] === itp3((qx, GridIdx(3), qz))
+            d = (DerivOp(1), DerivOp(0), DerivOp(0))
+            @test itp3([(qx, GridIdx(3), qz)]; deriv = d)[1] === itp3((qx, GridIdx(3), qz); deriv = d)
+        end
+    end
+
     # ========================================
     # 14. Batch interp!
     # ========================================

--- a/test/test_query_shape_preservation.jl
+++ b/test/test_query_shape_preservation.jl
@@ -641,3 +641,25 @@ end
         @test mC(ov, x, y, q12) <= ALLOC_THRESHOLD
     end
 end
+
+@testitem "query shape: KNOWN BROKEN — SoA with a pinned scalar axis" begin
+    # A mixed SoA tuple (`(coords_vector, scalar)`) has no protocol arm: it falls
+    # to the container fallbacks, so `_query_length` reports the TUPLE arity and
+    # extraction hands the kernel the wrong point. Present in v0.4.17 and earlier
+    # — recorded, not fixed, because the legitimate pinned-axis form is the
+    # NoInterp pre-slice entry (`interp!(out, grids, data, (xq, GridIdx(k));
+    # method = (…, NoInterp()))`), which a blanket rejection would break too.
+    x = [0.0, 1.0, 2.5, 3.0, 4.5]
+    y = [0.0, 1.0, 2.0, 3.5]
+    F = [(sin(a) + 2.0 * b) for a in x, b in y]
+    itp = interp((x, y), F; method = LinearInterp())
+    qs = [0.5, 1.5, 2.5]
+
+    # Root cause: three query points, but the tuple reports its own arity.
+    @test_broken FastInterpolations._query_length((qs, 0.5)) == 3
+    # User-visible: allocating form cannot type the output; in-place rejects the
+    # size. (When `length(qs) == N` the size check passes and the kernel reads
+    # past a scalar under `@inbounds` — the narrow silent window.)
+    @test_broken itp((qs, 0.5)) == [itp((q, 0.5)) for q in qs]
+    @test_broken itp(zeros(3), (qs, 0.5)) == [itp((q, 0.5)) for q in qs]
+end

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -292,6 +292,95 @@ end
     end
 end
 
+@testitem "Unitful ND: cubic PreCompute eval/deriv/OOB (P2)" setup = [AllocConstants] begin
+    using Unitful
+    using Test: @inferred
+
+    # The dimensionless solve runs the SAME arithmetic as the Float64 twin, so
+    # unit results are the twin's values re-tagged: value [Y], deriv [Y/Xᵏ] via
+    # the canonical `_nd_deriv_scale` restoration at the cell surface.
+    x = [0.0, 1.0, 2.5, 3.0, 4.5] .* u"s"
+    y = [0.0, 1.0, 2.0, 3.5] .* u"m"
+    xf = ustrip.(u"s", x)
+    yf = ustrip.(u"m", y)
+    F = [(sin(xi) + 2.0 * yj + 0.4 * xi * yj) * u"W" for xi in xf, yj in yf]
+    Ff = ustrip.(u"W", F)
+    itp = cubic_interp((x, y), F)
+    tw = cubic_interp((xf, yf), Ff)
+    q = (2.2u"s", 1.3u"m")
+    qf = (2.2, 1.3)
+
+    @testset "value ≡ Float64 twin × unit" begin
+        @test itp(q) ≈ tw(qf) * u"W" rtol = 1.0e-14
+        @test (@inferred itp(q)) isa typeof(1.0u"W")
+        @test itp((0.0u"s", 0.0u"m")) ≈ tw((0.0, 0.0)) * u"W" rtol = 1.0e-14
+        @test itp((4.5u"s", 3.5u"m")) ≈ tw((4.5, 3.5)) * u"W" rtol = 1.0e-14
+    end
+
+    @testset "deriv orders restore per-axis grid⁻ᵏ units" begin
+        @test itp(q; deriv = (DerivOp(1), DerivOp(0))) ≈
+            tw(qf; deriv = (DerivOp(1), DerivOp(0))) * u"W/s" rtol = 1.0e-14
+        @test itp(q; deriv = (DerivOp(0), DerivOp(1))) ≈
+            tw(qf; deriv = (DerivOp(0), DerivOp(1))) * u"W/m" rtol = 1.0e-14
+        @test itp(q; deriv = (DerivOp(1), DerivOp(1))) ≈
+            tw(qf; deriv = (DerivOp(1), DerivOp(1))) * u"W/(s*m)" rtol = 1.0e-14
+        @test itp(q; deriv = (DerivOp(2), DerivOp(0))) ≈
+            tw(qf; deriv = (DerivOp(2), DerivOp(0))) * u"W/s^2" rtol = 1.0e-14
+    end
+
+    @testset "vector calculus unlocks (mixed: grad/hess ✓, laplacian guarded)" begin
+        g = gradient(itp, q)
+        gt = gradient(tw, qf)
+        @test g[1] ≈ gt[1] * u"W/s" rtol = 1.0e-14
+        @test g[2] ≈ gt[2] * u"W/m" rtol = 1.0e-14
+        H = hessian(itp, q)
+        Ht = hessian(tw, qf)
+        @test H[1, 2] ≈ Ht[1, 2] * u"W/(s*m)" rtol = 1.0e-13
+        @test_throws ArgumentError laplacian(itp, q)
+    end
+
+    @testset "same-unit axes: laplacian works" begin
+        ys = [0.0, 1.0, 2.0, 3.5] .* u"s"
+        itp_s = cubic_interp((x, ys), F)
+        tw_s = cubic_interp((xf, yf), Ff)
+        @test laplacian(itp_s, (2.2u"s", 1.3u"s")) ≈
+            laplacian(tw_s, (2.2, 1.3)) * u"W/s^2" rtol = 1.0e-13
+    end
+
+    @testset "OOB: NoExtrap DomainError / Clamp value / Fill-NaN rule" begin
+        @test_throws DomainError itp((9.9u"s", 1.0u"m"))
+        itp_c = cubic_interp((x, y), F; extrap = ClampExtrap())
+        tw_c = cubic_interp((xf, yf), Ff; extrap = ClampExtrap())
+        @test itp_c((9.9u"s", 1.0u"m")) ≈ tw_c((9.9, 1.0)) * u"W" rtol = 1.0e-14
+        itp_f = cubic_interp((x, y), F; extrap = FillExtrap(NaN * u"W"))
+        @test isnan(itp_f((9.9u"s", 1.0u"m")))
+        @test isnan(itp_f((9.9u"s", 1.0u"m"); deriv = (DerivOp(1), DerivOp(0))))
+    end
+
+    @testset "unit Range axes + batch SoA" begin
+        xr = (0.0:1.0:4.0) .* u"s"
+        yr = (0.0:1.0:3.0) .* u"m"
+        Fr = [(xi + 2.0 * yj) * u"W" for xi in 0.0:1.0:4.0, yj in 0.0:1.0:3.0]
+        itp_r = cubic_interp((xr, yr), Fr)
+        tw_r = cubic_interp((0.0:1.0:4.0, 0.0:1.0:3.0), ustrip.(u"W", Fr))
+        @test itp_r((2.2u"s", 1.3u"m")) ≈ tw_r((2.2, 1.3)) * u"W" rtol = 1.0e-14
+        out = itp(([1.1, 2.2] .* u"s", [0.5, 1.5] .* u"m"))
+        @test eltype(out) === typeof(1.0u"W")
+        @test out[2] ≈ itp((2.2u"s", 1.5u"m")) rtol = 1.0e-14
+    end
+
+    @testset "alloc: unit scalar eval hot path" begin
+        # Function barriers: the testitem-global `itp` boxes the KWARG call form
+        # under `@allocated` (16 B measurement artifact, not a path allocation).
+        measure_val(itp, q) = @allocated itp(q)
+        measure_der(itp, q) = @allocated itp(q; deriv = (DerivOp(1), DerivOp(0)))
+        measure_val(itp, q)
+        measure_der(itp, q)
+        @test measure_val(itp, q) <= ND_ALLOC_THRESHOLD
+        @test measure_der(itp, q) <= ND_ALLOC_THRESHOLD
+    end
+end
+
 @testitem "Unitful ND: zero-alloc hot path, mixed-unit abstract-Tg (review pin F6)" setup = [AllocConstants] begin
     using Unitful
 

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -181,7 +181,39 @@ end
             e
         end
         @test err isa ArgumentError
-        @test occursin("unit-carrying", sprint(showerror, err))
+        # The gate condition is `Tg <: Real` — the message must name that, with
+        # units as the canonical example (not the condition itself).
+        @test occursin("non-Real", sprint(showerror, err))
+    end
+end
+
+@testitem "ND gates: units-free duck Number grid gets the accurate refusal" begin
+    # A units-free duck Number hits the same `<: Real` gate — the error must be
+    # the actionable ArgumentError naming the actual eltype, not a units claim.
+    # (Testitem name must NOT contain the pinned phrase: ReTestItems derives the
+    # module name from it, and qualified type names would smuggle it into `msg`.)
+    struct _OrderedDuckNum <: Number
+        v::Float64
+    end
+    Base.isless(a::_OrderedDuckNum, b::_OrderedDuckNum) = isless(a.v, b.v)
+    xd = [_OrderedDuckNum(0.0), _OrderedDuckNum(1.0), _OrderedDuckNum(2.0), _OrderedDuckNum(3.0)]
+    F = [Float64(i + j) for i in 1:4, j in 1:4]
+
+    for build in (
+            () -> cubic_interp((xd, xd), F),        # solver gate (cubic entry)
+            () -> quadratic_interp((xd, xd), F),    # solver gate (quadratic entry)
+            () -> pchip_interp((xd, xd), F),        # hetero gate
+        )
+        err = try
+            build()
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        msg = sprint(showerror, err)
+        @test occursin("non-Real", msg)
+        @test occursin("_OrderedDuckNum", msg)
     end
 end
 

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -68,7 +68,10 @@ end
     end
 
     @testset "solver families: friendly error (deferred)" begin
-        @test_throws ArgumentError interp((xs, ym), data; method = CubicInterp())
+        # Cubic ND admits unit axes since the scaled-store build — this pin
+        # tracks the still-gated solver family (quadratic; PolyFit min-points
+        # would mask the cubic probe on this 3-point axis anyway).
+        @test_throws ArgumentError interp((xs, ym), data; method = QuadraticInterp())
     end
 end
 
@@ -217,6 +220,78 @@ end
     end
 end
 
+@testitem "Unitful ND: cubic PreCompute build — scaled [Y]-homogeneous store (P1)" begin
+    using Unitful
+    using ForwardDiff: Dual
+
+    # Store contract: slot p holds ∂ᵏf · Π oneunit(axisᵢ)ᵏ — every 2^N slot in
+    # the value space [Y], so the single homogeneous partials array survives
+    # unit grids. Axis reparameterization is exact (t = x·inv(oneunit)), so the
+    # fiber solves are the SAME arithmetic as the 1D unit-native path.
+    x = [0.0, 1.0, 2.5, 3.0, 4.5] .* u"s"
+    y = [0.0, 1.0, 2.0, 3.5] .* u"m"
+    F = [
+        (
+                sin(ustrip(u"s", xi)) + 2.0 * ustrip(u"m", yj) +
+                0.4 * ustrip(u"s", xi) * ustrip(u"m", yj)
+            ) * u"W"
+            for xi in x, yj in y
+    ]
+
+    itp = cubic_interp((x, y), F)
+    P = itp.nodal_derivs.partials
+    @test eltype(P) === typeof(1.0u"W")
+
+    @testset "slot 1 = f verbatim" begin
+        @test all(P[1, i, j] === F[i, j] for i in eachindex(x), j in eachindex(y))
+    end
+
+    @testset "slot 2/3 = axis-fiber nodal derivative × oneunit(axis)" begin
+        for j in eachindex(y)
+            itp1 = cubic_interp(x, F[:, j])
+            for i in eachindex(x)
+                @test P[2, i, j] ≈ itp1(x[i]; deriv = DerivOp(1)) * oneunit(eltype(x)) rtol = 1.0e-12
+            end
+        end
+        for i in eachindex(x)
+            itp2 = cubic_interp(y, F[i, :])
+            for j in eachindex(y)
+                @test P[3, i, j] ≈ itp2(y[j]; deriv = DerivOp(1)) * oneunit(eltype(y)) rtol = 1.0e-12
+            end
+        end
+    end
+
+    @testset "slot 4 = mixed partial, [Y]-typed finite" begin
+        @test all(isfinite, ustrip.(P[4, :, :]))
+    end
+
+    @testset "payload-free zero BCs mint unit-correct boundary rows" begin
+        itp_z = cubic_interp((x, y), F; bc = (ZeroSlopeBC(), ZeroCurvBC()))
+        Pz = itp_z.nodal_derivs.partials
+        @test iszero(Pz[2, 1, 1]) && iszero(Pz[2, end, 1])   # ∂f/∂x₁ = 0 at both x-edges
+        @test Pz[2, 1, 1] isa typeof(1.0u"W")
+    end
+
+    @testset "typed per-axis payload BC scales into the store" begin
+        itp_p = cubic_interp((x, y), F; bc = (Deriv1(0.25u"W/s"), ZeroCurvBC()))
+        Pp = itp_p.nodal_derivs.partials
+        for j in eachindex(y)
+            @test Pp[2, 1, j] ≈ 0.25u"W/s" * oneunit(eltype(x)) rtol = 1.0e-12
+        end
+    end
+
+    @testset "Dual grids stay on the Real passthrough (no reparameterization)" begin
+        xd = Dual.(ustrip.(u"s", x), 1.0)
+        yd = Dual.(ustrip.(u"m", y), 0.0)
+        Fd = ustrip.(u"W", F)
+        itp_d = cubic_interp((xd, yd), Fd)
+        Pd = itp_d.nodal_derivs.partials
+        @test eltype(Pd) <: Dual
+        itp_d1 = cubic_interp(xd, Fd[:, 2])
+        @test Pd[2, 3, 2] ≈ itp_d1(xd[3]; deriv = DerivOp(1)) rtol = 1.0e-12
+    end
+end
+
 @testitem "Unitful ND: zero-alloc hot path, mixed-unit abstract-Tg (review pin F6)" setup = [AllocConstants] begin
     using Unitful
 
@@ -358,7 +433,10 @@ end
     q = (2.5u"s", 1.5u"s")
 
     @testset "solver families (Cubic/Quadratic): persistent + one-shot" begin
-        @test_throws ArgumentError cubic_interp((xs, xs2), data)
+        # Cubic persistent admits unit axes since the scaled-store build (P1);
+        # the concrete-Tg dispatch pin flips to build-success. One-shot mirrors
+        # and quadratic stay gated until their phases.
+        @test cubic_interp((xs, xs2), data) isa CubicInterpolantND
         @test_throws ArgumentError quadratic_interp((xs, xs2), data)
         @test_throws ArgumentError cubic_interp((xs, xs2), data, q)
         @test_throws ArgumentError quadratic_interp((xs, xs2), data, q)

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -423,6 +423,46 @@ end
     end
 end
 
+@testitem "Unitful ND: solver-family integrate — full + bounded (P4)" begin
+    using Unitful
+
+    # The separable engine runs on the exact dimensionless twins; the volume
+    # element Π oneunit(axis) restores ∫…dx from ∫…dt, so unit results are the
+    # Float64 twin's values re-tagged with [Y·X₁·X₂].
+    x = [0.0, 1.0, 2.5, 3.0, 4.5] .* u"s"
+    y = [0.0, 1.0, 2.0, 3.5] .* u"m"
+    xf = ustrip.(u"s", x)
+    yf = ustrip.(u"m", y)
+    F = [(sin(xi) + 2.0 * yj + 0.4 * xi * yj) * u"W" for xi in xf, yj in yf]
+    Ff = ustrip.(u"W", F)
+    lo = (0.5u"s", 0.5u"m")
+    hi = (3.5u"s", 3.0u"m")
+    lof = (0.5, 0.5)
+    hif = (3.5, 3.0)
+    TWSM = typeof(1.0u"W*s*m")
+
+    for (name, mk) in (("cubic", cubic_interp), ("quadratic", quadratic_interp))
+        @testset "$name: vec axes" begin
+            itp = mk((x, y), F)
+            tw = mk((xf, yf), Ff)
+            @test integrate(itp) ≈ integrate(tw) * u"W*s*m" rtol = 1.0e-13
+            @test integrate(itp) isa TWSM
+            @test integrate(itp, lo, hi) ≈ integrate(tw, lof, hif) * u"W*s*m" rtol = 1.0e-13
+        end
+    end
+
+    @testset "cubic: unit-Range axes" begin
+        xr = (0.0:1.0:4.0) .* u"s"
+        yr = (0.0:1.0:3.0) .* u"m"
+        Fr = [(xi + 2.0 * yj) * u"W" for xi in 0.0:1.0:4.0, yj in 0.0:1.0:3.0]
+        itp_r = cubic_interp((xr, yr), Fr)
+        tw_r = cubic_interp((0.0:1.0:4.0, 0.0:1.0:3.0), ustrip.(u"W", Fr))
+        @test integrate(itp_r) ≈ integrate(tw_r) * u"W*s*m" rtol = 1.0e-13
+        @test integrate(itp_r, lo, (3.5u"s", 2.5u"m")) ≈
+            integrate(tw_r, lof, (3.5, 2.5)) * u"W*s*m" rtol = 1.0e-13
+    end
+end
+
 @testitem "Unitful ND: zero-alloc hot path, mixed-unit abstract-Tg (review pin F6)" setup = [AllocConstants] begin
     using Unitful
 

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -713,6 +713,66 @@ end
     @test (@allocated integrate(itp)) <= ND_ALLOC_THRESHOLD
 end
 
+@testitem "Unitful ND: scaled-store twins cost no allocation (one-shot + integrate)" setup = [AllocConstants] begin
+    using Unitful
+
+    # The dimensionless twin is a per-call transform, not a stored array: the
+    # solver one-shot and the reparam integrate arm must hold the same alloc
+    # contract as their Real siblings (Range axes already did — Base's range
+    # broadcast keeps them isbits).
+    # Function barriers: measuring a testitem-global through a kwarg call form
+    # boxes the kwargs (16 B measurement artifact, not a path allocation).
+    oneshot_c(g, d, q) = @allocated cubic_interp(g, d, q; coeffs = PreCompute())
+    oneshot_q(g, d, q) = @allocated quadratic_interp(g, d, q; coeffs = PreCompute())
+    alloc_full(itp) = @allocated integrate(itp)
+    alloc_bnd(itp, lo, hi) = @allocated integrate(itp, lo, hi)
+
+    xf = collect(range(0.0, 4.0, 9))
+    yf = collect(range(0.0, 3.0, 7))
+    F = [sin(a) + 2.0 * b for a in xf, b in yf]
+    xs = xf .* u"s"
+    ym = yf .* u"m"
+    Fw = F .* u"W"
+    q = (2.2u"s", 1.3u"m")
+    lo, hi = (0.5u"s", 0.5u"m"), (3.5u"s", 2.5u"m")
+
+    @testset "unit Vector axes: one-shot scalar" begin
+        gv = (xs, ym)
+        oneshot_c(gv, Fw, q)
+        oneshot_q(gv, Fw, q)
+        @test oneshot_c(gv, Fw, q) <= ND_ALLOC_THRESHOLD
+        @test oneshot_q(gv, Fw, q) <= ND_ALLOC_THRESHOLD
+    end
+
+    @testset "unit Vector axes: persistent integrate (full + bounded)" begin
+        for mk in (cubic_interp, quadratic_interp)
+            itp = mk((xs, ym), Fw)
+            alloc_full(itp)
+            alloc_bnd(itp, lo, hi)
+            @test alloc_full(itp) <= ND_ALLOC_THRESHOLD
+            @test alloc_bnd(itp, lo, hi) <= ND_ALLOC_THRESHOLD
+        end
+    end
+
+    @testset "unit Range axes + Real axes stay put" begin
+        xr = range(0.0, 4.0, 9) .* u"s"
+        yr = range(0.0, 3.0, 7) .* u"m"
+        itr = cubic_interp((xr, yr), Fw)
+        alloc_full(itr)
+        oneshot_c((xr, yr), Fw, q)
+        @test alloc_full(itr) <= ND_ALLOC_THRESHOLD
+        @test oneshot_c((xr, yr), Fw, q) <= ND_ALLOC_THRESHOLD
+
+        itf = cubic_interp((xf, yf), F)
+        alloc_full(itf)
+        alloc_bnd(itf, (0.5, 0.5), (3.5, 2.5))
+        oneshot_c((xf, yf), F, (2.2, 1.3))
+        @test alloc_full(itf) <= ND_ALLOC_THRESHOLD
+        @test alloc_bnd(itf, (0.5, 0.5), (3.5, 2.5)) <= ND_ALLOC_THRESHOLD
+        @test oneshot_c((xf, yf), F, (2.2, 1.3)) <= ND_ALLOC_THRESHOLD
+    end
+end
+
 @testitem "Unitful ND: zero-alloc hot path, same-unit concrete-Tg (review pin F21)" setup = [AllocConstants] begin
     using Unitful
 

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -864,3 +864,43 @@ end
         @test (@inferred iu((0.5u"s", 0.5u"s"))) isa typeof(1.0u"W")   # concrete grid ⇒ no box
     end
 end
+
+@testitem "Unitful ND: Real BC payloads validate in their true derivative space" begin
+    using Unitful
+
+    # Real data on unit axes: a nonzero Real `Deriv1` payload is dimensionally
+    # incomplete ([Y/X] carries axis units) — the 1D builders reject it with an
+    # actionable error, and the reparam scale-in must match. The structural zero
+    # keeps minting in the true space before scaling into the [Y] store.
+    xf = [0.0, 1.0, 2.5, 3.0, 4.5]
+    yf = [0.0, 1.0, 2.0, 3.5]
+    xs = xf .* u"s"
+    ym = yf .* u"m"
+    Freal = [(sin(xi) + 2.0 * yj) for xi in xf, yj in yf]
+    q = (2.2u"s", 1.3u"m")
+
+    @testset "nonzero Real payload beside Real data + unit axes → ArgumentError" begin
+        err = try
+            cubic_interp((xs, ym), Freal; bc = (BCPair(Deriv1(0.25), Deriv1(0.25)), ZeroCurvBC()))
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("derivative space", sprint(showerror, err))
+    end
+
+    @testset "structural zero still mints (Real data + unit axes)" begin
+        ref = cubic_interp((xs, ym), Freal; bc = (ZeroCurvBC(), ZeroCurvBC()))
+        itp = cubic_interp((xs, ym), Freal; bc = (BCPair(Deriv2(0.0), Deriv2(0.0)), ZeroCurvBC()))
+        @test itp(q) === ref(q)
+    end
+
+    @testset "typed payloads in the true [Y/X] space stay accepted" begin
+        itp = cubic_interp(
+            (xs, ym), Freal;
+            bc = (BCPair(Deriv1(0.25u"s^-1"), Deriv1(0.25u"s^-1")), ZeroCurvBC())
+        )
+        @test itp(q) isa Float64
+    end
+end

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -67,11 +67,11 @@ end
         @test integrate(itp) ≈ integrate(tw) * u"W*s*m"
     end
 
-    @testset "solver families: friendly error (deferred)" begin
-        # Cubic ND admits unit axes since the scaled-store build — this pin
-        # tracks the still-gated solver family (quadratic; PolyFit min-points
-        # would mask the cubic probe on this 3-point axis anyway).
-        @test_throws ArgumentError interp((xs, ym), data; method = QuadraticInterp())
+    @testset "solver families on mixed-unit axes: quadratic builds (scaled store)" begin
+        # Both solver persistents admit unit axes now; quadratic is the probe
+        # here (3-point axis-1 — cubic's PolyFit min-points needs 4, covered by
+        # the dedicated P-testitems below).
+        @test interp((xs, ym), data; method = QuadraticInterp()) isa QuadraticInterpolantND
     end
 end
 
@@ -381,6 +381,48 @@ end
     end
 end
 
+@testitem "Unitful ND: quadratic PreCompute build+eval (P3 mirror)" begin
+    using Unitful
+
+    x = [0.0, 1.0, 2.5, 3.0, 4.5] .* u"s"
+    y = [0.0, 1.0, 2.0, 3.5] .* u"m"
+    xf = ustrip.(u"s", x)
+    yf = ustrip.(u"m", y)
+    F = [(sin(xi) + 2.0 * yj + 0.4 * xi * yj) * u"W" for xi in xf, yj in yf]
+    Ff = ustrip.(u"W", F)
+    itp = quadratic_interp((x, y), F)
+    tw = quadratic_interp((xf, yf), Ff)
+    q = (2.2u"s", 1.3u"m")
+    qf = (2.2, 1.3)
+
+    @testset "store slots in [Y]; axis-fiber oracle" begin
+        P = itp.nodal_derivs.partials
+        @test eltype(P) === typeof(1.0u"W")
+        itp1 = quadratic_interp(x, F[:, 2])
+        @test P[2, 3, 2] ≈ itp1(x[3]; deriv = DerivOp(1)) * oneunit(eltype(x)) rtol = 1.0e-12
+    end
+
+    @testset "eval/deriv ≡ twin with restored units" begin
+        @test itp(q) ≈ tw(qf) * u"W" rtol = 1.0e-14
+        @test itp(q; deriv = (DerivOp(1), DerivOp(0))) ≈
+            tw(qf; deriv = (DerivOp(1), DerivOp(0))) * u"W/s" rtol = 1.0e-14
+        @test itp(q; deriv = (DerivOp(1), DerivOp(1))) ≈
+            tw(qf; deriv = (DerivOp(1), DerivOp(1))) * u"W/(s*m)" rtol = 1.0e-14
+        g = gradient(itp, q)
+        gt = gradient(tw, qf)
+        @test g[1] ≈ gt[1] * u"W/s" rtol = 1.0e-14
+        @test g[2] ≈ gt[2] * u"W/m" rtol = 1.0e-14
+    end
+
+    @testset "Left/Right payload BCs scale in" begin
+        bcp = (Left(Deriv1(0.25u"W/s")), MinCurvFit())
+        itp_p = quadratic_interp((x, y), F; bc = bcp)
+        itp1p = quadratic_interp(x, F[:, 2]; bc = Left(Deriv1(0.25u"W/s")))
+        @test itp_p.nodal_derivs.partials[2, 1, 2] ≈
+            itp1p(x[1]; deriv = DerivOp(1)) * oneunit(eltype(x)) rtol = 1.0e-12
+    end
+end
+
 @testitem "Unitful ND: zero-alloc hot path, mixed-unit abstract-Tg (review pin F6)" setup = [AllocConstants] begin
     using Unitful
 
@@ -522,11 +564,11 @@ end
     q = (2.5u"s", 1.5u"s")
 
     @testset "solver families (Cubic/Quadratic): persistent + one-shot" begin
-        # Cubic persistent admits unit axes since the scaled-store build (P1);
-        # the concrete-Tg dispatch pin flips to build-success. One-shot mirrors
-        # and quadratic stay gated until their phases.
+        # Solver persistents admit unit axes since the scaled-store build; the
+        # concrete-Tg dispatch pins flip to build-success. One-shot mirrors
+        # stay gated until their phase.
         @test cubic_interp((xs, xs2), data) isa CubicInterpolantND
-        @test_throws ArgumentError quadratic_interp((xs, xs2), data)
+        @test quadratic_interp((xs, xs2), data) isa QuadraticInterpolantND
         @test_throws ArgumentError cubic_interp((xs, xs2), data, q)
         @test_throws ArgumentError quadratic_interp((xs, xs2), data, q)
     end

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -777,6 +777,47 @@ end
     end
 end
 
+@testitem "Unitful ND: Hermite ND rejects unit grids with the friendly refusal" begin
+    using Unitful
+
+    # Hermite ND has no scaled-store/reparam seam (user partials live per-axis in
+    # [Y/Xᵈ]) — unit axes died in deep MethodErrors (`_pack_and_extend_nodal_derivs`,
+    # abstract-Tv coerce) on persistent AND one-shot entries. Pin the gate refusal.
+    xf = [0.0, 1.0, 2.0, 3.0]
+    yfv = [0.0, 1.0, 2.0, 3.0]
+    xs = xf .* u"s"
+    ym = yfv .* u"m"
+    F = [sin(a) + 2.0 * b for a in xf, b in yfv]
+    pR = HermitePartials(
+        (1, 0) => [cos(a) for a in xf, b in yfv],
+        (0, 1) => [2.0 for a in xf, b in yfv],
+        (1, 1) => zeros(4, 4),
+    )
+
+    @testset "persistent + one-shot → ArgumentError" begin
+        @test_throws ArgumentError hermite_interp((xs, ym), F, pR)
+        @test_throws ArgumentError hermite_interp((xs, yfv), F, pR)   # mixed Real×unit
+        @test_throws ArgumentError hermite_interp((xs, ym), F, pR, (1.5u"s", 1.5u"m"))
+        @test_throws ArgumentError hermite_interp((xs, ym), F, pR, [(1.5u"s", 1.5u"m")])
+    end
+
+    @testset "unit data + true-unit partials → same refusal (not a size/coerce error)" begin
+        Fw = F .* u"W"
+        pW = HermitePartials(
+            (1, 0) => [cos(a) for a in xf, b in yfv] .* u"W/s",
+            (0, 1) => [2.0 for a in xf, b in yfv] .* u"W/m",
+            (1, 1) => zeros(4, 4) .* u"W/(s*m)",
+        )
+        @test_throws ArgumentError hermite_interp((xs, ym), Fw, pW)
+        @test_throws ArgumentError hermite_interp((xs, ym), Fw, pW, (1.5u"s", 1.5u"m"))
+    end
+
+    @testset "Real axes stay served" begin
+        @test hermite_interp((xf, yfv), F, pR)((1.5, 1.5)) isa Float64
+        @test hermite_interp((xf, yfv), F, pR, (1.5, 1.5)) isa Float64
+    end
+end
+
 @testitem "Unitful ND: solver/hetero guards fire on same-unit (concrete-Tg) axes (review pin F20)" begin
     using Unitful
 

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -971,3 +971,39 @@ end
         @test_throws ArgumentError cubic_interp((xs, ym), F, (GridIdx(2), GridIdx(3)))
     end
 end
+
+@testitem "Unitful ND: GriddedQuery on unit axes serves through the pointwise core" begin
+    using Unitful
+
+    # The cubic/quadratic gridded fast path stores PHYSICAL h/inv_h/dL anchors and
+    # calls the cell kernels directly — on non-Real axes the store is [Y]-scaled
+    # (dimensionless frame), so the fast path must decline and the restore-aware
+    # pointwise core serve instead.
+    xf = [0.0, 1.0, 2.5, 3.0, 4.5]
+    yf = [0.0, 1.0, 2.0, 3.5]
+    xs = xf .* u"s"
+    ym = yf .* u"m"
+    F = [(sin(xi) + 2.0 * yj) for xi in xf, yj in yf] .* u"W"
+    qx = [1.2, 2.2] .* u"s"
+    qy = [0.6, 1.3] .* u"m"
+    gq = GriddedQuery((qx, qy))
+    itp = cubic_interp((xs, ym), F)
+    itq = quadratic_interp((xs, ym), F)
+    d10 = (DerivOp(1), DerivOp(0))
+
+    @testset "persistent cubic/quadratic: value + deriv match pointwise" begin
+        g = itp(gq)
+        @test size(g) == (2, 2)
+        @test g[2, 2] === itp((qx[2], qy[2]))
+        # Deriv crosses two FP orderings (batch core vs scalar locate) — ≈, not ===.
+        gd = itp(gq; deriv = d10)
+        @test gd[1, 2] ≈ itp((qx[1], qy[2]); deriv = d10) rtol = 1.0e-14
+        g2 = itq(gq)
+        @test g2[2, 1] === itq((qx[2], qy[1]))
+    end
+
+    @testset "unified one-shot GriddedQuery (method = CubicInterp)" begin
+        g = interp((xs, ym), F, gq; method = CubicInterp())
+        @test g[2, 2] ≈ itp((qx[2], qy[2])) rtol = 1.0e-14
+    end
+end

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -463,6 +463,82 @@ end
     end
 end
 
+@testitem "Unitful ND: composition gaps — 3D, PolyFit{4}, Real-zero BCPair, periodic, in-place" begin
+    using Unitful
+
+    xf = [0.0, 1.0, 2.5, 3.0, 4.5]
+    yf = [0.0, 1.0, 2.0, 3.5]
+    x = xf .* u"s"
+    y = yf .* u"m"
+    F2 = [(sin(xi) + 2.0 * yj + 0.4 * xi * yj) * u"W" for xi in xf, yj in yf]
+    F2f = ustrip.(u"W", F2)
+
+    @testset "3D mixed-unit: build/eval/deriv/integrate vs twin" begin
+        zf = [0.0, 0.5, 1.0, 2.0]
+        z = zf .* u"kg"
+        F3 = [
+            (sin(xi) + 2.0 * yj + 0.3 * zk + 0.1 * xi * yj * zk) * u"W"
+                for xi in xf, yj in yf, zk in zf
+        ]
+        F3f = ustrip.(u"W", F3)
+        itp = cubic_interp((x, y, z), F3)
+        tw = cubic_interp((xf, yf, zf), F3f)
+        q = (2.2u"s", 1.3u"m", 0.7u"kg")
+        qf = (2.2, 1.3, 0.7)
+        @test itp(q) ≈ tw(qf) * u"W" rtol = 1.0e-14
+        @test itp(q; deriv = (DerivOp(1), DerivOp(0), DerivOp(0))) ≈
+            tw(qf; deriv = (DerivOp(1), DerivOp(0), DerivOp(0))) * u"W/s" rtol = 1.0e-14
+        @test itp(q; deriv = (DerivOp(1), DerivOp(1), DerivOp(0))) ≈
+            tw(qf; deriv = (DerivOp(1), DerivOp(1), DerivOp(0))) * u"W/(s*m)" rtol = 1.0e-13
+        @test integrate(itp) ≈ integrate(tw) * u"W*s*m*kg" rtol = 1.0e-13
+        @test integrate(itp, (0.5u"s", 0.5u"m", 0.2u"kg"), (3.5u"s", 3.0u"m", 1.5u"kg")) ≈
+            integrate(tw, (0.5, 0.5, 0.2), (3.5, 3.0, 1.5)) * u"W*s*m*kg" rtol = 1.0e-13
+    end
+
+    @testset "per-axis PolyFit{4} on unit axes ≡ twin" begin
+        itp = cubic_interp((x, y), F2; bc = (PolyFit{4}(), CubicFit()))
+        tw = cubic_interp((xf, yf), F2f; bc = (PolyFit{4}(), CubicFit()))
+        @test itp((2.2u"s", 1.3u"m")) ≈ tw((2.2, 1.3)) * u"W" rtol = 1.0e-14
+        @test itp((0.2u"s", 3.3u"m")) ≈ tw((0.2, 3.3)) * u"W" rtol = 1.0e-14
+    end
+
+    @testset "Real-zero BCPair payloads beside unit ND data (rehydrate composition)" begin
+        bcs = (BCPair(Deriv2(0.0), Deriv2(0.0)), ZeroCurvBC())
+        itp = cubic_interp((x, y), F2; bc = bcs)
+        tw = cubic_interp((xf, yf), F2f; bc = bcs)
+        @test itp((2.2u"s", 1.3u"m")) ≈ tw((2.2, 1.3)) * u"W" rtol = 1.0e-14
+        # structurally ≡ the payload-free zero-curvature axis
+        ref = cubic_interp((x, y), F2; bc = (ZeroCurvBC(), ZeroCurvBC()))
+        @test itp((2.2u"s", 1.3u"m")) === ref((2.2u"s", 1.3u"m"))
+    end
+
+    @testset "exclusive periodic unit axis composes with the twin build" begin
+        xpf = [0.0, 1.0, 2.0, 3.0]
+        xp = xpf .* u"s"
+        Fp = [(sin(2π * xi / 4.0) + 2.0 * yj) * u"W" for xi in xpf, yj in yf]
+        Fpf = ustrip.(u"W", Fp)
+        itp = cubic_interp(
+            (xp, y), Fp;
+            bc = (PeriodicBC(endpoint = :exclusive, period = 4.0u"s"), ZeroCurvBC())
+        )
+        tw = cubic_interp(
+            (xpf, yf), Fpf;
+            bc = (PeriodicBC(endpoint = :exclusive, period = 4.0), ZeroCurvBC())
+        )
+        @test itp((3.7u"s", 1.3u"m")) ≈ tw((3.7, 1.3)) * u"W" rtol = 1.0e-14
+        @test itp((0.3u"s", 1.3u"m")) ≈ tw((0.3, 1.3)) * u"W" rtol = 1.0e-14
+    end
+
+    @testset "gradient! into an eltype-compatible store" begin
+        itp = cubic_interp((x, y), F2)
+        q = (2.2u"s", 1.3u"m")
+        g_ref = gradient(itp, q)
+        buf = Vector{Any}(undef, 2)
+        gradient!(buf, itp, q)
+        @test buf[1] === g_ref[1] && buf[2] === g_ref[2]
+    end
+end
+
 @testitem "Unitful ND: zero-alloc hot path, mixed-unit abstract-Tg (review pin F6)" setup = [AllocConstants] begin
     using Unitful
 

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -99,6 +99,42 @@ end
         g = @inferred gradient(itp, (1.5u"s", 0.75u"m"))
         @test g isa Tuple{typeof(1.0u"W/s"), typeof(1.0u"W/m")}
     end
+
+    # Scaled-store families: the dimensionless-twin machinery (build/eval/restore/
+    # integrate/one-shot) must stay concretely inferred end to end.
+    xs4 = [0.0, 1.0, 2.5, 3.0] .* u"s"
+    ym4 = [0.0, 1.0, 2.0, 3.5] .* u"m"
+    F4 = [Float64(i + j) for i in 1:4, j in 1:4] .* u"W"
+    q4 = (1.5u"s", 0.75u"m")
+    d10 = (DerivOp(1), DerivOp(0))
+
+    @testset "solver families (scaled store): eval / deriv / integrate / one-shot" begin
+        itp = cubic_interp((xs4, ym4), F4)
+        @test (@inferred itp(q4)) isa TW
+        @test (@inferred itp(q4; deriv = d10)) isa typeof(1.0u"W/s")
+        @test (@inferred integrate(itp)) isa typeof(1.0u"W*s*m")
+        @test (@inferred integrate(itp, (0.5u"s", 0.25u"m"), (2.5u"s", 3.0u"m"))) isa
+            typeof(1.0u"W*s*m")
+        @test (@inferred quadratic_interp((xs4, ym4), F4)(q4)) isa TW
+        @test (@inferred cubic_interp((xs4, ym4), F4, q4)) isa TW
+        @test (@inferred cubic_interp((xs4, ym4), F4, q4; coeffs = PreCompute())) isa TW
+        @test (@inferred cubic_interp((xs4, ym4), F4, q4; deriv = d10)) isa typeof(1.0u"W/s")
+        @test (@inferred cubic_interp((xs4, ym4), F4, [q4, q4])) isa Vector{TW}
+    end
+
+    @testset "FillExtrap keeps the value type concrete (in-domain + OOB + deriv)" begin
+        q_oob = (9.9u"s", 0.75u"m")
+        itpf = cubic_interp((xs4, ym4), F4; extrap = FillExtrap(NaN * u"W"))
+        @test (@inferred itpf(q4)) isa TW
+        @test (@inferred itpf(q_oob)) isa TW
+        @test (@inferred itpf(q_oob; deriv = d10)) isa typeof(1.0u"W/s")
+        @test (
+            @inferred cubic_interp(
+                (xs4, ym4), F4, q_oob;
+                extrap = FillExtrap(NaN * u"W"), coeffs = PreCompute()
+            )
+        ) isa TW
+    end
 end
 
 @testitem "Unitful ND: 1-tuple adapters, vector-point, unit-Range axes (review F13)" begin

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -935,6 +935,22 @@ end
         twc = cubic_interp((xf, yf), Fint; extrap = FillExtrap(0.5))
         @test itc(q) === twc((2.2, 1.3))
     end
+
+    @testset "quadratic one-shot mirrors the cubic fill space (unit + Real axes)" begin
+        itq = quadratic_interp((xs, ym), Fint; extrap = FillExtrap(0.5))
+        twq = quadratic_interp((xf, yf), Fint; extrap = FillExtrap(0.5))
+        @test itq(q_oob) === 0.5
+        @test itq(q) === twq((2.2, 1.3))
+        # One-shot entries resolve the fill eagerly — raw-Int space threw
+        # InexactError even for in-domain queries. Scalar + batch, unit + Real.
+        @test quadratic_interp((xs, ym), Fint, q_oob; extrap = FillExtrap(0.5)) === 0.5
+        @test quadratic_interp(
+            (xs, ym), Fint, q;
+            extrap = FillExtrap(0.5), coeffs = PreCompute()
+        ) === itq(q)
+        @test quadratic_interp((xf, yf), Fint, (9.9, 1.3); extrap = FillExtrap(0.5)) === 0.5
+        @test quadratic_interp((xs, ym), Fint, [q, q_oob]; extrap = FillExtrap(0.5))[2] === 0.5
+    end
 end
 
 @testitem "Unitful ND: GridIdx queries resolve on unit axes" begin

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -539,6 +539,84 @@ end
     end
 end
 
+@testitem "Unitful ND: one-shot solver families mirror the persistent build (P5b)" begin
+    using Unitful
+
+    xf = [0.0, 1.0, 2.5, 3.0, 4.5]
+    yf = [0.0, 1.0, 2.0, 3.5]
+    x = xf .* u"s"
+    y = yf .* u"m"
+    F = [(sin(xi) + 2.0 * yj + 0.4 * xi * yj) * u"W" for xi in xf, yj in yf]
+    q = (2.2u"s", 1.3u"m")
+    qs = [(2.2u"s", 1.3u"m"), (0.4u"s", 3.1u"m")]
+    d10 = (DerivOp(1), DerivOp(0))
+    d01 = (DerivOp(0), DerivOp(1))
+
+    # The persistent interpolant is the reference — its unit forward path is pinned above.
+    ref = cubic_interp((x, y), F)
+
+    @testset "cubic scalar one-shot (AutoCoeffs → pool + explicit PreCompute)" begin
+        @test cubic_interp((x, y), F, q) ≈ ref(q) rtol = 1.0e-14
+        @test cubic_interp((x, y), F, q; coeffs = PreCompute()) ≈ ref(q) rtol = 1.0e-14
+        r10 = cubic_interp((x, y), F, q; deriv = d10)
+        @test unit(r10) === u"W/s"
+        @test r10 ≈ ref(q; deriv = d10) rtol = 1.0e-13
+        r11 = cubic_interp((x, y), F, q; deriv = (DerivOp(1), DerivOp(1)))
+        @test unit(r11) === u"W" / (u"s" * u"m")
+        @test r11 ≈ ref(q; deriv = (DerivOp(1), DerivOp(1))) rtol = 1.0e-13
+    end
+
+    @testset "cubic batch one-shot: op-aware output eltype + in-place" begin
+        out = cubic_interp((x, y), F, qs)
+        @test eltype(out) === typeof(ref(q))
+        @test out[1] ≈ ref(qs[1]) rtol = 1.0e-14
+        @test out[2] ≈ ref(qs[2]) rtol = 1.0e-14
+        outd = cubic_interp((x, y), F, qs; deriv = d10)
+        @test eltype(outd) === typeof(ref(q; deriv = d10))
+        @test outd[2] ≈ ref(qs[2]; deriv = d10) rtol = 1.0e-13
+        buf = Vector{typeof(ref(q))}(undef, 2)
+        cubic_interp!(buf, (x, y), F, qs)
+        @test buf[2] ≈ ref(qs[2]) rtol = 1.0e-14
+    end
+
+    @testset "quadratic scalar + batch one-shot" begin
+        refq = quadratic_interp((x, y), F)
+        @test quadratic_interp((x, y), F, q) ≈ refq(q) rtol = 1.0e-14
+        @test quadratic_interp((x, y), F, q; coeffs = PreCompute()) ≈ refq(q) rtol = 1.0e-14
+        rq = quadratic_interp((x, y), F, q; deriv = d01)
+        @test unit(rq) === u"W/m"
+        @test rq ≈ refq(q; deriv = d01) rtol = 1.0e-13
+        outq = quadratic_interp((x, y), F, qs)
+        @test eltype(outq) === typeof(refq(q))
+        @test outq[1] ≈ refq(qs[1]) rtol = 1.0e-14
+        outqd = quadratic_interp((x, y), F, qs; deriv = d01)
+        @test eltype(outqd) === typeof(refq(q; deriv = d01))
+        @test outqd[2] ≈ refq(qs[2]; deriv = d01) rtol = 1.0e-13
+    end
+
+    @testset "same-unit axes (concrete Tg) + unit Range axis" begin
+        ys = yf .* u"s"
+        Fs = [(xi + 2.0 * yj) * u"W" for xi in xf, yj in yf]
+        qsame = (2.2u"s", 1.3u"s")
+        @test cubic_interp((x, ys), Fs, qsame) ≈ cubic_interp((x, ys), Fs)(qsame) rtol = 1.0e-14
+        @test quadratic_interp((x, ys), Fs, qsame) ≈
+            quadratic_interp((x, ys), Fs)(qsame) rtol = 1.0e-14
+        xr = (0.0:1.0:4.0) * u"s"   # unit StepRangeLen → pooled _CachedRange arm
+        Fr = [(xi + 2.0 * yj) * u"W" for xi in 0.0:1.0:4.0, yj in yf]
+        @test cubic_interp((xr, y), Fr, q) ≈ cubic_interp((xr, y), Fr)(q) rtol = 1.0e-14
+    end
+
+    @testset "exclusive periodic unit axis through the pooled one-shot" begin
+        xpf = [0.0, 1.0, 2.0, 3.0]
+        xp = xpf .* u"s"
+        Fp = [(sin(2π * xi / 4.0) + 2.0 * yj) * u"W" for xi in xpf, yj in yf]
+        bcs = (PeriodicBC(endpoint = :exclusive, period = 4.0u"s"), ZeroCurvBC())
+        refp = cubic_interp((xp, y), Fp; bc = bcs)
+        @test cubic_interp((xp, y), Fp, (3.7u"s", 1.3u"m"); bc = bcs, coeffs = PreCompute()) ≈
+            refp((3.7u"s", 1.3u"m")) rtol = 1.0e-14
+    end
+end
+
 @testitem "Unitful ND: zero-alloc hot path, mixed-unit abstract-Tg (review pin F6)" setup = [AllocConstants] begin
     using Unitful
 
@@ -639,11 +717,10 @@ end
 @testitem "Unitful ND: one-shot builders reject unit grids with a friendly error (review pin F17)" begin
     using Unitful
 
-    # The persistent 2-arg builders gate unit-carrying solver/hetero ND grids with an
-    # actionable ArgumentError (`_check_nd_solver_grid` / `_check_nd_hetero_grid`). The
-    # one-shot 3-arg entries skipped the guard and fell into deep, non-actionable errors
-    # (`TypeError: Quantity … is not a valid key`, `MethodError: _collapse_dims(::Type{Quantity…})`).
-    # Both paths fail (unit ND solver/hetero builds are unsupported); this pins error *quality*.
+    # Hetero ND one-shots (pchip/akima/cardinal) gate unit-carrying grids with an
+    # actionable ArgumentError (`_check_nd_hetero_grid`) instead of deep, non-actionable
+    # errors (`TypeError: Quantity … is not a valid key`). Cubic/quadratic one-shots
+    # reparameterize and are pinned in the P5b mirror testitem above.
     xs = collect(1.0:5.0) .* u"s"
     ys = collect(1.0:5.0) .* u"m"
     data = [Float64(i + j) for i in 1:5, j in 1:5] .* u"W"
@@ -652,8 +729,6 @@ end
 
     # (name, scalar one-shot, batch one-shot)
     fams = [
-        ("cubic", () -> cubic_interp((xs, ys), data, qsc), () -> cubic_interp((xs, ys), data, qb)),
-        ("quadratic", () -> quadratic_interp((xs, ys), data, qsc), () -> quadratic_interp((xs, ys), data, qb)),
         ("pchip", () -> pchip_interp((xs, ys), data, qsc), () -> pchip_interp((xs, ys), data, qb)),
         ("akima", () -> akima_interp((xs, ys), data, qsc), () -> akima_interp((xs, ys), data, qb)),
         ("cardinal", () -> cardinal_interp((xs, ys), data, qsc), () -> cardinal_interp((xs, ys), data, qb)),
@@ -681,12 +756,13 @@ end
 
     @testset "solver families (Cubic/Quadratic): persistent + one-shot" begin
         # Solver persistents admit unit axes since the scaled-store build; the
-        # concrete-Tg dispatch pins flip to build-success. One-shot mirrors
-        # stay gated until their phase.
+        # concrete-Tg dispatch pins flip to build-success, and the one-shot
+        # mirrors (P5b) now agree with the persistent reference.
         @test cubic_interp((xs, xs2), data) isa CubicInterpolantND
         @test quadratic_interp((xs, xs2), data) isa QuadraticInterpolantND
-        @test_throws ArgumentError cubic_interp((xs, xs2), data, q)
-        @test_throws ArgumentError quadratic_interp((xs, xs2), data, q)
+        @test cubic_interp((xs, xs2), data, q) ≈ cubic_interp((xs, xs2), data)(q) rtol = 1.0e-14
+        @test quadratic_interp((xs, xs2), data, q) ≈
+            quadratic_interp((xs, xs2), data)(q) rtol = 1.0e-14
     end
 
     @testset "hetero families (PCHIP): persistent + one-shot" begin

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -497,6 +497,19 @@ end
         @test integrate(itp_r, lo, (3.5u"s", 2.5u"m")) ≈
             integrate(tw_r, lof, (3.5, 2.5)) * u"W*s*m" rtol = 1.0e-13
     end
+
+    @testset "bounded degenerate + reversed bounds on the reparam arm" begin
+        # `sign == 0` (point domain) short-circuits to `z_t * vol` — the zero must
+        # still live in [Y·X₁·X₂], same concrete type as a nondegenerate result.
+        itp = cubic_interp((x, y), F)
+        full = integrate(itp, lo, hi)
+        deg = integrate(itp, (2.0u"s", 1.5u"m"), (2.0u"s", 1.5u"m"))
+        @test iszero(deg)
+        @test typeof(deg) === typeof(full)
+        @test deg isa TWSM
+        # One flipped axis → sign == -1 rides `sign * (total * vol)`.
+        @test integrate(itp, (3.5u"s", 0.5u"m"), (0.5u"s", 3.0u"m")) === -full
+    end
 end
 
 @testitem "Unitful ND: composition gaps — 3D, PolyFit{4}, Real-zero BCPair, periodic, in-place" begin
@@ -1026,6 +1039,22 @@ end
         # Real-tuple arm; its collapse engine refuses non-Real grids with the
         # actionable error — explicit PreCompute above is the supported form.
         @test_throws ArgumentError cubic_interp((xs, ym), F, (GridIdx(2), GridIdx(3)))
+    end
+
+    @testset "deriv × GridIdx: the `-` seam feeds the dLs scaling" begin
+        # `Base.:-(g::GridIdx, x::Number)` is the one value-consuming seam; its
+        # result is scaled by `_deriv_oneunit` in the reparam dLs — pin against
+        # the flat-coordinate equivalents (same cell → bit-identical, [Y/Xᵈ]).
+        d10 = (DerivOp(1), DerivOp(0))
+        d01 = (DerivOp(0), DerivOp(1))
+        @test itp((GridIdx(2), GridIdx(3)); deriv = d10) ===
+            itp((xs[2], ym[3]); deriv = d10)
+        @test itp((2.2u"s", GridIdx(3)); deriv = d01) ===
+            itp((2.2u"s", ym[3]); deriv = d01)
+        @test unit(itp((GridIdx(2), GridIdx(3)); deriv = d10)) == u"W/s"
+        itq = quadratic_interp((xs, ym), F)
+        @test itq((GridIdx(2), GridIdx(3)); deriv = d10) ===
+            itq((xs[2], ym[3]); deriv = d10)
     end
 end
 

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -904,3 +904,35 @@ end
         @test itp(q) isa Float64
     end
 end
+
+@testitem "Unitful ND: promotable data floats on unit axes (fill-space parity with Real axes)" begin
+    using Unitful
+
+    # Real axes float Int data at the entry, so `FillExtrap(0.5)` lives in the
+    # float value space. The unit-axis arm kept promotable data raw → the fill
+    # normalized into Int and threw InexactError. Pin parity across families.
+    xf = [0.0, 1.0, 2.5, 3.0, 4.5]
+    yf = [0.0, 1.0, 2.0, 3.5]
+    xs = xf .* u"s"
+    ym = yf .* u"m"
+    Fint = [i + j for i in 1:5, j in 1:4]
+    q = (2.2u"s", 1.3u"m")
+    q_oob = (9.9u"s", 1.3u"m")
+
+    @testset "Int data + FillExtrap(0.5): linear + cubic persistent + cubic one-shot" begin
+        itl = interp((xs, ym), Fint; method = LinearInterp(), extrap = FillExtrap(0.5))
+        @test itl(q_oob) === 0.5
+        itc = cubic_interp((xs, ym), Fint; extrap = FillExtrap(0.5))
+        @test itc(q_oob) === 0.5
+        @test cubic_interp(
+            (xs, ym), Fint, q_oob;
+            extrap = FillExtrap(0.5), coeffs = PreCompute()
+        ) === 0.5
+    end
+
+    @testset "in-domain Real-axes parity (value + type)" begin
+        itc = cubic_interp((xs, ym), Fint; extrap = FillExtrap(0.5))
+        twc = cubic_interp((xf, yf), Fint; extrap = FillExtrap(0.5))
+        @test itc(q) === twc((2.2, 1.3))
+    end
+end

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -1131,7 +1131,28 @@ end
         @test_throws ArgumentError cubic_interp((xs, ym), F, (GridIdx(2), GridIdx(3)))
     end
 
-    @testset "deriv × GridIdx: the `-` seam feeds the dLs scaling" begin
+    @testset "every unit-axis family consumes a resolved GridIdx" begin
+        # The wrapper cannot ride promotion on a unit axis (nested Quantity), so
+        # each family's coordinate seam must read the payload. Constant ND was
+        # uncovered — value AND derivative, all-GridIdx and mixed.
+        d10 = (DerivOp(1), DerivOp(0))
+        xr = range(0.0, 4.0, 5) .* u"s"
+        yr = range(0.0, 3.0, 4) .* u"m"
+        Fr = [(a + 2.0 * b) for a in range(0.0, 4.0, 5), b in range(0.0, 3.0, 4)] .* u"W"
+        for (itp, ref) in (
+                (interp((xs, ym), F; method = LinearInterp()), (xs[2], ym[3])),
+                (interp((xs, ym), F; method = ConstantInterp()), (xs[2], ym[3])),
+                (interp((xr, yr), Fr; method = ConstantInterp()), (xr[2], yr[3])),
+                (cubic_interp((xs, ym), F), (xs[2], ym[3])),
+                (quadratic_interp((xs, ym), F), (xs[2], ym[3])),
+            )
+            @test itp((GridIdx(2), GridIdx(3))) === itp(ref)
+            @test itp((2.2u"s", GridIdx(3))) === itp((2.2u"s", ref[2]))
+            @test itp((GridIdx(2), GridIdx(3)); deriv = d10) === itp(ref; deriv = d10)
+        end
+    end
+
+    @testset "deriv × GridIdx: the coordinate seam feeds the dLs scaling" begin
         # `Base.:-(g::GridIdx, x::Number)` is the one value-consuming seam; its
         # result is scaled by `_deriv_oneunit` in the reparam dLs — pin against
         # the flat-coordinate equivalents (same cell → bit-identical, [Y/Xᵈ]).

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -254,6 +254,36 @@ end
         @test occursin("non-Real", msg)
         @test occursin("_OrderedDuckNum", msg)
     end
+
+    # `*`/`inv`-complete but `oneunit`-less: the `_coeff_op` probe inferred Real
+    # and let the build die deep in the twin transform (MethodError) — the gate
+    # must reject upfront, matching its own "needs `oneunit`, `inv`, `*`" promise.
+    struct _NoOneUnitLen <: Number
+        v::Float64
+    end
+    struct _NoOneUnitInv <: Number
+        v::Float64
+    end
+    Base.isless(a::_NoOneUnitLen, b::_NoOneUnitLen) = isless(a.v, b.v)
+    Base.inv(a::_NoOneUnitLen) = _NoOneUnitInv(inv(a.v))
+    Base.:*(a::_NoOneUnitLen, b::_NoOneUnitInv) = a.v * b.v
+    Base.:*(a::_NoOneUnitInv, b::_NoOneUnitLen) = a.v * b.v
+    xn = _NoOneUnitLen.([0.0, 1.0, 2.0, 3.0])
+
+    for build in (
+            () -> cubic_interp((xn, xn), F),
+            () -> quadratic_interp((xn, xn), F),
+            () -> cubic_interp((xn, xn), F, (_NoOneUnitLen(1.5), _NoOneUnitLen(1.5))),
+        )
+        err = try
+            build()
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("oneunit", sprint(showerror, err))
+    end
 end
 
 @testitem "Unitful ND: cubic PreCompute build — scaled [Y]-homogeneous store (P1)" begin

--- a/test/test_unitful_grid_nd.jl
+++ b/test/test_unitful_grid_nd.jl
@@ -936,3 +936,38 @@ end
         @test itc(q) === twc((2.2, 1.3))
     end
 end
+
+@testitem "Unitful ND: GridIdx queries resolve on unit axes" begin
+    using Unitful
+
+    # `_resolve_grididx` rebuilds the wrapper at the AXIS eltype — the payload
+    # constraint must admit Number, else every unit-axis GridIdx query dies in
+    # the constructor (TypeError) before evaluation.
+    xf = [0.0, 1.0, 2.5, 3.0, 4.5]
+    yf = [0.0, 1.0, 2.0, 3.5]
+    xs = xf .* u"s"
+    ym = yf .* u"m"
+    F = [(sin(xi) + 2.0 * yj) for xi in xf, yj in yf] .* u"W"
+    itp = cubic_interp((xs, ym), F)
+
+    @testset "persistent: all-GridIdx + mixed coordinate/GridIdx" begin
+        @test itp((GridIdx(2), GridIdx(3))) === itp((xs[2], ym[3]))
+        @test itp((2.2u"s", GridIdx(3))) === itp((2.2u"s", ym[3]))
+        itl = interp((xs, ym), F; method = LinearInterp())
+        @test itl((GridIdx(2), GridIdx(3))) === itl((xs[2], ym[3]))
+    end
+
+    @testset "one-shot mirrors (PreCompute / mixed-tuple Auto)" begin
+        @test cubic_interp((xs, ym), F, (GridIdx(2), GridIdx(3)); coeffs = PreCompute()) ≈
+            itp((xs[2], ym[3])) rtol = 1.0e-14
+        @test quadratic_interp((xs, ym), F, (2.2u"s", GridIdx(3))) ≈
+            quadratic_interp((xs, ym), F)((2.2u"s", ym[3])) rtol = 1.0e-14
+    end
+
+    @testset "all-GridIdx + AutoCoeffs keeps the hetero-collapse refusal" begin
+        # The wrapper subtypes Real, so an all-GridIdx tuple matches the OnTheFly
+        # Real-tuple arm; its collapse engine refuses non-Real grids with the
+        # actionable error — explicit PreCompute above is the supported form.
+        @test_throws ArgumentError cubic_interp((xs, ym), F, (GridIdx(2), GridIdx(3)))
+    end
+end


### PR DESCRIPTION
## Summary

Extends #201's unit-native solver core to the ND solver families (Cubic/Quadratic PreCompute): build, eval, derivatives, `integrate` (full + bounded), one-shot, gridded queries, `GridIdx` and `FillExtrap` all work on unit-carrying axes, mixed units included. The blocker was the shared `2^N` nodal-derivative store, whose slots differ by derivative order (`[Y]`, `[Y/X₁]`, `[Y/X₁X₂]`) and so cannot live in one homogeneous array. Each axis is therefore reparameterized to its exact dimensionless twin `t = x·inv(oneunit(x))`, the store stays `[Y]`-homogeneous, and `grid⁻ᵏ` is restored at a single cell seam.

## Mechanism

- **One witness.** `_reparam_op(x) = x * _deriv_oneunit(x, DerivOp(1))` — the gate probes it, the twin applies it, its eltype comes from it. Eval never builds a twin: it scales `h`/`inv_h`/`dL` per query and restores the grading with one scalar.
- **Lazy twin.** The two array-consuming seams (fiber solve, separable integrate) ask an axis only for `getindex` and `_get_h`/`_get_inv_h`, so `_ReparamAxis` is a view over the parent plus two scalar witnesses — no per-call array, widths straight from the parent's cache. Range axes keep the arithmetic form (already isbits, and it preserves the `_CachedRange` cache-bank fast path).
- **Dispatch, not value branches.** Solve frame, cell-seam restore, local params, integrate and fill-eltype all pick their arm from the promotion tag, with the Real arm an identity *method* — so Real executes the pre-existing bodies verbatim.

## Rides along

- **`GridIdx` in ND batches** carried its `val = NaN` poison into the kernel: on an *interpolating* axis, linear/cubic returned `NaN` and Constant a wrong cell — silently, on Real grids, since v0.4.17. Existing coverage only pinned `GridIdx` on `NoInterp` axes, whose kernel never reads the coordinate.
- **`FillExtrap` promotion space** — 1-D `constant_interp`/`cubic_interp`, `ConstantInterpolantND` and gridded constant promoted the fill against the raw data eltype, so Int data plus `FillExtrap(0.5)` threw `InexactError` at construction.
- Smaller: the solver gate now probes the transform it promises (an `oneunit`-less duck used to pass), Hermite ND gates non-Real axes at both entries, the gridded fused path declines them, and `_normalize_bounds_nd` unrolls its bounds tuple.

## Numbers

Real is unchanged by A/B: linear 10 k batch 12.2 µs both sides with values `===`, ND 20 k batch within noise, 0 B throughout. Unit axes now allocate nothing on the hot paths (one-shot 3328 B → 0, `integrate` full 7232 B → 0, bounded 7424 B → 0) and bounded integration went 245 µs → 114 µs, matching Real, because the lazy twin keeps the parent's cached widths. Eval values are bit-identical; bounded integrals move ≤ 1 ULP.

## Deferred

Adjoints/AD, Hermite ND and the hetero families on unit axes all refuse with actionable errors. Two query shapes stay broken and are now recorded with `@test_broken`, both verified identical on the v0.4.17 tag: 1-D batch `GridIdx` (loud — the 1-D loops never resolve the wrapper) and SoA queries with a pinned scalar axis (no protocol arm for a mixed `(vector, scalar)` tuple; fixing it is a design choice since the `NoInterp` pre-slice entry uses the same shape).
