### PR TITLE
fix(pchip): close the flat-data holes in the slope guard (Dual) and its adjoint (Float64)

### DIFF
--- a/src/pchip/pchip_adjoint.jl
+++ b/src/pchip/pchip_adjoint.jl
@@ -161,8 +161,12 @@ end
     @inbounds δ_curr = _forward_secant(x, y, 2)
 
     @inbounds for k in 2:(n - 1)
-        if sign(δ_prev) != sign(δ_curr)
-            # Clamped: dy[k] = 0 → all derivatives zero, skip
+        # Flat data (both secants exactly zero) takes the forward's zero-denominator guard in
+        # `_pchip_harmonic_mean`, i.e. dy[k] = 0 → this node contributes nothing. Without the
+        # `_flat_secants` test the active branch below divides by δ² == 0 and writes NaN into
+        # `f_bar` — on plain `Float64` input, no AD required.
+        if sign(δ_prev) != sign(δ_curr) || _flat_secants(δ_prev, δ_curr)
+            # Clamped or flat: dy[k] = 0 → all derivatives zero, skip
         else
             # Active: weighted harmonic mean
             # dy[k] = S / D where S = w1+w2, D = w1/δ_prev + w2/δ_curr
@@ -311,6 +315,9 @@ end
 
         # Zero-clamped branch: dy[k] = 0 → all derivatives zero, skip.
         sign(δ_prev) != sign(δ_curr) && return nothing
+        # Flat branch: the forward's zero-denominator guard also returns dy[k] = 0, and the
+        # active branch below would divide by δ² == 0. See `_flat_secants`.
+        _flat_secants(δ_prev, δ_curr) && return nothing
 
         # Active branch: harmonic mean dy[k] = S/D where
         #   S = w1+w2,  D = w1/δ_prev + w2/δ_curr,

--- a/src/pchip/pchip_slopes.jl
+++ b/src/pchip/pchip_slopes.jl
@@ -47,13 +47,32 @@ Fritsch–Carlson weighted harmonic mean of two secants, single-division form.
 Algebraically `(w1+w2)/(w1/δp + w2/δc) == (w1+w2)·δp·δc / (w1·δc + w2·δp)`, which
 trades 3 divisions for 1. Called only from the monotone branch where
 `sign(δp) == sign(δc)`, so the denominator is nonzero unless both secants are
-exactly zero (flat data) — the `iszero(den)` guard maps that 0·0/0 case to `0`,
+exactly zero (flat data) — the zero-denominator guard maps that 0·0/0 case to `0`,
 matching the old form's `Inf`-arithmetic limit (and avoiding a NaN).
+
+The guard tests the PRIMAL (`_extract_primal`, as in `_constant_kernel`): `iszero` on a
+`ForwardDiff.Dual` inspects the partials too, so a seeded flat stretch — `den` with value `0`
+but a nonzero partial — would skip the guard and evaluate the 0·0/0 it exists to prevent,
+returning `Dual(NaN, NaN)`. That is a NaN in the VALUE, not merely in the derivative.
 """
 @inline function _pchip_harmonic_mean(w1, w2, δp, δc)
     den = w1 * δc + w2 * δp
-    return iszero(den) ? zero(den) : (w1 + w2) * δp * δc / den
+    # Use primal value for comparison (supports ForwardDiff.Dual)
+    return iszero(_extract_primal(den)) ? zero(den) : (w1 + w2) * δp * δc / den
 end
+
+"""
+    _flat_secants(δp, δc)
+
+Is this the flat-data case the harmonic mean guards against — both secants exactly zero?
+
+Equivalent to the `iszero(den)` test in [`_pchip_harmonic_mean`](@ref) on the monotone branch
+(`w1, w2 > 0` and `sign(δp) == sign(δc)`, so `den` vanishes only when both secants do), stated in
+terms of the secants so the reverse-mode adjoint — which builds `D = w1/δp + w2/δc` rather than
+`den` — can select the same branch as the forward pass. Tests the PRIMAL, as the forward guard
+does.
+"""
+@inline _flat_secants(δp, δc) = iszero(_extract_primal(δp)) && iszero(_extract_primal(δc))
 
 """
     _pchip_slopes!(dy, x, y)

--- a/test/test_pchip_flat_data.jl
+++ b/test/test_pchip_flat_data.jl
@@ -1,0 +1,82 @@
+@testitem "PCHIP flat data: forward AD and adjoint" begin
+    using FastInterpolations: _pchip_harmonic_mean, _flat_secants
+    using LinearAlgebra: dot
+    using Random: MersenneTwister
+    import ForwardDiff
+
+    # Two adjacent control points holding the SAME value make a secant exactly zero, which is
+    # the degenerate case the harmonic mean guards against (0*0/0). Both derivative paths used
+    # to fall into the branch they were meant to avoid:
+    #
+    #   forward — `iszero(den)` inspects a Dual's PARTIALS, so a seeded flat stretch skipped the
+    #             guard and returned Dual(NaN, NaN): a NaN in the VALUE, not just the derivative;
+    #   adjoint — `sign(0) == sign(0)` takes the active branch, which divides by δ² == 0, so
+    #             `pchip_adjoint` returned NaN on plain Float64 input.
+    #
+    # Ties are ordinary in practice: clamped or saturated data, quantized/rounded inputs, a
+    # plateau in an otherwise monotone profile, optimizer variables resting on a shared bound.
+
+    x = collect(0.0:0.1:0.6)
+    xq = collect(range(0.0, 0.6; length = 13))
+    flat(p1, p2) = [0.0, 1.0, 2.0 + p1, 2.0 + p2, 2.0, 2.0, 5.0]   # plateau between two ramps
+
+    @testset "kernel guard" begin
+        D = ForwardDiff.Dual{:t}
+        # value 0 with a live partial: the guard must still fire
+        @test _pchip_harmonic_mean(3.0, 3.0, D(0.0, 8.0e-9), D(0.0, 0.0)) == D(0.0, 0.0)
+        @test _flat_secants(D(0.0, 8.0e-9), D(0.0, 0.0))
+        @test !_flat_secants(D(0.0, 0.0), D(1.0, 0.0))
+        # non-degenerate input is untouched by the primal test
+        @test _pchip_harmonic_mean(3.0, 3.0, 1.0, 2.0) ≈ 6 * 1.0 * 2.0 / (3.0 * 2.0 + 3.0 * 1.0)
+    end
+
+    @testset "forward under ForwardDiff" begin
+        # Perturbing points INSIDE the plateau: two live seeds are required to trip the bug —
+        # with a single seed the two secant partials cancel on a uniform grid, restoring
+        # `iszero(den)`, which is why single-variable AD checks never caught it.
+        g(p) = pchip_interp(x, flat(p[1], p[2]); extrap = ExtendExtrap()).(xq)
+        J = ForwardDiff.jacobian(p -> ForwardDiff.value.(g(p)), [0.0, 0.0])
+        @test !any(isnan, J)
+        # values are the plain-Float64 values (the AD path must not perturb the primal)
+        @test ForwardDiff.value.(g([0.0, 0.0])) ≈
+            pchip_interp(x, flat(0.0, 0.0); extrap = ExtendExtrap()).(xq)
+
+        # Perturbing points OUTSIDE the plateau: smooth there, so AD must match finite
+        # differences (the plateau still exists, exercising the guard).
+        f(p) = pchip_interp(x, [0.0 + p[1], 1.0, 2.0, 2.0, 2.0, 2.0, 5.0 + p[2]];
+            extrap = ExtendExtrap()).(xq)
+        J_ad = ForwardDiff.jacobian(f, [0.0, 0.0])
+        h = 1.0e-6
+        J_fd = hcat((f([h, 0.0]) .- f([-h, 0.0])) ./ 2h, (f([0.0, h]) .- f([0.0, -h])) ./ 2h)
+        @test isapprox(J_ad, J_fd; rtol = 1.0e-5, atol = 1.0e-8)
+    end
+
+    @testset "adjoint on flat data" begin
+        y = flat(0.0, 0.0)
+        f_bar = pchip_adjoint(x, y, xq; extrap = ExtendExtrap())(ones(length(xq)))
+        @test all(isfinite, f_bar)
+
+        # The exactly-tied result must agree with the no-ties limit: same shape, ties broken by
+        # a perturbation far below the slope scale.
+        y_near = [0.0, 1.0, 2.0, 2.0 + 1.0e-9, 2.0 + 2.0e-9, 2.0 + 3.0e-9, 5.0]
+        f_bar_near = pchip_adjoint(x, y_near, xq; extrap = ExtendExtrap())(ones(length(xq)))
+        @test isapprox(f_bar, f_bar_near; rtol = 1.0e-6)
+
+        # Dot-product identity <W*y, y_bar> == <y, W^T*y_bar>, on flat and fully-constant data
+        rng = MersenneTwister(20240607)
+        for yy in (flat(0.0, 0.0), fill(2.0, 7), [0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 2.0])
+            y_bar = randn(rng, length(xq))
+            lhs = dot(pchip_interp(x, yy; extrap = ExtendExtrap()).(xq), y_bar)
+            rhs = dot(yy, pchip_adjoint(x, yy, xq; extrap = ExtendExtrap())(y_bar))
+            @test isapprox(lhs, rhs; rtol = 1.0e-10)
+        end
+
+        # non-uniform grid, plateau not at the ends
+        xn = [0.0, 0.5, 1.7, 2.0, 3.3, 4.0]
+        yn = [1.0, 3.0, 3.0, 2.0, 2.0, 5.0]
+        qn = collect(range(0.0, 4.0; length = 17))
+        y_bar = randn(MersenneTwister(11), length(qn))
+        @test isapprox(dot(pchip_interp(xn, yn; extrap = ExtendExtrap()).(qn), y_bar),
+            dot(yn, pchip_adjoint(xn, yn, qn; extrap = ExtendExtrap())(y_bar)); rtol = 1.0e-10)
+    end
+end


### PR DESCRIPTION
Two related bugs, one trigger: **two adjacent control points holding the same value**, which
makes a secant exactly zero. Both derivative paths then fall into the degenerate branch they
were meant to avoid. Values are fine — only the derivatives break.

Exact ties are not exotic: clamped or saturated data, quantized/rounded inputs, a plateau in an
otherwise monotone profile, or optimizer variables resting on a shared bound all produce them.

### 1. Forward: `_pchip_harmonic_mean` returns `Dual(NaN, NaN)`

The guard for flat data (both secants zero → `0*0/0`, added with the single-division form in
#168) is `iszero(den)`. On a `ForwardDiff.Dual`, `iszero` is **partial-aware**, so a seeded
derivative skips it:

```julia
julia> w1 = w2 = 3.0;
julia> δp = Dual{:t}(0.0, 8e-9); δc = Dual{:t}(0.0, 0.0);
julia> den = w1*δc + w2*δp        # Dual(0.0, 2.4e-8)  →  iszero(den) == false
julia> (w1+w2)*δp*δc/den
Dual{:t}(NaN,NaN)                 # NaN in the VALUE, not just the partial
```

End to end:

```julia
julia> x  = collect(0.0:0.1:0.6);
julia> xq = collect(range(0.0, 0.6; length=13));
julia> g(p) = pchip_interp(x, [0.0, 1.0, 2.0 + p[1], 2.0 + p[2], 2.0, 2.0, 5.0];
                           extrap=ExtendExtrap()).(xq);
julia> any(isnan, ForwardDiff.jacobian(g, [0.0, 0.0]))
true
```

`_constant_kernel` already handles this correctly (`dL_primal = _extract_primal(dL)`); this is
the one place the convention was missed.

### 2. Adjoint: `pchip_adjoint` returns NaN on plain `Float64`

Same trigger, no AD required. `sign(δ_prev) != sign(δ_curr)` is false for `0` vs `0`, so the
interior loop takes the *active* branch and divides by `δ²`:

```julia
julia> y = [0.0, 1.0, 2.0, 2.0, 2.0, 2.0, 5.0];              # plateau between two ramps
julia> pchip_adjoint(x, y, xq; extrap=ExtendExtrap())(ones(13))
7-element Vector{Float64}:
 1.3125, 2.25, NaN, NaN, NaN, NaN, 1.3125

julia> y2 = [0.0, 1.0, 2.0, 2.001, 2.002, 2.003, 5.0];       # same shape, no exact ties
julia> pchip_adjoint(x, y2, xq; extrap=ExtendExtrap())(ones(13))
7-element Vector{Float64}:
 1.3125, 2.25, 1.9375, 2.0, 1.9375, 2.25, 1.3125
```

(`D = w1/0 + w2/0 = Inf`, then `S*w1/(D²*δ²) = Inf/NaN`.) After the fix the tied case returns
that second vector — the no-ties limit — which is one of the added tests.

### Why this is easy to miss

- **The forward case needs two live seeds.** Seed only one of two tied control points and the
  two secant partials cancel on a uniform grid, restoring `iszero(den)` — so single-variable
  AD/FD spot-checks pass while a full `ForwardDiff.jacobian` is NaN-poisoned.
- **It can surface as a *zero* derivative rather than a NaN.** Any caller that treats a NaN
  evaluation as an invalid point and substitutes a constant fallback hands ForwardDiff a
  partial-free value, so the whole seeded chunk comes back as exactly-zero Jacobian columns —
  a structurally singular system with nothing to warn on. That failure mode is silent, which
  is why it seems worth fixing at the source rather than leaving to callers.

### Fix

- Forward: `iszero(_extract_primal(den))`, matching `_constant_kernel`.
- Adjoint: skip the node when the forward pass takes its zero-denominator branch, via a shared
  `_flat_secants(δp, δc)` predicate, so forward and reverse select the same branch. (The
  adjoint builds `D = w1/δp + w2/δc` rather than `den`, hence stating the test in terms of the
  secants; on the monotone branch the two are equivalent.) Applied to both the interior loop
  and the periodic kernel; the endpoint blocks never divide by a secant and are unaffected.

At exactly-flat data the Fritsch–Carlson slope is genuinely non-differentiable (positively
homogeneous there), so zero is a subgradient choice — and it is the value the `Float64` forward
path already returns, which is what keeps the three paths consistent.

**No behavior change for any input whose denominator is nonzero.**

### Testing

New `test/test_pchip_flat_data.jl` (13 tests): the kernel guard under a seeded `Dual`; forward
`ForwardDiff.jacobian` across a plateau (no NaN, values unchanged, and agreement with finite
differences where the data is smooth); and the adjoint on flat data (finite, equal to the
no-ties limit, and satisfying the dot-product identity `⟨W·y, ȳ⟩ == ⟨y, Wᵀ·ȳ⟩` on uniform and
non-uniform grids).

Full suite on this branch: **70486 pass, 24 broken (pre-existing), 0 failures**.
